### PR TITLE
Encrypt member name/description, journal/revision content, and custom fields

### DIFF
--- a/alembic/versions/o5p6q7r8s9t0_encrypt_member_and_journal_content.py
+++ b/alembic/versions/o5p6q7r8s9t0_encrypt_member_and_journal_content.py
@@ -1,0 +1,248 @@
+"""Encrypt member name/description, journal/revision title+body,
+custom_field_values.value, and add Member.name_hash blind index.
+
+Revision ID: o5p6q7r8s9t0
+Revises: n4o5p6q7r8s9
+Create Date: 2026-04-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "o5p6q7r8s9t0"
+down_revision: Union[str, None] = "n4o5p6q7r8s9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Encrypt sensitive content + add Member.name_hash blind index.
+
+    Runs in a single transaction inside the app container, where
+    SHEAF_ENCRYPTION_KEY is loaded — so we can call sheaf.crypto directly
+    against existing rows. If anything fails, the whole migration rolls back.
+
+    Length expansion: ciphertext is base64(nonce + ct + tag) which is roughly
+    4/3 the binary size, so a 100-char plaintext name becomes ~165 chars of
+    ciphertext. We relax the SQLAlchemy column types to unbounded String, so
+    existing tables only need their length constraint dropped where one was
+    declared. Postgres VARCHAR(N) → VARCHAR is a no-op for stored data.
+    """
+    import json
+
+    from sheaf.crypto import blind_index, encrypt
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # ---- Schema changes ---------------------------------------------------
+
+    # Drop length constraints on encrypted columns (ciphertext is longer than
+    # the plaintext bound). Postgres handles VARCHAR(N) → VARCHAR in place.
+    op.alter_column("members", "name", type_=sa.String(), existing_nullable=False)
+    op.alter_column("members", "description", type_=sa.Text(), existing_nullable=True)
+    op.alter_column("journal_entries", "title", type_=sa.String(), existing_nullable=True)
+    op.alter_column("content_revisions", "title", type_=sa.String(), existing_nullable=True)
+
+    # Add Member.name_hash. server_default empty string for the nullable=False
+    # constraint to take while we backfill below.
+    members_cols = {c["name"] for c in inspector.get_columns("members")}
+    if "name_hash" not in members_cols:
+        op.add_column(
+            "members",
+            sa.Column(
+                "name_hash",
+                sa.String(64),
+                nullable=False,
+                server_default="",
+            ),
+        )
+        op.create_index("ix_members_name_hash", "members", ["name_hash"])
+
+    # ---- Backfill ---------------------------------------------------------
+
+    # Members: encrypt name + description, populate name_hash. Skip rows whose
+    # `name` already looks like our base64 ciphertext (idempotent re-runs).
+    rows = bind.execute(
+        sa.text("SELECT id, name, description FROM members")
+    ).fetchall()
+    for row in rows:
+        # Detection heuristic: ciphertext starts with base64-url chars and is
+        # >= 32 chars (24-byte nonce alone is 32 base64 chars). Plaintext names
+        # are bounded at 100 chars and may match base64 by accident, so also
+        # try to decrypt — if it succeeds we treat the row as already migrated.
+        if _looks_like_ciphertext(row.name):
+            continue
+        new_name = encrypt(row.name)
+        new_hash = blind_index(row.name)
+        new_description = (
+            encrypt(row.description) if row.description is not None else None
+        )
+        bind.execute(
+            sa.text(
+                "UPDATE members SET name = :n, name_hash = :h, "
+                "description = :d WHERE id = :id"
+            ),
+            {
+                "n": new_name,
+                "h": new_hash,
+                "d": new_description,
+                "id": row.id,
+            },
+        )
+
+    # Journal entries: encrypt title + body.
+    je_rows = bind.execute(
+        sa.text("SELECT id, title, body FROM journal_entries")
+    ).fetchall()
+    for row in je_rows:
+        if _looks_like_ciphertext(row.body):
+            continue
+        new_title = encrypt(row.title) if row.title is not None else None
+        new_body = encrypt(row.body) if row.body else encrypt("")
+        bind.execute(
+            sa.text(
+                "UPDATE journal_entries SET title = :t, body = :b WHERE id = :id"
+            ),
+            {"t": new_title, "b": new_body, "id": row.id},
+        )
+
+    # Content revisions: encrypt title + body.
+    cr_rows = bind.execute(
+        sa.text("SELECT id, title, body FROM content_revisions")
+    ).fetchall()
+    for row in cr_rows:
+        if _looks_like_ciphertext(row.body):
+            continue
+        new_title = encrypt(row.title) if row.title is not None else None
+        new_body = encrypt(row.body) if row.body else encrypt("")
+        bind.execute(
+            sa.text(
+                "UPDATE content_revisions SET title = :t, body = :b WHERE id = :id"
+            ),
+            {"t": new_title, "b": new_body, "id": row.id},
+        )
+
+    # Custom field values: encrypt the JSON-serialised plaintext into a JSON
+    # string at the JSONB column. After: column holds a JSON string whose
+    # value is the ciphertext token; before: any JSON shape.
+    cfv_rows = bind.execute(
+        sa.text("SELECT id, value FROM custom_field_values")
+    ).fetchall()
+    for row in cfv_rows:
+        if row.value is None:
+            continue
+        # Already-encrypted rows are stored as a JSON string (ciphertext).
+        if isinstance(row.value, str) and _looks_like_ciphertext(row.value):
+            continue
+        new_value = encrypt(json.dumps(row.value))
+        bind.execute(
+            sa.text("UPDATE custom_field_values SET value = :v WHERE id = :id"),
+            {"v": json.dumps(new_value), "id": row.id},
+        )
+
+
+def downgrade() -> None:
+    """Reverse: decrypt back to plaintext, drop name_hash.
+
+    Same caveat as upgrade — must run in the app container with the same
+    encryption key that wrote the ciphertexts. Rolls back length constraints
+    to their pre-encryption bounds.
+    """
+    import json
+
+    from sheaf.crypto import decrypt
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Decrypt members.name + description.
+    rows = bind.execute(
+        sa.text("SELECT id, name, description FROM members")
+    ).fetchall()
+    for row in rows:
+        plain_name = decrypt(row.name)[:100]
+        plain_description = (
+            decrypt(row.description) if row.description is not None else None
+        )
+        bind.execute(
+            sa.text("UPDATE members SET name = :n, description = :d WHERE id = :id"),
+            {"n": plain_name, "d": plain_description, "id": row.id},
+        )
+
+    # Decrypt journal_entries title + body.
+    je_rows = bind.execute(
+        sa.text("SELECT id, title, body FROM journal_entries")
+    ).fetchall()
+    for row in je_rows:
+        plain_title = decrypt(row.title)[:200] if row.title is not None else None
+        plain_body = decrypt(row.body) if row.body else ""
+        bind.execute(
+            sa.text(
+                "UPDATE journal_entries SET title = :t, body = :b WHERE id = :id"
+            ),
+            {"t": plain_title, "b": plain_body, "id": row.id},
+        )
+
+    # Decrypt content_revisions title + body.
+    cr_rows = bind.execute(
+        sa.text("SELECT id, title, body FROM content_revisions")
+    ).fetchall()
+    for row in cr_rows:
+        plain_title = decrypt(row.title)[:200] if row.title is not None else None
+        plain_body = decrypt(row.body) if row.body else ""
+        bind.execute(
+            sa.text(
+                "UPDATE content_revisions SET title = :t, body = :b WHERE id = :id"
+            ),
+            {"t": plain_title, "b": plain_body, "id": row.id},
+        )
+
+    # Decrypt custom_field_values.value back into JSONB.
+    cfv_rows = bind.execute(
+        sa.text("SELECT id, value FROM custom_field_values")
+    ).fetchall()
+    for row in cfv_rows:
+        if row.value is None:
+            continue
+        if not isinstance(row.value, str):
+            continue
+        plain = json.loads(decrypt(row.value))
+        bind.execute(
+            sa.text("UPDATE custom_field_values SET value = :v WHERE id = :id"),
+            {"v": json.dumps(plain), "id": row.id},
+        )
+
+    # Drop the blind-index column + index.
+    members_cols = {c["name"] for c in inspector.get_columns("members")}
+    if "name_hash" in members_cols:
+        op.drop_index("ix_members_name_hash", table_name="members")
+        op.drop_column("members", "name_hash")
+
+    # Restore length constraints.
+    op.alter_column("members", "name", type_=sa.String(100), existing_nullable=False)
+    op.alter_column(
+        "journal_entries", "title", type_=sa.String(200), existing_nullable=True
+    )
+    op.alter_column(
+        "content_revisions", "title", type_=sa.String(200), existing_nullable=True
+    )
+
+
+def _looks_like_ciphertext(value: str | None) -> bool:
+    """Heuristic: try to decrypt. If it succeeds the row is already migrated.
+
+    Plaintext that happens to be valid base64 will still fail at the libsodium
+    AEAD verification step, so a successful decrypt is a strong signal.
+    """
+    if not value or not isinstance(value, str):
+        return False
+    from sheaf.crypto import decrypt
+
+    try:
+        decrypt(value)
+        return True
+    except Exception:
+        return False

