### PR TITLE
Login/security refinements

### DIFF
--- a/alembic/versions/l2m3n4o5p6q7_add_trusted_devices.py
+++ b/alembic/versions/l2m3n4o5p6q7_add_trusted_devices.py
@@ -1,0 +1,62 @@
+"""Add trusted_devices table
+
+Revision ID: l2m3n4o5p6q7
+Revises: k1l2m3n4o5p6
+Create Date: 2026-04-25 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "l2m3n4o5p6q7"
+down_revision: Union[str, None] = "k1l2m3n4o5p6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trusted_devices",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("nickname", sa.String(length=128), nullable=True),
+        sa.Column("user_agent", sa.String(length=500), nullable=False, server_default=""),
+        sa.Column("created_ip", sa.String(length=45), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_ip", sa.String(length=45), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index(
+        "ix_trusted_devices_user_id", "trusted_devices", ["user_id"],
+    )
+    op.create_index(
+        "ix_trusted_devices_token_hash", "trusted_devices", ["token_hash"],
+    )
+    op.create_index(
+        "ix_trusted_devices_expires_at", "trusted_devices", ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_trusted_devices_expires_at", table_name="trusted_devices")
+    op.drop_index("ix_trusted_devices_token_hash", table_name="trusted_devices")
+    op.drop_index("ix_trusted_devices_user_id", table_name="trusted_devices")
+    op.drop_table("trusted_devices")

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -458,6 +458,12 @@ class PasswordReset(BaseModel):
     new_password: str
 
 
+class PasswordChange(BaseModel):
+    current_password: str
+    new_password: str
+    totp_code: str | None = None
+
+
 @router.post("/request-password-reset", dependencies=[rate_limit(3, 60, fail_closed=True)])
 async def request_password_reset(
     body: PasswordResetRequest,
@@ -546,6 +552,77 @@ async def reset_password(
     user.password_reset_sent_at = None
     await db.commit()
     return {"reset": True}
+
+
+@router.post(
+    "/change-password",
+    dependencies=[rate_limit(10, 3600, "user", fail_closed=True)],
+)
+async def change_password(
+    body: PasswordChange,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    session_id: str | None = Cookie(default=None, alias="sheaf_session"),
+):
+    """Change the signed-in user's password.
+
+    Gated on the current password and, if TOTP is enabled, a fresh TOTP or
+    recovery code. On success all other sessions are revoked so a stolen
+    cookie elsewhere can't survive the change; the calling session stays
+    alive.
+    """
+    if len(body.new_password) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Password must be at least 8 characters",
+        )
+    if len(body.new_password) > 128:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Password must be at most 128 characters",
+        )
+    if body.new_password == body.current_password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New password must differ from the current password",
+        )
+
+    if not verify_password(body.current_password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Current password is incorrect",
+        )
+
+    if user.totp_enabled:
+        if not body.totp_code:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="TOTP code required",
+                headers={"X-Sheaf-2FA": "required"},
+            )
+        secret = decrypt(user.totp_secret)
+        if not verify_code(secret, body.totp_code) and not await _check_recovery_code(
+            db, user, body.totp_code,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid TOTP code",
+            )
+
+    user.password_hash = hash_password(body.new_password)
+    user.failed_login_count = 0
+    user.locked_until = None
+    await db.commit()
+
+    # Revoke every other session for this user so any lingering copy of a
+    # session cookie elsewhere is dead. The calling session stays alive.
+    # Refresh tokens bound to revoked sessions fail at /refresh when the
+    # session lookup misses.
+    revoked = 0
+    if session_id:
+        revoked = await delete_other_sessions(user.id, session_id)
+
+    return {"changed": True, "revoked_other_sessions": revoked}
 
 
 @router.post(

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -3,6 +3,7 @@ import json
 import logging
 import math
 import secrets
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import jwt
@@ -31,12 +32,22 @@ from sheaf.auth.totp import (
     get_provisioning_uri,
     verify_code,
 )
+from sheaf.auth.trusted_devices import (
+    TRUSTED_DEVICE_COOKIE,
+    TRUSTED_DEVICE_TTL_DAYS,
+    list_trusted_devices,
+    mint_trusted_device,
+    revoke_all_trusted_devices,
+    revoke_trusted_device,
+    verify_trusted_device,
+)
 from sheaf.config import settings
 from sheaf.crypto import blind_index, decrypt, encrypt, hash_mail_token
 from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.api_key import ApiKey
 from sheaf.models.system import System
+from sheaf.models.trusted_device import TrustedDevice
 from sheaf.models.user import AccountStatus, User
 from sheaf.request import client_ip
 from sheaf.schemas.user import (
@@ -618,6 +629,9 @@ async def change_password(
     user.password_hash = hash_password(body.new_password)
     user.failed_login_count = 0
     user.locked_until = None
+    # Revoke every trusted device — a password change is the canonical
+    # "kick everything off" event.
+    await revoke_all_trusted_devices(db, user.id)
     await db.commit()
 
     # Revoke every other session for this user so any lingering copy of a
@@ -727,6 +741,9 @@ async def login(
     request: Request,
     response: Response,
     db: AsyncSession = Depends(get_db),
+    trusted_device_cookie: str | None = Cookie(
+        default=None, alias=TRUSTED_DEVICE_COOKIE,
+    ),
 ):
     if captcha.required_for_login() and not captcha.verify(body.captcha):
         raise HTTPException(
@@ -764,23 +781,32 @@ async def login(
             detail="Invalid email or password",
         )
 
-    # Enforce TOTP if enabled
+    # ---- login(): TOTP check + trusted-device handling ----
+    # Enforce TOTP if enabled — unless the browser presents a valid
+    # trusted-device cookie for this user.
+    bypassed_via_trusted_device = False
     if user.totp_enabled:
-        if not body.totp_code:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="TOTP code required",
-                headers={"X-Sheaf-2FA": "required"},
-            )
-        secret = decrypt(user.totp_secret)
-        if not verify_code(secret, body.totp_code) and not await _check_recovery_code(
-            db, user, body.totp_code
-        ):
-            await _record_login_failure(db, user)
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid TOTP code",
-            )
+        trusted = await verify_trusted_device(
+            db, trusted_device_cookie, user.id, ip=client_ip(request),
+        )
+        if trusted is not None:
+            bypassed_via_trusted_device = True
+        else:
+            if not body.totp_code:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="TOTP code required",
+                    headers={"X-Sheaf-2FA": "required"},
+                )
+            secret = decrypt(user.totp_secret)
+            if not verify_code(secret, body.totp_code) and not await _check_recovery_code(
+                db, user, body.totp_code
+            ):
+                await _record_login_failure(db, user)
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid TOTP code",
+                )
 
     # Rehash if argon2 params have been upgraded
     if needs_rehash(user.password_hash):
@@ -819,6 +845,31 @@ async def login(
         max_age=settings.jwt_refresh_token_expire_days * 86400,
         path="/v1/auth",
     )
+
+    # Mint a trusted-device cookie if the user opted in. Only meaningful
+    # when TOTP was actually exercised (or already trusted) — without TOTP
+    # the cookie wouldn't bypass anything anyway.
+    if (
+        body.remember_device
+        and user.totp_enabled
+        and not bypassed_via_trusted_device
+    ):
+        device_token, _ = await mint_trusted_device(
+            db,
+            user.id,
+            user_agent=request.headers.get("user-agent", ""),
+            ip=client_ip(request),
+        )
+        await db.commit()
+        response.set_cookie(
+            key=TRUSTED_DEVICE_COOKIE,
+            value=device_token,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=TRUSTED_DEVICE_TTL_DAYS * 86400,
+            path="/v1/auth",
+        )
 
     return TokenResponse(
         access_token=create_token(user.id, TokenType.ACCESS, session_id=session_id),
@@ -937,6 +988,120 @@ async def revoke_other_sessions(
             detail="No current session",
         )
     revoked = await delete_other_sessions(user.id, session_id)
+    return {"revoked": revoked}
+
+
+# ---------------------------------------------------------------------------
+# Trusted devices
+# ---------------------------------------------------------------------------
+
+
+class TrustedDeviceRename(BaseModel):
+    nickname: str
+
+
+@router.get("/trusted-devices")
+async def get_trusted_devices(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    trusted_cookie: str | None = Cookie(default=None, alias=TRUSTED_DEVICE_COOKIE),
+):
+    """List the user's non-expired trusted devices.
+
+    `is_current` is true for the device whose cookie is on this request.
+    """
+    devices = await list_trusted_devices(db, user.id)
+    current_hash = None
+    if trusted_cookie:
+        from sheaf.auth.trusted_devices import _hash_token
+
+        current_hash = _hash_token(trusted_cookie)
+    return [
+        {
+            "id": str(d.id),
+            "nickname": d.nickname,
+            "user_agent": d.user_agent,
+            "created_at": d.created_at,
+            "created_ip": d.created_ip,
+            "last_used_at": d.last_used_at,
+            "last_used_ip": d.last_used_ip,
+            "expires_at": d.expires_at,
+            "is_current": d.token_hash == current_hash,
+        }
+        for d in devices
+    ]
+
+
+@router.patch("/trusted-devices/{device_id}")
+async def rename_trusted_device(
+    device_id: uuid.UUID,
+    body: TrustedDeviceRename,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Rename a trusted device."""
+    result = await db.execute(
+        select(TrustedDevice)
+        .where(TrustedDevice.id == device_id)
+        .where(TrustedDevice.user_id == user.id),
+    )
+    device = result.scalar_one_or_none()
+    if device is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Device not found",
+        )
+    device.nickname = body.nickname[:128] if body.nickname else None
+    await db.commit()
+    return {"ok": True}
+
+
+@router.delete(
+    "/trusted-devices/{device_id}", status_code=status.HTTP_204_NO_CONTENT,
+)
+async def revoke_trusted_device_endpoint(
+    device_id: uuid.UUID,
+    response: Response,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    trusted_cookie: str | None = Cookie(default=None, alias=TRUSTED_DEVICE_COOKIE),
+):
+    """Revoke a trusted device. If the caller revoked the device tied to
+    this browser, also clear the cookie so the next login requires TOTP
+    again."""
+    # Look up the row first so we can compare its hash against the cookie
+    # before deletion.
+    result = await db.execute(
+        select(TrustedDevice)
+        .where(TrustedDevice.id == device_id)
+        .where(TrustedDevice.user_id == user.id),
+    )
+    device = result.scalar_one_or_none()
+    if device is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Device not found",
+        )
+    revoked_self = False
+    if trusted_cookie:
+        from sheaf.auth.trusted_devices import _hash_token
+
+        revoked_self = _hash_token(trusted_cookie) == device.token_hash
+    await revoke_trusted_device(db, user.id, device_id)
+    await db.commit()
+    if revoked_self:
+        response.delete_cookie(TRUSTED_DEVICE_COOKIE, path="/v1/auth")
+
+
+@router.post("/trusted-devices/revoke-all")
+async def revoke_all_trusted_devices_endpoint(
+    response: Response,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Revoke every trusted device for the user. Clears this browser's
+    cookie too."""
+    revoked = await revoke_all_trusted_devices(db, user.id)
+    await db.commit()
+    response.delete_cookie(TRUSTED_DEVICE_COOKIE, path="/v1/auth")
     return {"revoked": revoked}
 
 
@@ -1196,6 +1361,9 @@ async def totp_disable(
     user.totp_enabled = False
     user.totp_secret = None
     user.recovery_codes = None
+    # Trusted devices were minted under the old TOTP relationship; wipe
+    # them so a stale cookie can't bypass anything if TOTP is re-enabled.
+    await revoke_all_trusted_devices(db, user.id)
     await db.commit()
 
 

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 
 import jwt
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from sqlalchemy import and_, case, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -464,6 +464,12 @@ class PasswordChange(BaseModel):
     totp_code: str | None = None
 
 
+class EmailChange(BaseModel):
+    new_email: EmailStr
+    current_password: str
+    totp_code: str | None = None
+
+
 @router.post("/request-password-reset", dependencies=[rate_limit(3, 60, fail_closed=True)])
 async def request_password_reset(
     body: PasswordResetRequest,
@@ -623,6 +629,89 @@ async def change_password(
         revoked = await delete_other_sessions(user.id, session_id)
 
     return {"changed": True, "revoked_other_sessions": revoked}
+
+
+@router.post(
+    "/change-email",
+    dependencies=[rate_limit(10, 3600, "user", fail_closed=True)],
+)
+async def change_email(
+    body: EmailChange,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    session_id: str | None = Cookie(default=None, alias="sheaf_session"),
+):
+    """Change the signed-in user's email.
+
+    Gated on the current password and, if TOTP is enabled, a fresh TOTP or
+    recovery code. The new address is verified again — verification status
+    is reset to false and a verification email is sent. Pre-apply
+    verification doesn't actually defend against session compromise (the
+    attacker controls the destination inbox); the password+TOTP gate is
+    the real protection. The re-verification is a typo safety net.
+    Other sessions are revoked, same as change-password.
+    """
+    new_email = body.new_email.strip().lower()
+    current_email = decrypt(user.email).strip().lower()
+    if new_email == current_email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New email must differ from the current email",
+        )
+
+    if not verify_password(body.current_password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Current password is incorrect",
+        )
+
+    if user.totp_enabled:
+        if not body.totp_code:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="TOTP code required",
+                headers={"X-Sheaf-2FA": "required"},
+            )
+        secret = decrypt(user.totp_secret)
+        if not verify_code(secret, body.totp_code) and not await _check_recovery_code(
+            db, user, body.totp_code,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid TOTP code",
+            )
+
+    new_hash = blind_index(new_email)
+    existing = await db.execute(select(User).where(User.email_hash == new_hash))
+    conflict = existing.scalar_one_or_none()
+    if conflict is not None and conflict.id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already in use",
+        )
+
+    user.email = encrypt(new_email)
+    user.email_hash = new_hash
+    user.email_verified = False
+    user.email_verification_token = None
+    user.email_verification_sent_at = None
+
+    verification_sent = False
+    if settings.email_backend != "none":
+        await _send_verification_email(db, user, new_email)
+        verification_sent = True
+
+    await db.commit()
+
+    revoked = 0
+    if session_id:
+        revoked = await delete_other_sessions(user.id, session_id)
+
+    return {
+        "email": new_email,
+        "verification_sent": verification_sent,
+        "revoked_other_sessions": revoked,
+    }
 
 
 @router.post(

--- a/sheaf/auth/jwt.py
+++ b/sheaf/auth/jwt.py
@@ -6,6 +6,15 @@ import jwt
 
 from sheaf.config import settings
 
+JWT_AUDIENCE = "sheaf-api"
+
+
+def _jwt_issuer() -> str:
+    """The issuer claim. Prefer sheaf_base_url if configured so tokens are
+    tied to the exact origin; fall back to "sheaf" for installs with no
+    explicit base URL."""
+    return settings.sheaf_base_url or "sheaf"
+
 
 class TokenType(StrEnum):
     ACCESS = "access"
@@ -28,6 +37,8 @@ def create_token(
         "type": token_type.value,
         "exp": datetime.now(UTC) + expires,
         "iat": datetime.now(UTC),
+        "iss": _jwt_issuer(),
+        "aud": JWT_AUDIENCE,
     }
     if session_id is not None:
         payload["sid"] = session_id
@@ -37,5 +48,16 @@ def create_token(
 
 
 def decode_token(token: str) -> dict:
-    """Decode and validate a JWT. Raises jwt.PyJWTError on failure."""
-    return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+    """Decode and validate a JWT. Raises jwt.PyJWTError on failure.
+
+    Enforces the iss and aud claims; tokens issued before these were added
+    fail here and the caller treats them as invalid (user re-logs in).
+    """
+    return jwt.decode(
+        token,
+        settings.jwt_secret_key,
+        algorithms=[settings.jwt_algorithm],
+        audience=JWT_AUDIENCE,
+        issuer=_jwt_issuer(),
+        options={"require": ["exp", "iat", "sub", "iss", "aud"]},
+    )

--- a/sheaf/auth/totp.py
+++ b/sheaf/auth/totp.py
@@ -21,5 +21,12 @@ def verify_code(secret: str, code: str) -> bool:
 
 
 def generate_recovery_codes(count: int = 8) -> list[str]:
-    """Generate single-use recovery codes."""
-    return [secrets.token_hex(4) for _ in range(count)]
+    """Generate single-use recovery codes.
+
+    Each code is 16 hex chars (64 bits of entropy). Formatted as two
+    hyphen-separated groups of 8 for readability when users transcribe them.
+    """
+    return [
+        f"{secrets.token_hex(4)}-{secrets.token_hex(4)}"
+        for _ in range(count)
+    ]

--- a/sheaf/auth/trusted_devices.py
+++ b/sheaf/auth/trusted_devices.py
@@ -1,0 +1,132 @@
+"""Trusted-device tokens — 30-day TOTP bypass cookies.
+
+A trusted device is a long-lived cookie a user can opt into at login when
+they enter their TOTP code. While the cookie is valid, the same browser
+can log in with just email + password and skip the TOTP step. Devices
+are listed in settings, can be revoked individually, and are wiped on
+password change, TOTP disable, and TOTP re-enrolment.
+
+The cookie carries an opaque random token. The DB stores only an HMAC
+of that token (same scheme as mail tokens) so a DB dump alone can't
+forge a cookie.
+"""
+
+import hashlib
+import hmac
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.config import settings
+from sheaf.models.trusted_device import TrustedDevice
+
+TRUSTED_DEVICE_COOKIE = "sheaf_trusted_device"
+TRUSTED_DEVICE_TTL_DAYS = 30
+
+
+def _hash_token(token: str) -> str:
+    """Keyed HMAC of a trusted-device token. Same key as mail tokens — the
+    JWT secret — so the running app's in-memory key is required to verify
+    a cookie against a stored row."""
+    key = settings.jwt_secret_key.encode()
+    return hmac.new(key, token.encode(), hashlib.sha256).hexdigest()
+
+
+async def mint_trusted_device(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    user_agent: str,
+    ip: str | None,
+    nickname: str | None = None,
+) -> tuple[str, TrustedDevice]:
+    """Create a new trusted-device row and return (raw_token, row).
+
+    The caller sets the cookie with the raw token; the DB only ever sees
+    the HMAC.
+    """
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.now(UTC) + timedelta(days=TRUSTED_DEVICE_TTL_DAYS)
+    device = TrustedDevice(
+        user_id=user_id,
+        token_hash=_hash_token(token),
+        nickname=nickname,
+        user_agent=user_agent[:500],
+        created_ip=ip,
+        expires_at=expires_at,
+    )
+    db.add(device)
+    await db.flush()
+    return token, device
+
+
+async def verify_trusted_device(
+    db: AsyncSession,
+    token: str | None,
+    user_id: uuid.UUID,
+    *,
+    ip: str | None,
+) -> TrustedDevice | None:
+    """If `token` is a non-expired trusted device for `user_id`, return the
+    row (with last_used_at + last_used_ip touched). Otherwise return None.
+
+    Ties the device to the user so a cookie minted by user A can't bypass
+    TOTP on user B's account.
+    """
+    if not token:
+        return None
+    token_hash = _hash_token(token)
+    result = await db.execute(
+        select(TrustedDevice).where(TrustedDevice.token_hash == token_hash),
+    )
+    device = result.scalar_one_or_none()
+    if device is None:
+        return None
+    if device.user_id != user_id:
+        return None
+    if device.expires_at <= datetime.now(UTC):
+        return None
+    device.last_used_at = datetime.now(UTC)
+    device.last_used_ip = ip
+    return device
+
+
+async def list_trusted_devices(
+    db: AsyncSession, user_id: uuid.UUID,
+) -> list[TrustedDevice]:
+    """List all non-expired trusted devices for a user, newest first."""
+    now = datetime.now(UTC)
+    result = await db.execute(
+        select(TrustedDevice)
+        .where(TrustedDevice.user_id == user_id)
+        .where(TrustedDevice.expires_at > now)
+        .order_by(TrustedDevice.created_at.desc()),
+    )
+    return list(result.scalars().all())
+
+
+async def revoke_trusted_device(
+    db: AsyncSession, user_id: uuid.UUID, device_id: uuid.UUID,
+) -> bool:
+    """Delete one of the user's trusted devices. Returns True if a row
+    was deleted, False if no match (wrong owner or already gone)."""
+    result = await db.execute(
+        delete(TrustedDevice)
+        .where(TrustedDevice.id == device_id)
+        .where(TrustedDevice.user_id == user_id),
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def revoke_all_trusted_devices(
+    db: AsyncSession, user_id: uuid.UUID,
+) -> int:
+    """Delete every trusted device for a user. Called on password change,
+    TOTP disable, TOTP re-enrolment, and account deletion."""
+    result = await db.execute(
+        delete(TrustedDevice).where(TrustedDevice.user_id == user_id),
+    )
+    return result.rowcount or 0

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -9,6 +9,7 @@ from sheaf.models.job_run import JobRun
 from sheaf.models.member import Member, front_members, group_members, member_tags
 from sheaf.models.system import PrivacyLevel, System
 from sheaf.models.tag import Tag
+from sheaf.models.trusted_device import TrustedDevice
 from sheaf.models.uploaded_file import UploadedFile
 from sheaf.models.user import AccountStatus, User, UserTier
 
@@ -29,6 +30,7 @@ __all__ = [
     "ServerAnnouncement",
     "System",
     "Tag",
+    "TrustedDevice",
     "UploadedFile",
     "User",
     "UserTier",

--- a/sheaf/models/trusted_device.py
+++ b/sheaf/models/trusted_device.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sheaf.models.base import Base, TimestampMixin, UUIDMixin
+
+
+class TrustedDevice(UUIDMixin, TimestampMixin, Base):
+    """A device the user has marked as trusted, allowing TOTP to be skipped
+    on subsequent logins from the same browser within the device's TTL.
+
+    The cookie carries an opaque random token; the server stores only its
+    HMAC. A trusted device matches at login time when the cookie's HMAC is
+    found here AND the row's user_id matches the user logging in AND the
+    row hasn't expired. Bulk-revoked on password change, TOTP disable,
+    TOTP re-enrolment, and account deletion.
+    """
+
+    __tablename__ = "trusted_devices"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True,
+    )
+    token_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True, index=True,
+    )
+    nickname: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    user_agent: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+    created_ip: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_used_ip: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True,
+    )

--- a/sheaf/schemas/user.py
+++ b/sheaf/schemas/user.py
@@ -17,6 +17,7 @@ class UserLogin(BaseModel):
     password: str
     totp_code: str | None = None
     captcha: str | None = None
+    remember_device: bool = False
 
 
 class TokenResponse(BaseModel):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -270,6 +270,224 @@ def test_change_email_with_totp(client: httpx.Client):
     assert resp.status_code == 200
 
 
+def _enrol_totp(client: httpx.Client) -> "pyotp.TOTP":
+    setup = client.post("/v1/auth/totp/setup")
+    assert setup.status_code == 200, setup.text
+    secret = setup.json()["secret"]
+    totp = pyotp.TOTP(secret)
+    verify = client.post("/v1/auth/totp/verify", json={"code": totp.now()})
+    assert verify.status_code == 204, verify.text
+    return totp
+
+
+def test_remember_device_skips_totp_on_next_login(client: httpx.Client):
+    email = f"rd-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    token = _register_and_login(client, email, password)
+    client.headers["Authorization"] = f"Bearer {token}"
+    totp = _enrol_totp(client)
+
+    # First login with remember_device=True: must include a TOTP code, and
+    # the response sets the trusted-device cookie.
+    r = client.post(
+        "/v1/auth/login",
+        json={
+            "email": email,
+            "password": password,
+            "totp_code": totp.now(),
+            "remember_device": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    trusted_cookie = r.cookies.get("sheaf_trusted_device")
+    assert trusted_cookie
+
+    # Second login without TOTP, but presenting the trusted-device cookie
+    # — should succeed.
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": password},
+        cookies={"sheaf_trusted_device": trusted_cookie},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_remember_device_requires_totp_first(client: httpx.Client):
+    email = f"rd-need-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    token = _register_and_login(client, email, password)
+    client.headers["Authorization"] = f"Bearer {token}"
+    _enrol_totp(client)
+
+    # remember_device=True without a TOTP code on the first login still
+    # rejects with the 2FA-required signal.
+    del client.headers["Authorization"]
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": password, "remember_device": True},
+    )
+    assert r.status_code == 401
+    assert r.headers.get("X-Sheaf-2FA") == "required"
+
+
+def test_trusted_device_bound_to_user(client: httpx.Client):
+    """A cookie minted for user A must not let user B skip TOTP."""
+    pw = "testpassword123"
+    email_a = f"rd-bind-a-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    email_b = f"rd-bind-b-{uuid.uuid4().hex[:8]}@sheaf.dev"
+
+    # User A: enrol TOTP and mint a trusted-device cookie.
+    token_a = _register_and_login(client, email_a, pw)
+    client.headers["Authorization"] = f"Bearer {token_a}"
+    totp_a = _enrol_totp(client)
+    r = client.post(
+        "/v1/auth/login",
+        json={
+            "email": email_a, "password": pw,
+            "totp_code": totp_a.now(), "remember_device": True,
+        },
+    )
+    cookie_a = r.cookies.get("sheaf_trusted_device")
+    assert cookie_a
+
+    # User B: enrol TOTP, then try to log in presenting A's cookie.
+    del client.headers["Authorization"]
+    token_b = _register_and_login(client, email_b, pw)
+    client.headers["Authorization"] = f"Bearer {token_b}"
+    _enrol_totp(client)
+    del client.headers["Authorization"]
+
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": email_b, "password": pw},
+        cookies={"sheaf_trusted_device": cookie_a},
+    )
+    # B has TOTP enabled and didn't supply a code; A's cookie shouldn't
+    # bypass for B.
+    assert r.status_code == 401
+    assert r.headers.get("X-Sheaf-2FA") == "required"
+
+
+def test_change_password_revokes_trusted_devices(client: httpx.Client):
+    email = f"rd-pw-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    token = _register_and_login(client, email, password)
+    client.headers["Authorization"] = f"Bearer {token}"
+    totp = _enrol_totp(client)
+    r = client.post(
+        "/v1/auth/login",
+        json={
+            "email": email, "password": password,
+            "totp_code": totp.now(), "remember_device": True,
+        },
+    )
+    cookie = r.cookies.get("sheaf_trusted_device")
+    assert cookie
+
+    # Change password.
+    r = client.post(
+        "/v1/auth/change-password",
+        json={
+            "current_password": password, "new_password": "newpassword456",
+            "totp_code": totp.now(),
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    # Old cookie no longer bypasses TOTP — the row was wiped.
+    del client.headers["Authorization"]
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": "newpassword456"},
+        cookies={"sheaf_trusted_device": cookie},
+    )
+    assert r.status_code == 401
+    assert r.headers.get("X-Sheaf-2FA") == "required"
+
+
+def test_totp_disable_revokes_trusted_devices(client: httpx.Client):
+    email = f"rd-totp-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    token = _register_and_login(client, email, password)
+    client.headers["Authorization"] = f"Bearer {token}"
+    totp = _enrol_totp(client)
+    r = client.post(
+        "/v1/auth/login",
+        json={
+            "email": email, "password": password,
+            "totp_code": totp.now(), "remember_device": True,
+        },
+    )
+    cookie = r.cookies.get("sheaf_trusted_device")
+    assert cookie
+
+    # Disable TOTP.
+    r = client.post(
+        "/v1/auth/totp/disable",
+        json={"email": email, "password": password, "totp_code": totp.now()},
+    )
+    assert r.status_code == 204, r.text
+
+    # Re-enable TOTP — old cookie must not work even though we're back to
+    # TOTP-enabled.
+    r = client.post("/v1/auth/totp/setup")
+    new_totp = pyotp.TOTP(r.json()["secret"])
+    r = client.post("/v1/auth/totp/verify", json={"code": new_totp.now()})
+    assert r.status_code == 204, r.text
+
+    del client.headers["Authorization"]
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": password},
+        cookies={"sheaf_trusted_device": cookie},
+    )
+    assert r.status_code == 401
+    assert r.headers.get("X-Sheaf-2FA") == "required"
+
+
+def test_list_and_revoke_trusted_device(client: httpx.Client):
+    email = f"rd-list-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    token = _register_and_login(client, email, password)
+    client.headers["Authorization"] = f"Bearer {token}"
+    totp = _enrol_totp(client)
+    r = client.post(
+        "/v1/auth/login",
+        json={
+            "email": email, "password": password,
+            "totp_code": totp.now(), "remember_device": True,
+        },
+    )
+    cookie = r.cookies.get("sheaf_trusted_device")
+    assert cookie
+
+    # List shows one device, marked is_current when the cookie is sent.
+    r = client.get(
+        "/v1/auth/trusted-devices",
+        cookies={"sheaf_trusted_device": cookie},
+    )
+    assert r.status_code == 200
+    devices = r.json()
+    assert len(devices) == 1
+    assert devices[0]["is_current"] is True
+
+    # Revoke it; subsequent login with the cookie no longer bypasses.
+    device_id = devices[0]["id"]
+    r = client.delete(
+        f"/v1/auth/trusted-devices/{device_id}",
+        cookies={"sheaf_trusted_device": cookie},
+    )
+    assert r.status_code == 204
+
+    del client.headers["Authorization"]
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": password},
+        cookies={"sheaf_trusted_device": cookie},
+    )
+    assert r.status_code == 401
+
+
 def test_change_password_revokes_other_sessions(client: httpx.Client):
     email = f"chpw-rev-{uuid.uuid4().hex[:8]}@sheaf.dev"
     password = "oldpassword123"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
 import uuid
 
 import httpx
+import pyotp
 
 
 def test_register(client: httpx.Client):
@@ -66,3 +67,142 @@ def test_refresh_token(client: httpx.Client):
     resp = client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
     assert resp.status_code == 200
     assert "access_token" in resp.json()
+
+
+def _register_and_login(client: httpx.Client, email: str, password: str) -> str:
+    """Register a user and log in via cookie session. Returns access token."""
+    r = client.post("/v1/auth/register", json={"email": email, "password": password})
+    assert r.status_code == 201, r.text
+    r = client.post("/v1/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def test_change_password_success(client: httpx.Client):
+    email = f"chpw-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    token = _register_and_login(client, email, "oldpassword123")
+    client.headers["Authorization"] = f"Bearer {token}"
+
+    resp = client.post(
+        "/v1/auth/change-password",
+        json={"current_password": "oldpassword123", "new_password": "newpassword456"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["changed"] is True
+
+    # Old password no longer logs in.
+    r = client.post("/v1/auth/login", json={"email": email, "password": "oldpassword123"})
+    assert r.status_code == 401
+    # New password does.
+    r = client.post("/v1/auth/login", json={"email": email, "password": "newpassword456"})
+    assert r.status_code == 200
+
+
+def test_change_password_wrong_current(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/auth/change-password",
+        json={"current_password": "wrong", "new_password": "newpassword456"},
+    )
+    assert resp.status_code == 401
+
+
+def test_change_password_same_as_current(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/auth/change-password",
+        json={"current_password": "testpassword123", "new_password": "testpassword123"},
+    )
+    assert resp.status_code == 400
+
+
+def test_change_password_too_short(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/auth/change-password",
+        json={"current_password": "testpassword123", "new_password": "short"},
+    )
+    assert resp.status_code == 400
+
+
+def test_change_password_unauthenticated(client: httpx.Client):
+    resp = client.post(
+        "/v1/auth/change-password",
+        json={"current_password": "x", "new_password": "newpassword456"},
+    )
+    assert resp.status_code in (401, 403)
+
+
+def test_change_password_with_totp(client: httpx.Client):
+    email = f"chpw-totp-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    token = _register_and_login(client, email, "oldpassword123")
+    client.headers["Authorization"] = f"Bearer {token}"
+
+    setup = client.post("/v1/auth/totp/setup")
+    assert setup.status_code == 200, setup.text
+    secret = setup.json()["secret"]
+    totp = pyotp.TOTP(secret)
+    verify = client.post("/v1/auth/totp/verify", json={"code": totp.now()})
+    assert verify.status_code == 204, verify.text
+
+    # Missing TOTP -> 401 with X-Sheaf-2FA header.
+    resp = client.post(
+        "/v1/auth/change-password",
+        json={"current_password": "oldpassword123", "new_password": "newpassword456"},
+    )
+    assert resp.status_code == 401
+    assert resp.headers.get("X-Sheaf-2FA") == "required"
+
+    # Wrong TOTP -> 401, no header (the gate is past).
+    resp = client.post(
+        "/v1/auth/change-password",
+        json={
+            "current_password": "oldpassword123",
+            "new_password": "newpassword456",
+            "totp_code": "000000",
+        },
+    )
+    assert resp.status_code == 401
+
+    # Correct TOTP -> success.
+    resp = client.post(
+        "/v1/auth/change-password",
+        json={
+            "current_password": "oldpassword123",
+            "new_password": "newpassword456",
+            "totp_code": totp.now(),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_change_password_revokes_other_sessions(client: httpx.Client):
+    email = f"chpw-rev-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "oldpassword123"
+
+    # Session A: register (also logs in). Cookies are Secure, so over plain
+    # HTTP httpx won't auto-send them — pull the session id out of the
+    # response and pass it explicitly on later requests.
+    r = client.post("/v1/auth/register", json={"email": email, "password": password})
+    assert r.status_code == 201
+    access_a = r.json()["access_token"]
+    session_a = r.cookies.get("sheaf_session")
+    assert session_a
+
+    # Session B: log in from a separate client.
+    with httpx.Client(base_url=str(client.base_url)) as other:
+        r = other.post("/v1/auth/login", json={"email": email, "password": password})
+        assert r.status_code == 200
+        refresh_b = r.json()["refresh_token"]
+
+        # Session A changes the password (bearer + session cookie).
+        resp = client.post(
+            "/v1/auth/change-password",
+            json={"current_password": password, "new_password": "newpassword456"},
+            headers={"Authorization": f"Bearer {access_a}"},
+            cookies={"sheaf_session": session_a},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["revoked_other_sessions"] >= 1
+
+        # Session B's refresh token now fails — its session was wiped, so
+        # /refresh's session-existence check misses.
+        r = other.post("/v1/auth/refresh", json={"refresh_token": refresh_b})
+        assert r.status_code == 401

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -173,6 +173,103 @@ def test_change_password_with_totp(client: httpx.Client):
     assert resp.status_code == 200, resp.text
 
 
+def test_change_email_success(client: httpx.Client):
+    email = f"chem-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    new_email = f"chem-new-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    token = _register_and_login(client, email, "testpassword123")
+    client.headers["Authorization"] = f"Bearer {token}"
+
+    resp = client.post(
+        "/v1/auth/change-email",
+        json={"new_email": new_email, "current_password": "testpassword123"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["email"] == new_email
+
+    # Old email no longer logs in.
+    r = client.post("/v1/auth/login", json={"email": email, "password": "testpassword123"})
+    assert r.status_code == 401
+    # New email does.
+    r = client.post(
+        "/v1/auth/login", json={"email": new_email, "password": "testpassword123"},
+    )
+    assert r.status_code == 200
+
+
+def test_change_email_wrong_password(auth_client: httpx.Client):
+    new_email = f"chem-bad-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = auth_client.post(
+        "/v1/auth/change-email",
+        json={"new_email": new_email, "current_password": "wrong"},
+    )
+    assert resp.status_code == 401
+
+
+def test_change_email_same_as_current(auth_client: httpx.Client):
+    me = auth_client.get("/v1/auth/me").json()
+    resp = auth_client.post(
+        "/v1/auth/change-email",
+        json={"new_email": me["email"], "current_password": "testpassword123"},
+    )
+    assert resp.status_code == 400
+
+
+def test_change_email_invalid_format(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/auth/change-email",
+        json={"new_email": "not-an-email", "current_password": "testpassword123"},
+    )
+    assert resp.status_code == 422
+
+
+def test_change_email_conflict(client: httpx.Client):
+    a = f"chem-a-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    b = f"chem-b-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    # Register both users.
+    client.post("/v1/auth/register", json={"email": a, "password": "testpassword123"})
+    token_b = _register_and_login(client, b, "testpassword123")
+
+    # User B tries to take user A's email.
+    client.headers["Authorization"] = f"Bearer {token_b}"
+    resp = client.post(
+        "/v1/auth/change-email",
+        json={"new_email": a, "current_password": "testpassword123"},
+    )
+    assert resp.status_code == 409
+
+
+def test_change_email_with_totp(client: httpx.Client):
+    email = f"chem-totp-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    new_email = f"chem-totp-new-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    token = _register_and_login(client, email, "testpassword123")
+    client.headers["Authorization"] = f"Bearer {token}"
+
+    setup = client.post("/v1/auth/totp/setup")
+    secret = setup.json()["secret"]
+    totp = pyotp.TOTP(secret)
+    client.post("/v1/auth/totp/verify", json={"code": totp.now()})
+
+    # Missing TOTP -> 401 with X-Sheaf-2FA header.
+    resp = client.post(
+        "/v1/auth/change-email",
+        json={"new_email": new_email, "current_password": "testpassword123"},
+    )
+    assert resp.status_code == 401
+    assert resp.headers.get("X-Sheaf-2FA") == "required"
+
+    # Correct TOTP -> success.
+    resp = client.post(
+        "/v1/auth/change-email",
+        json={
+            "new_email": new_email,
+            "current_password": "testpassword123",
+            "totp_code": totp.now(),
+        },
+    )
+    assert resp.status_code == 200
+
+
 def test_change_password_revokes_other_sessions(client: httpx.Client):
     email = f"chpw-rev-{uuid.uuid4().hex[:8]}@sheaf.dev"
     password = "oldpassword123"

--- a/web/src/components/change-email.tsx
+++ b/web/src/components/change-email.tsx
@@ -1,0 +1,125 @@
+import { type FormEvent, useState } from "react";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/use-auth";
+import { changeEmail } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function ChangeEmail() {
+  const { user, refreshUser } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function reset() {
+    setNewEmail("");
+    setCurrentPassword("");
+    setTotpCode("");
+    setError("");
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (newEmail.trim().toLowerCase() === user?.email?.trim().toLowerCase()) {
+      setError("New email must differ from the current email");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await changeEmail(
+        newEmail,
+        currentPassword,
+        user?.totp_enabled ? totpCode : undefined,
+      );
+      reset();
+      setOpen(false);
+      await refreshUser();
+      const parts: string[] = [];
+      if (res.verification_sent) {
+        parts.push("Check the new address for a verification link.");
+      }
+      if (res.revoked_other_sessions > 0) {
+        parts.push(`${res.revoked_other_sessions} other session(s) signed out.`);
+      }
+      toast.success(`Email changed to ${res.email}.${parts.length ? " " + parts.join(" ") : ""}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Change failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        Change email
+      </Button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="new-email">New email address</Label>
+        <Input
+          id="new-email"
+          type="email"
+          autoComplete="email"
+          value={newEmail}
+          onChange={(e) => setNewEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="email-current-password">Current password</Label>
+        <Input
+          id="email-current-password"
+          type="password"
+          autoComplete="current-password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          required
+        />
+      </div>
+      {user?.totp_enabled && (
+        <div className="space-y-1.5">
+          <Label htmlFor="email-totp-code">TOTP or recovery code</Label>
+          <Input
+            id="email-totp-code"
+            type="text"
+            inputMode="text"
+            autoComplete="one-time-code"
+            value={totpCode}
+            onChange={(e) => setTotpCode(e.target.value)}
+            required
+          />
+        </div>
+      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <p className="text-xs text-muted-foreground">
+        You'll need to verify the new address. All other sessions on this account will be signed out.
+      </p>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Changing..." : "Change email"}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            reset();
+            setOpen(false);
+          }}
+          disabled={loading}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/components/change-password.tsx
+++ b/web/src/components/change-password.tsx
@@ -1,0 +1,146 @@
+import { type FormEvent, useState } from "react";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/use-auth";
+import { changePassword } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function ChangePassword() {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function reset() {
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setTotpCode("");
+    setError("");
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (newPassword.length < 8) {
+      setError("New password must be at least 8 characters");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("New passwords do not match");
+      return;
+    }
+    if (newPassword === currentPassword) {
+      setError("New password must differ from the current password");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await changePassword(
+        currentPassword,
+        newPassword,
+        user?.totp_enabled ? totpCode : undefined,
+      );
+      reset();
+      setOpen(false);
+      if (res.revoked_other_sessions > 0) {
+        toast.success(
+          `Password changed. ${res.revoked_other_sessions} other session(s) signed out.`,
+        );
+      } else {
+        toast.success("Password changed.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Change failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        Change password
+      </Button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="current-password">Current password</Label>
+        <Input
+          id="current-password"
+          type="password"
+          autoComplete="current-password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="new-password">New password</Label>
+        <Input
+          id="new-password"
+          type="password"
+          autoComplete="new-password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          minLength={8}
+          required
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="confirm-password">Confirm new password</Label>
+        <Input
+          id="confirm-password"
+          type="password"
+          autoComplete="new-password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          minLength={8}
+          required
+        />
+      </div>
+      {user?.totp_enabled && (
+        <div className="space-y-1.5">
+          <Label htmlFor="totp-code">TOTP or recovery code</Label>
+          <Input
+            id="totp-code"
+            type="text"
+            inputMode="text"
+            autoComplete="one-time-code"
+            value={totpCode}
+            onChange={(e) => setTotpCode(e.target.value)}
+            required
+          />
+        </div>
+      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <p className="text-xs text-muted-foreground">
+        All other sessions on this account will be signed out.
+      </p>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Changing..." : "Change password"}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            reset();
+            setOpen(false);
+          }}
+          disabled={loading}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/contexts/auth-context.tsx
+++ b/web/src/contexts/auth-context.tsx
@@ -11,6 +11,7 @@ interface AuthState {
     password: string,
     totp_code?: string,
     captcha?: string,
+    remember_device?: boolean,
   ) => Promise<void>;
   register: (
     email: string,
@@ -56,8 +57,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       password: string,
       totp_code?: string,
       captcha?: string,
+      remember_device?: boolean,
     ) => {
-      const tokens = await authApi.login(email, password, totp_code, captcha);
+      const tokens = await authApi.login(
+        email, password, totp_code, captcha, remember_device,
+      );
       setAccessToken(tokens.access_token);
       // Refresh token is set as HttpOnly cookie by the server
       const me = await authApi.getMe();

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -122,6 +122,20 @@ export function resetPassword(token: string, new_password: string) {
   });
 }
 
+export function changePassword(
+  current_password: string,
+  new_password: string,
+  totp_code?: string,
+) {
+  return apiFetch<{ changed: boolean; revoked_other_sessions: number }>(
+    "/v1/auth/change-password",
+    {
+      method: "POST",
+      body: JSON.stringify({ current_password, new_password, totp_code }),
+    },
+  );
+}
+
 export function regenerateRecoveryCodes(totp_code: string) {
   return apiFetch<{ recovery_codes: string[] }>(
     "/v1/auth/totp/regenerate-recovery-codes",

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -50,6 +50,7 @@ export function login(
   password: string,
   totp_code?: string,
   captcha?: string,
+  remember_device?: boolean,
 ) {
   return apiFetch<TokenResponse>("/v1/auth/login", {
     method: "POST",
@@ -59,6 +60,7 @@ export function login(
       password,
       ...(totp_code ? { totp_code } : {}),
       ...(captcha ? { captcha } : {}),
+      ...(remember_device ? { remember_device } : {}),
     }),
   });
 }
@@ -178,6 +180,39 @@ export interface Session {
 
 export function getSessions() {
   return apiFetch<Session[]>("/v1/auth/sessions");
+}
+
+export interface TrustedDevice {
+  id: string;
+  nickname: string | null;
+  user_agent: string;
+  created_at: string;
+  created_ip: string | null;
+  last_used_at: string | null;
+  last_used_ip: string | null;
+  expires_at: string;
+  is_current: boolean;
+}
+
+export function getTrustedDevices() {
+  return apiFetch<TrustedDevice[]>("/v1/auth/trusted-devices");
+}
+
+export function renameTrustedDevice(id: string, nickname: string) {
+  return apiFetch<{ ok: boolean }>(`/v1/auth/trusted-devices/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ nickname }),
+  });
+}
+
+export function revokeTrustedDevice(id: string) {
+  return apiFetch<void>(`/v1/auth/trusted-devices/${id}`, { method: "DELETE" });
+}
+
+export function revokeAllTrustedDevices() {
+  return apiFetch<{ revoked: number }>("/v1/auth/trusted-devices/revoke-all", {
+    method: "POST",
+  });
 }
 
 export function renameSession(id: string, nickname: string) {

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -122,6 +122,21 @@ export function resetPassword(token: string, new_password: string) {
   });
 }
 
+export function changeEmail(
+  new_email: string,
+  current_password: string,
+  totp_code?: string,
+) {
+  return apiFetch<{
+    email: string;
+    verification_sent: boolean;
+    revoked_other_sessions: number;
+  }>("/v1/auth/change-email", {
+    method: "POST",
+    body: JSON.stringify({ new_email, current_password, totp_code }),
+  });
+}
+
 export function changePassword(
   current_password: string,
   new_password: string,

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -26,6 +26,7 @@ export function LoginPage() {
   const [termsAgreed, setTermsAgreed] = useState(false);
   const [totpCode, setTotpCode] = useState("");
   const [needs2FA, setNeeds2FA] = useState(false);
+  const [rememberDevice, setRememberDevice] = useState(false);
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [config, setConfig] = useState<AuthConfig | null>(null);
@@ -56,6 +57,7 @@ export function LoginPage() {
           password,
           totpCode || undefined,
           loginCaptcha || undefined,
+          rememberDevice,
         );
       } else {
         await register(
@@ -133,17 +135,33 @@ export function LoginPage() {
                 />
               </div>
               {needs2FA && (
-                <div className="space-y-2">
-                  <Label htmlFor="login-totp">2FA code</Label>
-                  <Input
-                    id="login-totp"
-                    value={totpCode}
-                    onChange={(e) => setTotpCode(e.target.value)}
-                    placeholder="6-digit code or recovery code"
-                    autoComplete="off"
-                    autoFocus
-                  />
-                </div>
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="login-totp">2FA code</Label>
+                    <Input
+                      id="login-totp"
+                      value={totpCode}
+                      onChange={(e) => setTotpCode(e.target.value)}
+                      placeholder="6-digit code or recovery code"
+                      autoComplete="off"
+                      autoFocus
+                    />
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <Checkbox
+                      id="login-remember"
+                      checked={rememberDevice}
+                      onCheckedChange={(v) => setRememberDevice(v === true)}
+                    />
+                    <Label
+                      htmlFor="login-remember"
+                      className="text-sm font-normal leading-snug cursor-pointer"
+                    >
+                      Trust this device for 30 days. Skip the 2FA prompt on
+                      this browser until then.
+                    </Label>
+                  </div>
+                </>
               )}
               {captchaOnLogin && (
                 <Captcha
@@ -204,17 +222,33 @@ export function LoginPage() {
                     />
                   </div>
                   {needs2FA && (
-                    <div className="space-y-2">
-                      <Label htmlFor="login-totp">2FA code</Label>
-                      <Input
-                        id="login-totp"
-                        value={totpCode}
-                        onChange={(e) => setTotpCode(e.target.value)}
-                        placeholder="6-digit code or recovery code"
-                        autoComplete="off"
-                        autoFocus
-                      />
-                    </div>
+                    <>
+                      <div className="space-y-2">
+                        <Label htmlFor="login-totp">2FA code</Label>
+                        <Input
+                          id="login-totp"
+                          value={totpCode}
+                          onChange={(e) => setTotpCode(e.target.value)}
+                          placeholder="6-digit code or recovery code"
+                          autoComplete="off"
+                          autoFocus
+                        />
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <Checkbox
+                          id="login-remember"
+                          checked={rememberDevice}
+                          onCheckedChange={(v) => setRememberDevice(v === true)}
+                        />
+                        <Label
+                          htmlFor="login-remember"
+                          className="text-sm font-normal leading-snug cursor-pointer"
+                        >
+                          Trust this device for 30 days. Skip the 2FA prompt on
+                          this browser until then.
+                        </Label>
+                      </div>
+                    </>
                   )}
                   {captchaOnLogin && (
                     <Captcha

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -27,6 +27,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { useShowImageBadges } from "@/hooks/use-preferences";
 import { useUiScale } from "@/hooks/use-theme";
 import { TOTPSetup } from "@/components/totp-setup";
+import { ChangePassword } from "@/components/change-password";
 import type { ApiKey, ApiKeyCreated, DateFormat, DeleteConfirmation, FieldType, PrivacyLevel } from "@/types/api";
 import { listApiKeys, createApiKey, revokeApiKey } from "@/lib/api-keys";
 import { getSessions, renameSession, revokeSession, revokeOtherSessions, requestAccountDeletion, cancelDeletion, updateMe, getAuthConfig, type Session } from "@/lib/auth";
@@ -621,6 +622,11 @@ function AccountInfo() {
             <span className="text-muted-foreground">Tier:</span>{" "}
             <Badge variant="outline">{user?.tier}</Badge>
           </div>
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Password</p>
+          <ChangePassword />
         </div>
         <Separator />
         <div className="space-y-2">

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -28,6 +28,7 @@ import { useShowImageBadges } from "@/hooks/use-preferences";
 import { useUiScale } from "@/hooks/use-theme";
 import { TOTPSetup } from "@/components/totp-setup";
 import { ChangePassword } from "@/components/change-password";
+import { ChangeEmail } from "@/components/change-email";
 import type { ApiKey, ApiKeyCreated, DateFormat, DeleteConfirmation, FieldType, PrivacyLevel } from "@/types/api";
 import { listApiKeys, createApiKey, revokeApiKey } from "@/lib/api-keys";
 import { getSessions, renameSession, revokeSession, revokeOtherSessions, requestAccountDeletion, cancelDeletion, updateMe, getAuthConfig, type Session } from "@/lib/auth";
@@ -622,6 +623,11 @@ function AccountInfo() {
             <span className="text-muted-foreground">Tier:</span>{" "}
             <Badge variant="outline">{user?.tier}</Badge>
           </div>
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Email</p>
+          <ChangeEmail />
         </div>
         <Separator />
         <div className="space-y-2">

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -31,7 +31,7 @@ import { ChangePassword } from "@/components/change-password";
 import { ChangeEmail } from "@/components/change-email";
 import type { ApiKey, ApiKeyCreated, DateFormat, DeleteConfirmation, FieldType, PrivacyLevel } from "@/types/api";
 import { listApiKeys, createApiKey, revokeApiKey } from "@/lib/api-keys";
-import { getSessions, renameSession, revokeSession, revokeOtherSessions, requestAccountDeletion, cancelDeletion, updateMe, getAuthConfig, type Session } from "@/lib/auth";
+import { getSessions, renameSession, revokeSession, revokeOtherSessions, requestAccountDeletion, cancelDeletion, updateMe, getAuthConfig, getTrustedDevices, renameTrustedDevice, revokeTrustedDevice, revokeAllTrustedDevices, type Session, type TrustedDevice } from "@/lib/auth";
 import { listClientSettings, deleteClientSettings } from "@/lib/client-settings";
 import { timeAgo } from "@/lib/utils";
 import { Pencil, AlertTriangle } from "lucide-react";
@@ -1338,6 +1338,146 @@ function ActiveSessionsCard() {
   );
 }
 
+function TrustedDevicesCard() {
+  const qc = useQueryClient();
+  const { data: devices } = useQuery({
+    queryKey: ["trusted-devices"],
+    queryFn: getTrustedDevices,
+  });
+  const revoke = useMutation({
+    mutationFn: revokeTrustedDevice,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["trusted-devices"] });
+      toast.success("Device revoked");
+    },
+  });
+  const revokeAll = useMutation({
+    mutationFn: revokeAllTrustedDevices,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["trusted-devices"] });
+      toast.success("All trusted devices revoked");
+    },
+  });
+  const renameMut = useMutation({
+    mutationFn: ({ id, nickname }: { id: string; nickname: string }) =>
+      renameTrustedDevice(id, nickname),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["trusted-devices"] });
+      toast.success("Device renamed");
+    },
+  });
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editNickname, setEditNickname] = useState("");
+
+  function startEdit(d: TrustedDevice) {
+    setEditingId(d.id);
+    setEditNickname(d.nickname ?? "");
+  }
+
+  function saveNickname() {
+    if (editingId) {
+      renameMut.mutate({ id: editingId, nickname: editNickname });
+      setEditingId(null);
+    }
+  }
+
+  if (!devices) return null;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base">Trusted devices</CardTitle>
+        {devices.length > 0 && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => revokeAll.mutate()}
+            disabled={revokeAll.isPending}
+          >
+            {revokeAll.isPending ? "Revoking..." : "Revoke all"}
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Browsers that can skip the 2FA prompt for 30 days. Revoked
+          automatically when you change your password or disable 2FA.
+        </p>
+        {devices.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No trusted devices.
+          </p>
+        )}
+        {devices.map((d) => (
+          <div
+            key={d.id}
+            className="flex items-start justify-between rounded-md border px-3 py-2 text-sm"
+          >
+            <div className="space-y-1 min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                {editingId === d.id ? (
+                  <form
+                    className="flex items-center gap-1"
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      saveNickname();
+                    }}
+                  >
+                    <Input
+                      value={editNickname}
+                      onChange={(e) => setEditNickname(e.target.value)}
+                      className="h-6 w-40 text-xs"
+                      placeholder="Device name"
+                      autoFocus
+                      onBlur={saveNickname}
+                    />
+                  </form>
+                ) : (
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 font-medium hover:text-muted-foreground transition-colors"
+                    onClick={() => startEdit(d)}
+                  >
+                    {d.nickname || d.user_agent.slice(0, 60) || "Device"}
+                    <Pencil className="h-3 w-3 text-muted-foreground" />
+                  </button>
+                )}
+                {d.is_current && (
+                  <Badge variant="outline" className="text-xs">
+                    This browser
+                  </Badge>
+                )}
+              </div>
+              {d.nickname && editingId !== d.id && (
+                <p className="text-xs text-muted-foreground truncate">
+                  {d.user_agent}
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                {d.last_used_at
+                  ? `Last used ${timeAgo(d.last_used_at)}`
+                  : "Not yet used"}
+                {d.last_used_ip && ` from ${d.last_used_ip}`}
+                {" · "}Expires {new Date(d.expires_at).toLocaleDateString()}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-destructive hover:text-destructive shrink-0"
+              onClick={() => revoke.mutate(d.id)}
+              disabled={revoke.isPending}
+            >
+              Revoke
+            </Button>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
 function DeleteAccountCard() {
   const { user, refreshUser } = useAuth();
   const [password, setPassword] = useState("");
@@ -1543,6 +1683,7 @@ export function SettingsPage() {
         <AccountInfo />
         <ApiKeysCard />
         <ActiveSessionsCard />
+        <TrustedDevicesCard />
         <StorageUsageCard />
         <UploadedFilesCard />
         <ClientSettingsCard />


### PR DESCRIPTION
## Summary

Smaller changes to login flow and security model

## Changes

- Increase 2FA recovery code entropy to 64 bits, 
- Email/Password change endpoints
- "Remember this device" 2FA bypass option, invalidated on password change, session revocation, and 2FA config change
- Harden JWTs

## Testing

- [x] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Tested manually

## Security / privacy impact

- Increased recovery code entropy for bruteforce resistance even against low-and-slow efforts. 
- Ability to change email+password generally considered a good thing
- Remember this device is well-understood as a choice, and revoked on any change with account security implications.
