### PR TITLE
Add per-device companion sessions for paired wearables

### DIFF
--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -53,6 +53,8 @@ from sheaf.models.trusted_device import TrustedDevice
 from sheaf.models.user import AccountStatus, User
 from sheaf.request import client_ip
 from sheaf.schemas.user import (
+    SecondarySessionRequest,
+    SecondarySessionResponse,
     TokenRefresh,
     TokenResponse,
     TOTPSetupResponse,
@@ -1001,6 +1003,62 @@ async def revoke_other_sessions(
         )
     revoked = await delete_other_sessions(user.id, session_id)
     return {"revoked": revoked}
+
+
+@router.post(
+    "/sessions/secondary",
+    response_model=SecondarySessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[rate_limit(10, 3600, "user", fail_closed=True)],
+)
+async def create_secondary_session(
+    request: Request,
+    body: SecondarySessionRequest | None = None,
+    user: User = Depends(get_current_user),
+):
+    """Mint a child session + refresh token for a paired companion device.
+
+    Use case: an iOS app pairing a watchOS app. Both devices used to share
+    one refresh token, which serialised them through the one-shot rotation
+    and made the watch's offline-then-refresh path collide with the phone's.
+    The phone now calls this endpoint after login and ships the returned
+    tokens to the watch via WatchConnectivity, so each device rotates
+    independently.
+
+    The new session is registered as a child of the caller's session: when
+    the parent is revoked (logout, /sessions DELETE, change-password) the
+    child is cascaded automatically, matching the user expectation that
+    "kicking out my phone also kicks out its watch."
+    """
+    parent_sid = getattr(request.state, "session_id", None)
+    if not parent_sid:
+        # API-key callers don't have a session, and minting a child without
+        # a parent would defeat the cascade contract.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A session-bound caller is required to mint a secondary session",
+        )
+
+    client_name = (body.client_name if body and body.client_name else None) or (
+        request.headers.get("x-sheaf-client")
+    )
+
+    child_sid = await create_session(
+        user.id,
+        ip=client_ip(request),
+        user_agent=request.headers.get("user-agent", ""),
+        client_header=client_name,
+        parent_session_id=parent_sid,
+    )
+
+    refresh_token = await _mint_refresh_token(user.id, child_sid)
+    access_token = create_token(user.id, TokenType.ACCESS, session_id=child_sid)
+
+    return SecondarySessionResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        session_id=child_sid,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/sheaf/auth/sessions.py
+++ b/sheaf/auth/sessions.py
@@ -25,6 +25,13 @@ def _user_sessions_key(user_id: uuid.UUID) -> str:
     return f"sheaf:user_sessions:{user_id}"
 
 
+def _session_children_key(parent_session_id: str) -> str:
+    """Set of child session ids spawned from a parent (e.g. a watch
+    companion session minted by a phone session). Used to cascade
+    revocation when the parent is deleted."""
+    return f"sheaf:session_children:{parent_session_id}"
+
+
 def _parse_client_name(user_agent: str, client_header: str | None = None) -> str:
     """Extract a friendly client name from headers.
 
@@ -61,8 +68,14 @@ async def create_session(
     ip: str | None = None,
     user_agent: str = "",
     client_header: str | None = None,
+    parent_session_id: str | None = None,
 ) -> str:
-    """Create a new session with metadata, return the session ID."""
+    """Create a new session with metadata, return the session ID.
+
+    If `parent_session_id` is given, the new session is registered as a child
+    of the parent so deleting the parent cascades to this session too. Used
+    for companion/wearable sessions minted from a primary device.
+    """
     r = await get_redis()
     session_id = secrets.token_urlsafe(32)
     now = datetime.now(UTC).isoformat()
@@ -70,22 +83,28 @@ async def create_session(
 
     ttl = settings.session_expire_hours * 3600
 
+    mapping = {
+        "user_id": str(user_id),
+        "created_at": now,
+        "created_ip": ip or "",
+        "last_active_at": now,
+        "last_active_ip": ip or "",
+        "user_agent": user_agent,
+        "client_name": client_name,
+        "nickname": "",
+    }
+    if parent_session_id:
+        mapping["parent_session_id"] = parent_session_id
+
     pipe = r.pipeline()
-    pipe.hset(
-        _session_key(session_id),
-        mapping={
-            "user_id": str(user_id),
-            "created_at": now,
-            "created_ip": ip or "",
-            "last_active_at": now,
-            "last_active_ip": ip or "",
-            "user_agent": user_agent,
-            "client_name": client_name,
-            "nickname": "",
-        },
-    )
+    pipe.hset(_session_key(session_id), mapping=mapping)
     pipe.expire(_session_key(session_id), ttl)
     pipe.sadd(_user_sessions_key(user_id), session_id)
+    if parent_session_id:
+        pipe.sadd(_session_children_key(parent_session_id), session_id)
+        # Children-set TTL tracks the longest-lived child; bump it on each
+        # add so it doesn't expire while a child is still alive.
+        pipe.expire(_session_children_key(parent_session_id), ttl)
     await pipe.execute()
 
     return session_id
@@ -147,10 +166,26 @@ async def list_user_sessions(user_id: uuid.UUID) -> list[dict]:
 
 
 async def delete_session(session_id: str) -> None:
-    """Delete a session and remove it from the user's session set."""
+    """Delete a session and any child sessions linked to it.
+
+    Children come from `create_session(parent_session_id=...)` — a phone
+    minting a watch companion session, etc. Cascading here means revoking
+    a primary session (logout, /sessions DELETE) also kills the wearable
+    bound to it, so the watch can't keep refreshing after the user has
+    explicitly killed the parent.
+    """
     r = await get_redis()
     # Get user_id before deleting so we can clean the set
     user_id_str = await r.hget(_session_key(session_id), "user_id")