--- a/sheaf/api/v1/custom_fields.py
+++ b/sheaf/api/v1/custom_fields.py
@@ -20,11 +20,24 @@ from sheaf.schemas.custom_field import (
     CustomFieldValueSet,
 )
 from sheaf.schemas.member import MemberDeleteConfirm
+from sheaf.services.custom_fields import (
+    decrypt_field_value,
+    encrypt_field_value,
+)
 from sheaf.services.system_safety import (
     is_safeguarded,
     queue_pending_action,
     verify_destructive_auth,
 )
+
+
+def _value_read(v: CustomFieldValue) -> CustomFieldValueRead:
+    """Build CustomFieldValueRead with decrypted value."""
+    return CustomFieldValueRead.model_validate({
+        "field_id": v.field_id,
+        "member_id": v.member_id,
+        "value": decrypt_field_value(v.value),
+    })
 
 router = APIRouter(tags=["custom fields"])
 
@@ -192,7 +205,7 @@ async def get_member_field_values(
     result = await db.execute(
         select(CustomFieldValue).where(CustomFieldValue.member_id == member_id)
     )
-    return result.scalars().all()
+    return [_value_read(v) for v in result.scalars().all()]
 
 
 @router.put(
@@ -230,7 +243,7 @@ async def set_member_field_values(
             detail="One or more field IDs are invalid",
         )
 
-    # Upsert values
+    # Upsert values. Stored value is the encrypted JSON-serialised plaintext.
     for item in body:
         existing = await db.execute(
             select(CustomFieldValue).where(
@@ -239,14 +252,15 @@ async def set_member_field_values(
             )
         )
         value = existing.scalar_one_or_none()
+        encrypted = encrypt_field_value(item.value)
         if value is not None:
-            value.value = item.value
+            value.value = encrypted
         else:
             db.add(
                 CustomFieldValue(
                     field_id=item.field_id,
                     member_id=member_id,
-                    value=item.value,
+                    value=encrypted,
                 )
             )
 
@@ -256,4 +270,4 @@ async def set_member_field_values(
     result = await db.execute(
         select(CustomFieldValue).where(CustomFieldValue.member_id == member_id)
     )
-    return result.scalars().all()
+    return [_value_read(v) for v in result.scalars().all()]

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -12,6 +12,8 @@ from sheaf.models.member import Member
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
 from sheaf.models.user import User
+from sheaf.services.custom_fields import field_value_plaintext
+from sheaf.services.members import member_plaintext
 
 router = APIRouter(prefix="/export", tags=["export"])
 
@@ -30,11 +32,15 @@ async def export_all(
     if system is None:
         return {"system": None, "members": [], "fronts": [], "groups": [], "tags": [], "fields": []}
 
-    # Members
+    # Members. Member.name is encrypted ciphertext, so DB-side ORDER BY on
+    # it is meaningless — sort in Python after decrypting names below.
     members_result = await db.execute(
-        select(Member).where(Member.system_id == system.id).order_by(Member.name)
+        select(Member).where(Member.system_id == system.id)
     )
-    members = members_result.scalars().all()
+    members_with_plaintext = [
+        (m, *member_plaintext(m)) for m in members_result.scalars().all()
+    ]
+    members_with_plaintext.sort(key=lambda t: t[1].casefold())
 
     # Fronts with members
     fronts_result = await db.execute(
@@ -83,9 +89,9 @@ async def export_all(
         "members": [
             {
                 "id": str(m.id),
-                "name": m.name,
+                "name": name,
                 "display_name": m.display_name,
-                "description": m.description,
+                "description": description,
                 "pronouns": m.pronouns,
                 "avatar_url": m.avatar_url,
                 "color": m.color,
@@ -93,7 +99,7 @@ async def export_all(
                 "privacy": m.privacy.value,
                 "created_at": m.created_at.isoformat(),
             }
-            for m in members
+            for (m, name, description) in members_with_plaintext
         ],
         "fronts": [
             {
@@ -135,7 +141,7 @@ async def export_all(
                 "values": [
                     {
                         "member_id": str(v.member_id),
-                        "value": v.value,
+                        "value": field_value_plaintext(v),
                     }
                     for v in fd.values
                 ],

--- a/sheaf/api/v1/groups.py
+++ b/sheaf/api/v1/groups.py
@@ -15,6 +15,7 @@ from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.group import GroupCreate, GroupMemberUpdate, GroupRead, GroupUpdate
 from sheaf.schemas.member import MemberDeleteConfirm, MemberRead
+from sheaf.services.members import decrypt_member_for_read
 from sheaf.services.system_safety import (
     is_safeguarded,
     queue_pending_action,
@@ -194,7 +195,7 @@ async def get_group_members(
     group = result.scalar_one_or_none()
     if group is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
-    return group.members
+    return [decrypt_member_for_read(m) for m in group.members]
 
 
 @router.put(
@@ -233,4 +234,4 @@ async def set_group_members(
 
     group.members = members
     await db.commit()
-    return members
+    return [decrypt_member_for_read(m) for m in members]

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -35,7 +35,10 @@ from sheaf.schemas.journal import (
 )
 from sheaf.services.journals import (
     create_journal_entry,
+    decrypt_entry_for_read,
+    decrypt_revision_for_read,
     delete_revisions_for,
+    entry_plaintext,
     restore_journal_revision,
     revision_count_for,
     update_journal_entry,
@@ -68,8 +71,9 @@ async def _verify_member_in_system(
 
 def _label_for(entry: JournalEntry) -> str:
     """Pending-action label — title if set, else timestamp fallback."""
-    if entry.title:
-        return entry.title
+    title, _ = entry_plaintext(entry)
+    if title:
+        return title
     return f"Untitled — {entry.created_at.date().isoformat()}"
 
 
@@ -104,7 +108,10 @@ async def list_journals(
     rows = list(result.scalars().all())
     next_cursor = rows[limit].created_at if len(rows) > limit else None
     return JournalListResponse(
-        items=[JournalEntryRead.model_validate(r) for r in rows[:limit]],
+        items=[
+            JournalEntryRead.model_validate(decrypt_entry_for_read(r))
+            for r in rows[:limit]
+        ],
         next_cursor=next_cursor,
     )
 
@@ -138,7 +145,7 @@ async def create_entry(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     await db.commit()
     await db.refresh(entry)
-    return entry
+    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
 
 
 @router.get("/{entry_id}", response_model=JournalEntryReadWithCount)
@@ -152,7 +159,7 @@ async def get_entry(
     count = await revision_count_for(
         ContentRevisionTarget.JOURNAL_ENTRY, entry.id, db
     )
-    payload = JournalEntryReadWithCount.model_validate(entry)
+    payload = JournalEntryReadWithCount.model_validate(decrypt_entry_for_read(entry))
     payload.revision_count = count
     return payload
 
@@ -185,7 +192,7 @@ async def patch_entry(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     await db.commit()
     await db.refresh(entry)
-    return entry
+    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
 
 
 @router.delete(
@@ -256,7 +263,10 @@ async def list_revisions(
         )
         .order_by(ContentRevision.created_at.desc())
     )
-    return [ContentRevisionRead.model_validate(r) for r in result.scalars().all()]
+    return [
+        ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
+        for r in result.scalars().all()
+    ]
 
 
 @router.post(
@@ -284,4 +294,4 @@ async def restore_revision(
     )
     await db.commit()
     await db.refresh(entry)
-    return entry
+    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.config import settings
+from sheaf.crypto import blind_index, encrypt
 from sheaf.database import get_db
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.member import Member
@@ -17,9 +18,11 @@ from sheaf.schemas.journal import ContentRevisionRead, RestoreRevisionRequest
 from sheaf.schemas.member import MemberCreate, MemberDeleteConfirm, MemberRead, MemberUpdate
 from sheaf.services.journals import (
     capture_revision,
+    decrypt_revision_for_read,
     delete_revisions_for,
     restore_member_bio_revision,
 )
+from sheaf.services.members import decrypt_member_for_read, member_plaintext
 from sheaf.services.system_safety import (
     is_safeguarded,
     queue_pending_action,
@@ -55,10 +58,15 @@ async def list_members(
     db: AsyncSession = Depends(get_db),
 ):
     system = await _get_user_system(user, db)
+    # Member.name is encrypted ciphertext, so DB-side ORDER BY on it is
+    # meaningless. Decrypt then sort by display_name fallback to name.
     result = await db.execute(
-        select(Member).where(Member.system_id == system.id).order_by(Member.name)
+        select(Member).where(Member.system_id == system.id)
     )
-    return result.scalars().all()
+    members = result.scalars().all()
+    decoded = [decrypt_member_for_read(m) for m in members]
+    decoded.sort(key=lambda m: (m.display_name or m.name).casefold())
+    return decoded
 
 
 _MEMBER_LIMIT_MAP = {
@@ -100,11 +108,22 @@ async def create_member(
                 detail=f"Member limit reached ({limit}). Contact support for an increase.",
             )
 
-    member = Member(system_id=system.id, **body.model_dump())
+    data = body.model_dump()
+    plaintext_name: str = data.pop("name")
+    plaintext_description: str | None = data.pop("description", None)
+    member = Member(
+        system_id=system.id,
+        name=encrypt(plaintext_name),
+        name_hash=blind_index(plaintext_name),
+        description=(
+            encrypt(plaintext_description) if plaintext_description is not None else None
+        ),
+        **data,
+    )
     db.add(member)
     await db.commit()
     await db.refresh(member)
-    return member
+    return decrypt_member_for_read(member)
 
 
 @router.get("/{member_id}", response_model=MemberRead)
@@ -114,7 +133,8 @@ async def get_member(
     db: AsyncSession = Depends(get_db),
 ):
     system = await _get_user_system(user, db)
-    return await _get_own_member(member_id, system, db)
+    member = await _get_own_member(member_id, system, db)
+    return decrypt_member_for_read(member)
 
 
 @router.patch(
@@ -131,9 +151,10 @@ async def update_member(
     system = await _get_user_system(user, db)
     member = await _get_own_member(member_id, system, db)
     update_data = body.model_dump(exclude_unset=True)
+    _, current_description = member_plaintext(member)
     if (
         "description" in update_data
-        and update_data["description"] != member.description
+        and update_data["description"] != current_description
     ):
         await capture_revision(
             db=db,
@@ -142,13 +163,19 @@ async def update_member(
             user=user,
             system_id=system.id,
             title=None,
-            body=member.description or "",
+            body=current_description or "",
         )
     for key, value in update_data.items():
-        setattr(member, key, value)
+        if key == "name":
+            member.name = encrypt(value)
+            member.name_hash = blind_index(value)
+        elif key == "description":
+            member.description = encrypt(value) if value is not None else None
+        else:
+            setattr(member, key, value)
     await db.commit()
     await db.refresh(member)
-    return member
+    return decrypt_member_for_read(member)
 
 
 @router.delete(
@@ -177,7 +204,7 @@ async def delete_member(
             user=user,
             action_type=PendingActionType.MEMBER_DELETE,
             target_id=member.id,
-            target_label=member.display_name or member.name,
+            target_label=member.display_name or member_plaintext(member)[0],
         )
         await db.commit()
         await db.refresh(pending)
@@ -215,7 +242,10 @@ async def list_bio_revisions(
         )
         .order_by(ContentRevision.created_at.desc())
     )
-    return [ContentRevisionRead.model_validate(r) for r in result.scalars().all()]
+    return [
+        ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
+        for r in result.scalars().all()
+    ]
 
 
 @router.post(
@@ -243,4 +273,4 @@ async def restore_bio_revision(
     )
     await db.commit()
     await db.refresh(member)
-    return member
+    return decrypt_member_for_read(member)

--- a/sheaf/models/content_revision.py
+++ b/sheaf/models/content_revision.py
@@ -48,7 +48,9 @@ class ContentRevision(UUIDMixin, Base):
     )
 
     # Captured content as it was before the edit that produced this revision.
-    title: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # title and body are encrypted at application level — store ciphertext.
+    # image_keys stays plaintext (orphan cleanup needs to read it without keys).
+    title: Mapped[str | None] = mapped_column(String, nullable=True)
     body: Mapped[str] = mapped_column(Text, nullable=False)
 
     image_keys: Mapped[list] = mapped_column(

--- a/sheaf/models/journal_entry.py
+++ b/sheaf/models/journal_entry.py
@@ -29,7 +29,10 @@ class JournalEntry(UUIDMixin, TimestampMixin, Base):
         index=True,
     )
 
-    title: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # Encrypted at application level — store ciphertext.
+    # title and body are encrypted; image_keys stays plaintext so orphan
+    # cleanup and read-time URL rewrites don't require key access.
+    title: Mapped[str | None] = mapped_column(String, nullable=True)
     body: Mapped[str] = mapped_column(Text, nullable=False)
 
     # v1 only honors "system". "member_private" and "public" are reserved

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -60,8 +60,18 @@ class Member(UUIDMixin, TimestampMixin, Base):
         index=True,
     )
 
-    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Encrypted at application level — store ciphertext.
+    # Length is generous to accommodate the base64-encoded
+    # nonce+ciphertext+tag for a 100-char plaintext.
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    # Blind index on the *plaintext* name (keyed HMAC-SHA-256, normalised).
+    # Used for exact-match lookups within a system (e.g. autocomplete dedup).
+    # Not unique — duplicate names within a system are allowed.
+    name_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, index=True, server_default=""
+    )
     display_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # Encrypted at application level — store ciphertext.
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     pronouns: Mapped[str | None] = mapped_column(String(100), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/sheaf/services/custom_fields.py
+++ b/sheaf/services/custom_fields.py
@@ -1,0 +1,39 @@
+"""Custom-field-value encryption helpers.
+
+CustomFieldValue.value holds arbitrary user-supplied content (text answers,
+selected options, dates, etc.). It's encrypted at rest: the JSON-serialised
+plaintext is encrypted, and the resulting ciphertext string is stored in the
+JSONB column. JSONB happily accepts a JSON string as a top-level value.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sheaf.crypto import decrypt, encrypt
+from sheaf.models.custom_field import CustomFieldValue
+
+
+def encrypt_field_value(value: Any) -> str:
+    """JSON-serialise then encrypt a custom-field value."""
+    return encrypt(json.dumps(value))
+
+
+def decrypt_field_value(stored: Any) -> Any:
+    """Decrypt + JSON-decode a stored custom-field value.
+
+    Returns None if the column was NULL. Stored ciphertext is always a string;
+    if we encounter a non-string (e.g. legacy plaintext rows from before
+    encryption), pass it through untouched as a defensive fallback.
+    """
+    if stored is None:
+        return None
+    if not isinstance(stored, str):
+        return stored
+    return json.loads(decrypt(stored))
+
+
+def field_value_plaintext(v: CustomFieldValue) -> Any:
+    """Return the decrypted, JSON-decoded plaintext for a value row."""
+    return decrypt_field_value(v.value)

--- a/sheaf/services/file_cleanup.py
+++ b/sheaf/services/file_cleanup.py
@@ -10,6 +10,7 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sheaf.crypto import decrypt
 from sheaf.models.content_revision import ContentRevision
 from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
@@ -74,6 +75,10 @@ async def find_orphaned_files(
     )
     for avatar_url, description in result:
         referenced.update(_key_from_avatar(avatar_url))
+        # Member.description is encrypted at rest; decrypt for the markdown
+        # scan. This runs in the app container which has the key.
+        if description is not None:
+            description = decrypt(description)
         referenced.update(_extract_keys_from_markdown(description))
 
     # Journal entries for this user's system. image_keys is pre-extracted

--- a/sheaf/services/journals.py
+++ b/sheaf/services/journals.py
@@ -14,6 +14,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import settings
+from sheaf.crypto import decrypt, encrypt
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
@@ -92,6 +93,10 @@ async def capture_revision(
 ) -> ContentRevision:
     """Insert a content_revisions row capturing the *outgoing* content.
 
+    `title` and `body` are *plaintext* — encrypted at write time.
+    image_keys is extracted from the plaintext body, then stored unencrypted
+    so orphan cleanup can read it without key access.
+
     Caller is responsible for then overwriting the target row with the new
     content and committing.
     """
@@ -105,12 +110,62 @@ async def capture_revision(
         user_id=user.id,
         editor_member_ids=editor_ids,
         editor_member_names=editor_names,
-        title=title,
-        body=body,
+        title=encrypt(title) if title is not None else None,
+        body=encrypt(body),
         image_keys=extract_image_keys(body),
     )
     db.add(revision)
     return revision
+
+
+def revision_plaintext(revision: ContentRevision) -> tuple[str | None, str]:
+    """Decrypt a revision's title/body to plaintext."""
+    title = decrypt(revision.title) if revision.title is not None else None
+    body = decrypt(revision.body) if revision.body else ""
+    return title, body
+
+
+def decrypt_revision_for_read(revision: ContentRevision) -> dict:
+    """Build a dict suitable for ContentRevisionRead.model_validate(...)."""
+    title, body = revision_plaintext(revision)
+    return {
+        "id": revision.id,
+        "target_type": revision.target_type,
+        "target_id": revision.target_id,
+        "user_id": revision.user_id,
+        "editor_member_ids": revision.editor_member_ids,
+        "editor_member_names": revision.editor_member_names,
+        "title": title,
+        "body": body,
+        "image_keys": revision.image_keys,
+        "created_at": revision.created_at,
+    }
+
+
+def entry_plaintext(entry: JournalEntry) -> tuple[str | None, str]:
+    """Decrypt a journal entry's title/body to plaintext."""
+    title = decrypt(entry.title) if entry.title is not None else None
+    body = decrypt(entry.body) if entry.body else ""
+    return title, body
+
+
+def decrypt_entry_for_read(entry: JournalEntry) -> dict:
+    """Build a dict suitable for JournalEntryRead.model_validate(...)."""
+    title, body = entry_plaintext(entry)
+    return {
+        "id": entry.id,
+        "system_id": entry.system_id,
+        "member_id": entry.member_id,
+        "title": title,
+        "body": body,
+        "visibility": entry.visibility,
+        "author_user_id": entry.author_user_id,
+        "author_member_ids": entry.author_member_ids,
+        "author_member_names": entry.author_member_names,
+        "image_keys": entry.image_keys,
+        "created_at": entry.created_at,
+        "updated_at": entry.updated_at,
+    }
 
 
 async def delete_revisions_for(
@@ -190,7 +245,10 @@ async def resolve_author_snapshot(
     for mid in ordered:
         member = by_id[mid]
         ids.append(str(member.id))
-        names.append(member.display_name or member.name)
+        # display_name is plaintext; name is ciphertext — decrypt for the
+        # snapshot. Author-name snapshots are display strings, not lookups,
+        # so we store them in plaintext (same as how they're shown to users).
+        names.append(member.display_name or decrypt(member.name))
     return ids, names
 
 
@@ -212,6 +270,9 @@ async def create_journal_entry(
 ) -> JournalEntry:
     """Create a journal entry with a fronting snapshot at write time.
 
+    `title` and `body` are *plaintext* — stored encrypted; image_keys is
+    extracted from the plaintext and stored unencrypted for orphan cleanup.
+
     If `author_member_ids` is provided, those override the fronting snapshot
     (used when the user explicitly picks authors in the UI). Otherwise we
     snapshot whoever is currently fronting.
@@ -227,8 +288,8 @@ async def create_journal_entry(
     entry = JournalEntry(
         system_id=system.id,
         member_id=member_id,
-        title=title,
-        body=body,
+        title=encrypt(title) if title is not None else None,
+        body=encrypt(body),
         visibility=visibility,
         author_user_id=user.id,
         author_member_ids=author_ids,
@@ -251,12 +312,17 @@ async def update_journal_entry(
 ) -> JournalEntry:
     """Apply an update to an entry, capturing a revision if content changed.
 
+    `title` and `body` are *plaintext* (None = unchanged). Comparison against
+    the existing entry decrypts the stored ciphertext so no-op nonce rerolls
+    don't trigger spurious revision captures.
+
     Author edits don't trigger revision capture — revisions track title/body
     only. An empty list (`[]`) clears authors back to "account fallback".
     `None` means "don't touch authors".
     """
-    content_changed = (title is not None and title != entry.title) or (
-        body is not None and body != entry.body
+    current_title, current_body = entry_plaintext(entry)
+    content_changed = (title is not None and title != current_title) or (
+        body is not None and body != current_body
     )
     if content_changed:
         await capture_revision(
@@ -265,13 +331,13 @@ async def update_journal_entry(
             target_id=entry.id,
             user=user,
             system_id=entry.system_id,
-            title=entry.title,
-            body=entry.body,
+            title=current_title,
+            body=current_body,
         )
     if title is not None:
-        entry.title = title
+        entry.title = encrypt(title)
     if body is not None:
-        entry.body = body
+        entry.body = encrypt(body)
         entry.image_keys = extract_image_keys(body)
     if visibility is not None:
         entry.visibility = visibility
@@ -298,18 +364,20 @@ async def restore_journal_revision(
     overwrites the entry with the chosen revision's content. The chosen
     revision row is left in place — restore is a forward action, not a rewind.
     """
+    current_title, current_body = entry_plaintext(entry)
     await capture_revision(
         db=db,
         target_type=ContentRevisionTarget.JOURNAL_ENTRY,
         target_id=entry.id,
         user=user,
         system_id=entry.system_id,
-        title=entry.title,
-        body=entry.body,
+        title=current_title,
+        body=current_body,
     )
-    entry.title = revision.title
-    entry.body = revision.body
-    entry.image_keys = extract_image_keys(revision.body)
+    revision_title, revision_body = revision_plaintext(revision)
+    entry.title = encrypt(revision_title) if revision_title is not None else None
+    entry.body = encrypt(revision_body)
+    entry.image_keys = extract_image_keys(revision_body)
     entry.updated_at = datetime.now(UTC)
     return entry
 
@@ -328,6 +396,9 @@ async def restore_member_bio_revision(
     the revision body. Image keys for member bios are tracked through the
     revision rows themselves (the member table has no `image_keys` column).
     """
+    current_description = (
+        decrypt(member.description) if member.description is not None else ""
+    )
     await capture_revision(
         db=db,
         target_type=ContentRevisionTarget.MEMBER_BIO,
@@ -335,7 +406,8 @@ async def restore_member_bio_revision(
         user=user,
         system_id=member.system_id,
         title=None,
-        body=member.description or "",
+        body=current_description,
     )
-    member.description = revision.body or None
+    _, revision_body = revision_plaintext(revision)
+    member.description = encrypt(revision_body) if revision_body else None
     return member

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -1,0 +1,60 @@
+"""Member encryption helpers.
+
+Member.name and Member.description are encrypted at application level. This
+module owns the small set of helpers that translate between the persisted
+ciphertext columns and the plaintext used by API endpoints, services, and
+schema serialisation.
+
+Member.name_hash is a keyed blind index of the (normalised) plaintext name,
+so exact-match lookups within a system stay possible without having to
+decrypt the whole table.
+"""
+
+from __future__ import annotations
+
+from sheaf.crypto import blind_index, decrypt, encrypt
+from sheaf.models.member import Member
+from sheaf.schemas.member import MemberRead
+
+
+def member_name_plaintext(member: Member) -> str:
+    return decrypt(member.name)
+
+
+def member_description_plaintext(member: Member) -> str | None:
+    if member.description is None:
+        return None
+    return decrypt(member.description)
+
+
+def set_member_name(member: Member, plaintext: str) -> None:
+    """Encrypt + hash a new plaintext name onto a Member instance."""
+    member.name = encrypt(plaintext)
+    member.name_hash = blind_index(plaintext)
+
+
+def set_member_description(member: Member, plaintext: str | None) -> None:
+    member.description = encrypt(plaintext) if plaintext is not None else None
+
+
+def decrypt_member_for_read(member: Member) -> MemberRead:
+    """Build a MemberRead with name + description decrypted to plaintext."""
+    return MemberRead.model_validate({
+        "id": member.id,
+        "system_id": member.system_id,
+        "name": member_name_plaintext(member),
+        "display_name": member.display_name,
+        "description": member_description_plaintext(member),
+        "pronouns": member.pronouns,
+        "avatar_url": member.avatar_url,
+        "color": member.color,
+        "birthday": member.birthday,
+        "privacy": member.privacy,
+        "created_at": member.created_at,
+        "updated_at": member.updated_at,
+    })
+
+
+def member_plaintext(member: Member) -> tuple[str, str | None]:
+    """Convenience: return (name, description) decrypted in one call."""
+    return member_name_plaintext(member), member_description_plaintext(member)

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -10,12 +10,14 @@ from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sheaf.crypto import blind_index, encrypt
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
 from sheaf.models.front import Front
 from sheaf.models.group import Group
 from sheaf.models.member import Member, front_members, group_members, member_tags
 from sheaf.models.system import PrivacyLevel, System
 from sheaf.models.tag import Tag
+from sheaf.services.custom_fields import encrypt_field_value
 
 logger = logging.getLogger("sheaf.import.sheaf")
 
@@ -122,12 +124,19 @@ async def run_import(
 
     for m_data in export_members:
         old_id = m_data.get("id", "")
+        plaintext_name = (m_data.get("name") or "unnamed")[:100]
+        plaintext_description = m_data.get("description")
         member = Member(
             id=uuid.uuid4(),
             system_id=system.id,
-            name=(m_data.get("name") or "unnamed")[:100],
+            name=encrypt(plaintext_name),
+            name_hash=blind_index(plaintext_name),
             display_name=_trunc(m_data.get("display_name"), 100),
-            description=m_data.get("description"),
+            description=(
+                encrypt(plaintext_description)
+                if plaintext_description is not None
+                else None
+            ),
             pronouns=_trunc(m_data.get("pronouns"), 100),
             avatar_url=_trunc(m_data.get("avatar_url"), 500),
             color=_trunc(m_data.get("color"), 7),
@@ -205,7 +214,7 @@ async def run_import(
                     id=uuid.uuid4(),
                     field_id=field_def.id,
                     member_id=member.id,
-                    value=v_data.get("value"),
+                    value=encrypt_field_value(v_data.get("value")),
                 )
                 db.add(cfv)
 

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sheaf.crypto import blind_index, encrypt
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
 from sheaf.models.front import Front
 from sheaf.models.group import Group
@@ -30,6 +31,7 @@ from sheaf.schemas.sp_import import (
     SPPreviewMember,
     SPPreviewSummary,
 )
+from sheaf.services.custom_fields import encrypt_field_value
 
 logger = logging.getLogger("sheaf.import")
 
@@ -124,12 +126,19 @@ async def run_import(
 
     for sp_m in sp_members:
         sp_id = sp_m.get("_id", "")
+        plaintext_name = (sp_m.get("name") or "unnamed")[:100]
+        plaintext_description = sp_m.get("desc")
         member = Member(
             id=uuid.uuid4(),
             system_id=system.id,
-            name=(sp_m.get("name") or "unnamed")[:100],
+            name=encrypt(plaintext_name),
+            name_hash=blind_index(plaintext_name),
             display_name=_truncate(sp_m.get("displayName"), 100),
-            description=sp_m.get("desc"),
+            description=(
+                encrypt(plaintext_description)
+                if plaintext_description is not None
+                else None
+            ),
             pronouns=_truncate(sp_m.get("pronouns"), 100),
             avatar_url=_truncate(sp_m.get("avatarUrl"), 500),
             color=_normalize_color(sp_m.get("color")),
@@ -144,11 +153,18 @@ async def run_import(
     if options.custom_fronts:
         for sp_cf in _get_collection(data, "frontStatuses"):
             sp_id = sp_cf.get("_id", "")
+            plaintext_cf_name = (sp_cf.get("name") or "unnamed")[:100]
+            plaintext_cf_description = _prefix_custom_front_desc(sp_cf.get("desc"))
             member = Member(
                 id=uuid.uuid4(),
                 system_id=system.id,
-                name=(sp_cf.get("name") or "unnamed")[:100],
-                description=_prefix_custom_front_desc(sp_cf.get("desc")),
+                name=encrypt(plaintext_cf_name),
+                name_hash=blind_index(plaintext_cf_name),
+                description=(
+                    encrypt(plaintext_cf_description)
+                    if plaintext_cf_description is not None
+                    else None
+                ),
                 color=_normalize_color(sp_cf.get("color")),
                 avatar_url=_truncate(sp_cf.get("avatarUrl"), 500),
                 privacy=_map_privacy(sp_cf.get("private", True)),
@@ -200,7 +216,7 @@ async def run_import(
                     id=uuid.uuid4(),
                     field_id=field_def.id,
                     member_id=member.id,
-                    value={"v": str(raw_value)},
+                    value=encrypt_field_value({"v": str(raw_value)}),
                 )
                 db.add(cfv)
 

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -214,9 +214,13 @@ async def snapshot_current_fronts(
         .distinct()
     )
     members = result.scalars().all()
+    # Member.name is encrypted; decrypt for the display-snapshot. display_name
+    # is plaintext and used as-is when set.
+    from sheaf.crypto import decrypt
+
     return (
         [str(m.id) for m in members],
-        [m.display_name or m.name for m in members],
+        [m.display_name or decrypt(m.name) for m in members],
     )
 
 


### PR DESCRIPTION
## Summary

Extends the at-rest encryption surface beyond authentication secrets to cover identity-bearing user content. Adds members.name_hash blind index (keyed HMAC-SHA-256) so exact-match lookups still work without plaintext storage. Backfill migration runs in-app so the encryption key is available; idempotent via try-decrypt heuristic.


## Testing

- [x] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Tested manually

## Security / privacy impact
Sensitive fields are now encrypted at-rest at the member level, in addition to account-level (email, TOTP secret)
