### PR TITLE
Add System Safety: grace periods + re-auth for destructive actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,20 @@ alembic upgrade head
 
 When adding enum columns, ensure the migration creates the Postgres enum type with **lowercase values** to match the StrEnum values.
 
+#### Idempotency on long-running feature branches
+
+If your branch lives long enough to be rebased onto new schema changes — or its migration revision id ever needs renumbering to resolve a chain conflict — write the `upgrade()` so it can run on a DB that already has a previous version applied. Use the SQLAlchemy inspector to check before each `add_column` / `create_table`:
+
+```python
+bind = op.get_bind()
+inspector = sa.inspect(bind)
+existing_cols = {c["name"] for c in inspector.get_columns("my_table")}
+if "my_new_col" not in existing_cols:
+    op.add_column("my_table", sa.Column("my_new_col", ...))
+```
+
+Why: dev DBs that ran the original revision id won't know to skip the renumbered one, and the app crashes in a restart loop before you can `alembic stamp` it manually. Production isn't affected, but everyone testing the branch will hit it.
+
 ## How to contribute
 
 ### Reporting bugs

--- a/alembic/versions/m3n4o5p6q7r8_add_system_safety.py
+++ b/alembic/versions/m3n4o5p6q7r8_add_system_safety.py
@@ -1,0 +1,135 @@
+"""Add System Safety columns, pending_actions, and safety_change_requests
+
+Revision ID: m3n4o5p6q7r8
+Revises: l2m3n4o5p6q7
+Create Date: 2026-04-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "m3n4o5p6q7r8"
+down_revision = "l2m3n4o5p6q7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent guard: the predecessor of this migration shipped on a
+    # pre-rebase feature branch under a different revision id, so some
+    # dev DBs already have these columns/tables. Skip anything already there.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_systems_cols = {c["name"] for c in inspector.get_columns("systems")}
+    existing_tables = set(inspector.get_table_names())
+
+    if "safety_grace_period_days" not in existing_systems_cols:
+        op.add_column(
+            "systems",
+            sa.Column(
+                "safety_grace_period_days",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+    for category in ("members", "groups", "tags", "fields", "fronts"):
+        col = f"safety_applies_to_{category}"
+        if col not in existing_systems_cols:
+            op.add_column(
+                "systems",
+                sa.Column(
+                    col,
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.false(),
+                ),
+            )
+
+    if "pending_actions" not in existing_tables:
+        _create_pending_actions()
+    if "safety_change_requests" not in existing_tables:
+        _create_safety_change_requests()
+
+
+def _create_pending_actions() -> None:
+    op.create_table(
+        "pending_actions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "system_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("systems.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("action_type", sa.String(32), nullable=False),
+        sa.Column("target_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("target_label", sa.String(200), nullable=False),
+        sa.Column("requested_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "requested_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("finalize_after", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("fronting_member_ids", JSONB, nullable=False),
+        sa.Column("fronting_member_names", JSONB, nullable=False),
+        sa.Column("status", sa.String(16), nullable=False),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "cancelled_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_message", sa.String(1000), nullable=True),
+    )
+    op.create_index(
+        "ix_pending_actions_due",
+        "pending_actions",
+        ["system_id", "status", "finalize_after"],
+    )
+
+
+def _create_safety_change_requests() -> None:
+    op.create_table(
+        "safety_change_requests",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "system_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("systems.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("requested_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "requested_by_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("finalize_after", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("changes", JSONB, nullable=False),
+        sa.Column("status", sa.String(16), nullable=False),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_safety_change_requests_due",
+        "safety_change_requests",
+        ["system_id", "status", "finalize_after"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_safety_change_requests_due", table_name="safety_change_requests")
+    op.drop_table("safety_change_requests")
+    op.drop_index("ix_pending_actions_due", table_name="pending_actions")
+    op.drop_table("pending_actions")
+
+    for category in ("fronts", "fields", "tags", "groups", "members"):
+        op.drop_column("systems", f"safety_applies_to_{category}")
+    op.drop_column("systems", "safety_grace_period_days")

--- a/sheaf/api/v1/custom_fields.py
+++ b/sheaf/api/v1/custom_fields.py
@@ -1,6 +1,7 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,6 +9,7 @@ from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue
 from sheaf.models.member import Member
+from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.custom_field import (
@@ -16,6 +18,12 @@ from sheaf.schemas.custom_field import (
     CustomFieldUpdate,
     CustomFieldValueRead,
     CustomFieldValueSet,
+)
+from sheaf.schemas.member import MemberDeleteConfirm
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
 )
 
 router = APIRouter(tags=["custom fields"])
@@ -115,15 +123,21 @@ async def update_field(
 
 @router.delete(
     "/fields/{field_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_scope("fields:delete"))],
 )
 async def delete_field(
     field_id: uuid.UUID,
+    body: MemberDeleteConfirm | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-):
+) -> Response:
     system = await _get_user_system(user, db)
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
     result = await db.execute(
         select(CustomFieldDefinition).where(
             CustomFieldDefinition.id == field_id,
@@ -133,8 +147,29 @@ async def delete_field(
     field = result.scalar_one_or_none()
     if field is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Field not found")
+
+    if is_safeguarded(system, PendingActionType.FIELD_DELETE):
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.FIELD_DELETE,
+            target_id=field.id,
+            target_label=field.name,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
+        )
+
     await db.delete(field)
     await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 # --- Field values on members ---

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -10,9 +11,16 @@ from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
 from sheaf.models.front import Front
 from sheaf.models.member import Member
+from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.front import FrontCreate, FrontRead, FrontUpdate
+from sheaf.schemas.member import MemberDeleteConfirm
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
+)
 
 router = APIRouter(prefix="/fronts", tags=["fronts"])
 
@@ -166,20 +174,47 @@ async def update_front(
 
 @router.delete(
     "/{front_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_scope("fronts:delete"))],
 )
 async def delete_front(
     front_id: uuid.UUID,
+    body: MemberDeleteConfirm | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-):
+) -> Response:
     system = await _get_user_system(user, db)
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
     result = await db.execute(
         select(Front).where(Front.id == front_id, Front.system_id == system.id)
     )
     front = result.scalar_one_or_none()
     if front is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Front not found")
+
+    if is_safeguarded(system, PendingActionType.FRONT_DELETE):
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.FRONT_DELETE,
+            target_id=front.id,
+            target_label=f"Front starting {front.started_at.isoformat()}",
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
+        )
+
     await db.delete(front)
     await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/sheaf/api/v1/groups.py
+++ b/sheaf/api/v1/groups.py
@@ -1,6 +1,7 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -9,10 +10,16 @@ from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
 from sheaf.models.group import Group
 from sheaf.models.member import Member
+from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.group import GroupCreate, GroupMemberUpdate, GroupRead, GroupUpdate
-from sheaf.schemas.member import MemberRead
+from sheaf.schemas.member import MemberDeleteConfirm, MemberRead
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
+)
 
 router = APIRouter(prefix="/groups", tags=["groups"])
 
@@ -131,18 +138,45 @@ async def update_group(
 
 @router.delete(
     "/{group_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_scope("groups:delete"))],
 )
 async def delete_group(
     group_id: uuid.UUID,
+    body: MemberDeleteConfirm | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-):
+) -> Response:
     system = await _get_user_system(user, db)
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
     group = await _get_own_group(group_id, system, db)
+
+    if is_safeguarded(system, PendingActionType.GROUP_DELETE):
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.GROUP_DELETE,
+            target_id=group.id,
+            target_label=group.name,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
+        )
+
     await db.delete(group)
     await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{group_id}/members", response_model=list[MemberRead])

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -1,19 +1,23 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user, require_scope
-from sheaf.auth.passwords import verify_password
-from sheaf.auth.totp import verify_code
 from sheaf.config import settings
-from sheaf.crypto import decrypt
 from sheaf.database import get_db
 from sheaf.models.member import Member
-from sheaf.models.system import DeleteConfirmation, System
+from sheaf.models.pending_action import PendingActionType
+from sheaf.models.system import System
 from sheaf.models.user import User, UserTier
 from sheaf.schemas.member import MemberCreate, MemberDeleteConfirm, MemberRead, MemberUpdate
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
+)
 
 router = APIRouter(prefix="/members", tags=["members"])
 
@@ -129,7 +133,6 @@ async def update_member(
 
 @router.delete(
     "/{member_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_scope("members:delete"))],
 )
 async def delete_member(
@@ -137,34 +140,35 @@ async def delete_member(
     body: MemberDeleteConfirm | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-):
+) -> Response:
     system = await _get_user_system(user, db)
-    level = system.delete_confirmation
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
+    member = await _get_own_member(member_id, system, db)
 
-    if level in (DeleteConfirmation.PASSWORD, DeleteConfirmation.BOTH) and (
-        not body or not body.password or not verify_password(body.password, user.password_hash)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Password required to delete member",
+    if is_safeguarded(system, PendingActionType.MEMBER_DELETE):
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.MEMBER_DELETE,
+            target_id=member.id,
+            target_label=member.display_name or member.name,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
         )
 
-    if level in (DeleteConfirmation.TOTP, DeleteConfirmation.BOTH):
-        if not user.totp_enabled:
-            pass  # TOTP not configured, skip
-        elif not body or not body.totp_code:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="TOTP code required to delete member",
-            )
-        else:
-            secret = decrypt(user.totp_secret)
-            if not verify_code(secret, body.totp_code):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid TOTP code",
-                )
-
-    member = await _get_own_member(member_id, system, db)
     await db.delete(member)
     await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -13,6 +13,7 @@ from sheaf.api.v1 import (
     members,
     sheaf_import,
     sp_import,
+    system_safety,
     systems,
     tags,
     webhooks,
@@ -34,6 +35,10 @@ v1_router.include_router(
 # Resource routers: router-level read scope dep + per-endpoint write scope dep
 v1_router.include_router(
     systems.router,
+    dependencies=[Depends(require_scope("system:read"))],
+)
+v1_router.include_router(
+    system_safety.router,
     dependencies=[Depends(require_scope("system:read"))],
 )
 v1_router.include_router(

--- a/sheaf/api/v1/system_safety.py
+++ b/sheaf/api/v1/system_safety.py
@@ -1,0 +1,215 @@
+"""System Safety API endpoints.
+
+External field names (`grace_period_days`, `auth_tier`, `applies_to_*`) are
+mapped to the internal column names (`safety_grace_period_days`,
+`delete_confirmation`, `safety_applies_to_*`). `auth_tier` is the historical
+`delete_confirmation` column — see sheaf/models/system.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.api.v1.members import _get_user_system
+from sheaf.auth.dependencies import get_current_user, require_scope
+from sheaf.database import get_db
+from sheaf.models.pending_action import PendingAction, PendingActionStatus
+from sheaf.models.safety_change_request import (
+    SafetyChangeRequest,
+    SafetyChangeStatus,
+)
+from sheaf.models.system import System
+from sheaf.models.user import User
+from sheaf.schemas.system_safety import (
+    PendingActionRead,
+    SafetyChangeRequestRead,
+    SystemSafetyResponse,
+    SystemSafetySettings,
+    SystemSafetyUpdate,
+    SystemSafetyUpdateResponse,
+)
+from sheaf.services.system_safety import (
+    split_safety_changes,
+    verify_destructive_auth,
+)
+
+router = APIRouter(prefix="/system/safety", tags=["system-safety"])
+
+
+# External -> internal field name translation. Kept here (not in the service)
+# because only the API surface cares about the nicer external naming.
+_EXTERNAL_TO_INTERNAL = {
+    "grace_period_days": "safety_grace_period_days",
+    "auth_tier": "delete_confirmation",
+    "applies_to_members": "safety_applies_to_members",
+    "applies_to_groups": "safety_applies_to_groups",
+    "applies_to_tags": "safety_applies_to_tags",
+    "applies_to_fields": "safety_applies_to_fields",
+    "applies_to_fronts": "safety_applies_to_fronts",
+}
+_INTERNAL_TO_EXTERNAL = {v: k for k, v in _EXTERNAL_TO_INTERNAL.items()}
+
+
+def _settings_from_system(system: System) -> SystemSafetySettings:
+    return SystemSafetySettings(
+        grace_period_days=system.safety_grace_period_days,
+        auth_tier=system.delete_confirmation,
+        applies_to_members=system.safety_applies_to_members,
+        applies_to_groups=system.safety_applies_to_groups,
+        applies_to_tags=system.safety_applies_to_tags,
+        applies_to_fields=system.safety_applies_to_fields,
+        applies_to_fronts=system.safety_applies_to_fronts,
+    )
+
+
+async def _load_pending(
+    system_id: uuid.UUID, db: AsyncSession
+) -> tuple[list[PendingAction], list[SafetyChangeRequest]]:
+    actions_result = await db.execute(
+        select(PendingAction)
+        .where(
+            PendingAction.system_id == system_id,
+            PendingAction.status == PendingActionStatus.PENDING,
+        )
+        .order_by(PendingAction.finalize_after)
+    )
+    changes_result = await db.execute(
+        select(SafetyChangeRequest)
+        .where(
+            SafetyChangeRequest.system_id == system_id,
+            SafetyChangeRequest.status == SafetyChangeStatus.PENDING,
+        )
+        .order_by(SafetyChangeRequest.finalize_after)
+    )
+    return list(actions_result.scalars().all()), list(changes_result.scalars().all())
+
+
+@router.get("", response_model=SystemSafetyResponse)
+async def get_system_safety(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    actions, changes = await _load_pending(system.id, db)
+    return SystemSafetyResponse(
+        settings=_settings_from_system(system),
+        pending_actions=[PendingActionRead.model_validate(a) for a in actions],
+        pending_changes=[SafetyChangeRequestRead.model_validate(c) for c in changes],
+    )
+
+
+@router.patch(
+    "",
+    response_model=SystemSafetyUpdateResponse,
+    dependencies=[Depends(require_scope("system:write"))],
+)
+async def update_system_safety(
+    body: SystemSafetyUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+
+    external_updates = body.model_dump(
+        exclude_none=True, exclude={"password", "totp_code"}
+    )
+    internal_updates = {
+        _EXTERNAL_TO_INTERNAL[k]: v
+        for k, v in external_updates.items()
+        if k in _EXTERNAL_TO_INTERNAL
+    }
+    split = split_safety_changes(system, internal_updates)
+
+    # Re-auth gate applies to any loosening change. For tightening-only changes
+    # we skip re-auth — there's no attack surface in strengthening protection.
+    if split.deferred:
+        verify_destructive_auth(user, system, body.password, body.totp_code)
+
+    # Apply tightening immediately.
+    for field, value in split.applied.items():
+        setattr(system, field, value)
+
+    pending_change: SafetyChangeRequest | None = None
+    if split.deferred:
+        now = datetime.now(UTC)
+        # Grace period for loosening is whatever is currently in force.
+        # If grace is 0 (safety fully off), loosening applies immediately too.
+        if system.safety_grace_period_days <= 0:
+            for field, value in split.deferred.items():
+                setattr(system, field, value)
+            split.applied.update(split.deferred)
+            split.deferred.clear()
+        else:
+            pending_change = SafetyChangeRequest(
+                system_id=system.id,
+                requested_at=now,
+                requested_by_user_id=user.id,
+                finalize_after=now + timedelta(days=system.safety_grace_period_days),
+                changes=split.deferred,
+                status=SafetyChangeStatus.PENDING,
+            )
+            db.add(pending_change)
+
+    await db.commit()
+    await db.refresh(system)
+    if pending_change is not None:
+        await db.refresh(pending_change)
+
+    return SystemSafetyUpdateResponse(
+        settings=_settings_from_system(system),
+        applied=[_INTERNAL_TO_EXTERNAL.get(f, f) for f in split.applied],
+        deferred=[_INTERNAL_TO_EXTERNAL.get(f, f) for f in split.deferred],
+        pending_change=(
+            SafetyChangeRequestRead.model_validate(pending_change)
+            if pending_change is not None
+            else None
+        ),
+    )
+
+
+@router.delete(
+    "/pending-actions/{pending_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_scope("system:write"))],
+)
+async def cancel_pending_action(
+    pending_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    pending = await db.get(PendingAction, pending_id)
+    if pending is None or pending.system_id != system.id:
+        raise HTTPException(status_code=404, detail="Pending action not found")
+    if pending.status != PendingActionStatus.PENDING:
+        raise HTTPException(status_code=400, detail="Not pending")
+    pending.status = PendingActionStatus.CANCELLED
+    pending.cancelled_at = datetime.now(UTC)
+    pending.cancelled_by_user_id = user.id
+    await db.commit()
+
+
+@router.delete(
+    "/pending-changes/{change_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_scope("system:write"))],
+)
+async def cancel_pending_change(
+    change_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    change = await db.get(SafetyChangeRequest, change_id)
+    if change is None or change.system_id != system.id:
+        raise HTTPException(status_code=404, detail="Pending change not found")
+    if change.status != SafetyChangeStatus.PENDING:
+        raise HTTPException(status_code=400, detail="Not pending")
+    change.status = SafetyChangeStatus.CANCELLED
+    change.cancelled_at = datetime.now(UTC)
+    await db.commit()

--- a/sheaf/api/v1/tags.py
+++ b/sheaf/api/v1/tags.py
@@ -1,15 +1,23 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
+from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
 from sheaf.models.user import User
+from sheaf.schemas.member import MemberDeleteConfirm
 from sheaf.schemas.tag import TagCreate, TagRead, TagUpdate
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
+)
 
 router = APIRouter(prefix="/tags", tags=["tags"])
 
@@ -98,20 +106,47 @@ async def update_tag(
 
 @router.delete(
     "/{tag_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_scope("tags:delete"))],
 )
 async def delete_tag(
     tag_id: uuid.UUID,
+    body: MemberDeleteConfirm | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-):
+) -> Response:
     system = await _get_user_system(user, db)
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
     result = await db.execute(
         select(Tag).where(Tag.id == tag_id, Tag.system_id == system.id)
     )
     tag = result.scalar_one_or_none()
     if tag is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tag not found")
+
+    if is_safeguarded(system, PendingActionType.TAG_DELETE):
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.TAG_DELETE,
+            target_id=tag.id,
+            target_label=tag.name,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
+        )
+
     await db.delete(tag)
     await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -7,7 +7,9 @@ from sheaf.models.group import Group
 from sheaf.models.invite_code import InviteCode
 from sheaf.models.job_run import JobRun
 from sheaf.models.member import Member, front_members, group_members, member_tags
-from sheaf.models.system import PrivacyLevel, System
+from sheaf.models.pending_action import PendingAction, PendingActionStatus, PendingActionType
+from sheaf.models.safety_change_request import SafetyChangeRequest, SafetyChangeStatus
+from sheaf.models.system import DeleteConfirmation, PrivacyLevel, System
 from sheaf.models.tag import Tag
 from sheaf.models.trusted_device import TrustedDevice
 from sheaf.models.uploaded_file import UploadedFile
@@ -20,13 +22,19 @@ __all__ = [
     "Base",
     "CustomFieldDefinition",
     "CustomFieldValue",
+    "DeleteConfirmation",
     "FieldType",
     "Front",
     "Group",
     "InviteCode",
     "JobRun",
     "Member",
+    "PendingAction",
+    "PendingActionStatus",
+    "PendingActionType",
     "PrivacyLevel",
+    "SafetyChangeRequest",
+    "SafetyChangeStatus",
     "ServerAnnouncement",
     "System",
     "Tag",

--- a/sheaf/models/pending_action.py
+++ b/sheaf/models/pending_action.py
@@ -1,0 +1,82 @@
+import uuid
+from datetime import datetime
+from enum import StrEnum
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from sheaf.models.base import Base, UUIDMixin
+
+
+class PendingActionType(StrEnum):
+    MEMBER_DELETE = "member_delete"
+    GROUP_DELETE = "group_delete"
+    TAG_DELETE = "tag_delete"
+    FIELD_DELETE = "field_delete"
+    FRONT_DELETE = "front_delete"
+
+
+class PendingActionStatus(StrEnum):
+    PENDING = "pending"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    ERRORED = "errored"
+
+
+class PendingAction(UUIDMixin, Base):
+    __tablename__ = "pending_actions"
+
+    system_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("systems.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    action_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target_label: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    requested_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    finalize_after: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    # Snapshot of who was fronting when the action was requested.
+    # Frozen — members may be deleted or front composition may change before finalization.
+    fronting_member_ids: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    fronting_member_names: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=PendingActionStatus.PENDING
+    )
+    cancelled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cancelled_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    error_message: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+
+    system: Mapped["System"] = relationship()
+
+    __table_args__ = (
+        Index(
+            "ix_pending_actions_due",
+            "system_id",
+            "status",
+            "finalize_after",
+        ),
+    )

--- a/sheaf/models/safety_change_request.py
+++ b/sheaf/models/safety_change_request.py
@@ -1,0 +1,66 @@
+import uuid
+from datetime import datetime
+from enum import StrEnum
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from sheaf.models.base import Base, UUIDMixin
+
+
+class SafetyChangeStatus(StrEnum):
+    PENDING = "pending"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+
+
+class SafetyChangeRequest(UUIDMixin, Base):
+    """A queued loosening of System Safety settings, held during the grace period.
+
+    Tightening changes apply immediately; only changes that reduce protection
+    (shorter grace, weaker auth tier, disabling categories) land here.
+    """
+
+    __tablename__ = "safety_change_requests"
+
+    system_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("systems.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    requested_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    finalize_after: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    changes: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=SafetyChangeStatus.PENDING
+    )
+    cancelled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    system: Mapped["System"] = relationship()
+
+    __table_args__ = (
+        Index(
+            "ix_safety_change_requests_due",
+            "system_id",
+            "status",
+            "finalize_after",
+        ),
+    )

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -1,7 +1,7 @@
 import enum
 import uuid
 
-from sqlalchemy import Boolean, Enum, ForeignKey, String, Text
+from sqlalchemy import Boolean, Enum, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -20,6 +20,8 @@ class DateFormat(enum.StrEnum):
     YMD = "ymd"  # 2026-03-19
 
 
+# Name is historical. Now used across System Safety as the auth tier for all
+# safeguarded destructive actions, not just delete confirmation.
 class DeleteConfirmation(enum.StrEnum):
     NONE = "none"
     PASSWORD = "password"
@@ -47,6 +49,8 @@ class System(UUIDMixin, TimestampMixin, Base):
         default=PrivacyLevel.PRIVATE,
         nullable=False,
     )
+    # Historical name. Now the auth tier for all safeguarded destructive
+    # actions under System Safety (members, groups, tags, fields, fronts).
     delete_confirmation: Mapped[DeleteConfirmation] = mapped_column(
         Enum(DeleteConfirmation, values_callable=lambda e: [m.value for m in e]),
         default=DeleteConfirmation.NONE,
@@ -60,6 +64,27 @@ class System(UUIDMixin, TimestampMixin, Base):
     # When True, creating a new front automatically ends all currently open fronts.
     replace_fronts_default: Mapped[bool] = mapped_column(
         Boolean, default=True, server_default="true", nullable=False
+    )
+
+    # System Safety — grace period + per-category toggles for destructive actions.
+    # 0 days means no grace; paired with all category toggles off by default.
+    safety_grace_period_days: Mapped[int] = mapped_column(
+        Integer, default=0, server_default="0", nullable=False
+    )
+    safety_applies_to_members: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    safety_applies_to_groups: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    safety_applies_to_tags: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    safety_applies_to_fields: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    safety_applies_to_fronts: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
     )
 
     # Relationships

--- a/sheaf/schemas/system_safety.py
+++ b/sheaf/schemas/system_safety.py
@@ -1,0 +1,73 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# `delete_confirmation` is re-exported here as the System Safety auth tier.
+# Historical name retained for API / DB compatibility.
+from sheaf.models.system import DeleteConfirmation
+
+
+class SystemSafetySettings(BaseModel):
+    grace_period_days: int
+    auth_tier: DeleteConfirmation
+    applies_to_members: bool
+    applies_to_groups: bool
+    applies_to_tags: bool
+    applies_to_fields: bool
+    applies_to_fronts: bool
+
+
+class SystemSafetyUpdate(BaseModel):
+    """All fields optional — caller sends only the fields they want to change."""
+
+    grace_period_days: int | None = Field(default=None, ge=0, le=365)
+    auth_tier: DeleteConfirmation | None = None
+    applies_to_members: bool | None = None
+    applies_to_groups: bool | None = None
+    applies_to_tags: bool | None = None
+    applies_to_fields: bool | None = None
+    applies_to_fronts: bool | None = None
+
+    # Re-auth for loosening changes is checked against the *current* auth tier.
+    password: str | None = None
+    totp_code: str | None = None
+
+
+class PendingActionRead(BaseModel):
+    id: uuid.UUID
+    action_type: str
+    target_id: uuid.UUID
+    target_label: str
+    requested_at: datetime
+    requested_by_user_id: uuid.UUID | None
+    finalize_after: datetime
+    fronting_member_ids: list[str]
+    fronting_member_names: list[str]
+    status: str
+
+    model_config = {"from_attributes": True}
+
+
+class SafetyChangeRequestRead(BaseModel):
+    id: uuid.UUID
+    requested_at: datetime
+    requested_by_user_id: uuid.UUID | None
+    finalize_after: datetime
+    changes: dict
+    status: str
+
+    model_config = {"from_attributes": True}
+
+
+class SystemSafetyResponse(BaseModel):
+    settings: SystemSafetySettings
+    pending_actions: list[PendingActionRead]
+    pending_changes: list[SafetyChangeRequestRead]
+
+
+class SystemSafetyUpdateResponse(BaseModel):
+    settings: SystemSafetySettings
+    applied: list[str]
+    deferred: list[str]
+    pending_change: SafetyChangeRequestRead | None = None

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -521,6 +521,69 @@ async def _cleanup_job_logs(db: AsyncSession) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# System Safety — finalize pending destructive actions + safety-setting changes
+# ---------------------------------------------------------------------------
+
+
+async def _finalize_pending_actions(db: AsyncSession) -> dict:
+    """Execute pending destructive actions whose grace period has elapsed."""
+    from sheaf.models.pending_action import PendingAction, PendingActionStatus
+    from sheaf.services.system_safety import finalize_pending_action
+
+    now = datetime.now(UTC)
+    result = await db.execute(
+        select(PendingAction).where(
+            PendingAction.status == PendingActionStatus.PENDING,
+            PendingAction.finalize_after <= now,
+        )
+    )
+    pending = list(result.scalars().all())
+    if not pending:
+        return {"items_processed": 0}
+
+    detail_lines: list[str] = []
+    for row in pending:
+        try:
+            await finalize_pending_action(row, db)
+            detail_lines.append(f"{row.action_type} {row.target_label}")
+        except Exception as exc:
+            row.status = PendingActionStatus.ERRORED
+            row.error_message = str(exc)[:1000]
+            row.completed_at = datetime.now(UTC)
+            logger.exception("Failed to finalize pending action %s", row.id)
+
+    return {
+        "items_processed": len(pending),
+        "details": "\n".join(detail_lines) if detail_lines else None,
+    }
+
+
+async def _finalize_safety_changes(db: AsyncSession) -> dict:
+    """Apply deferred safety-setting loosenings whose grace period has elapsed."""
+    from sheaf.models.safety_change_request import (
+        SafetyChangeRequest,
+        SafetyChangeStatus,
+    )
+    from sheaf.services.system_safety import finalize_safety_change
+
+    now = datetime.now(UTC)
+    result = await db.execute(
+        select(SafetyChangeRequest).where(
+            SafetyChangeRequest.status == SafetyChangeStatus.PENDING,
+            SafetyChangeRequest.finalize_after <= now,
+        )
+    )
+    changes = list(result.scalars().all())
+    if not changes:
+        return {"items_processed": 0}
+
+    for row in changes:
+        await finalize_safety_change(row, db)
+
+    return {"items_processed": len(changes)}
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -580,6 +643,20 @@ def _register_all_jobs() -> None:
         description="Delete job run logs older than 30 days",
         func=_cleanup_job_logs,
         interval_seconds=lambda: 86400,  # daily
+    )
+
+    register_job(
+        name="finalize_pending_actions",
+        description="Execute System Safety pending destructive actions past their grace period",
+        func=_finalize_pending_actions,
+        interval_seconds=lambda: settings.job_check_interval_minutes * 60,
+    )
+
+    register_job(
+        name="finalize_safety_changes",
+        description="Apply deferred System Safety setting loosenings past their grace period",
+        func=_finalize_safety_changes,
+        interval_seconds=lambda: settings.job_check_interval_minutes * 60,
     )
 
     register_job(

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -1,0 +1,293 @@
+"""System Safety service layer.
+
+Contains:
+- Auth helper shared by every destructive action endpoint.
+- Loosening detection for safety-setting changes (asymmetric delay).
+- Fronting snapshot helper used when queuing pending actions.
+- Dispatcher for finalizing pending actions against the right model.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.passwords import verify_password
+from sheaf.auth.totp import verify_code
+from sheaf.crypto import decrypt
+from sheaf.models.custom_field import CustomFieldDefinition
+from sheaf.models.front import Front
+from sheaf.models.group import Group
+from sheaf.models.member import Member
+from sheaf.models.pending_action import (
+    PendingAction,
+    PendingActionStatus,
+    PendingActionType,
+)
+from sheaf.models.safety_change_request import (
+    SafetyChangeRequest,
+    SafetyChangeStatus,
+)
+from sheaf.models.system import DeleteConfirmation, System
+from sheaf.models.tag import Tag
+from sheaf.models.user import User
+
+# Categories that safety can apply to — kept in one place so the API,
+# schemas, and finalize dispatcher all agree on the set.
+SAFETY_CATEGORIES: tuple[str, ...] = (
+    "members",
+    "groups",
+    "tags",
+    "fields",
+    "fronts",
+)
+
+_CATEGORY_BY_ACTION: dict[str, str] = {
+    PendingActionType.MEMBER_DELETE: "members",
+    PendingActionType.GROUP_DELETE: "groups",
+    PendingActionType.TAG_DELETE: "tags",
+    PendingActionType.FIELD_DELETE: "fields",
+    PendingActionType.FRONT_DELETE: "fronts",
+}
+
+_MODEL_BY_ACTION: dict[str, type] = {
+    PendingActionType.MEMBER_DELETE: Member,
+    PendingActionType.GROUP_DELETE: Group,
+    PendingActionType.TAG_DELETE: Tag,
+    PendingActionType.FIELD_DELETE: CustomFieldDefinition,
+    PendingActionType.FRONT_DELETE: Front,
+}
+
+
+# Auth tier strength — PASSWORD and TOTP are treated as equivalent
+# strength (either-or, not both). NONE < PASSWORD/TOTP < BOTH.
+_TIER_STRENGTH: dict[str, int] = {
+    DeleteConfirmation.NONE: 0,
+    DeleteConfirmation.PASSWORD: 1,
+    DeleteConfirmation.TOTP: 1,
+    DeleteConfirmation.BOTH: 2,
+}
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+def verify_destructive_auth(
+    user: User,
+    system: System,
+    password: str | None,
+    totp_code: str | None,
+) -> None:
+    """Raise HTTPException if the required re-auth for destructive actions isn't satisfied.
+
+    Mirrors the existing member-delete pattern. Called at the top of every
+    safeguarded destructive endpoint and again before finalizing safety-setting
+    loosening changes.
+    """
+    level = system.delete_confirmation
+
+    if level in (DeleteConfirmation.PASSWORD, DeleteConfirmation.BOTH) and (
+        not password or not verify_password(password, user.password_hash)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Password required",
+        )
+
+    if level in (DeleteConfirmation.TOTP, DeleteConfirmation.BOTH):
+        if not user.totp_enabled:
+            # TOTP gate requested but not configured — skip silently, as
+            # elsewhere in the codebase (members.py:154).
+            return
+        if not totp_code:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="TOTP code required",
+            )
+        secret = decrypt(user.totp_secret)
+        if not verify_code(secret, totp_code):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid TOTP code",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Safety settings change detection (asymmetric loosening delay)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SafetyChangeSplit:
+    applied: dict[str, Any]
+    deferred: dict[str, Any]
+
+
+def split_safety_changes(system: System, updates: dict[str, Any]) -> SafetyChangeSplit:
+    """Split proposed updates into immediate (tighten) vs. deferred (loosen).
+
+    Loosening means:
+      - grace period reduced
+      - delete_confirmation tier strength reduced
+      - any safety_applies_to_<category> flipped True -> False
+    """
+    applied: dict[str, Any] = {}
+    deferred: dict[str, Any] = {}
+
+    for field, new_value in updates.items():
+        if new_value is None:
+            continue
+        current = getattr(system, field, None)
+        if current == new_value:
+            continue
+
+        if field == "safety_grace_period_days":
+            if new_value < current:
+                deferred[field] = new_value
+            else:
+                applied[field] = new_value
+        elif field == "delete_confirmation":
+            new_strength = _TIER_STRENGTH.get(new_value, 0)
+            old_strength = _TIER_STRENGTH.get(current, 0)
+            if new_strength < old_strength:
+                deferred[field] = new_value
+            else:
+                applied[field] = new_value
+        elif field.startswith("safety_applies_to_"):
+            if current is True and new_value is False:
+                deferred[field] = new_value
+            else:
+                applied[field] = new_value
+        else:
+            # Unknown field — apply immediately (router should reject unknowns upstream).
+            applied[field] = new_value
+
+    return SafetyChangeSplit(applied=applied, deferred=deferred)
+
+
+# ---------------------------------------------------------------------------
+# Fronting snapshot
+# ---------------------------------------------------------------------------
+
+
+async def snapshot_current_fronts(
+    system_id: uuid.UUID, db: AsyncSession
+) -> tuple[list[str], list[str]]:
+    """Return (member_ids, member_names) for members currently fronting."""
+    result = await db.execute(
+        select(Member)
+        .join(Member.fronts)
+        .where(Front.system_id == system_id, Front.ended_at.is_(None))
+        .distinct()
+    )
+    members = result.scalars().all()
+    return (
+        [str(m.id) for m in members],
+        [m.display_name or m.name for m in members],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Queue pending action
+# ---------------------------------------------------------------------------
+
+
+def is_safeguarded(system: System, action_type: str) -> bool:
+    """True if grace > 0 AND the category toggle is on for this action type."""
+    if system.safety_grace_period_days <= 0:
+        return False
+    category = _CATEGORY_BY_ACTION.get(action_type)
+    if category is None:
+        return False
+    return bool(getattr(system, f"safety_applies_to_{category}"))
+
+
+async def queue_pending_action(
+    *,
+    db: AsyncSession,
+    system: System,
+    user: User,
+    action_type: str,
+    target_id: uuid.UUID,
+    target_label: str,
+) -> PendingAction:
+    """Create a PendingAction row with a fronting snapshot. Caller commits."""
+    fronting_ids, fronting_names = await snapshot_current_fronts(system.id, db)
+    now = datetime.now(UTC)
+    pending = PendingAction(
+        system_id=system.id,
+        action_type=action_type,
+        target_id=target_id,
+        target_label=target_label,
+        requested_at=now,
+        requested_by_user_id=user.id,
+        finalize_after=now + timedelta(days=system.safety_grace_period_days),
+        fronting_member_ids=fronting_ids,
+        fronting_member_names=fronting_names,
+        status=PendingActionStatus.PENDING,
+    )
+    db.add(pending)
+    return pending
+
+
+def has_pending_action_for_target(
+    db_actions: list[PendingAction], target_id: uuid.UUID, action_type: str
+) -> bool:
+    """Check a preloaded list for an existing pending action on this target."""
+    return any(
+        p.target_id == target_id
+        and p.action_type == action_type
+        and p.status == PendingActionStatus.PENDING
+        for p in db_actions
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finalize pending action
+# ---------------------------------------------------------------------------
+
+
+async def finalize_pending_action(
+    pending: PendingAction, db: AsyncSession
+) -> None:
+    """Execute the queued delete. Idempotent: missing target marks completed."""
+    model = _MODEL_BY_ACTION.get(pending.action_type)
+    if model is None:
+        pending.status = PendingActionStatus.ERRORED
+        pending.error_message = f"Unknown action_type: {pending.action_type}"
+        pending.completed_at = datetime.now(UTC)
+        return
+
+    target = await db.get(model, pending.target_id)
+    # Verify scope — guard against target reparented somehow.
+    if target is not None and getattr(target, "system_id", None) == pending.system_id:
+        await db.delete(target)
+
+    pending.status = PendingActionStatus.COMPLETED
+    pending.completed_at = datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Finalize safety-setting changes
+# ---------------------------------------------------------------------------
+
+
+async def finalize_safety_change(
+    request: SafetyChangeRequest, db: AsyncSession
+) -> None:
+    """Apply a deferred safety-setting loosening to the system."""
+    system = await db.get(System, request.system_id)
+    if system is not None:
+        for field, value in (request.changes or {}).items():
+            if hasattr(system, field):
+                setattr(system, field, value)
+    request.status = SafetyChangeStatus.COMPLETED
+    request.completed_at = datetime.now(UTC)

--- a/tests/test_system_safety.py
+++ b/tests/test_system_safety.py
@@ -1,0 +1,461 @@
+"""Tests for System Safety: grace periods, deferred safety changes, finalization."""
+
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import httpx
+
+
+def _set_system_safety_via_db(user_email: str, **fields) -> None:
+    """Directly patch columns on the user's System row (bypasses re-auth + loosening delay)."""
+    from sqlalchemy import select
+
+    from sheaf.crypto import blind_index
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.system import System
+        from sheaf.models.user import User
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            email_hash = blind_index(user_email)
+            user = (
+                await db.execute(select(User).where(User.email_hash == email_hash))
+            ).scalar_one()
+            system = (
+                await db.execute(select(System).where(System.user_id == user.id))
+            ).scalar_one()
+            for k, v in fields.items():
+                setattr(system, k, v)
+            await db.commit()
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def _backdate_pending_action(pending_id: str, days: int) -> None:
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.pending_action import PendingAction
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            pending = await db.get(PendingAction, uuid.UUID(pending_id))
+            assert pending is not None
+            pending.finalize_after = datetime.now(UTC) - timedelta(days=days)
+            await db.commit()
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def _backdate_safety_change(change_id: str, days: int) -> None:
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.safety_change_request import SafetyChangeRequest
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            change = await db.get(SafetyChangeRequest, uuid.UUID(change_id))
+            assert change is not None
+            change.finalize_after = datetime.now(UTC) - timedelta(days=days)
+            await db.commit()
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def _register(client: httpx.Client) -> tuple[str, str]:
+    email = f"safety-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "testpassword123"},
+    )
+    assert resp.status_code == 201
+    token = resp.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {token}"
+    return email, "testpassword123"
+
+
+# ---------------------------------------------------------------------------
+# Baseline: safety off — delete is immediate, nothing queued
+# ---------------------------------------------------------------------------
+
+
+def test_delete_immediate_when_safety_off(auth_client: httpx.Client):
+    member = auth_client.post("/v1/members", json={"name": "Alpha"}).json()
+    resp = auth_client.delete(f"/v1/members/{member['id']}")
+    assert resp.status_code == 204
+
+    listing = auth_client.get("/v1/system/safety").json()
+    assert listing["pending_actions"] == []
+
+
+# ---------------------------------------------------------------------------
+# Delete queues when safeguarded
+# ---------------------------------------------------------------------------
+
+
+def test_delete_queues_when_safety_on(client: httpx.Client):
+    email, _ = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_members=True,
+    )
+    member = client.post("/v1/members", json={"name": "Beta"}).json()
+
+    resp = client.delete(f"/v1/members/{member['id']}")
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert "pending_action_id" in body
+    assert "finalize_after" in body
+
+    # Member still exists
+    assert client.get(f"/v1/members/{member['id']}").status_code == 200
+
+    # Shows up in pending list
+    listing = client.get("/v1/system/safety").json()
+    assert len(listing["pending_actions"]) == 1
+    assert listing["pending_actions"][0]["target_label"] == "Beta"
+
+
+def test_delete_queues_captures_fronting_snapshot(client: httpx.Client):
+    email, _ = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_members=True,
+        safety_applies_to_fronts=True,
+    )
+    alice = client.post("/v1/members", json={"name": "Alice"}).json()
+    bob = client.post("/v1/members", json={"name": "Bob"}).json()
+    charlie = client.post("/v1/members", json={"name": "Charlie"}).json()
+
+    # Start a front with Alice + Bob
+    client.post("/v1/fronts", json={"member_ids": [alice["id"], bob["id"]]})
+
+    # Queue Charlie's deletion
+    resp = client.delete(f"/v1/members/{charlie['id']}")
+    assert resp.status_code == 202
+
+    listing = client.get("/v1/system/safety").json()
+    pending = listing["pending_actions"][0]
+    assert set(pending["fronting_member_names"]) == {"Alice", "Bob"}
+
+
+# ---------------------------------------------------------------------------
+# Category toggles: only enabled categories are safeguarded
+# ---------------------------------------------------------------------------
+
+
+def test_category_toggle_controls_safeguarding(client: httpx.Client):
+    email, _ = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_members=True,
+        safety_applies_to_tags=False,
+    )
+    member = client.post("/v1/members", json={"name": "Zed"}).json()
+    tag = client.post("/v1/tags", json={"name": "TestTag"}).json()
+
+    # Members is enabled — should queue
+    assert client.delete(f"/v1/members/{member['id']}").status_code == 202
+
+    # Tags is not enabled — immediate delete
+    assert client.delete(f"/v1/tags/{tag['id']}").status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_pending_action(client: httpx.Client):
+    email, _ = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_members=True,
+    )
+    member = client.post("/v1/members", json={"name": "Delta"}).json()
+    resp = client.delete(f"/v1/members/{member['id']}")
+    pending_id = resp.json()["pending_action_id"]
+
+    cancel = client.delete(f"/v1/system/safety/pending-actions/{pending_id}")
+    assert cancel.status_code == 204
+
+    # Member still exists
+    assert client.get(f"/v1/members/{member['id']}").status_code == 200
+    # No longer pending
+    listing = client.get("/v1/system/safety").json()
+    assert listing["pending_actions"] == []
+
+
+# ---------------------------------------------------------------------------
+# Finalization via admin job trigger
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_pending_action_runs(
+    client: httpx.Client, admin_client: httpx.Client
+):
+    email, _ = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_members=True,
+    )
+    member = client.post("/v1/members", json={"name": "Epsilon"}).json()
+    pending_id = client.delete(f"/v1/members/{member['id']}").json()[
+        "pending_action_id"
+    ]
+
+    _backdate_pending_action(pending_id, days=8)
+
+    resp = admin_client.post("/v1/admin/jobs/finalize_pending_actions/run")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "success"
+
+    # Member is gone
+    assert client.get(f"/v1/members/{member['id']}").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric loosening delay
+# ---------------------------------------------------------------------------
+
+
+def test_tightening_applies_immediately(client: httpx.Client):
+    _register(client)
+    resp = client.patch(
+        "/v1/system/safety",
+        json={"grace_period_days": 7, "applies_to_members": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["applied"]) == {"grace_period_days", "applies_to_members"}
+    assert body["deferred"] == []
+    assert body["settings"]["grace_period_days"] == 7
+
+
+def test_loosening_is_deferred(client: httpx.Client):
+    email, password = _register(client)
+    # Tighten first (immediate).
+    client.patch(
+        "/v1/system/safety",
+        json={
+            "grace_period_days": 7,
+            "applies_to_members": True,
+            "auth_tier": "password",
+        },
+    )
+
+    # Attempt to loosen (lower grace) — needs re-auth and should defer.
+    resp = client.patch(
+        "/v1/system/safety",
+        json={"grace_period_days": 1, "password": password},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deferred"] == ["grace_period_days"]
+    assert body["settings"]["grace_period_days"] == 7  # unchanged
+    assert body["pending_change"] is not None
+
+
+def test_loosening_requires_reauth(client: httpx.Client):
+    _register(client)
+    client.patch(
+        "/v1/system/safety",
+        json={
+            "grace_period_days": 7,
+            "applies_to_members": True,
+            "auth_tier": "password",
+        },
+    )
+
+    # No password supplied — should be rejected
+    resp = client.patch("/v1/system/safety", json={"grace_period_days": 0})
+    assert resp.status_code == 401
+
+
+def test_cancel_pending_safety_change(client: httpx.Client):
+    _, password = _register(client)
+    client.patch(
+        "/v1/system/safety",
+        json={
+            "grace_period_days": 7,
+            "applies_to_members": True,
+            "auth_tier": "password",
+        },
+    )
+    resp = client.patch(
+        "/v1/system/safety",
+        json={"grace_period_days": 0, "password": password},
+    )
+    change_id = resp.json()["pending_change"]["id"]
+
+    cancel = client.delete(f"/v1/system/safety/pending-changes/{change_id}")
+    assert cancel.status_code == 204
+
+    current = client.get("/v1/system/safety").json()
+    assert current["settings"]["grace_period_days"] == 7
+    assert current["pending_changes"] == []
+
+
+def test_finalize_safety_change_applies_loosening(
+    client: httpx.Client, admin_client: httpx.Client
+):
+    _, password = _register(client)
+    client.patch(
+        "/v1/system/safety",
+        json={
+            "grace_period_days": 7,
+            "applies_to_members": True,
+            "auth_tier": "password",
+        },
+    )
+    resp = client.patch(
+        "/v1/system/safety",
+        json={"grace_period_days": 1, "password": password},
+    )
+    change_id = resp.json()["pending_change"]["id"]
+
+    _backdate_safety_change(change_id, days=8)
+
+    run = admin_client.post("/v1/admin/jobs/finalize_safety_changes/run")
+    assert run.status_code == 200, run.text
+    assert run.json()["status"] == "success"
+
+    current = client.get("/v1/system/safety").json()
+    assert current["settings"]["grace_period_days"] == 1
+
+
+def test_mixed_change_splits_applied_and_deferred(client: httpx.Client):
+    _, password = _register(client)
+    client.patch(
+        "/v1/system/safety",
+        json={
+            "grace_period_days": 7,
+            "applies_to_members": True,
+            "auth_tier": "password",
+        },
+    )
+    # Raise grace (tighten) + drop auth_tier to none (loosen) in one call.
+    resp = client.patch(
+        "/v1/system/safety",
+        json={
+            "grace_period_days": 14,
+            "auth_tier": "none",
+            "password": password,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "grace_period_days" in body["applied"]
+    assert "auth_tier" in body["deferred"]
+    # Tightening visible now.
+    assert body["settings"]["grace_period_days"] == 14
+    # Loosening still pending.
+    assert body["settings"]["auth_tier"] == "password"
+
+
+def test_loosening_when_grace_zero_applies_immediately(client: httpx.Client):
+    """If safety is fully off (grace=0), nothing to defer — loosening applies instantly."""
+    _register(client)
+    # Safety starts off (grace=0). Lowering auth tier or toggling off categories
+    # should apply immediately since there's no grace to wait through.
+    resp = client.patch(
+        "/v1/system/safety",
+        json={"applies_to_members": False},
+    )
+    assert resp.status_code == 200
+    # Already False — nothing applied, nothing deferred.
+    assert resp.json()["applied"] == []
+    assert resp.json()["deferred"] == []
+
+
+# ---------------------------------------------------------------------------
+# Re-auth gate on destructive endpoints (delete_confirmation tier)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_endpoint_requires_password_when_tier_set(client: httpx.Client):
+    """delete_confirmation=password gates the delete endpoint regardless of grace."""
+    email, password = _register(client)
+    _set_system_safety_via_db(email, delete_confirmation="password")
+    member = client.post("/v1/members", json={"name": "Gated"}).json()
+
+    # No body → 401 Password required
+    no_body = client.delete(f"/v1/members/{member['id']}")
+    assert no_body.status_code == 401
+    assert no_body.json()["detail"] == "Password required"
+
+    # Wrong password → 401
+    wrong = client.request(
+        "DELETE",
+        f"/v1/members/{member['id']}",
+        json={"password": "not-the-password"},
+    )
+    assert wrong.status_code == 401
+
+    # Member still exists.
+    assert client.get(f"/v1/members/{member['id']}").status_code == 200
+
+    # Correct password → 204 (no safety grace configured)
+    ok = client.request(
+        "DELETE",
+        f"/v1/members/{member['id']}",
+        json={"password": password},
+    )
+    assert ok.status_code == 204
+
+
+def test_delete_endpoint_reauth_then_queues_when_safeguarded(client: httpx.Client):
+    """Re-auth must pass first, *then* the safeguard queues — both gates apply."""
+    email, password = _register(client)
+    _set_system_safety_via_db(
+        email,
+        delete_confirmation="password",
+        safety_grace_period_days=7,
+        safety_applies_to_members=True,
+    )
+    member = client.post("/v1/members", json={"name": "DoubleGated"}).json()
+
+    # Wrong password is rejected before the safeguard even considers queuing.
+    wrong = client.request(
+        "DELETE",
+        f"/v1/members/{member['id']}",
+        json={"password": "nope"},
+    )
+    assert wrong.status_code == 401
+    assert client.get("/v1/system/safety").json()["pending_actions"] == []
+
+    # Correct password → 202 pending (safeguard takes over).
+    ok = client.request(
+        "DELETE",
+        f"/v1/members/{member['id']}",
+        json={"password": password},
+    )
+    assert ok.status_code == 202
+    assert client.get(f"/v1/members/{member['id']}").status_code == 200
+    assert len(client.get("/v1/system/safety").json()["pending_actions"]) == 1

--- a/web/src/components/announcement-banners.tsx
+++ b/web/src/components/announcement-banners.tsx
@@ -3,32 +3,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getActiveAnnouncements, type Announcement } from "@/lib/announcements";
 import { apiFetch } from "@/lib/api-client";
 import { Button } from "@/components/ui/button";
-import { Info, AlertTriangle, AlertOctagon, X } from "lucide-react";
+import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-const severityConfig = {
-  info: {
-    icon: Info,
-    bg: "bg-blue-500/10",
-    border: "border-blue-500/20",
-    text: "text-blue-700 dark:text-blue-300",
-    iconColor: "text-blue-500",
-  },
-  warning: {
-    icon: AlertTriangle,
-    bg: "bg-yellow-500/10",
-    border: "border-yellow-500/20",
-    text: "text-yellow-800 dark:text-yellow-200",
-    iconColor: "text-yellow-500",
-  },
-  critical: {
-    icon: AlertOctagon,
-    bg: "bg-destructive/10",
-    border: "border-destructive/20",
-    text: "text-destructive",
-    iconColor: "text-destructive",
-  },
-};
+import { severityConfig } from "@/components/banner-severity";
 
 function useClientSettings(clientId: string) {
   return useQuery({

--- a/web/src/components/banner-severity.ts
+++ b/web/src/components/banner-severity.ts
@@ -1,0 +1,27 @@
+import { Info, AlertTriangle, AlertOctagon } from "lucide-react";
+
+export type BannerSeverity = "info" | "warning" | "critical";
+
+export const severityConfig = {
+  info: {
+    icon: Info,
+    bg: "bg-blue-500/10",
+    border: "border-blue-500/20",
+    text: "text-blue-700 dark:text-blue-300",
+    iconColor: "text-blue-500",
+  },
+  warning: {
+    icon: AlertTriangle,
+    bg: "bg-yellow-500/10",
+    border: "border-yellow-500/20",
+    text: "text-yellow-800 dark:text-yellow-200",
+    iconColor: "text-yellow-500",
+  },
+  critical: {
+    icon: AlertOctagon,
+    bg: "bg-destructive/10",
+    border: "border-destructive/20",
+    text: "text-destructive",
+    iconColor: "text-destructive",
+  },
+} as const;

--- a/web/src/components/destructive-confirm-dialog.tsx
+++ b/web/src/components/destructive-confirm-dialog.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/hooks/use-auth";
+import type { DeleteConfirmation, DestructiveConfirm } from "@/types/api";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  /** Current auth tier from system settings — drives which fields to show. */
+  tier: DeleteConfirmation;
+  onConfirm: (confirm?: DestructiveConfirm) => void;
+  loading?: boolean;
+}
+
+export function DestructiveConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  tier,
+  onConfirm,
+  loading,
+}: Props) {
+  const { user } = useAuth();
+  const [password, setPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setPassword("");
+      setTotpCode("");
+    }
+    onOpenChange(next);
+  }
+
+  const needsPassword = tier === "password" || tier === "both";
+  const needsTotp = (tier === "totp" || tier === "both") && !!user?.totp_enabled;
+
+  function handleConfirm() {
+    const confirm: DestructiveConfirm = {};
+    if (needsPassword) confirm.password = password;
+    if (needsTotp) confirm.totp_code = totpCode;
+    onConfirm(Object.keys(confirm).length > 0 ? confirm : undefined);
+  }
+
+  const disabled =
+    loading ||
+    (needsPassword && !password) ||
+    (needsTotp && !totpCode);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {(needsPassword || needsTotp) && (
+          <div className="space-y-3">
+            {needsPassword && (
+              <div className="space-y-1">
+                <Label className="text-sm">Password</Label>
+                <Input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter your password"
+                />
+              </div>
+            )}
+            {needsTotp && (
+              <div className="space-y-1">
+                <Label className="text-sm">TOTP code</Label>
+                <Input
+                  value={totpCode}
+                  onChange={(e) => setTotpCode(e.target.value)}
+                  placeholder="6-digit code"
+                  maxLength={6}
+                  autoComplete="off"
+                />
+              </div>
+            )}
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={disabled}
+          >
+            {loading ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/onboarding-prompt.tsx
+++ b/web/src/components/onboarding-prompt.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Shield, KeyRound } from "lucide-react";
+import { useAuth } from "@/hooks/use-auth";
+import { apiFetch } from "@/lib/api-client";
+
+function useWebSettings() {
+  return useQuery({
+    queryKey: ["client-settings", "web"],
+    queryFn: async () => {
+      try {
+        const res = await apiFetch<{ settings: Record<string, unknown> }>(
+          "/v1/settings/client/web",
+        );
+        return res.settings;
+      } catch {
+        return {};
+      }
+    },
+    staleTime: 60 * 1000,
+  });
+}
+
+export function OnboardingPrompt() {
+  const { user } = useAuth();
+  const { data: settings, isLoading } = useWebSettings();
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+  const [dismissing, setDismissing] = useState(false);
+
+  if (isLoading || !user) return null;
+  if (settings?.onboarding_complete === true) return null;
+
+  async function markComplete() {
+    setDismissing(true);
+    try {
+      await apiFetch("/v1/settings/client/web", {
+        method: "PUT",
+        body: JSON.stringify({
+          settings: { ...settings, onboarding_complete: true },
+        }),
+      });
+      qc.invalidateQueries({ queryKey: ["client-settings", "web"] });
+    } finally {
+      setDismissing(false);
+    }
+  }
+
+  async function goTo(hash: string) {
+    await markComplete();
+    navigate(`/settings${hash}`);
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && markComplete()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Welcome to Sheaf</DialogTitle>
+          <DialogDescription>
+            Quick optional setup to protect your account and system data. You
+            can always configure these later in Settings.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <OptionRow
+            icon={<KeyRound className="h-4 w-4" />}
+            title="Set up two-factor auth"
+            desc="Add an extra step at sign-in, and unlock the TOTP-based auth tiers for destructive actions."
+            enabled={!user.totp_enabled}
+            badge={user.totp_enabled ? "Already on" : undefined}
+            onClick={() => goTo("#security")}
+          />
+          <OptionRow
+            icon={<Shield className="h-4 w-4" />}
+            title="Configure System Safety"
+            desc="Optional grace periods and re-auth prompts before members, groups, tags, fields, or front entries can be deleted."
+            enabled
+            onClick={() => goTo("#safety")}
+          />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={markComplete}
+            disabled={dismissing}
+          >
+            Skip for now
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function OptionRow({
+  icon,
+  title,
+  desc,
+  enabled,
+  badge,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+  enabled: boolean;
+  badge?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={!enabled}
+      onClick={onClick}
+      className="flex w-full items-start gap-3 rounded-md border px-3 py-3 text-left hover:bg-muted disabled:opacity-60 disabled:cursor-not-allowed"
+    >
+      <span className="mt-0.5 shrink-0 text-muted-foreground">{icon}</span>
+      <span className="flex-1 min-w-0">
+        <span className="flex items-center gap-2">
+          <span className="font-medium text-sm">{title}</span>
+          {badge && (
+            <span className="text-xs rounded bg-muted px-1.5 py-0.5 text-muted-foreground">
+              {badge}
+            </span>
+          )}
+        </span>
+        <span className="block text-xs text-muted-foreground mt-0.5">
+          {desc}
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/web/src/components/pending-action-row.tsx
+++ b/web/src/components/pending-action-row.tsx
@@ -1,0 +1,62 @@
+import { Button } from "@/components/ui/button";
+import type { PendingAction, PendingActionType } from "@/types/api";
+
+const actionLabels: Record<PendingActionType, string> = {
+  member_delete: "Delete member",
+  group_delete: "Delete group",
+  tag_delete: "Delete tag",
+  field_delete: "Delete custom field",
+  front_delete: "Delete front entry",
+};
+
+function timeRemaining(finalizeAfter: string): string {
+  const target = new Date(finalizeAfter).getTime();
+  const now = Date.now();
+  const ms = target - now;
+  if (ms <= 0) return "finalizing…";
+  const hours = Math.ceil(ms / 3_600_000);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.ceil(ms / 86_400_000);
+  return `in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+export function PendingActionRow({
+  action,
+  onCancel,
+  cancelling,
+}: {
+  action: PendingAction;
+  onCancel: () => void;
+  cancelling: boolean;
+}) {
+  const label = actionLabels[action.action_type] ?? action.action_type;
+  const fronting = action.fronting_member_names;
+
+  return (
+    <div className="flex items-start gap-3 rounded-md border px-3 py-2 text-sm">
+      <div className="flex-1 min-w-0 space-y-0.5">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <span className="font-medium">{label}</span>
+          <span className="text-muted-foreground truncate">
+            {action.target_label}
+          </span>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          Finalizes {timeRemaining(action.finalize_after)}
+          {fronting.length > 0 && (
+            <> · {fronting.join(", ")} {fronting.length === 1 ? "was" : "were"} fronting</>
+          )}
+        </div>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 text-xs"
+        onClick={onCancel}
+        disabled={cancelling}
+      >
+        {cancelling ? "Cancelling…" : "Cancel"}
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/system-safety-banner.tsx
+++ b/web/src/components/system-safety-banner.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { cn } from "@/lib/utils";
+import { getSystemSafety } from "@/lib/system-safety";
+import {
+  severityConfig,
+  type BannerSeverity,
+} from "@/components/banner-severity";
+
+const URGENT_WINDOW_MS = 24 * 3_600_000;
+
+function severityFor(finalizeAfter: string): BannerSeverity {
+  const ms = new Date(finalizeAfter).getTime() - Date.now();
+  return ms < URGENT_WINDOW_MS ? "critical" : "warning";
+}
+
+function timeRemaining(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return "any moment";
+  const hours = Math.ceil(ms / 3_600_000);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.ceil(ms / 86_400_000);
+  return `in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+export function SystemSafetyBanner() {
+  const { data } = useQuery({
+    queryKey: ["system-safety"],
+    queryFn: getSystemSafety,
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+
+  const actions = data?.pending_actions ?? [];
+  const changes = data?.pending_changes ?? [];
+
+  if (actions.length === 0 && changes.length === 0) return null;
+
+  return (
+    <div className="flex flex-col">
+      {actions.length > 0 && (
+        <Banner
+          severity={earliestSeverity(actions.map((a) => a.finalize_after))}
+          message={
+            actions.length === 1
+              ? `1 pending destructive action finalizes ${timeRemaining(actions[0].finalize_after)}.`
+              : `${actions.length} pending destructive actions — next finalizes ${timeRemaining(earliest(actions.map((a) => a.finalize_after)))}.`
+          }
+        />
+      )}
+      {changes.length > 0 && (
+        <Banner
+          severity={earliestSeverity(changes.map((c) => c.finalize_after))}
+          message={
+            changes.length === 1
+              ? `Safety settings change pending — finalizes ${timeRemaining(changes[0].finalize_after)}.`
+              : `${changes.length} safety settings changes pending — next finalizes ${timeRemaining(earliest(changes.map((c) => c.finalize_after)))}.`
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+function earliest(isos: string[]): string {
+  return isos.reduce((a, b) =>
+    new Date(a).getTime() <= new Date(b).getTime() ? a : b,
+  );
+}
+
+function earliestSeverity(isos: string[]): BannerSeverity {
+  return severityFor(earliest(isos));
+}
+
+function Banner({
+  severity,
+  message,
+}: {
+  severity: BannerSeverity;
+  message: string;
+}) {
+  const config = severityConfig[severity];
+  const Icon = config.icon;
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 border-b px-4 py-2 text-sm",
+        config.bg,
+        config.border,
+      )}
+    >
+      <Icon className={cn("h-4 w-4 shrink-0", config.iconColor)} />
+      <span className={cn("flex-1 min-w-0", config.text)}>{message}</span>
+      <Link
+        to="/settings"
+        className={cn("shrink-0 underline text-xs", config.text)}
+      >
+        Review
+      </Link>
+    </div>
+  );
+}

--- a/web/src/components/system-safety-card.tsx
+++ b/web/src/components/system-safety-card.tsx
@@ -1,0 +1,401 @@
+import { type FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/use-auth";
+import {
+  cancelPendingAction,
+  cancelPendingChange,
+  getSystemSafety,
+  updateSystemSafety,
+} from "@/lib/system-safety";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { PendingActionRow } from "@/components/pending-action-row";
+import type {
+  DeleteConfirmation,
+  PendingAction,
+  SafetyChangeRequest,
+  SystemSafetySettings,
+  SystemSafetyUpdate,
+} from "@/types/api";
+
+const categoryLabels: {
+  key: keyof SystemSafetySettings;
+  label: string;
+  desc: string;
+}[] = [
+  { key: "applies_to_members", label: "Members", desc: "Deleting a member" },
+  { key: "applies_to_groups", label: "Groups", desc: "Deleting a group" },
+  { key: "applies_to_tags", label: "Tags", desc: "Deleting a tag" },
+  { key: "applies_to_fields", label: "Custom fields", desc: "Deleting a custom field" },
+  { key: "applies_to_fronts", label: "Front entries", desc: "Deleting a front entry" },
+];
+
+function changeSummary(changes: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(changes)) {
+    if (k === "safety_grace_period_days") {
+      parts.push(`grace period → ${v} days`);
+    } else if (k === "delete_confirmation") {
+      parts.push(`auth tier → ${v}`);
+    } else if (k.startsWith("safety_applies_to_")) {
+      const cat = k.replace("safety_applies_to_", "");
+      parts.push(`disable ${cat}`);
+    } else {
+      parts.push(`${k} → ${v}`);
+    }
+  }
+  return parts.join(", ");
+}
+
+function timeRemaining(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return "finalizing…";
+  const hours = Math.ceil(ms / 3_600_000);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.ceil(ms / 86_400_000);
+  return `in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+export function SystemSafetyCard() {
+  const { data } = useQuery({
+    queryKey: ["system-safety"],
+    queryFn: getSystemSafety,
+  });
+
+  if (!data) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">System Safety</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Optional grace periods and re-auth for destructive actions. Tightening
+          applies immediately; loosening waits the current grace period before
+          taking effect.
+        </p>
+        <SafetyForm settings={data.settings} />
+        {data.pending_actions.length > 0 && (
+          <>
+            <Separator />
+            <PendingActionsList actions={data.pending_actions} />
+          </>
+        )}
+        {data.pending_changes.length > 0 && (
+          <>
+            <Separator />
+            <PendingChangesList changes={data.pending_changes} />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SafetyForm({ settings }: { settings: SystemSafetySettings }) {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const [draft, setDraft] = useState<SystemSafetySettings>(settings);
+  const [password, setPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
+  const [error, setError] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: updateSystemSafety,
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ["system-safety"] });
+      qc.invalidateQueries({ queryKey: ["system", "me"] });
+      setPassword("");
+      setTotpCode("");
+      setError("");
+      if (res.deferred.length > 0) {
+        toast.success(
+          `Queued: ${res.deferred.join(", ")}. Finalizes after the current grace period.`,
+        );
+      } else {
+        toast.success("Safety settings saved");
+      }
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
+  });
+
+  const dirty = hasDiff(settings, draft);
+  const loosening = detectLoosening(settings, draft);
+  const needsReauth =
+    loosening && (settings.grace_period_days > 0 || draft.grace_period_days > 0);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    const patch: SystemSafetyUpdate = diffFields(settings, draft);
+    if (needsReauth) {
+      patch.password = password || undefined;
+      patch.totp_code = totpCode || undefined;
+    }
+    mutation.mutate(patch);
+  }
+
+  function setField<K extends keyof SystemSafetySettings>(
+    key: K,
+    value: SystemSafetySettings[K],
+  ) {
+    setDraft((d) => ({ ...d, [key]: value }));
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <Label className="text-sm">Grace period (days)</Label>
+          <Input
+            type="number"
+            min={0}
+            max={365}
+            value={draft.grace_period_days}
+            onChange={(e) =>
+              setField("grace_period_days", Number(e.target.value) || 0)
+            }
+          />
+          <p className="text-xs text-muted-foreground">
+            0 disables the grace period entirely.
+          </p>
+        </div>
+        <div className="space-y-1">
+          <Label className="text-sm">Auth tier</Label>
+          <Select
+            value={draft.auth_tier}
+            onValueChange={(v) => setField("auth_tier", v as DeleteConfirmation)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">No confirmation</SelectItem>
+              <SelectItem value="password">Require password</SelectItem>
+              {user?.totp_enabled && (
+                <SelectItem value="totp">Require TOTP</SelectItem>
+              )}
+              {user?.totp_enabled && (
+                <SelectItem value="both">Password + TOTP</SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Required for safeguarded destructive actions.
+          </p>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label className="text-sm">Apply safety to</Label>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {categoryLabels.map(({ key, label, desc }) => (
+            <label
+              key={key}
+              className="flex items-start gap-2 text-sm cursor-pointer"
+            >
+              <Checkbox
+                checked={draft[key] as boolean}
+                onCheckedChange={(v) => setField(key, Boolean(v))}
+                className="mt-0.5"
+              />
+              <span>
+                <span className="font-medium">{label}</span>
+                <span className="block text-xs text-muted-foreground">
+                  {desc}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+      {needsReauth && (
+        <div className="space-y-3 border-t pt-3">
+          <p className="text-sm text-muted-foreground">
+            Loosening safety requires re-auth and will take effect after the
+            current grace period.
+          </p>
+          {(settings.auth_tier === "password" || settings.auth_tier === "both") && (
+            <div className="space-y-1">
+              <Label className="text-sm">Password</Label>
+              <Input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+          )}
+          {(settings.auth_tier === "totp" || settings.auth_tier === "both") &&
+            user?.totp_enabled && (
+              <div className="space-y-1">
+                <Label className="text-sm">TOTP code</Label>
+                <Input
+                  value={totpCode}
+                  onChange={(e) => setTotpCode(e.target.value)}
+                  placeholder="6-digit code"
+                  maxLength={6}
+                  autoComplete="off"
+                  required
+                />
+              </div>
+            )}
+        </div>
+      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <div className="flex gap-2">
+        <Button type="submit" size="sm" disabled={!dirty || mutation.isPending}>
+          {mutation.isPending ? "Saving…" : "Save"}
+        </Button>
+        {dirty && (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setDraft(settings)}
+            disabled={mutation.isPending}
+          >
+            Revert
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function PendingActionsList({ actions }: { actions: PendingAction[] }) {
+  const qc = useQueryClient();
+  const cancel = useMutation({
+    mutationFn: cancelPendingAction,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["system-safety"] });
+      toast.success("Cancelled");
+    },
+  });
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-sm font-medium">Pending destructive actions</h4>
+      <div className="space-y-2">
+        {actions.map((a) => (
+          <PendingActionRow
+            key={a.id}
+            action={a}
+            onCancel={() => cancel.mutate(a.id)}
+            cancelling={cancel.isPending && cancel.variables === a.id}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PendingChangesList({ changes }: { changes: SafetyChangeRequest[] }) {
+  const qc = useQueryClient();
+  const cancel = useMutation({
+    mutationFn: cancelPendingChange,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["system-safety"] });
+      toast.success("Cancelled");
+    },
+  });
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-sm font-medium">Pending safety changes</h4>
+      {changes.map((c) => (
+        <div
+          key={c.id}
+          className="flex items-start gap-3 rounded-md border px-3 py-2 text-sm"
+        >
+          <div className="flex-1 min-w-0 space-y-0.5">
+            <div className="font-medium">{changeSummary(c.changes)}</div>
+            <div className="text-xs text-muted-foreground">
+              Finalizes {timeRemaining(c.finalize_after)}
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => cancel.mutate(c.id)}
+            disabled={cancel.isPending && cancel.variables === c.id}
+          >
+            {cancel.isPending && cancel.variables === c.id
+              ? "Cancelling…"
+              : "Cancel"}
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function hasDiff(a: SystemSafetySettings, b: SystemSafetySettings): boolean {
+  return (
+    a.grace_period_days !== b.grace_period_days ||
+    a.auth_tier !== b.auth_tier ||
+    a.applies_to_members !== b.applies_to_members ||
+    a.applies_to_groups !== b.applies_to_groups ||
+    a.applies_to_tags !== b.applies_to_tags ||
+    a.applies_to_fields !== b.applies_to_fields ||
+    a.applies_to_fronts !== b.applies_to_fronts
+  );
+}
+
+function diffFields(
+  current: SystemSafetySettings,
+  draft: SystemSafetySettings,
+): SystemSafetyUpdate {
+  const patch: SystemSafetyUpdate = {};
+  if (current.grace_period_days !== draft.grace_period_days)
+    patch.grace_period_days = draft.grace_period_days;
+  if (current.auth_tier !== draft.auth_tier) patch.auth_tier = draft.auth_tier;
+  for (const key of [
+    "applies_to_members",
+    "applies_to_groups",
+    "applies_to_tags",
+    "applies_to_fields",
+    "applies_to_fronts",
+  ] as const) {
+    if (current[key] !== draft[key]) patch[key] = draft[key];
+  }
+  return patch;
+}
+
+const tierStrength: Record<DeleteConfirmation, number> = {
+  none: 0,
+  password: 1,
+  totp: 1,
+  both: 2,
+};
+
+function detectLoosening(
+  current: SystemSafetySettings,
+  draft: SystemSafetySettings,
+): boolean {
+  if (draft.grace_period_days < current.grace_period_days) return true;
+  if (tierStrength[draft.auth_tier] < tierStrength[current.auth_tier]) return true;
+  for (const key of [
+    "applies_to_members",
+    "applies_to_groups",
+    "applies_to_tags",
+    "applies_to_fields",
+    "applies_to_fronts",
+  ] as const) {
+    if (current[key] && !draft[key]) return true;
+  }
+  return false;
+}

--- a/web/src/hooks/use-custom-fields.ts
+++ b/web/src/hooks/use-custom-fields.ts
@@ -1,6 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { CustomFieldCreate, CustomFieldUpdate, CustomFieldValueSet } from "@/types/api";
+import {
+  isDeleteQueued,
+  type CustomFieldCreate,
+  type CustomFieldUpdate,
+  type CustomFieldValueSet,
+  type DestructiveConfirm,
+} from "@/types/api";
 import * as api from "@/lib/custom-fields";
 import { memberKeys } from "./use-members";
 
@@ -42,10 +48,23 @@ export function useUpdateField() {
 export function useDeleteField() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.deleteField(id),
-    onSuccess: () => {
+    mutationFn: ({
+      id,
+      confirm,
+    }: {
+      id: string;
+      confirm?: DestructiveConfirm;
+    }) => api.deleteField(id, confirm),
+    onSuccess: (result) => {
       qc.invalidateQueries({ queryKey: fieldKeys.all });
-      toast.success("Field deleted");
+      if (isDeleteQueued(result)) {
+        qc.invalidateQueries({ queryKey: ["system-safety"] });
+        toast.success(
+          `Field scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+        );
+      } else {
+        toast.success("Field deleted");
+      }
     },
   });
 }

--- a/web/src/hooks/use-fronts.ts
+++ b/web/src/hooks/use-fronts.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { FrontCreate, FrontUpdate } from "@/types/api";
+import {
+  isDeleteQueued,
+  type DestructiveConfirm,
+  type FrontCreate,
+  type FrontUpdate,
+} from "@/types/api";
 import * as api from "@/lib/fronts";
 
 export const frontKeys = {
@@ -51,11 +56,24 @@ export function useUpdateFront() {
 export function useDeleteFront() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.deleteFront(id),
-    onSuccess: () => {
+    mutationFn: ({
+      id,
+      confirm,
+    }: {
+      id: string;
+      confirm?: DestructiveConfirm;
+    }) => api.deleteFront(id, confirm),
+    onSuccess: (result) => {
       qc.invalidateQueries({ queryKey: frontKeys.all });
       qc.invalidateQueries({ queryKey: frontKeys.current });
-      toast.success("Front deleted");
+      if (isDeleteQueued(result)) {
+        qc.invalidateQueries({ queryKey: ["system-safety"] });
+        toast.success(
+          `Front entry scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+        );
+      } else {
+        toast.success("Front deleted");
+      }
     },
   });
 }

--- a/web/src/hooks/use-groups.ts
+++ b/web/src/hooks/use-groups.ts
@@ -1,7 +1,12 @@
 import { useMemo } from "react";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { GroupCreate, GroupUpdate } from "@/types/api";
+import {
+  isDeleteQueued,
+  type DestructiveConfirm,
+  type GroupCreate,
+  type GroupUpdate,
+} from "@/types/api";
 import * as api from "@/lib/groups";
 
 export const groupKeys = {
@@ -68,10 +73,23 @@ export function useUpdateGroup() {
 export function useDeleteGroup() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.deleteGroup(id),
-    onSuccess: () => {
+    mutationFn: ({
+      id,
+      confirm,
+    }: {
+      id: string;
+      confirm?: DestructiveConfirm;
+    }) => api.deleteGroup(id, confirm),
+    onSuccess: (result) => {
       qc.invalidateQueries({ queryKey: groupKeys.all });
-      toast.success("Group deleted");
+      if (isDeleteQueued(result)) {
+        qc.invalidateQueries({ queryKey: ["system-safety"] });
+        toast.success(
+          `Group scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+        );
+      } else {
+        toast.success("Group deleted");
+      }
     },
   });
 }

--- a/web/src/hooks/use-members.ts
+++ b/web/src/hooks/use-members.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { MemberCreate, MemberUpdate } from "@/types/api";
+import {
+  isDeleteQueued,
+  type DestructiveConfirm,
+  type MemberCreate,
+  type MemberUpdate,
+} from "@/types/api";
 import * as api from "@/lib/members";
 
 export const memberKeys = {
@@ -54,11 +59,18 @@ export function useDeleteMember() {
       confirm,
     }: {
       id: string;
-      confirm?: { password?: string; totp_code?: string };
+      confirm?: DestructiveConfirm;
     }) => api.deleteMember(id, confirm),
-    onSuccess: () => {
+    onSuccess: (result) => {
       qc.invalidateQueries({ queryKey: memberKeys.all });
-      toast.success("Member deleted");
+      if (isDeleteQueued(result)) {
+        qc.invalidateQueries({ queryKey: ["system-safety"] });
+        toast.success(
+          `Member scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+        );
+      } else {
+        toast.success("Member deleted");
+      }
     },
   });
 }

--- a/web/src/hooks/use-tags.ts
+++ b/web/src/hooks/use-tags.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { TagCreate, TagUpdate } from "@/types/api";
+import {
+  isDeleteQueued,
+  type DestructiveConfirm,
+  type TagCreate,
+  type TagUpdate,
+} from "@/types/api";
 import * as api from "@/lib/tags";
 
 export const tagKeys = {
@@ -40,10 +45,23 @@ export function useUpdateTag() {
 export function useDeleteTag() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.deleteTag(id),
-    onSuccess: () => {
+    mutationFn: ({
+      id,
+      confirm,
+    }: {
+      id: string;
+      confirm?: DestructiveConfirm;
+    }) => api.deleteTag(id, confirm),
+    onSuccess: (result) => {
       qc.invalidateQueries({ queryKey: tagKeys.all });
-      toast.success("Tag deleted");
+      if (isDeleteQueued(result)) {
+        qc.invalidateQueries({ queryKey: ["system-safety"] });
+        toast.success(
+          `Tag scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+        );
+      } else {
+        toast.success("Tag deleted");
+      }
     },
   });
 }

--- a/web/src/lib/custom-fields.ts
+++ b/web/src/lib/custom-fields.ts
@@ -4,6 +4,8 @@ import type {
   CustomFieldUpdate,
   CustomFieldValue,
   CustomFieldValueSet,
+  DeleteResult,
+  DestructiveConfirm,
 } from "@/types/api";
 import { apiFetch } from "./api-client";
 
@@ -25,8 +27,11 @@ export function updateField(id: string, data: CustomFieldUpdate) {
   });
 }
 
-export function deleteField(id: string) {
-  return apiFetch<void>(`/v1/fields/${id}`, { method: "DELETE" });
+export function deleteField(id: string, confirm?: DestructiveConfirm) {
+  return apiFetch<DeleteResult>(`/v1/fields/${id}`, {
+    method: "DELETE",
+    ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
 }
 
 export function getMemberFieldValues(memberId: string) {

--- a/web/src/lib/fronts.ts
+++ b/web/src/lib/fronts.ts
@@ -1,4 +1,10 @@
-import type { Front, FrontCreate, FrontUpdate } from "@/types/api";
+import type {
+  DeleteResult,
+  DestructiveConfirm,
+  Front,
+  FrontCreate,
+  FrontUpdate,
+} from "@/types/api";
 import { apiFetch } from "./api-client";
 
 export function listFronts(limit = 50, offset = 0) {
@@ -23,6 +29,9 @@ export function updateFront(id: string, data: FrontUpdate) {
   });
 }
 
-export function deleteFront(id: string) {
-  return apiFetch<void>(`/v1/fronts/${id}`, { method: "DELETE" });
+export function deleteFront(id: string, confirm?: DestructiveConfirm) {
+  return apiFetch<DeleteResult>(`/v1/fronts/${id}`, {
+    method: "DELETE",
+    ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
 }

--- a/web/src/lib/groups.ts
+++ b/web/src/lib/groups.ts
@@ -1,4 +1,11 @@
-import type { Group, GroupCreate, GroupUpdate, Member } from "@/types/api";
+import type {
+  DeleteResult,
+  DestructiveConfirm,
+  Group,
+  GroupCreate,
+  GroupUpdate,
+  Member,
+} from "@/types/api";
 import { apiFetch } from "./api-client";
 
 export function listGroups() {
@@ -23,8 +30,11 @@ export function updateGroup(id: string, data: GroupUpdate) {
   });
 }
 
-export function deleteGroup(id: string) {
-  return apiFetch<void>(`/v1/groups/${id}`, { method: "DELETE" });
+export function deleteGroup(id: string, confirm?: DestructiveConfirm) {
+  return apiFetch<DeleteResult>(`/v1/groups/${id}`, {
+    method: "DELETE",
+    ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
 }
 
 export function getGroupMembers(id: string) {

--- a/web/src/lib/members.ts
+++ b/web/src/lib/members.ts
@@ -1,4 +1,10 @@
-import type { Member, MemberCreate, MemberUpdate } from "@/types/api";
+import type {
+  DeleteResult,
+  DestructiveConfirm,
+  Member,
+  MemberCreate,
+  MemberUpdate,
+} from "@/types/api";
 import { apiFetch } from "./api-client";
 
 export function listMembers() {
@@ -23,11 +29,8 @@ export function updateMember(id: string, data: MemberUpdate) {
   });
 }
 
-export function deleteMember(
-  id: string,
-  confirm?: { password?: string; totp_code?: string },
-) {
-  return apiFetch<void>(`/v1/members/${id}`, {
+export function deleteMember(id: string, confirm?: DestructiveConfirm) {
+  return apiFetch<DeleteResult>(`/v1/members/${id}`, {
     method: "DELETE",
     ...(confirm ? { body: JSON.stringify(confirm) } : {}),
   });

--- a/web/src/lib/system-safety.ts
+++ b/web/src/lib/system-safety.ts
@@ -1,0 +1,29 @@
+import type {
+  SystemSafetyResponse,
+  SystemSafetyUpdate,
+  SystemSafetyUpdateResponse,
+} from "@/types/api";
+import { apiFetch } from "./api-client";
+
+export function getSystemSafety() {
+  return apiFetch<SystemSafetyResponse>("/v1/system/safety");
+}
+
+export function updateSystemSafety(data: SystemSafetyUpdate) {
+  return apiFetch<SystemSafetyUpdateResponse>("/v1/system/safety", {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export function cancelPendingAction(id: string) {
+  return apiFetch<void>(`/v1/system/safety/pending-actions/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export function cancelPendingChange(id: string) {
+  return apiFetch<void>(`/v1/system/safety/pending-changes/${id}`, {
+    method: "DELETE",
+  });
+}

--- a/web/src/lib/systems.ts
+++ b/web/src/lib/systems.ts
@@ -1,4 +1,4 @@
-import type { DeleteConfirmation, System, SystemUpdate } from "@/types/api";
+import type { System, SystemUpdate } from "@/types/api";
 import { apiFetch } from "./api-client";
 
 export function getMySystem() {
@@ -8,17 +8,6 @@ export function getMySystem() {
 export function updateMySystem(data: SystemUpdate) {
   return apiFetch<System>("/v1/systems/me", {
     method: "PATCH",
-    body: JSON.stringify(data),
-  });
-}
-
-export function updateDeleteConfirmation(data: {
-  level: DeleteConfirmation;
-  password: string;
-  totp_code?: string;
-}) {
-  return apiFetch<System>("/v1/systems/me/delete-confirmation", {
-    method: "PUT",
     body: JSON.stringify(data),
   });
 }

--- a/web/src/lib/tags.ts
+++ b/web/src/lib/tags.ts
@@ -1,4 +1,10 @@
-import type { Tag, TagCreate, TagUpdate } from "@/types/api";
+import type {
+  DeleteResult,
+  DestructiveConfirm,
+  Tag,
+  TagCreate,
+  TagUpdate,
+} from "@/types/api";
 import { apiFetch } from "./api-client";
 
 export function listTags() {
@@ -19,6 +25,9 @@ export function updateTag(id: string, data: TagUpdate) {
   });
 }
 
-export function deleteTag(id: string) {
-  return apiFetch<void>(`/v1/tags/${id}`, { method: "DELETE" });
+export function deleteTag(id: string, confirm?: DestructiveConfirm) {
+  return apiFetch<DeleteResult>(`/v1/tags/${id}`, {
+    method: "DELETE",
+    ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
 }

--- a/web/src/routes/_layout.tsx
+++ b/web/src/routes/_layout.tsx
@@ -5,6 +5,8 @@ import { AccountPending } from "@/components/account-pending";
 import { AnnouncementBanners } from "@/components/announcement-banners";
 import { DeletionBanner } from "@/components/deletion-banner";
 import { LegalFooter } from "@/components/legal-footer";
+import { SystemSafetyBanner } from "@/components/system-safety-banner";
+import { OnboardingPrompt } from "@/components/onboarding-prompt";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export function AppLayout() {
@@ -33,11 +35,13 @@ export function AppLayout() {
       <div className="flex flex-1 flex-col overflow-hidden">
         <AnnouncementBanners />
         {user.account_status === "pending_deletion" && <DeletionBanner />}
+        <SystemSafetyBanner />
         <main className="flex-1 overflow-auto p-6">
           <Outlet />
         </main>
         <LegalFooter />
       </div>
+      <OnboardingPrompt />
     </div>
   );
 }

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -11,7 +11,7 @@ import { useMembers } from "@/hooks/use-members";
 import { PageHeader } from "@/components/page-header";
 import { MemberSelect } from "@/components/member-select";
 import { ColorDot } from "@/components/color-dot";
-import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -206,16 +206,18 @@ export function FrontsPage() {
       </Dialog>
 
       {/* Delete confirm */}
-      <ConfirmDialog
+      <DestructiveConfirmDialog
         open={!!deleting}
         onOpenChange={(open) => !open && setDeleting(null)}
         title="Delete front entry"
         description="Are you sure? This removes this front from history."
-        onConfirm={() =>
+        tier={system?.delete_confirmation ?? "none"}
+        onConfirm={(confirm) =>
           deleting &&
-          deleteFront.mutate(deleting, {
-            onSuccess: () => setDeleting(null),
-          })
+          deleteFront.mutate(
+            { id: deleting, confirm },
+            { onSuccess: () => setDeleting(null) },
+          )
         }
         loading={deleteFront.isPending}
       />

--- a/web/src/routes/groups.tsx
+++ b/web/src/routes/groups.tsx
@@ -7,10 +7,12 @@ import {
   useGroupMembers,
   useSetGroupMembers,
 } from "@/hooks/use-groups";
+import { useQuery } from "@tanstack/react-query";
+import { getMySystem } from "@/lib/systems";
 import { PageHeader } from "@/components/page-header";
 import { ColorDot } from "@/components/color-dot";
 import { MemberSelect } from "@/components/member-select";
-import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -61,6 +63,10 @@ export function GroupsPage() {
   const createGroup = useCreateGroup();
   const updateGroup = useUpdateGroup();
   const deleteGroup = useDeleteGroup();
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+  });
   const [showCreate, setShowCreate] = useState(false);
   const [editing, setEditing] = useState<Group | null>(null);
   const [deleting, setDeleting] = useState<Group | null>(null);
@@ -228,16 +234,18 @@ export function GroupsPage() {
       </Dialog>
 
       {/* Delete confirm */}
-      <ConfirmDialog
+      <DestructiveConfirmDialog
         open={!!deleting}
         onOpenChange={(open) => !open && setDeleting(null)}
         title="Delete group"
         description={`Are you sure you want to delete "${deleting?.name}"?`}
-        onConfirm={() =>
+        tier={system?.delete_confirmation ?? "none"}
+        onConfirm={(confirm) =>
           deleting &&
-          deleteGroup.mutate(deleting.id, {
-            onSuccess: () => setDeleting(null),
-          })
+          deleteGroup.mutate(
+            { id: deleting.id, confirm },
+            { onSuccess: () => setDeleting(null) },
+          )
         }
         loading={deleteGroup.isPending}
       />

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
 import { useTags, useCreateTag, useUpdateTag, useDeleteTag } from "@/hooks/use-tags";
 import { useCustomFields, useCreateField, useUpdateField, useDeleteField } from "@/hooks/use-custom-fields";
-import { getMySystem, updateMySystem, updateDeleteConfirmation, exportData } from "@/lib/systems";
+import { getMySystem, updateMySystem, exportData } from "@/lib/systems";
 import { getStorageUsage, cleanupFiles, listFiles, deleteFile, type UploadedFileInfo } from "@/lib/files";
 import { AvatarUpload } from "@/components/avatar-upload";
 import { PageHeader } from "@/components/page-header";
@@ -29,7 +29,9 @@ import { useUiScale } from "@/hooks/use-theme";
 import { TOTPSetup } from "@/components/totp-setup";
 import { ChangePassword } from "@/components/change-password";
 import { ChangeEmail } from "@/components/change-email";
-import type { ApiKey, ApiKeyCreated, DateFormat, DeleteConfirmation, FieldType, PrivacyLevel } from "@/types/api";
+import type { ApiKey, ApiKeyCreated, DateFormat, FieldType, PrivacyLevel } from "@/types/api";
+import { SystemSafetyCard } from "@/components/system-safety-card";
+import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { listApiKeys, createApiKey, revokeApiKey } from "@/lib/api-keys";
 import { getSessions, renameSession, revokeSession, revokeOtherSessions, requestAccountDeletion, cancelDeletion, updateMe, getAuthConfig, getTrustedDevices, renameTrustedDevice, revokeTrustedDevice, revokeAllTrustedDevices, type Session, type TrustedDevice } from "@/lib/auth";
 import { listClientSettings, deleteClientSettings } from "@/lib/client-settings";
@@ -183,6 +185,10 @@ function SystemSettingsForm({
 
 function TagsManager() {
   const { data: tags } = useTags();
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+  });
   const createTag = useCreateTag();
   const updateTag = useUpdateTag();
   const deleteTag = useDeleteTag();
@@ -191,6 +197,8 @@ function TagsManager() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [editColor, setEditColor] = useState("");
+  const [deletingTag, setDeletingTag] =
+    useState<{ id: string; name: string } | null>(null);
 
   function handleCreate(e: FormEvent) {
     e.preventDefault();
@@ -273,7 +281,7 @@ function TagsManager() {
                 onClick={() => startEdit(t)}
                 onContextMenu={(e) => {
                   e.preventDefault();
-                  deleteTag.mutate(t.id);
+                  setDeletingTag({ id: t.id, name: t.name });
                 }}
               >
                 <ColorDot color={t.color} />
@@ -288,12 +296,31 @@ function TagsManager() {
           </p>
         )}
       </CardContent>
+      <DestructiveConfirmDialog
+        open={!!deletingTag}
+        onOpenChange={(open) => !open && setDeletingTag(null)}
+        title="Delete tag"
+        description={`Are you sure you want to delete "${deletingTag?.name}"?`}
+        tier={system?.delete_confirmation ?? "none"}
+        onConfirm={(confirm) =>
+          deletingTag &&
+          deleteTag.mutate(
+            { id: deletingTag.id, confirm },
+            { onSuccess: () => setDeletingTag(null) },
+          )
+        }
+        loading={deleteTag.isPending}
+      />
     </Card>
   );
 }
 
 function CustomFieldsManager() {
   const { data: fields } = useCustomFields();
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+  });
   const createField = useCreateField();
   const updateField = useUpdateField();
   const deleteField = useDeleteField();
@@ -301,7 +328,8 @@ function CustomFieldsManager() {
   const [newType, setNewType] = useState<FieldType>("text");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
-  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [deletingField, setDeletingField] =
+    useState<{ id: string; name: string } | null>(null);
 
   function handleCreate(e: FormEvent) {
     e.preventDefault();
@@ -392,38 +420,14 @@ function CustomFieldsManager() {
                   {f.name}
                   <span className="ml-2 text-xs text-muted-foreground">{f.field_type}</span>
                 </span>
-                {deleteConfirmId === f.id ? (
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      className="h-6 px-2 text-xs"
-                      onClick={() => {
-                        deleteField.mutate(f.id);
-                        setDeleteConfirmId(null);
-                      }}
-                    >
-                      Confirm
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-6 px-2 text-xs"
-                      onClick={() => setDeleteConfirmId(null)}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                ) : (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-                    onClick={() => setDeleteConfirmId(f.id)}
-                  >
-                    Delete
-                  </Button>
-                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+                  onClick={() => setDeletingField({ id: f.id, name: f.name })}
+                >
+                  Delete
+                </Button>
               </div>
             ),
           )}
@@ -434,125 +438,21 @@ function CustomFieldsManager() {
           </p>
         )}
       </CardContent>
-    </Card>
-  );
-}
-
-function DeleteConfirmationSetting() {
-  const { user } = useAuth();
-  const qc = useQueryClient();
-  const { data: system } = useQuery({
-    queryKey: ["system", "me"],
-    queryFn: getMySystem,
-  });
-  const mutation = useMutation({
-    mutationFn: updateDeleteConfirmation,
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["system", "me"] });
-      toast.success("Delete confirmation updated");
-    },
-  });
-
-  const [pending, setPending] = useState<DeleteConfirmation | null>(null);
-  const [password, setPassword] = useState("");
-  const [totpCode, setTotpCode] = useState("");
-  const [error, setError] = useState("");
-
-  if (!system) return null;
-
-  function handleChange(value: DeleteConfirmation) {
-    if (value === system!.delete_confirmation) return;
-    setPending(value);
-    setPassword("");
-    setTotpCode("");
-    setError("");
-  }
-
-  function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (!pending) return;
-    setError("");
-    mutation.mutate(
-      { level: pending, password, totp_code: totpCode || undefined },
-      {
-        onSuccess: () => setPending(null),
-        onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
-      },
-    );
-  }
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Delete confirmation</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <p className="text-sm text-muted-foreground">
-          Require extra verification before deleting a member.
-        </p>
-        <Select
-          value={pending ?? system.delete_confirmation}
-          onValueChange={(v) => handleChange(v as DeleteConfirmation)}
-        >
-          <SelectTrigger className="w-48">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">No confirmation</SelectItem>
-            <SelectItem value="password">Require password</SelectItem>
-            {user?.totp_enabled && (
-              <SelectItem value="totp">Require TOTP</SelectItem>
-            )}
-            {user?.totp_enabled && (
-              <SelectItem value="both">Password + TOTP</SelectItem>
-            )}
-          </SelectContent>
-        </Select>
-
-        {pending && (
-          <form onSubmit={handleSubmit} className="space-y-3 border-t pt-3">
-            <p className="text-sm text-muted-foreground">
-              Confirm your identity to change this setting.
-            </p>
-            <div className="space-y-1">
-              <Label className="text-sm">Password</Label>
-              <Input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-            </div>
-            {user?.totp_enabled && (
-              <div className="space-y-1">
-                <Label className="text-sm">TOTP code</Label>
-                <Input
-                  value={totpCode}
-                  onChange={(e) => setTotpCode(e.target.value)}
-                  placeholder="6-digit code"
-                  maxLength={6}
-                  autoComplete="off"
-                  required
-                />
-              </div>
-            )}
-            {error && <p className="text-sm text-destructive">{error}</p>}
-            <div className="flex gap-2">
-              <Button type="submit" size="sm" disabled={mutation.isPending}>
-                {mutation.isPending ? "Saving..." : "Confirm"}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={() => setPending(null)}
-              >
-                Cancel
-              </Button>
-            </div>
-          </form>
-        )}
-      </CardContent>
+      <DestructiveConfirmDialog
+        open={!!deletingField}
+        onOpenChange={(open) => !open && setDeletingField(null)}
+        title="Delete custom field"
+        description={`Are you sure you want to delete "${deletingField?.name}"? All values set on members will be lost.`}
+        tier={system?.delete_confirmation ?? "none"}
+        onConfirm={(confirm) =>
+          deletingField &&
+          deleteField.mutate(
+            { id: deletingField.id, confirm },
+            { onSuccess: () => setDeletingField(null) },
+          )
+        }
+        loading={deleteField.isPending}
+      />
     </Card>
   );
 }
@@ -1676,11 +1576,15 @@ export function SettingsPage() {
         <SystemSettings />
         <TagsManager />
         <CustomFieldsManager />
-        <DeleteConfirmationSetting />
+        <div id="safety" className="scroll-mt-20">
+          <SystemSafetyCard />
+        </div>
         <DisplayPreferences />
         <FrontPreferences />
         <Separator />
-        <AccountInfo />
+        <div id="security" className="scroll-mt-20">
+          <AccountInfo />
+        </div>
         <ApiKeysCard />
         <ActiveSessionsCard />
         <TrustedDevicesCard />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -206,3 +206,93 @@ export interface CustomFieldValueSet {
   field_id: string;
   value: unknown;
 }
+
+export type PendingActionType =
+  | "member_delete"
+  | "group_delete"
+  | "tag_delete"
+  | "field_delete"
+  | "front_delete";
+
+export type PendingActionStatus =
+  | "pending"
+  | "cancelled"
+  | "completed"
+  | "errored";
+
+export interface PendingAction {
+  id: string;
+  action_type: PendingActionType;
+  target_id: string;
+  target_label: string;
+  requested_at: string;
+  requested_by_user_id: string | null;
+  finalize_after: string;
+  fronting_member_ids: string[];
+  fronting_member_names: string[];
+  status: PendingActionStatus;
+}
+
+export type SafetyChangeStatus = "pending" | "cancelled" | "completed";
+
+export interface SafetyChangeRequest {
+  id: string;
+  requested_at: string;
+  requested_by_user_id: string | null;
+  finalize_after: string;
+  changes: Record<string, unknown>;
+  status: SafetyChangeStatus;
+}
+
+// auth_tier is the historical `delete_confirmation` setting, repurposed
+// as the auth tier for all safeguarded destructive actions.
+export interface SystemSafetySettings {
+  grace_period_days: number;
+  auth_tier: DeleteConfirmation;
+  applies_to_members: boolean;
+  applies_to_groups: boolean;
+  applies_to_tags: boolean;
+  applies_to_fields: boolean;
+  applies_to_fronts: boolean;
+}
+
+export interface SystemSafetyUpdate {
+  grace_period_days?: number;
+  auth_tier?: DeleteConfirmation;
+  applies_to_members?: boolean;
+  applies_to_groups?: boolean;
+  applies_to_tags?: boolean;
+  applies_to_fields?: boolean;
+  applies_to_fronts?: boolean;
+  password?: string;
+  totp_code?: string;
+}
+
+export interface SystemSafetyResponse {
+  settings: SystemSafetySettings;
+  pending_actions: PendingAction[];
+  pending_changes: SafetyChangeRequest[];
+}
+
+export interface SystemSafetyUpdateResponse {
+  settings: SystemSafetySettings;
+  applied: string[];
+  deferred: string[];
+  pending_change: SafetyChangeRequest | null;
+}
+
+export interface DeleteQueued {
+  pending_action_id: string;
+  finalize_after: string;
+}
+
+export type DeleteResult = void | DeleteQueued;
+
+export function isDeleteQueued(r: DeleteResult): r is DeleteQueued {
+  return !!r && typeof (r as DeleteQueued).pending_action_id === "string";
+}
+
+export interface DestructiveConfirm {
+  password?: string;
+  totp_code?: string;
+}


### PR DESCRIPTION
## Summary
- Opt-in deletion grace periods on important data (members, groups, tags, custom fields, history), designed to 
- Pending actions trigger a notification banner and are viewable and cancellable any time during the grace period
- Once set, changes to loosen system safety settings themselves are also protected by the same grace period and cancellable action. Changes that tighten them are applied immediately.
- Reuses the existing `systems.delete_confirmation` column as the system-wide auth tier (comments added to flag the historical name).
- Added skippable prompt to setup 2FA and safety settings after account creation

## Testing
- [x] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Tested manually