+
+    # Cascade to children first so a partial failure leaves orphans rather
+    # than zombies that look like live sessions.
+    children_key = _session_children_key(session_id)
+    child_ids = await r.smembers(children_key)
+    for child_sid in child_ids:
+        await delete_session(child_sid)
+    await r.delete(children_key)
+
     await r.delete(_session_key(session_id))
     if user_id_str:
         await r.srem(_user_sessions_key(uuid.UUID(user_id_str)), session_id)
@@ -159,17 +194,27 @@ async def delete_session(session_id: str) -> None:
 async def delete_other_sessions(
     user_id: uuid.UUID, keep_session_id: str,
 ) -> int:
-    """Revoke all sessions for a user except the given one. Returns count revoked."""
+    """Revoke all sessions for a user except the given one. Returns count revoked.
+
+    A child session of the kept session also stays alive — useful for
+    change-password from a phone, where the user almost certainly wants
+    their paired watch to keep working without re-pairing.
+    """
     r = await get_redis()
     set_key = _user_sessions_key(user_id)
     session_ids = await r.smembers(set_key)
 
+    keep_children = await r.smembers(_session_children_key(keep_session_id))
+    keep_set = {keep_session_id, *keep_children}
+
     revoked = 0
     for sid in session_ids:
-        if sid == keep_session_id:
+        if sid in keep_set:
             continue
-        await r.delete(_session_key(sid))
-        await r.srem(set_key, sid)
+        # Use delete_session so any *other* parent's children also cascade —
+        # e.g. a stale phone session being revoked here pulls its watch with
+        # it instead of stranding the watch session as an orphan.
+        await delete_session(sid)
         revoked += 1
 
     return revoked
@@ -187,6 +232,7 @@ async def delete_all_user_sessions(user_id: uuid.UUID) -> int:
     pipe = r.pipeline()
     for sid in session_ids:
         pipe.delete(_session_key(sid))
+        pipe.delete(_session_children_key(sid))
     pipe.delete(set_key)
     await pipe.execute()
 

--- a/sheaf/schemas/user.py
+++ b/sheaf/schemas/user.py
@@ -26,6 +26,23 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
+class SecondarySessionResponse(TokenResponse):
+    """Tokens plus the session id, so the caller (typically a phone minting
+    a wearable companion session) can track the child for later management."""
+
+    session_id: str
+
+
+class SecondarySessionRequest(BaseModel):
+    """Optional metadata for a wearable/companion session.
+
+    `client_name` mirrors the X-Sheaf-Client header semantics — it's what
+    surfaces in /sessions UI as the device label.
+    """
+
+    client_name: str | None = None
+
+
 class TokenRefresh(BaseModel):
     refresh_token: str | None = None
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -129,6 +129,205 @@ def test_refresh_concurrent_replay_does_not_kill_session(client: httpx.Client):
     assert me.status_code == 200, me.text
 
 
