### PR TITLE
Verifiable builds (ongoing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # sigstore/cosign keyless OIDC
     strategy:
       fail-fast: false
       matrix:
@@ -111,6 +115,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -125,3 +130,36 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      # Sign by digest. cosign stores the signature at <repo>:sha256-DIGEST.sig
+      # so a single sign call covers every tag pointing at the same digest.
+      - name: Sign image
+        env:
+          REF: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            -a "git_sha=${{ github.sha }}" \
+            -a "git_ref=${{ github.ref }}" \
+            -a "workflow=${{ github.workflow }}" \
+            -a "run_id=${{ github.run_id }}" \
+            "$REF"
+
+      - name: Generate SBOM (SPDX)
+        env:
+          REF: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+        run: syft "$REF" -o spdx-json > sbom.spdx.json
+
+      - name: Attest SBOM
+        env:
+          REF: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate sbom.spdx.json \
+            --type spdxjson \
+            "$REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,11 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           platforms: linux/amd64,linux/arm64
-          build-args: ${{ matrix.build_args }}
+          build-args: |
+            ${{ matrix.build_args }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_TAG=${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+            BUILD_TIME=${{ github.event.head_commit.timestamp || github.run_started_at }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,3 +196,74 @@ jobs:
             --predicate web/dist/build-manifest.json \
             --type custom \
             "$REF"
+
+  # Manual-approval gate for tag pushes. Image signing happens unconditionally
+  # in the docker job above; this job pauses for human approval before
+  # publishing the GitHub release page and uploading verifiable artefacts.
+  # Configure repo Settings → Environments → "release" with required reviewers.
+  release:
+    name: Publish GitHub release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [docker]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify pyproject.toml version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PY=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')
+          if [ "$TAG" != "$PY" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${PY}"
+            exit 1
+          fi
+          echo "ok: tag ${GITHUB_REF_NAME} matches pyproject.toml ${PY}"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build frontend
+        env:
+          VITE_GIT_COMMIT: ${{ github.sha }}
+          VITE_GIT_TAG: ${{ github.ref_name }}
+          VITE_BUILD_TIME: ${{ github.event.head_commit.timestamp || github.run_started_at }}
+        run: |
+          cd web
+          npm ci
+          npm run build
+
+      - name: Package frontend tarball
+        run: |
+          tar czf "web-dist-${GITHUB_REF_NAME}.tar.gz" -C web/dist .
+
+      # Extract this version's section out of CHANGELOG.md for the release
+      # body. Falls through to empty if the section is missing — auto-notes
+      # still get appended either way.
+      - name: Extract changelog section
+        run: |
+          awk -v ver="${GITHUB_REF_NAME}" '
+            $0 ~ "^## \\[" ver "\\]" { capture=1; next }
+            capture && /^## \[/ { exit }
+            capture { print }
+          ' CHANGELOG.md > release-body.md || true
+          if [ ! -s release-body.md ]; then
+            echo "(no CHANGELOG.md section for ${GITHUB_REF_NAME})" > release-body.md
+          fi
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: release-body.md
+          generate_release_notes: true
+          prerelease: ${{ startsWith(github.ref_name, 'v0.') }}
+          files: |
+            web-dist-${{ github.ref_name }}.tar.gz
+            web/dist/build-manifest.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,36 @@ jobs:
             --predicate sbom.spdx.json \
             --type spdxjson \
             "$REF"
+
+      # Build manifest attestation — only for sheaf-web. Re-run the frontend
+      # build on the runner to produce dist/build-manifest.json, then attest
+      # it against the image. Same machine + same envs as the docker build,
+      # so the resulting manifest mirrors what's served from the image.
+      - name: Setup Node (manifest)
+        if: matrix.name == 'sheaf-web'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build frontend manifest
+        if: matrix.name == 'sheaf-web'
+        env:
+          VITE_GIT_COMMIT: ${{ github.sha }}
+          VITE_GIT_TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+          VITE_BUILD_TIME: ${{ github.event.head_commit.timestamp || github.run_started_at }}
+        run: |
+          cd web
+          npm ci
+          npm run build
+
+      - name: Attest build manifest
+        if: matrix.name == 'sheaf-web'
+        env:
+          REF: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate web/dist/build-manifest.json \
+            --type custom \
+            "$REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,21 @@ jobs:
             build_args: ""
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # ancestor check on tag pushes needs full history
+
+      # Tag pushes must point at a commit already on main. GitHub's deployment
+      # branch policy is name-pattern only and can't enforce this; checking
+      # here means a v* tag pushed from an unmerged branch fails before any
+      # image is built or signed.
+      - name: Validate tag is on main
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::tagged commit $GITHUB_SHA is not on main — merge first, then tag"
+            exit 1
+          fi
 
       - uses: docker/setup-qemu-action@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to Sheaf are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and Sheaf adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+`v0.x.y` releases are betas — APIs and database schema may still change. The first stable release will be `v1.0.0`.
+
+## [Unreleased]
+
+## [v0.1.0]
+
+First public beta. The features below are the baseline that subsequent releases build on.
+
+### Plural system tracking
+
+- Members with name, pronouns, role, description, color, avatar, custom fields, tags, groups, and per-member privacy.
+- Front log: who's currently fronting, history, and timeline view.
+- Journals: per-member and system-wide markdown entries with image embeds, fronting snapshots, revision history with retention.
+- System Safety: configurable grace periods on destructive actions (member/journal/image deletes, retention loosening) with re-auth.
+- Encrypted at rest: member name, descriptions, journal content, custom field values, email, TOTP secrets — all application-level encrypted; lookups use blind indexes.
+
+### Auth & accounts
+
+- Argon2id password hashing, optional TOTP, trusted-device enrolment.
+- HttpOnly refresh-cookie sessions with reuse-detection grace window.
+- API keys with per-resource scopes; admin scopes are admin-gated.
+- Account deletion with grace period; admin promotion via env-driven email list.
+
+### Self-hosting & operations
+
+- Multi-arch Docker images on GHCR for the backend (`sheaf`) and frontend (`sheaf-web`); `docker compose` reference setup.
+- Postgres + Redis required; Alembic runs `upgrade head` on container start.
+- Storage adapters: local disk and S3-compatible.
+- Email adapters: SMTP, SES, SendGrid (optional dependencies).
+- `SHEAF_MODE` flag toggles selfhosted vs SaaS behaviour without forking.
+
+### Build verifiability
+
+- `/v1/version` endpoint reports the running commit, tag, and build time.
+- Multi-arch Docker images on GHCR signed via `sigstore/cosign` keyless OIDC.
+- SPDX SBOMs published as Sigstore attestations against each image.
+- Frontend bundle protected by sha384 SRI integrity attributes.
+- `build-manifest.json` listing every dist file's hash, also published as a Sigstore attestation against the `sheaf-web` image.
+- `/about` page surfaces backend + frontend build provenance and a manifest summary.
+- `scripts/verify-release.sh` automates `/v1/version` → cosign verification.
+- See [docs/VERIFYING.md](docs/VERIFYING.md) for the full trust model.
+
+### Releases
+
+- Tag-driven release workflow with a manual approval gate via the `release` GitHub Environment.
+- Release assets: signed Docker images on GHCR, frontend tarball, build manifest, SPDX SBOM attestations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
-## [v0.1.0]
+## [v0.1.0] - 2026-04-29
 
 First public beta. The features below are the baseline that subsequent releases build on.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,29 @@ If you're coming from SimplyPlural, we're especially interested in hearing about
 - If your change adds an API endpoint, add a test.
 - Don't include unrelated formatting changes, refactors, or dependency bumps.
 
+## Cutting a release
+
+Releases are tag-driven and gated on a manual approval. The workflow:
+
+1. Bump the version in `pyproject.toml` and `web/package.json` to match the target tag (e.g. `0.1.1`).
+2. Move the `## [Unreleased]` section in `CHANGELOG.md` to a new `## [v0.1.1]` heading. The release workflow extracts that section verbatim into the GitHub release body.
+3. Land those changes on `main` via PR.
+4. Tag and push: `git tag v0.1.1 && git push --tags`.
+5. The CI workflow's `docker` job builds, signs, and attests the images. Then the `release` job pauses for human approval — the request shows up under repo Actions → workflow run → "Review deployments". Approving creates the GitHub release and uploads the frontend tarball + build manifest.
+6. If the tag's version doesn't match `pyproject.toml`, the release job fails before publishing — re-tag rather than overriding.
+
+`v0.x.y` releases are tagged as GitHub prereleases automatically (until `v1.0.0`).
+
+### One-time repo setup
+
+The manual gate requires a configured GitHub Environment:
+
+1. Repo Settings → Environments → New environment named `release`.
+2. Enable "Required reviewers" and add the maintainers who can sign off on releases.
+3. Optionally add a deployment protection rule (e.g. only allow `refs/tags/v*`).
+
+Without the environment, the release job runs with no approval gate. Create it before cutting any tag you actually want to publish.
+
 ## Architecture notes
 
 Before making significant changes, it helps to understand a few design decisions:

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -23,6 +23,19 @@ RUN if [ "$INCLUDE_DEV_TOOLS" = "true" ]; then \
 
 RUN mkdir -p /app/data && chown sheaf:sheaf /app/data
 
+# Build provenance — populated by CI (or `docker build --build-arg`).
+# Late in the file so the heavyweight pip-install cache layer survives
+# unrelated commit changes.
+ARG GIT_COMMIT=
+ARG GIT_TAG=
+ARG BUILD_TIME=
+ENV SHEAF_GIT_COMMIT=${GIT_COMMIT}
+ENV SHEAF_GIT_TAG=${GIT_TAG}
+ENV SHEAF_BUILD_TIME=${BUILD_TIME}
+LABEL org.opencontainers.image.revision=${GIT_COMMIT}
+LABEL org.opencontainers.image.version=${GIT_TAG}
+LABEL org.opencontainers.image.source=https://github.com/sheaf-project/sheaf
+
 USER sheaf
 
 EXPOSE 8000

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -8,10 +8,26 @@ COPY web/package.json web/package-lock.json ./
 RUN npm ci
 
 COPY web/ ./
+
+# Build provenance — passed through to Vite so the bundle can show its
+# build origin. ARGs do not cross stages; redeclare in the runtime stage.
+ARG GIT_COMMIT=
+ARG GIT_TAG=
+ARG BUILD_TIME=
+ENV VITE_GIT_COMMIT=${GIT_COMMIT}
+ENV VITE_GIT_TAG=${GIT_TAG}
+ENV VITE_BUILD_TIME=${BUILD_TIME}
+
 RUN npm run build
 
 FROM nginx:1.27
 
 COPY --from=build /build/dist /usr/share/nginx/html
+
+ARG GIT_COMMIT=
+ARG GIT_TAG=
+LABEL org.opencontainers.image.revision=${GIT_COMMIT}
+LABEL org.opencontainers.image.version=${GIT_TAG}
+LABEL org.opencontainers.image.source=https://github.com/sheaf-project/sheaf
 
 EXPOSE 80 443

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ See **[docs/SELFHOSTING.md](docs/SELFHOSTING.md)** for the full guide covering:
 - Public test / demo mode (periodic non-admin wipe + warning banner)
 - Backups
 
+## Verifying your build
+
+Sheaf publishes signed Docker images and a verifiable frontend bundle so users can confirm a running instance corresponds to the public source. Image signatures use sigstore/cosign keyless OIDC (no key material to manage; signatures tied to the GitHub Actions workflow identity, recorded in Rekor's public transparency log). The frontend ships with Subresource Integrity hashes and a published build manifest, so a browser-side verifier can confirm byte-for-byte that loaded JavaScript matches the published source.
+
+See **[docs/VERIFYING.md](docs/VERIFYING.md)** for the trust model, how to run `cosign verify`, how to compare the served `build-manifest.json` against your own `npm run build`, and what the design explicitly does *not* claim (no hardware attestation; backend behaviour beyond the served frontend is operator-attested).
+
 ## Development
 
 ```bash

--- a/docs/VERIFYING.md
+++ b/docs/VERIFYING.md
@@ -45,7 +45,7 @@ What you can't check from this alone: that the running backend is *actually* ser
 
 ### How it works (high level)
 
-When Sheaf releases a new version, GitHub Actions builds the Docker image and uses **[sigstore/cosign](https://docs.sigstore.dev/cosign/installation/)** to sign it. Cosign uses what's called *keyless OIDC signing*:
+When Sheaf releases a new version, GitHub Actions builds the Docker image and uses **[sigstore/cosign](https://github.com/sigstore/cosign)** to sign it. Cosign uses what's called *keyless OIDC signing*:
 
 - There's no private key sitting somewhere that could leak or be otherwise obtained via legal or covert methods.
 - Instead, every signature is tied to the GitHub Actions workflow that produced it ("this was signed by `https://github.com/sheaf-project/sheaf/.github/workflows/ci.yml` running on tag `v0.1.1`").

--- a/docs/VERIFYING.md
+++ b/docs/VERIFYING.md
@@ -1,0 +1,197 @@
+# Verifying your Sheaf build
+
+This guide explains how to confirm that the Sheaf instance you're using — whether self-hosted or the hosted SaaS — is running the code that's actually published on GitHub. It's aimed at curious users, security-aware self-hosters, and anyone who wants to understand the trust model.
+
+This guide is necessarily technically-oriented but tries to keep assumptions about knowledge to the minimum necessary. It does assume basic familiarity with git (commit hashes, the nature and limitations of git's integrity protections, etc), public-key cryptography, hashing algorithms, and digital signatures. It also assumes basic familiarity with using software on the command line in order to use the automatic verification scripts.
+
+## Why verify?
+
+Sheaf stores GDPR Article 9 special-category data — mental-health context, identity information that could out people, therapy-adjacent notes. Trusting the operator is reasonable for low-stakes apps, but for an app like this, "trust me" isn't enough on its own. So Sheaf gives you tools to verify.
+
+There are limits to what verification can prove. Hardware attestation (a [Trusted Execution Environment](https://en.wikipedia.org/wiki/Trusted_execution_environment), or TEE) is the strongest commercially-viable thing you can do, and is prohibitive in terms of costs and complexity for a small-scale project where the threat model doesn't justify it. What Sheaf *does* offer is two layers of verifiability that cover most realistic concerns:
+
+1. **Image verifiability** — confirm the Docker image being deployed corresponds to a specific public commit, signed by Sheaf's CI.
+2. **Frontend verifiability** — confirm the JavaScript your browser is executing right now is byte-for-byte the published frontend code.
+
+The second one is the strong claim, because it's verifiable from your browser without trusting the server.
+
+## What's protected, and what isn't
+
+| Concern | Layer 1 (image) | Layer 3 (frontend) |
+|---|---|---|
+| "Is this the published code?" | ✅ — verified via cosign | ✅ — verified via SRI + manifest |
+| "Did Sheaf's CI build it?" | ✅ — signature ties to the workflow | ✅ — manifest is signed |
+| "Could the operator deploy a different image?" | ❌ — operator-attested | ✅ — your browser checks every loaded file |
+| "Could someone tamper with assets in transit?" | ✅ — image digest pinned | ✅ — browser refuses bad hashes |
+| "Could the host kernel / hypervisor be compromised?" | ❌ | ❌ (would need a TEE) |
+
+The crucial gap Layer 3 closes: a malicious operator can't ship modified frontend code to your browser without you noticing, because the browser checks every file's hash against the published manifest. Layer 1 doesn't have that property — it only proves "an image with this commit exists and was signed."
+
+For Sheaf specifically, this matters because the frontend handles the interesting things: passwords, TOTP codes, the bio-editor textarea, and so on. Pinning the frontend means malicious operator behaviour around those surfaces is detectable.
+
+---
+
+## Layer 1: image verifiability
+
+### What you can check
+
+For any Sheaf instance, you can:
+
+1. `GET /v1/version` to see what commit the backend was built from.
+2. Pull that commit's image from GHCR and verify it was signed by Sheaf's official CI workflow.
+3. Confirm the image digest matches what was signed (so nothing was swapped after publication).
+
+What you can't check from this alone: that the running backend is *actually* serving the image it claims to be. A malicious operator could lie at the `/v1/version` endpoint. This is a known limitation; Layer 3 is what closes it for browser-loaded code.
+
+### How it works (high level)
+
+When Sheaf releases a new version, GitHub Actions builds the Docker image and uses **[sigstore/cosign](https://docs.sigstore.dev/cosign/installation/)** to sign it. Cosign uses what's called *keyless OIDC signing*:
+
+- There's no private key sitting somewhere that could leak or be otherwise obtained via legal or covert methods.
+- Instead, every signature is tied to the GitHub Actions workflow that produced it ("this was signed by `https://github.com/sheaf-project/sheaf/.github/workflows/ci.yml` running on tag `v0.1.1`").
+- The signature is recorded in **[Rekor](https://github.com/sigstore/rekor)**, Sigstore's public transparency log — an append-only ledger that anyone can audit.
+
+This means verification doesn't depend on Sheaf's project owner protecting a key — it depends on GitHub's identity provider and Sigstore's public infrastructure, both of which are operated by independent parties with public auditing.
+
+When you verify a signature, you're checking: "This image digest was signed by the Sheaf CI workflow, and the signature is recorded in the public log." If any of those don't hold — wrong workflow, missing log entry, modified image — verification fails.
+
+### How to verify (manual)
+
+Install [cosign](https://docs.sigstore.dev/cosign/installation/), then:
+
+```sh
+# 1. Find out what commit the instance is running.
+curl -s https://your-sheaf-instance/v1/version | jq
+
+# 2. Verify the image was signed by Sheaf's CI workflow.
+cosign verify ghcr.io/sheaf-project/sheaf:0.1.1 \
+  --certificate-identity-regexp "https://github.com/sheaf-project/sheaf/.github/workflows/ci.yml@.*" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A successful verification prints the image digest and metadata — the workflow run ID, the git SHA, the tag. A failed verification prints an error explaining why (wrong identity, missing signature, etc.).
+
+You can also inspect the image's OCI labels without running it:
+
+```sh
+docker inspect ghcr.io/sheaf-project/sheaf:0.1.1 \
+  | jq '.[].Config.Labels."org.opencontainers.image.revision"'
+```
+
+This returns the git commit baked into the image at build time, independent of whatever the running backend reports.
+
+### How to verify (automated)
+
+Sheaf ships a verification script at `scripts/verify-release.sh`. Run it against an instance URL:
+
+```sh
+./scripts/verify-release.sh https://your-sheaf-instance
+```
+
+The script fetches `/v1/version`, runs the cosign verification with the correct workflow identity, compares the image's `org.opencontainers.image.revision` label against the reported commit, and prints a pass/fail summary. Use this for routine spot checks.
+
+---
+
+## Layer 3: frontend verifiability
+
+### What you can check
+
+For any Sheaf instance:
+
+1. Open your browser's devtools. Look at the `<script>` tags on the page — every one has an `integrity="sha384-..."` attribute.
+2. Browsers refuse to execute any script whose actual content doesn't match the `integrity` hash. This is enforced by the browser; the server can't lie.
+3. Sheaf publishes a `build-manifest.json` listing the expected hash of every file in the frontend bundle, tied to a specific git commit.
+4. You can compare what your browser loaded against what the manifest says — and against what *you* would build from the published source.
+
+If everything matches: the JavaScript running in your browser is byte-for-byte identical to what's in the public Sheaf repo at that commit. No server trust required.
+
+### How it works (high level)
+
+**SRI (Subresource Integrity)** is a web-platform feature: when an HTML file says `<script src="/x.js" integrity="sha384-...">`, the browser computes the SHA-384 hash of `x.js` after fetching it and refuses to run the script if the hash doesn't match. It's strong because the check happens on bytes the browser actually received — neither the server nor a man-in-the-middle can fake their way past it.
+
+Sheaf's build process generates these `integrity` attributes automatically for every script and stylesheet, then writes a **build manifest** (a JSON file at `/build-manifest.json`) listing every expected hash. The manifest itself is also signed via cosign, so paranoid users can fetch it from a Sigstore-attested source rather than trusting the server.
+
+The "`index.html` problem": SRI protects everything *except* `index.html`, because `index.html` is what carries the `integrity` attributes. If `index.html` were tampered with, the wrong attributes could be substituted. Mitigation: `index.html` is small enough that you can hash it manually, and its expected hash is in the manifest. So the trust chain is: cosign-attested manifest → `index.html` hash → all referenced files via SRI.
+
+### How to verify (manual, browser-side)
+
+1. Visit your Sheaf instance.
+2. Open devtools → Sources or Network → click a script file → look for `integrity` in the request headers / page source.
+3. Visit `https://your-sheaf-instance/build-manifest.json`.
+4. Compare the hashes. They should match the `integrity=` attributes on your loaded page.
+
+If they match, your browser is loading what Sheaf's CI built.
+
+### How to verify (against the published source)
+
+The strongest claim: rebuild from source and compare hashes.
+
+```sh
+git clone https://github.com/sheaf-project/sheaf.git
+cd sheaf
+git checkout <commit-from-/v1/version>
+cd web
+npm ci
+npm run build
+
+# Now diff your build-manifest against the served one:
+diff <(jq -S .files dist/build-manifest.json) \
+     <(curl -s https://your-sheaf-instance/build-manifest.json | jq -S .files)
+```
+
+If the file lists are identical, the served frontend is the published source.
+
+> **A caveat**: Vite builds aren't perfectly deterministic across machines (some plugins inject timestamps or vary chunk-naming order). In practice most files reproduce exactly because they're content-hashed; if you see a small diff in `index.html` ordering, that's likely build-tooling non-determinism rather than tampering. Moving toward fully reproducible builds is a known goal.
+
+### Cosign-attested manifest verification
+
+For verification independent of the running server, the build manifest is also published as a Sigstore attestation against the `sheaf-web` image:
+
+```sh
+cosign verify-attestation --type custom \
+  --certificate-identity-regexp "https://github.com/sheaf-project/sheaf/.github/workflows/ci.yml@.*" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/sheaf-project/sheaf-web:0.1.1
+```
+
+This pulls the manifest as a Sigstore-attested predicate. Useful for verifying without trusting the instance you're hitting — useful when you want to know what the canonical build is independently of whatever a particular server claims.
+
+---
+
+## Releases and the trust chain
+
+Sheaf publishes signed releases on a manual-approval workflow:
+
+1. A maintainer cuts a tag (`v0.x.y`).
+2. CI builds and signs the Docker images automatically.
+3. CI **pauses for human approval** before publishing the GitHub release page and uploading verifiable artefacts (frontend tarball, build manifest, SBOM).
+4. Approval happens via the GitHub Actions UI by an authorized reviewer.
+
+This means:
+- An accidental tag push doesn't create a public release.
+- Every release has a sentient reviewer in the loop, named in the GitHub Actions audit log.
+- Image signing happens *before* the gate, so even if approval is delayed, the signed image is verifiable from GHCR.
+
+### What you get with a release
+
+- Signed multi-arch Docker images on GHCR.
+- A GitHub release page with auto-generated notes from PR titles plus a hand-curated `CHANGELOG.md` summary.
+- A frontend tarball (`web-dist-vX.Y.Z.tar.gz`) and `build-manifest.json` as release assets.
+- An SPDX SBOM for each image, published as a Sigstore attestation.
+
+---
+
+## What we explicitly do *not* claim
+
+- **Hardware attestation**: Sheaf doesn't run in a TEE. If your threat model includes a malicious host kernel or hypervisor, this design doesn't help you. At that level, you'd want something like AMD SEV-SNP confidential VMs or similar.
+- **Backend behaviour matches frontend integrity**: Layer 3 proves the frontend is what you expect; the backend's behaviour beyond that is operator-attested.
+- **Reproducible builds**: byte-for-byte reproducibility from source is a future goal, not a guarantee yet. Most of the bundle is reproducible but some non-determinism in HTML/asset ordering is known.
+- **Old versions stay verifiable forever**: cosign keyless signatures rely on Rekor (Sigstore's public log). Rekor is an append-only log run by an independent foundation, not Sheaf — so signatures stay verifiable as long as Sigstore stays operational. Realistic horizon: many years, but not "forever."
+
+---
+
+## Questions or concerns?
+
+- File an issue at <https://github.com/sheaf-project/sheaf/issues>.
+- Discord: <https://discord.gg/WFaKQPzFx8>.
+- If you spot a tampered or mis-signed image, please report it via GitHub security advisory rather than a public issue.

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Sheaf release verification.
+#
+# Fetches /v1/version from a Sheaf instance, verifies the corresponding
+# Docker image was signed by Sheaf's official CI workflow via sigstore/cosign
+# (keyless OIDC, recorded in Rekor), and checks the signed git_sha annotation
+# matches what the instance reports.
+#
+# Usage:
+#   verify-release.sh <instance-url>
+#   verify-release.sh https://your-sheaf-instance
+#
+# Exit codes:
+#   0  — verified
+#   1  — verification failed (signature, mismatch, or unreachable instance)
+#   64 — bad usage
+#   69 — required tool missing
+
+set -eu
+
+usage() {
+    cat <<'EOF' >&2
+usage: verify-release.sh <instance-url>
+
+Verifies that the Sheaf instance at <instance-url> is running a Docker image
+signed by Sheaf's official CI workflow.
+
+Requires: curl, jq, cosign.
+EOF
+    exit 64
+}
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: required tool not found: $1" >&2
+        echo "  install: $2" >&2
+        exit 69
+    fi
+}
+
+INSTANCE="${1:-}"
+[ -z "$INSTANCE" ] && usage
+
+require curl   "https://curl.se/"
+require jq     "https://stedolan.github.io/jq/"
+require cosign "https://docs.sigstore.dev/cosign/installation/"
+
+INSTANCE="${INSTANCE%/}"
+REGISTRY="ghcr.io/sheaf-project"
+IMAGE_NAME="sheaf"
+
+echo "→ Fetching $INSTANCE/v1/version"
+VERSION_JSON=$(curl -fsS "$INSTANCE/v1/version") || {
+    echo "FAIL: could not reach $INSTANCE/v1/version" >&2
+    exit 1
+}
+
+GIT_COMMIT=$(echo "$VERSION_JSON" | jq -r '.git_commit // empty')
+GIT_TAG=$(echo "$VERSION_JSON" | jq -r '.git_tag // empty')
+APP_VERSION=$(echo "$VERSION_JSON" | jq -r '.version // empty')
+
+echo "  app version: ${APP_VERSION:-<unknown>}"
+echo "  git commit:  ${GIT_COMMIT:-<unknown>}"
+echo "  git tag:     ${GIT_TAG:-<unset>}"
+
+if [ -z "$GIT_COMMIT" ]; then
+    echo "FAIL: instance reports no git commit (built from source without CI?)" >&2
+    exit 1
+fi
+
+# Tagged releases pin to the version tag; mainline builds use the sha tag.
+if [ -n "$GIT_TAG" ]; then
+    REF="${REGISTRY}/${IMAGE_NAME}:${GIT_TAG#v}"
+else
+    REF="${REGISTRY}/${IMAGE_NAME}:sha-${GIT_COMMIT}"
+fi
+
+echo
+echo "→ Verifying cosign signature on $REF"
+
+COSIGN_OUT=$(mktemp)
+trap 'rm -f "$COSIGN_OUT"' EXIT
+
+cosign verify "$REF" \
+    --certificate-identity-regexp "https://github.com/sheaf-project/sheaf/.github/workflows/ci.yml@.*" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    > "$COSIGN_OUT" 2>/tmp/cosign-stderr || {
+    echo "FAIL: cosign verify failed" >&2
+    cat /tmp/cosign-stderr >&2
+    exit 1
+}
+
+# The git_sha annotation is recorded at signing time by CI. If it doesn't
+# match what the instance reports, either the instance is lying or it's
+# running a different build than the one signed at this tag.
+SIGNED_SHA=$(jq -r '.[0].optional.git_sha // empty' "$COSIGN_OUT")
+
+if [ -z "$SIGNED_SHA" ]; then
+    echo "FAIL: signature has no git_sha annotation (older signing format?)" >&2
+    exit 1
+fi
+
+if [ "$SIGNED_SHA" != "$GIT_COMMIT" ]; then
+    echo "FAIL: instance reports commit $GIT_COMMIT but signed annotation is $SIGNED_SHA" >&2
+    exit 1
+fi
+
+echo
+echo "✓ PASS: $INSTANCE is running a verified Sheaf build."
+echo "  signed by: github.com/sheaf-project/sheaf CI workflow"
+echo "  commit:    $GIT_COMMIT"
+echo "  ref:       $REF"

--- a/sheaf/__init__.py
+++ b/sheaf/__init__.py
@@ -1,3 +1,8 @@
 """Sheaf — open-source plural system tracking."""
 
-__version__ = "0.1.0"
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version("sheaf")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0-dev"

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -18,11 +18,15 @@ from sheaf.api.v1 import (
     system_safety,
     systems,
     tags,
+    version,
     webhooks,
 )
 from sheaf.auth.dependencies import require_scope
 
 v1_router = APIRouter(prefix="/v1")
+
+# Public (no auth): build provenance for verifiability tooling.
+v1_router.include_router(version.router)
 
 # Auth, admin, announcements: no scope enforcement
 v1_router.include_router(auth.router)

--- a/sheaf/api/v1/version.py
+++ b/sheaf/api/v1/version.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+
+from sheaf import __version__
+from sheaf.config import settings
+
+router = APIRouter(tags=["version"])
+
+
+@router.get("/version")
+async def get_version() -> dict[str, str | None]:
+    return {
+        "version": __version__,
+        "git_commit": settings.sheaf_git_commit or None,
+        "git_tag": settings.sheaf_git_tag or None,
+        "build_time": settings.sheaf_build_time or None,
+        "mode": settings.sheaf_mode.value,
+    }

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -36,6 +36,12 @@ class Settings(BaseSettings):
     # Mode
     sheaf_mode: SheafMode = SheafMode.SELFHOSTED
 
+    # Build provenance — populated by Docker build args at image build time.
+    # Empty when running from source (dev) or from an image built without CI.
+    sheaf_git_commit: str = ""
+    sheaf_git_tag: str = ""
+    sheaf_build_time: str = ""
+
     # aaS settings
     free_tier_front_retention_days: int = 30
     retention_check_interval_hours: int = 6

--- a/sheaf/main.py
+++ b/sheaf/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from sheaf import __version__
 from sheaf.api.v1.router import v1_router
 from sheaf.config import _validate_settings, settings
 from sheaf.middleware.body_size import BodyTooLargeError, MaxBodySizeMiddleware
@@ -58,7 +59,7 @@ async def lifespan(app: FastAPI):
     _validate_settings()
     # Eagerly initialise encryption key so we get the warning at startup
     settings.get_encryption_key()
-    logger.info("Sheaf %s starting in %s mode", "0.1.0", settings.sheaf_mode.value)
+    logger.info("Sheaf %s starting in %s mode", __version__, settings.sheaf_mode.value)
 
     await _promote_admin_emails()
 
@@ -87,7 +88,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Sheaf",
     description="Open-source plural system tracking",
-    version="0.1.0",
+    version=__version__,
     lifespan=lifespan,
     docs_url="/v1/docs",
     redoc_url="/v1/redoc",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -49,7 +49,8 @@
         "globals": "^17.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
-        "vite": "^7.3.2"
+        "vite": "^7.3.2",
+        "vite-plugin-sri3": "^2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7474,6 +7475,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-sri3": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-sri3/-/vite-plugin-sri3-2.0.0.tgz",
+      "integrity": "sha512-bBeKFPbiIcipMhmeJYB1PSNqZLrvlfUdxX2Tqn7+V4XVLKlh5+TdwxPPfsS/gP1OH2gdfdui0nlxeaOjudbV8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/build-manifest.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -51,6 +51,7 @@
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "vite-plugin-sri3": "^2.0.0"
   }
 }

--- a/web/scripts/build-manifest.mjs
+++ b/web/scripts/build-manifest.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Emits dist/build-manifest.json — a sha384 of every file in dist/, plus
+// build provenance from VITE_* envs. Lets verifiers compare a deployed
+// instance's served bundle against the manifest published by CI.
+//
+// Run after `vite build`.
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+const distDir = resolve(process.cwd(), "dist");
+const manifestPath = resolve(distDir, "build-manifest.json");
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...walk(full));
+    } else if (st.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function sri(buf) {
+  return "sha384-" + createHash("sha384").update(buf).digest("base64");
+}
+
+const files = walk(distDir)
+  .filter((p) => p !== manifestPath)
+  .map((p) => {
+    const buf = readFileSync(p);
+    const rel = relative(distDir, p).split(sep).join("/");
+    return { path: rel, size: buf.length, integrity: sri(buf) };
+  })
+  .sort((a, b) => a.path.localeCompare(b.path));
+
+const manifest = {
+  version: 1,
+  git_commit: process.env.VITE_GIT_COMMIT || "",
+  git_tag: process.env.VITE_GIT_TAG || "",
+  build_time: process.env.VITE_BUILD_TIME || "",
+  files,
+};
+
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+console.log(
+  `wrote ${manifestPath} — ${files.length} files, ${
+    manifest.git_tag || manifest.git_commit?.slice(0, 7) || "dev"
+  }`,
+);

--- a/web/src/components/legal-footer.tsx
+++ b/web/src/components/legal-footer.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getAuthConfig } from "@/lib/auth";
+import { VersionChip } from "@/components/version-chip";
 
 export function LegalFooter() {
   const { data: config } = useQuery({
@@ -9,8 +10,6 @@ export function LegalFooter() {
 
   const terms = config?.terms_url;
   const privacy = config?.privacy_url;
-
-  if (!terms && !privacy) return null;
 
   return (
     <footer className="border-t bg-background px-4 py-2 text-center text-xs text-muted-foreground">
@@ -35,6 +34,8 @@ export function LegalFooter() {
           Privacy Policy
         </a>
       )}
+      {(terms || privacy) && <span className="mx-2">·</span>}
+      <VersionChip />
     </footer>
   );
 }

--- a/web/src/components/version-chip.tsx
+++ b/web/src/components/version-chip.tsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router";
+import { FRONTEND_BUILD, buildLabel } from "@/lib/version";
+
+export function VersionChip() {
+  const label = buildLabel({
+    gitTag: FRONTEND_BUILD.gitTag,
+    gitCommit: FRONTEND_BUILD.gitCommit,
+  });
+
+  return (
+    <Link
+      to="/about"
+      className="rounded-md border border-transparent px-1.5 py-0.5 font-mono hover:border-border hover:text-foreground"
+      title="Build info & verification"
+    >
+      {label}
+    </Link>
+  );
+}

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,0 +1,37 @@
+import { apiFetch } from "./api-client";
+
+// Build provenance baked into the bundle by Vite at build time. Empty in dev
+// or when an image was built outside CI.
+export const FRONTEND_BUILD = {
+  gitCommit: import.meta.env.VITE_GIT_COMMIT || "",
+  gitTag: import.meta.env.VITE_GIT_TAG || "",
+  buildTime: import.meta.env.VITE_BUILD_TIME || "",
+} as const;
+
+export interface BackendVersion {
+  version: string;
+  git_commit: string | null;
+  git_tag: string | null;
+  build_time: string | null;
+  mode: string;
+}
+
+export function getBackendVersion() {
+  return apiFetch<BackendVersion>("/v1/version", { skipRefresh: true });
+}
+
+export function shortSha(sha: string | null | undefined): string {
+  if (!sha) return "";
+  return sha.slice(0, 7);
+}
+
+// Display label for the running build. Prefers the tag (e.g. "v0.1.0"), falls
+// back to a short commit, then to "dev".
+export function buildLabel(opts: {
+  gitTag?: string | null;
+  gitCommit?: string | null;
+}): string {
+  if (opts.gitTag) return opts.gitTag;
+  if (opts.gitCommit) return shortSha(opts.gitCommit);
+  return "dev";
+}

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -20,6 +20,30 @@ export function getBackendVersion() {
   return apiFetch<BackendVersion>("/v1/version", { skipRefresh: true });
 }
 
+export interface BuildManifestFile {
+  path: string;
+  size: number;
+  integrity: string;
+}
+
+export interface BuildManifest {
+  version: number;
+  git_commit: string;
+  git_tag: string;
+  build_time: string;
+  files: BuildManifestFile[];
+}
+
+// Fetched from the served bundle, not the API — the manifest sits next to
+// index.html and reflects what *this* nginx is actually shipping.
+export async function getBuildManifest(): Promise<BuildManifest> {
+  const res = await fetch("/build-manifest.json", { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`build manifest unavailable (${res.status})`);
+  }
+  return (await res.json()) as BuildManifest;
+}
+
 export function shortSha(sha: string | null | undefined): string {
   if (!sha) return "";
   return sha.slice(0, 7);

--- a/web/src/routes/about.tsx
+++ b/web/src/routes/about.tsx
@@ -4,7 +4,12 @@ import { PageHeader } from "@/components/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-import { FRONTEND_BUILD, getBackendVersion, shortSha } from "@/lib/version";
+import {
+  FRONTEND_BUILD,
+  getBackendVersion,
+  getBuildManifest,
+  shortSha,
+} from "@/lib/version";
 
 const REPO = "sheaf-project/sheaf";
 const REGISTRY = "ghcr.io/sheaf-project";
@@ -22,6 +27,11 @@ export function AboutPage() {
   const { data: backend, isLoading } = useQuery({
     queryKey: ["version", "backend"],
     queryFn: getBackendVersion,
+  });
+  const { data: manifest, error: manifestError } = useQuery({
+    queryKey: ["version", "manifest"],
+    queryFn: getBuildManifest,
+    retry: false,
   });
 
   const frontendCommit = FRONTEND_BUILD.gitCommit;
@@ -107,6 +117,59 @@ export function AboutPage() {
             <p className="text-muted-foreground">
               One side reports no build provenance — likely a dev build or an
               image built outside the official CI pipeline.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-3">
+            Bundle integrity
+            {manifest && (
+              <Badge variant="outline">{manifest.files.length} files</Badge>
+            )}
+            {manifestError && (
+              <Badge variant="outline">unavailable</Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {manifest && (
+            <>
+              <p className="text-muted-foreground">
+                Every JS/CSS file in the served bundle has a sha384 integrity
+                hash injected into <code>index.html</code> and listed in{" "}
+                <a
+                  href="/build-manifest.json"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                >
+                  /build-manifest.json
+                </a>
+                . Browsers will refuse to run a script whose hash doesn't match
+                — and the manifest itself records what those hashes should be
+                at build time.
+              </p>
+              <Field
+                label="Manifest tag"
+                value={manifest.git_tag || null}
+              />
+              <Field
+                label="Manifest commit"
+                value={manifest.git_commit || null}
+              />
+              <Field
+                label="Manifest built"
+                value={manifest.build_time || null}
+              />
+            </>
+          )}
+          {manifestError && (
+            <p className="text-muted-foreground">
+              No build manifest at <code>/build-manifest.json</code> — likely a
+              dev build or an image built outside CI.
             </p>
           )}
         </CardContent>

--- a/web/src/routes/about.tsx
+++ b/web/src/routes/about.tsx
@@ -1,0 +1,168 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { PageHeader } from "@/components/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { FRONTEND_BUILD, getBackendVersion, shortSha } from "@/lib/version";
+
+const REPO = "sheaf-project/sheaf";
+const REGISTRY = "ghcr.io/sheaf-project";
+
+function Field({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="grid grid-cols-[8rem_1fr] gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono break-all">{value || "—"}</span>
+    </div>
+  );
+}
+
+export function AboutPage() {
+  const { data: backend, isLoading } = useQuery({
+    queryKey: ["version", "backend"],
+    queryFn: getBackendVersion,
+  });
+
+  const frontendCommit = FRONTEND_BUILD.gitCommit;
+  const backendCommit = backend?.git_commit ?? "";
+  const commitsMatch =
+    !!frontendCommit && !!backendCommit && frontendCommit === backendCommit;
+  const eitherUnknown = !frontendCommit || !backendCommit;
+
+  const ref = backend?.git_tag
+    ? `${REGISTRY}/sheaf:${backend.git_tag.replace(/^v/, "")}`
+    : backendCommit
+      ? `${REGISTRY}/sheaf:sha-${backendCommit}`
+      : null;
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <PageHeader title="About this build" />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-3">
+            Backend
+            {isLoading ? (
+              <Skeleton className="h-5 w-16" />
+            ) : (
+              <Badge variant="outline" className="font-mono">
+                {backend?.version ?? "unknown"}
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Field label="Version" value={backend?.version} />
+          <Field label="Git tag" value={backend?.git_tag} />
+          <Field label="Git commit" value={backendCommit || null} />
+          <Field label="Build time" value={backend?.build_time} />
+          <Field label="Mode" value={backend?.mode} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Frontend</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Field label="Git tag" value={FRONTEND_BUILD.gitTag || null} />
+          <Field label="Git commit" value={frontendCommit || null} />
+          <Field label="Build time" value={FRONTEND_BUILD.buildTime || null} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-3">
+            Frontend ↔ Backend match
+            {!isLoading && (
+              <Badge
+                variant={commitsMatch ? "default" : eitherUnknown ? "outline" : "destructive"}
+              >
+                {commitsMatch ? "match" : eitherUnknown ? "unknown" : "mismatch"}
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          {commitsMatch && (
+            <p className="text-muted-foreground">
+              Frontend and backend were built from the same commit{" "}
+              <span className="font-mono">{shortSha(frontendCommit)}</span>.
+            </p>
+          )}
+          {!commitsMatch && !eitherUnknown && (
+            <p className="text-muted-foreground">
+              Frontend commit{" "}
+              <span className="font-mono">{shortSha(frontendCommit)}</span>{" "}
+              does not match backend commit{" "}
+              <span className="font-mono">{shortSha(backendCommit)}</span>. This
+              can happen during a staged rollout, or if a reverse proxy is
+              serving an older asset bundle.
+            </p>
+          )}
+          {eitherUnknown && (
+            <p className="text-muted-foreground">
+              One side reports no build provenance — likely a dev build or an
+              image built outside the official CI pipeline.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Verify this build</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-muted-foreground">
+            Sheaf publishes signed Docker images via{" "}
+            <a
+              href="https://www.sigstore.dev/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground"
+            >
+              sigstore
+            </a>{" "}
+            with keyless OIDC signing. You can verify that this instance is
+            running an image built and signed by the official CI workflow.
+          </p>
+          {ref && (
+            <pre className="overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs">
+{`cosign verify ${ref} \\
+  --certificate-identity-regexp "https://github.com/${REPO}/.github/workflows/ci.yml@.*" \\
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com`}
+            </pre>
+          )}
+          <p className="text-muted-foreground">
+            Or run the bundled script:
+          </p>
+          <pre className="overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs">
+{`./scripts/verify-release.sh ${typeof window !== "undefined" ? window.location.origin : "<instance-url>"}`}
+          </pre>
+          <p className="text-muted-foreground">
+            See{" "}
+            <a
+              href={`https://github.com/${REPO}/blob/main/docs/VERIFYING.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground"
+            >
+              docs/VERIFYING.md
+            </a>{" "}
+            for the full trust model.
+          </p>
+        </CardContent>
+      </Card>
+
+      <p className="text-center text-xs text-muted-foreground">
+        <Link to="/" className="hover:text-foreground hover:underline">
+          ← Back to dashboard
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { FrontsPage } from "./fronts";
 import { GroupsPage } from "./groups";
 import { SettingsPage } from "./settings";
 import { ImportPage } from "./import";
+import { AboutPage } from "./about";
 import { JournalsPage } from "./journals";
 import { JournalDetailPage } from "./journals.$id";
 import { AdminLayout } from "./admin/_layout";
@@ -48,6 +49,7 @@ export const router = createBrowserRouter([
       { path: "groups", element: <GroupsPage /> },
       { path: "settings", element: <SettingsPage /> },
       { path: "import", element: <ImportPage /> },
+      { path: "about", element: <AboutPage /> },
       {
         path: "admin",
         element: <AdminLayout />,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,9 +2,10 @@ import path from "path"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
+import { sri } from "vite-plugin-sri3"
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), sri()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Layered build verifiability for Sheaf

 - Image signing — multi-arch GHCR images signed via cosign keyless OIDC; SPDX SBOMs attached as Sigstore attestations.
- Build provenance — /v1/version endpoint reports the running commit/tag/build-time, baked in by Docker build args.
- Frontend integrity — sha384 SRI attributes on every script/style; build-manifest.json listing every dist file's hash, also Sigstore-attested against the sheaf-web image.
- About page + version chip — surfaces backend + frontend build info, flags commit mismatches, shows copy-paste cosign command.
- Release workflow — tag-driven, gated on a release GitHub Environment with required reviewers; verifies pyproject ↔ tag, blocks tags from unmerged commits, extracts CHANGELOG section, attaches frontend tarball + manifest.
- Verification script — scripts/verify-release.sh automates the /v1/version → cosign check.
- Docs — docs/VERIFYING.md (full trust model, present-tense), README pointer, CHANGELOG.md, CONTRIBUTING release procedure.

 Test plan

- PR CI green (lint/test only — docker+release fire on push/tag, not PR)
- After merge: tag v0.1.0 from main → docker job builds + signs all 3 images
- Approve release environment deployment → GitHub release page created with tarball + manifest
- Run ./scripts/verify-release.sh https://test-instance → PASS
