### PR TITLE
fix refresh token handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,8 +157,16 @@ REGISTRATION_MODE=open
 # Minutes between password reset requests for the same account (default: 15).
 # PASSWORD_RESET_RATE_LIMIT_MINUTES=15
 
-# Base URL for email links (verification, password reset).
-# Required when EMAIL_BACKEND is not "none".
+# Base URL for the instance — used for email links (verification, password
+# reset), as the JWT issuer claim, and to decide whether auth cookies should
+# carry the Secure flag.
+#
+# Required when EMAIL_BACKEND is not "none". Optional otherwise, but strongly
+# recommended: leave it unset and Sheaf assumes HTTPS and emits Secure cookies
+# (correct for production behind a TLS reverse proxy). Set it to an http://
+# URL to opt in to non-Secure cookies for plain-HTTP dev/LAN setups —
+# browsers silently drop Secure cookies on HTTP origins, which breaks
+# refresh-token rotation.
 # SHEAF_BASE_URL=https://sheaf.example.com
 
 # =============================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run test suite
-        run: ./run_tests.sh
+        run: ./run_tests.sh || ./run_tests.sh --no-build
 
   docker:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Sheaf
 
+[![CI](https://github.com/sheaf-project/sheaf/actions/workflows/ci.yml/badge.svg)](https://github.com/sheaf-project/sheaf/actions/workflows/ci.yml)
+![transrights](https://pride-badges.pony.workers.dev/static/v1?label=trans%20rights&stripeWidth=6&stripeColors=5BCEFA,F5A9B8,FFFFFF,F5A9B8,5BCEFA)
+![enbyware](https://pride-badges.pony.workers.dev/static/v1?label=enbyware&labelColor=%23555&stripeWidth=8&stripeColors=FCF434%2CFFFFFF%2C9C59D1%2C2C2C2C)
+![pluralmade](https://pride-badges.pony.workers.dev/static/v1?label=plural+made&labelColor=%23555&stripeWidth=8&stripeColors=2e0525%2C553578%2C7675c3%2C89c7b0%2Cf4ecbd)
+
 > *noun*: a bundle; in mathematics, a structure that describes how local pieces fit together into a coherent whole.
 
 Open-source plural system tracking. A self-hostable replacement for SimplyPlural, built with data security and sustainability in mind.
@@ -148,7 +153,7 @@ See **[docs/SELFHOSTING.md](docs/SELFHOSTING.md)** for the full guide covering:
 - File storage (filesystem / S3) with hotlink protection
 - Storage quotas and upload limits
 - Frontend build and serving
-- Reverse proxy setup (nginx, Caddy)
+- Reverse proxy setup (nginx, Caddy) and the `SHEAF_BASE_URL` / cookie-Secure relationship
 - Rate limiting and trusted proxies
 - Public test / demo mode (periodic non-admin wipe + warning banner)
 - Backups

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,6 +10,7 @@ services:
       REDIS_URL: redis://redis:6379/0
       JWT_SECRET_KEY: test-jwt-secret-not-for-production
       SHEAF_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      SHEAF_BASE_URL: "http://localhost:8001"
       SHEAF_MODE: "${SHEAF_MODE:-selfhosted}"
       ADMIN_AUTH_LEVEL: "${ADMIN_AUTH_LEVEL:-none}"
       REGISTRATION_MODE: open

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -218,7 +218,11 @@ INVITE_CODES_ENABLED=false
 # off (default) | required
 EMAIL_VERIFICATION=off
 
-# Required when email is enabled — used in verification/reset links
+# Public base URL of the instance — used for email links, the JWT issuer
+# claim, and to decide whether auth cookies carry the Secure flag. Required
+# when email is enabled; otherwise optional. Leave unset (or set to https://...)
+# in production. Set to an http:// URL only for plain-HTTP dev/LAN setups —
+# see "Reverse proxy / TLS" below.
 SHEAF_BASE_URL=https://sheaf.example.com
 ```
 
@@ -660,6 +664,20 @@ If you don't want uvicorn directly exposed on the network:
 ```env
 SHEAF_HOST=127.0.0.1
 ```
+
+### Cookie Secure flag and `SHEAF_BASE_URL`
+
+Auth cookies (`sheaf_session`, `sheaf_refresh`, trusted-device cookie) are marked `Secure` by default. Browsers silently drop Secure cookies on plain-HTTP origins, which breaks refresh-token rotation and login persistence.
+
+Sheaf decides based on `SHEAF_BASE_URL`:
+
+| `SHEAF_BASE_URL` | Cookie `Secure` flag | Use case |
+|---|---|---|
+| Unset / empty | **Set** | Production behind HTTPS reverse proxy (default) |
+| `https://...` | **Set** | Production with explicit base URL |
+| `http://...` | **Not set** | Plain-HTTP dev or trusted LAN only |
+
+If you serve the UI over plain HTTP (e.g. `http://sheaf.lan` for a home setup) and don't set `SHEAF_BASE_URL`, login appears to work but refresh fails the moment the access token expires. Either put TLS in front (recommended) or set `SHEAF_BASE_URL=http://your-host` to opt out of the Secure flag.
 
 ---
 

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -17,10 +17,12 @@ from sheaf.auth.dependencies import get_current_user, get_current_user_allow_unv
 from sheaf.auth.jwt import TokenType, create_token, decode_token
 from sheaf.auth.passwords import hash_password, needs_rehash, verify_password
 from sheaf.auth.sessions import (
+    cache_refresh_rotation,
     consume_refresh_jti,
     create_session,
     delete_other_sessions,
     delete_session,
+    get_cached_refresh_rotation,
     list_user_sessions,
     register_refresh_jti,
     rename_session,
@@ -1147,25 +1149,31 @@ async def refresh(
             detail="Invalid or expired refresh token",
         ) from exc
 
-    # Consume the old jti atomically. If it's already gone, either the token
-    # was used before (reuse — likely theft) or was never tracked (pre-
-    # rotation token). Treat both as invalid and kill the session: if it
-    # really was theft, we contain the blast radius; if it was a pre-
-    # rotation token, the user re-logs in once.
+    # Consume the old jti atomically. GETDEL ensures only one of N parallel
+    # callers wins; the rest see None. None means either (a) genuine reuse —
+    # likely theft, kill the session — or (b) a concurrent legitimate caller
+    # raced and lost (StrictMode double-fire, parallel queries on page load,
+    # multiple tabs). To distinguish, the winner caches its rotation result
+    # for a few seconds; losers within that window replay it instead of
+    # tripping the kill-session path. Outside the grace window, treat as
+    # reuse and burn the session.
     if jti is None or sid is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
         )
     consumed_sid = await consume_refresh_jti(jti)
+    replay_token: str | None = None
     if consumed_sid is None:
-        await delete_session(sid)
-        response.delete_cookie("sheaf_session")
-        response.delete_cookie("sheaf_refresh", path="/v1/auth")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired refresh token",
-        )
+        replay_token = await get_cached_refresh_rotation(jti)
+        if replay_token is None:
+            await delete_session(sid)
+            response.delete_cookie("sheaf_session")
+            response.delete_cookie("sheaf_refresh", path="/v1/auth")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired refresh token",
+            )
 
     # Verify the session still exists (may have been revoked out-of-band).
     from sheaf.auth.sessions import get_session_user_id
@@ -1178,7 +1186,11 @@ async def refresh(
             detail="Session revoked",
         )
 
-    new_refresh = await _mint_refresh_token(user_id, sid)
+    if replay_token is not None:
+        new_refresh = replay_token
+    else:
+        new_refresh = await _mint_refresh_token(user_id, sid)
+        await cache_refresh_rotation(jti, new_refresh)
     response.set_cookie(
         key="sheaf_refresh",
         value=new_refresh,

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -101,6 +101,16 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 logger = logging.getLogger("sheaf.auth")
 
 
+def _cookie_secure() -> bool:
+    """Whether to mark auth cookies as Secure.
+
+    Browsers silently drop Secure cookies on plain-HTTP origins, which would
+    break refresh-token rotation in HTTP dev setups. Default to Secure
+    (production-safe); only relax when sheaf_base_url is explicitly http://.
+    """
+    return not settings.sheaf_base_url.startswith("http://")
+
+
 @router.get("/config")
 async def get_auth_config():
     """Public endpoint returning registration settings for the login UI."""
@@ -375,7 +385,7 @@ async def register(
         key="sheaf_session",
         value=session_id,
         httponly=True,
-        secure=True,
+        secure=_cookie_secure(),
         samesite="lax",
     )
 
@@ -384,7 +394,7 @@ async def register(
         key="sheaf_refresh",
         value=refresh_token,
         httponly=True,
-        secure=True,
+        secure=_cookie_secure(),
         samesite="lax",
         max_age=settings.jwt_refresh_token_expire_days * 86400,
         path="/v1/auth",
@@ -831,7 +841,7 @@ async def login(
         key="sheaf_session",
         value=session_id,
         httponly=True,
-        secure=True,
+        secure=_cookie_secure(),
         samesite="lax",
     )
 
@@ -840,7 +850,7 @@ async def login(
         key="sheaf_refresh",
         value=refresh_token,
         httponly=True,
-        secure=True,
+        secure=_cookie_secure(),
         samesite="lax",
         max_age=settings.jwt_refresh_token_expire_days * 86400,
         path="/v1/auth",
@@ -865,7 +875,7 @@ async def login(
             key=TRUSTED_DEVICE_COOKIE,
             value=device_token,
             httponly=True,
-            secure=True,
+            secure=_cookie_secure(),
             samesite="lax",
             max_age=TRUSTED_DEVICE_TTL_DAYS * 86400,
             path="/v1/auth",
@@ -1173,7 +1183,7 @@ async def refresh(
         key="sheaf_refresh",
         value=new_refresh,
         httponly=True,
-        secure=True,
+        secure=_cookie_secure(),
         samesite="lax",
         max_age=settings.jwt_refresh_token_expire_days * 86400,
         path="/v1/auth",

--- a/sheaf/auth/sessions.py
+++ b/sheaf/auth/sessions.py
@@ -210,6 +210,18 @@ def _refresh_jti_key(jti: str) -> str:
     return f"sheaf:refresh:{jti}"
 
 
+def _refresh_rotation_key(jti: str) -> str:
+    return f"sheaf:refresh:rotation:{jti}"
+
+
+# Window during which a just-rotated refresh token can be replayed by a
+# concurrent caller that raced with the winner. Has to cover client-side
+# parallelism (StrictMode double-fire, multiple tabs, parallel queries on
+# page load) but stay short enough that real reuse-after-theft still trips
+# the kill-session path.
+REFRESH_ROTATION_GRACE_SECONDS = 10
+
+
 async def register_refresh_jti(jti: str, session_id: str, ttl_seconds: int) -> None:
     """Record a minted refresh token's jti so we can detect later reuse."""
     r = await get_redis()
@@ -226,10 +238,27 @@ async def consume_refresh_jti(jti: str) -> str | None:
     return await r.getdel(_refresh_jti_key(jti))
 
 
+async def cache_refresh_rotation(jti: str, new_refresh_token: str) -> None:
+    """After a successful rotation, cache the freshly-minted refresh token
+    keyed by the *old* jti for a brief grace window. A concurrent caller that
+    raced and lost the GETDEL can pick up this entry and replay the rotation
+    instead of getting the session nuked as suspected reuse."""
+    r = await get_redis()
+    await r.setex(_refresh_rotation_key(jti), REFRESH_ROTATION_GRACE_SECONDS, new_refresh_token)
+
+
+async def get_cached_refresh_rotation(jti: str) -> str | None:
+    """Return the cached new refresh token for a recently-consumed jti, or
+    None if the grace window has expired or no rotation was cached."""
+    r = await get_redis()
+    return await r.get(_refresh_rotation_key(jti))
+
+
 async def revoke_refresh_jti(jti: str) -> None:
     """Best-effort revoke of a refresh jti (e.g. on logout)."""
     r = await get_redis()
     await r.delete(_refresh_jti_key(jti))
+    await r.delete(_refresh_rotation_key(jti))
 
 
 # ---------------------------------------------------------------------------

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -144,7 +144,11 @@ class Settings(BaseSettings):
     invite_codes_enabled: bool = False  # Accept invite codes in open/approval modes too
     email_verification: str = "off"  # "off" or "required"
     password_reset_rate_limit_minutes: int = 15
-    sheaf_base_url: str = ""  # Required when email is enabled, e.g. "https://sheaf.example.com"
+    # Public base URL of the instance. Required when email is enabled (used in
+    # verification/reset links); also seeds the JWT issuer claim and decides
+    # whether auth cookies carry the Secure flag. Empty = assume HTTPS (Secure).
+    # An explicit http:// URL opts in to non-Secure cookies for plain-HTTP dev.
+    sheaf_base_url: str = ""
 
     # Admin dashboard step-up authentication level.
     # "none"     — any admin can access the dashboard immediately.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 
 import httpx
@@ -67,6 +68,35 @@ def test_refresh_token(client: httpx.Client):
     resp = client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
     assert resp.status_code == 200
     assert "access_token" in resp.json()
+
+
+def test_refresh_token_via_cookie(client: httpx.Client):
+    """Frontend pattern: POST /refresh with empty body, refresh JWT comes from
+    the HttpOnly cookie set on register/login. Browsers will silently drop a
+    Secure cookie sent over HTTP, so we also assert the cookie's Secure flag
+    matches the server's base URL scheme — otherwise dev-over-HTTP refresh
+    breaks the moment the access token expires."""
+    email = f"refresh-cookie-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post("/v1/auth/register", json={"email": email, "password": "securepassword"})
+    assert resp.status_code == 201
+    refresh_header = next(
+        (h for h in resp.headers.get_list("set-cookie") if h.startswith("sheaf_refresh=")),
+        "",
+    )
+    assert refresh_header, "register must set sheaf_refresh cookie"
+    base_url = os.environ.get("SHEAF_TEST_URL", "http://localhost:8000")
+    if base_url.startswith("http://"):
+        assert "Secure" not in refresh_header, (
+            "cookie must NOT be Secure when serving over HTTP — "
+            "browsers drop it and refresh silently breaks"
+        )
+    else:
+        assert "Secure" in refresh_header
+
+    assert client.cookies.get("sheaf_refresh"), "client should have stored sheaf_refresh"
+    cookie_resp = client.post("/v1/auth/refresh", json={})
+    assert cookie_resp.status_code == 200, cookie_resp.text
+    assert "access_token" in cookie_resp.json()
 
 
 def _register_and_login(client: httpx.Client, email: str, password: str) -> str:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -99,6 +99,36 @@ def test_refresh_token_via_cookie(client: httpx.Client):
     assert "access_token" in cookie_resp.json()
 
 
+def test_refresh_concurrent_replay_does_not_kill_session(client: httpx.Client):
+    """Two callers race to /refresh with the same refresh token (StrictMode
+    double-fire, parallel queries on page load, two tabs reloading at once).
+    Only one wins the GETDEL; the other historically tripped reuse-detection
+    and the session was nuked. The grace-window cache lets the loser replay
+    the same rotation result instead.
+    """
+    email = f"refresh-replay-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post("/v1/auth/register", json={"email": email, "password": "securepassword"})
+    assert resp.status_code == 201
+    original_refresh_jwt = resp.json()["refresh_token"]
+
+    # Winner consumes the jti and gets a new refresh.
+    r1 = client.post("/v1/auth/refresh", json={"refresh_token": original_refresh_jwt})
+    assert r1.status_code == 200, r1.text
+
+    # Loser arrives with the *same* original token — within the grace window
+    # this should replay rather than trigger session-kill.
+    r2 = client.post("/v1/auth/refresh", json={"refresh_token": original_refresh_jwt})
+    assert r2.status_code == 200, (
+        f"Concurrent /refresh duplicate should replay within the grace window, "
+        f"got {r2.status_code}: {r2.text}"
+    )
+
+    # Session must still be usable: hit /me with the winner's access token.
+    access = r1.json()["access_token"]
+    me = client.get("/v1/auth/me", headers={"Authorization": f"Bearer {access}"})
+    assert me.status_code == 200, me.text
+
+
 def _register_and_login(client: httpx.Client, email: str, password: str) -> str:
     """Register a user and log in via cookie session. Returns access token."""
     r = client.post("/v1/auth/register", json={"email": email, "password": password})

--- a/web/src/contexts/auth-context.tsx
+++ b/web/src/contexts/auth-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useEffect, useState } from "react";
 import type { User } from "@/types/api";
-import { setAccessToken } from "@/lib/api-client";
+import { bootstrapAuth, setAccessToken } from "@/lib/api-client";
 import * as authApi from "@/lib/auth";
 
 interface AuthState {
@@ -30,18 +30,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Try silent refresh on mount using HttpOnly cookie
+  // Try silent refresh on mount using HttpOnly cookie. Routes through the
+  // shared single-flight in api-client so StrictMode's double-fire (and any
+  // other parallel callers — e.g. queries that mount with the provider)
+  // share one /v1/auth/refresh round-trip instead of racing to consume the
+  // same one-shot jti.
   useEffect(() => {
-    fetch("/v1/auth/refresh", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-      credentials: "same-origin",
-    })
-      .then(async (resp) => {
-        if (!resp.ok) throw new Error("refresh failed");
-        const data = await resp.json();
-        setAccessToken(data.access_token);
+    bootstrapAuth()
+      .then(async (token) => {
+        if (!token) {
+          setAccessToken(null);
+          return;
+        }
         const me = await authApi.getMe();
         setUser(me);
       })

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -12,6 +12,24 @@ export function getAccessToken(): string | null {
 }
 
 /**
+ * Run the silent-refresh on app boot through the same single-flight that
+ * apiFetch uses for 401-retry. Without this, StrictMode double-firing the
+ * mount effect (or any other parallel-on-mount path) would send two
+ * /v1/auth/refresh requests with the same cookie — the loser of the
+ * server-side GETDEL would historically be treated as reuse and kill the
+ * session. The backend now has a grace window for that, but deduping on
+ * the client too keeps the cookie rotation tidy.
+ */
+export async function bootstrapAuth(): Promise<string | null> {
+  if (!refreshPromise) {
+    refreshPromise = refreshAccessToken();
+  }
+  const token = await refreshPromise;
+  refreshPromise = null;
+  return token;
+}
+
+/**
  * Refresh the access token using the HttpOnly refresh cookie.
  * The cookie is sent automatically by the browser — no localStorage involved.
  */


### PR DESCRIPTION
## Summary

Fixes 2 different bugs related to refresh tokens

## Changes

<!-- Bullet list of the main changes -->

- Do not set `Secure=true` on auth cookies if app is known to be served over plain HTTP. Only relevant to localdev.
- After refresh token is rotated, cache old jti for 10 seconds (may tune threshold in future) to catch double-reload (performed by web UI with StrictMode, also resulted in session invalidation when e.g. reloading multiple tabs or restoring a browser session
  - May increase from 10s later if needed

## Testing

- [x] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Tested manually