+def test_secondary_session_mints_independent_session(client: httpx.Client):
+    """A primary device (phone) can mint a child session for a paired
+    companion (watch). Both sessions exist concurrently in /sessions and
+    each holds its own one-shot refresh token, so the two devices can
+    rotate independently without colliding through the GETDEL serialisation
+    that previously made shared tokens fragile across the WCSession sync."""
+    email = f"secondary-mint-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register", json={"email": email, "password": "securepassword"},
+    )
+    assert resp.status_code == 201, resp.text
+    primary_access = resp.json()["access_token"]
+    primary_refresh = resp.json()["refresh_token"]
+
+    secondary_resp = client.post(
+        "/v1/auth/sessions/secondary",
+        headers={
+            "Authorization": f"Bearer {primary_access}",
+            "X-Sheaf-Client": "Sheaf watchOS/1.0",
+        },
+        json={"client_name": "Sheaf watchOS/1.0"},
+    )
+    assert secondary_resp.status_code == 201, secondary_resp.text
+    body = secondary_resp.json()
+    assert body["access_token"] and body["refresh_token"]
+    assert body["session_id"]
+    watch_access = body["access_token"]
+    watch_refresh = body["refresh_token"]
+
+    # Both sessions show up in /sessions, distinct ids.
+    list_resp = client.get(
+        "/v1/auth/sessions",
+        headers={"Authorization": f"Bearer {primary_access}"},
+    )
+    assert list_resp.status_code == 200, list_resp.text
+    ids = {s["id"] for s in list_resp.json()}
+    assert body["session_id"] in ids
+    assert len(ids) >= 2
+
+    # Watch's refresh works — independent jti, doesn't touch primary's.
+    r_watch = client.post(
+        "/v1/auth/refresh", json={"refresh_token": watch_refresh},
+    )
+    assert r_watch.status_code == 200, r_watch.text
+
+    # Primary's refresh ALSO still works — was never consumed by the watch.
+    r_phone = client.post(
+        "/v1/auth/refresh", json={"refresh_token": primary_refresh},
+    )
+    assert r_phone.status_code == 200, r_phone.text
+
+
+def test_secondary_session_cascade_on_parent_logout(client: httpx.Client):
+    """Revoking the parent session must take its child sessions with it.
+    Cascade lives server-side so it fires whether the user logs out from
+    the phone, deletes the phone session from a browser, or anywhere else
+    — the phone doesn't have to remember the watch sid to do the cleanup
+    itself."""
+    email = f"secondary-cascade-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register", json={"email": email, "password": "securepassword"},
+    )
+    primary_access = resp.json()["access_token"]
+
+    secondary_resp = client.post(
+        "/v1/auth/sessions/secondary",
+        headers={"Authorization": f"Bearer {primary_access}"},
+        json={"client_name": "Sheaf watchOS/1.0"},
+    )
+    assert secondary_resp.status_code == 201, secondary_resp.text
+    watch_access = secondary_resp.json()["access_token"]
+    watch_refresh = secondary_resp.json()["refresh_token"]
+
+    # Watch can hit /me before the cascade.
+    me = client.get(
+        "/v1/auth/me", headers={"Authorization": f"Bearer {watch_access}"},
+    )
+    assert me.status_code == 200
+
+    # Logging out the phone should cascade-kill the watch's session too.
+    logout = client.post(
+        "/v1/auth/logout",
+        headers={"Authorization": f"Bearer {primary_access}"},
+    )
+    assert logout.status_code == 204
+
+    # Watch access token is now bound to a dead session.
+    me_after = client.get(
+        "/v1/auth/me", headers={"Authorization": f"Bearer {watch_access}"},
+    )
+    assert me_after.status_code == 401
+
+    # And the watch's refresh token can't resurrect the session either.
+    refresh_after = client.post(
+        "/v1/auth/refresh", json={"refresh_token": watch_refresh},
+    )
+    assert refresh_after.status_code == 401
+
+
+def test_secondary_session_can_be_revoked_alone(client: httpx.Client):
+    """Killing only the watch session must leave the phone alive — the user
+    revoking a wearable from /sessions shouldn't get logged out of the
+    primary device."""
+    email = f"secondary-solo-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register", json={"email": email, "password": "securepassword"},
+    )
+    primary_access = resp.json()["access_token"]
+
+    secondary_resp = client.post(
+        "/v1/auth/sessions/secondary",
+        headers={"Authorization": f"Bearer {primary_access}"},
+        json={"client_name": "Sheaf watchOS/1.0"},
+    )
+    watch_sid = secondary_resp.json()["session_id"]
+    watch_access = secondary_resp.json()["access_token"]
+
+    revoke = client.delete(
+        f"/v1/auth/sessions/{watch_sid}",
+        headers={"Authorization": f"Bearer {primary_access}"},
+    )
+    assert revoke.status_code == 204, revoke.text
+
+    # Watch is dead.
+    me_watch = client.get(
+        "/v1/auth/me", headers={"Authorization": f"Bearer {watch_access}"},
+    )
+    assert me_watch.status_code == 401
+
+    # Phone is still alive.
+    me_phone = client.get(
+        "/v1/auth/me", headers={"Authorization": f"Bearer {primary_access}"},
+    )
+    assert me_phone.status_code == 200
+
+
+def test_secondary_session_change_password_keeps_paired_watch(
+    client: httpx.Client,
+):
+    """change-password runs delete_other_sessions, which would naively kill
+    the watch (it's "another session"). The whole point of the parent/child
+    link is that the watch is a *companion* of the calling phone — keep it
+    alive across the calling session's password change so the user doesn't
+    have to re-pair the watch every time they rotate their password."""
+    email = f"secondary-chpw-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register", json={"email": email, "password": "originalpass1"},
+    )
+    primary_access = resp.json()["access_token"]
+
+    secondary_resp = client.post(
+        "/v1/auth/sessions/secondary",
+        headers={"Authorization": f"Bearer {primary_access}"},
+        json={"client_name": "Sheaf watchOS/1.0"},
+    )
+    assert secondary_resp.status_code == 201, secondary_resp.text
+    watch_access = secondary_resp.json()["access_token"]
+
+    # Need the session cookie for change-password to identify "this session".
+    login = client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": "originalpass1"},
+    )
+    assert login.status_code == 200
+    login_access = login.json()["access_token"]
+
+    # Mint a watch session bound to the *cookie* session (which is the one
+    # that will run change-password).
+    secondary_via_cookie = client.post(
+        "/v1/auth/sessions/secondary",
+        headers={"Authorization": f"Bearer {login_access}"},
+        json={"client_name": "Sheaf watchOS/1.0"},
+    )
+    assert secondary_via_cookie.status_code == 201
+    cookie_watch_access = secondary_via_cookie.json()["access_token"]
+
+    chpw = client.post(
+        "/v1/auth/change-password",
+        headers={"Authorization": f"Bearer {login_access}"},
+        json={
+            "current_password": "originalpass1",
+            "new_password": "freshpass2",
+        },
+    )
+    assert chpw.status_code == 200, chpw.text
+
+    # Watch paired with the calling session survives.
+    me_keep = client.get(
+        "/v1/auth/me", headers={"Authorization": f"Bearer {cookie_watch_access}"},
+    )
+    assert me_keep.status_code == 200, me_keep.text
+
+    # Watch paired with the *other* (now-revoked) session does not.
+    me_gone = client.get(
+        "/v1/auth/me", headers={"Authorization": f"Bearer {watch_access}"},
+    )
+    assert me_gone.status_code == 401
+
+
 def _register_and_login(client: httpx.Client, email: str, password: str) -> str:
     """Register a user and log in via cookie session. Returns access token."""
     r = client.post("/v1/auth/register", json={"email": email, "password": password})


### PR DESCRIPTION
## Summary
A phone and its watch were sharing one refresh token via WatchConnectivity + iCloud Keychain. After the [one-shot refresh-rotation hardening](https://github.com/sheaf-project/sheaf/pull/8), whichever device refreshed second outside the 10s window tripped reuse-detection and the session was terminated, logging out both devices.

Adds endpoint to create a child session, so revoking the parent (logout, /sessions DELETE, change-password, etc) cascades to the child automatically - the user expectation is that kicking the phone off also kicks its watch off.

## Changes

<!-- Bullet list of the main changes -->

-Add `POST /v1/auth/sessions/secondary`: mints a secondary session + refresh JWT for the companion device, returns access_token / refresh_token / session_id.
- create_session learns a parent_session_id parameter; delete_session cascades to children before deleting the parent. delete_other_sessions preserves the calling session's children, so changing your password from the phone doesn't force you to re-pair the watch afterwards.
- Tests: independent rotation of phone vs watch tokens, cascade revoke on parent logout, independent revocation of the child, and the change-password "keep my watch" carve-out.
- Sessions live in Redis only — no DB migration needed.

## Testing

<!-- How was this tested? -->

- [x] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Tested manually

https://github.com/sheaf-project/ios/pull/5
