### PR TITLE
Cap dialog height to 90vh so tall content scrolls instead of overflows

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -72,7 +72,7 @@ function DialogContent({
         data-slot="dialog-content"
         onInteractOutside={(e) => e.preventDefault()}
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -72,7 +72,7 @@ function DialogContent({
         data-slot="dialog-content"
         onInteractOutside={(e) => e.preventDefault()}
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

Dialogs with many custom fields (e.g. the member edit dialog) could grow past the bottom of the viewport with no way to scroll to the save button.

## Changes

- Added `max-h-[90vh] overflow-y-auto` to the base `DialogContent` component

## Testing

- [ ] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Tested manually

## Security / privacy impact

None.

## Screenshots
<img width="1513" height="1013" alt="Screenshot 2026-04-22 at 3 23 31 AM" src="https://github.com/user-attachments/assets/35e8dfa4-4c06-4e34-a71a-7f2a874428bb" />


<!-- If this changes the UI, include before/after screenshots -->