### PR TITLE
Revision pinning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,23 @@ SHEAF_MODE=selfhosted
 # =============================================================================
 FREE_TIER_FRONT_RETENTION_DAYS=30
 
+# Revision-history retention caps per tier. 0 = unlimited.
+# Covers both journal entries and member bios. Per-system overrides in the
+# Safety panel can lower these but never raise above the tier max.
+# JOURNAL_MAX_REVISIONS_FREE=10
+# JOURNAL_MAX_REVISIONS_PLUS=100
+# JOURNAL_MAX_REVISIONS_SELFHOSTED=0
+# JOURNAL_MAX_REVISION_DAYS_FREE=30
+# JOURNAL_MAX_REVISION_DAYS_PLUS=365
+# JOURNAL_MAX_REVISION_DAYS_SELFHOSTED=0
+
+# Per-target pinned-revision caps. Pinned revisions are exempt from the
+# rolling retention sweep above, so this bounds extra storage from pins.
+# Per-system override in the Safety panel can lower but not raise.
+# PINNED_REVISION_MAX_PER_TARGET_FREE=3
+# PINNED_REVISION_MAX_PER_TARGET_PLUS=5
+# PINNED_REVISION_MAX_PER_TARGET_SELFHOSTED=10
+
 # =============================================================================
 # File Storage
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 - **Groups** — Organize members into groups with nesting (subsystems)
 - **Tags** — Flexible member tagging
 - **Custom fields** — Define your own fields (text, number, date, boolean, select) with per-field privacy
+- **Journals** — Per-member or system-wide markdown journal entries with edit history
+- **Revision history** — Member bios and journal entries are versioned, with tier-aware retention caps
+- **Revision pinning** — Pin specific revisions to protect them from automatic trim, with optional re-auth + grace on unpin
+- **System Safety** — Optional grace period and re-auth (password / TOTP) on destructive actions (member/journal/group/etc deletion, revision unpin)
 - **SimplyPlural import** — Import your SP export with granular control (select specific members, toggle front history, etc.)
 - **File storage** — File uploads with filesystem or S3-compatible backends
 - **Data export**
@@ -39,6 +43,7 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 - **Registration modes** — Open, approval-required, invite-only, or closed
 - **Email verification** — Optional required verification with configurable flow
 - **Account deletion** — Self-service with configurable grace period
+- **Field-level encryption** — Member names/bios, journal titles/bodies, and revision history encrypted at rest with XChaCha20-Poly1305
 - **Eye-friendly** — Default dark, with Dark Reader compatibility and a clear light toggle
 
 ## FAQ
@@ -128,6 +133,11 @@ Key endpoints:
 | `GET/POST /v1/tags` | Tags |
 | `GET/POST /v1/fields` | Custom field definitions |
 | `PUT /v1/members/{id}/fields` | Set custom field values |
+| `GET/POST /v1/journals` | List/create journal entries |
+| `GET /v1/journals/{id}/revisions` | Edit history for an entry |
+| `POST /v1/journals/{id}/pin-revision` | Pin a revision (exempt from trim) |
+| `POST /v1/journals/{id}/unpin-revision` | Unpin (immediate or queued behind grace) |
+| `GET/PATCH /v1/system/safety` | System Safety settings + pending actions |
 | `POST /v1/import/simplyplural` | Import SP data |
 | `POST /v1/import/sheaf` | Import Sheaf export |
 | `GET /v1/export` | Export all data |
@@ -155,6 +165,8 @@ See **[docs/SELFHOSTING.md](docs/SELFHOSTING.md)** for the full guide covering:
 - Account deletion with configurable grace period
 - File storage (filesystem / S3) with hotlink protection
 - Storage quotas and upload limits
+- Revision-history retention caps and pinned-revision tier knobs
+- System Safety (destructive-action grace, re-auth, per-category toggles)
 - Frontend build and serving
 - Reverse proxy setup (nginx, Caddy) and the `SHEAF_BASE_URL` / cookie-Secure relationship
 - Rate limiting and trusted proxies
@@ -191,7 +203,7 @@ SHEAF_TEST_DB_URL=postgresql+asyncpg://sheaf:<POSTGRES_PASSWORD>@localhost:5432/
 - [ ] Named fronts — save a named combination of members and make them searchable in the start front dialog
 - [ ] CLI similar to [simplyplural-cli](https://github.com/SiteRelEnby/simplyplural-cli)
 - [ ] Front change notifications (WebSocket push)
-- [ ] Journals/notes (per-member, encrypted at rest)
+- [x] Journals/notes (per-member, encrypted at rest)
 - [ ] PluralKit bidirectional sync
 - [ ] Friend/trust system (cross-system visibility controls)
 - [ ] Per-field-per-member privacy overrides

--- a/alembic/versions/q7r8s9t0u1v2_add_revision_pinning.py
+++ b/alembic/versions/q7r8s9t0u1v2_add_revision_pinning.py
@@ -1,0 +1,64 @@
+"""Revision pinning: pinned_at on content_revisions + system toggles + cap
+
+Revision ID: q7r8s9t0u1v2
+Revises: p6q7r8s9t0u1
+Create Date: 2026-04-30
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "q7r8s9t0u1v2"
+down_revision: Union[str, None] = "p6q7r8s9t0u1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "content_revisions",
+        sa.Column("pinned_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_content_revisions_pinned",
+        "content_revisions",
+        ["target_type", "target_id", "pinned_at"],
+        postgresql_where=sa.text("pinned_at IS NOT NULL"),
+    )
+
+    op.add_column(
+        "systems",
+        sa.Column(
+            "safety_applies_to_revisions",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "systems",
+        sa.Column(
+            "auto_pin_first_revision",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "systems",
+        sa.Column(
+            "pinned_revision_max_per_target",
+            sa.Integer(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("systems", "pinned_revision_max_per_target")
+    op.drop_column("systems", "auto_pin_first_revision")
+    op.drop_column("systems", "safety_applies_to_revisions")
+    op.drop_index("ix_content_revisions_pinned", table_name="content_revisions")
+    op.drop_column("content_revisions", "pinned_at")

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -404,6 +404,51 @@ RETENTION_CHECK_INTERVAL_HOURS=6
 
 ---
 
+## Revision history retention
+
+Member bios and journal entries capture a revision on every edit. The rolling sweep keeps the newest N revisions per target and trims anything older than M days. Both caps apply per-tier (0 = unlimited):
+
+```env
+JOURNAL_MAX_REVISIONS_FREE=10
+JOURNAL_MAX_REVISIONS_PLUS=100
+JOURNAL_MAX_REVISIONS_SELFHOSTED=0
+JOURNAL_MAX_REVISION_DAYS_FREE=30
+JOURNAL_MAX_REVISION_DAYS_PLUS=365
+JOURNAL_MAX_REVISION_DAYS_SELFHOSTED=0
+
+# How often the sweep runs.
+JOURNAL_GC_INTERVAL_HOURS=6
+
+# Notice period before a tier downgrade actually trims older revisions.
+TIER_DOWNGRADE_GRACE_DAYS=14
+```
+
+Per-system overrides (Settings -> Safety -> Revision retention) can lower the cap below the tier max but never raise it. Reductions made while System Safety is active are deferred through the grace flow before applying.
+
+### Pinned revisions
+
+Pinned revisions are exempt from the rolling sweep, so they form a separate per-target storage budget. The cap applies per journal entry / per member bio (0 = unlimited):
+
+```env
+PINNED_REVISION_MAX_PER_TARGET_FREE=3
+PINNED_REVISION_MAX_PER_TARGET_PLUS=5
+PINNED_REVISION_MAX_PER_TARGET_SELFHOSTED=10
+```
+
+The `auto_pin_first_revision` toggle (per-system, default on) auto-pins the first captured revision so casual users get baseline protection against history-spam eviction without UI discovery. The `applies_to_revisions` Safety toggle gates whether unpin requires re-auth + grace.
+
+---
+
+## System Safety
+
+Optional grace + re-auth on destructive actions: member/group/tag/field/front/journal/image deletes, plus revision unpin. Configured per-system in Settings -> Safety, no env vars: each system picks its own grace period (0 disables), auth tier (none / password / TOTP / both), and which categories the policy applies to.
+
+Tightening (longer grace, stronger auth tier, enabling more categories) takes effect immediately. Loosening (shorter grace, weaker auth, disabling categories, lowering revision caps, disabling auto-pin) requires re-auth and is deferred behind the current grace period as a `SafetyChangeRequest` the user can cancel before it finalizes.
+
+Pending destructive actions and pending safety changes are visible in Settings -> Safety. Both can be cancelled before `finalize_after`.
+
+---
+
 ## Member limits
 
 Per-tier member limits (0 = unlimited). These are only enforced in `saas` mode or when overridden per-user via the admin UI.

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -31,7 +31,10 @@ from sheaf.schemas.journal import (
     JournalEntryReadWithCount,
     JournalEntryUpdate,
     JournalListResponse,
+    PinRevisionRequest,
     RestoreRevisionRequest,
+    UnpinRevisionRequest,
+    UnpinRevisionResponse,
 )
 from sheaf.services.journals import (
     create_journal_entry,
@@ -39,8 +42,10 @@ from sheaf.services.journals import (
     decrypt_revision_for_read,
     delete_revisions_for,
     entry_plaintext,
+    pin_revision,
     restore_journal_revision,
     revision_count_for,
+    unpin_revision_immediate,
     update_journal_entry,
 )
 from sheaf.services.system_safety import (
@@ -295,3 +300,82 @@ async def restore_revision(
     await db.commit()
     await db.refresh(entry)
     return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
+
+
+@router.post(
+    "/{entry_id}/pin-revision",
+    response_model=ContentRevisionRead,
+    dependencies=[Depends(require_scope("members:write"))],
+)
+async def pin_journal_revision(
+    entry_id: uuid.UUID,
+    body: PinRevisionRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    entry = await _get_own_entry(entry_id, system.id, db)
+    revision = await db.get(ContentRevision, body.revision_id)
+    if (
+        revision is None
+        or revision.target_type != ContentRevisionTarget.JOURNAL_ENTRY.value
+        or revision.target_id != entry.id
+    ):
+        raise HTTPException(status_code=404, detail="Revision not found")
+    try:
+        await pin_revision(db=db, user=user, system=system, revision=revision)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(revision)
+    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
+
+
+@router.post(
+    "/{entry_id}/unpin-revision",
+    response_model=UnpinRevisionResponse,
+    dependencies=[Depends(require_scope("members:write"))],
+)
+async def unpin_journal_revision(
+    entry_id: uuid.UUID,
+    body: UnpinRevisionRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    entry = await _get_own_entry(entry_id, system.id, db)
+    revision = await db.get(ContentRevision, body.revision_id)
+    if (
+        revision is None
+        or revision.target_type != ContentRevisionTarget.JOURNAL_ENTRY.value
+        or revision.target_id != entry.id
+    ):
+        raise HTTPException(status_code=404, detail="Revision not found")
+    if revision.pinned_at is None:
+        raise HTTPException(status_code=409, detail="Revision is not pinned")
+
+    if is_safeguarded(system, PendingActionType.REVISION_UNPIN):
+        verify_destructive_auth(user, system, body.password, body.totp_code)
+        title, _ = entry_plaintext(entry)
+        target_label = f"Pinned revision: {title or 'Untitled entry'}"
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.REVISION_UNPIN,
+            target_id=revision.id,
+            target_label=target_label,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return UnpinRevisionResponse(
+            pending_action_id=pending.id,
+            finalize_after=pending.finalize_after,
+        )
+
+    unpin_revision_immediate(revision)
+    await db.commit()
+    await db.refresh(revision)
+    return UnpinRevisionResponse(
+        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision)),
+    )

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -14,13 +14,21 @@ from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User, UserTier
-from sheaf.schemas.journal import ContentRevisionRead, RestoreRevisionRequest
+from sheaf.schemas.journal import (
+    ContentRevisionRead,
+    PinRevisionRequest,
+    RestoreRevisionRequest,
+    UnpinRevisionRequest,
+    UnpinRevisionResponse,
+)
 from sheaf.schemas.member import MemberCreate, MemberDeleteConfirm, MemberRead, MemberUpdate
 from sheaf.services.journals import (
     capture_revision,
     decrypt_revision_for_read,
     delete_revisions_for,
+    pin_revision,
     restore_member_bio_revision,
+    unpin_revision_immediate,
 )
 from sheaf.services.members import decrypt_member_for_read, member_plaintext
 from sheaf.services.system_safety import (
@@ -274,3 +282,82 @@ async def restore_bio_revision(
     await db.commit()
     await db.refresh(member)
     return decrypt_member_for_read(member)
+
+
+@router.post(
+    "/{member_id}/pin-revision",
+    response_model=ContentRevisionRead,
+    dependencies=[Depends(require_scope("members:write"))],
+)
+async def pin_bio_revision(
+    member_id: uuid.UUID,
+    body: PinRevisionRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    member = await _get_own_member(member_id, system, db)
+    revision = await db.get(ContentRevision, body.revision_id)
+    if (
+        revision is None
+        or revision.target_type != ContentRevisionTarget.MEMBER_BIO.value
+        or revision.target_id != member.id
+    ):
+        raise HTTPException(status_code=404, detail="Revision not found")
+    try:
+        await pin_revision(db=db, user=user, system=system, revision=revision)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(revision)
+    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
+
+
+@router.post(
+    "/{member_id}/unpin-revision",
+    response_model=UnpinRevisionResponse,
+    dependencies=[Depends(require_scope("members:write"))],
+)
+async def unpin_bio_revision(
+    member_id: uuid.UUID,
+    body: UnpinRevisionRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    member = await _get_own_member(member_id, system, db)
+    revision = await db.get(ContentRevision, body.revision_id)
+    if (
+        revision is None
+        or revision.target_type != ContentRevisionTarget.MEMBER_BIO.value
+        or revision.target_id != member.id
+    ):
+        raise HTTPException(status_code=404, detail="Revision not found")
+    if revision.pinned_at is None:
+        raise HTTPException(status_code=409, detail="Revision is not pinned")
+
+    if is_safeguarded(system, PendingActionType.REVISION_UNPIN):
+        verify_destructive_auth(user, system, body.password, body.totp_code)
+        member_name, _ = member_plaintext(member)
+        target_label = f"Pinned bio revision: {member_name or 'Unnamed member'}"
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.REVISION_UNPIN,
+            target_id=revision.id,
+            target_label=target_label,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return UnpinRevisionResponse(
+            pending_action_id=pending.id,
+            finalize_after=pending.finalize_after,
+        )
+
+    unpin_revision_immediate(revision)
+    await db.commit()
+    await db.refresh(revision)
+    return UnpinRevisionResponse(
+        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision)),
+    )

--- a/sheaf/api/v1/system_safety.py
+++ b/sheaf/api/v1/system_safety.py
@@ -53,6 +53,8 @@ _EXTERNAL_TO_INTERNAL = {
     "applies_to_fronts": "safety_applies_to_fronts",
     "applies_to_journals": "safety_applies_to_journals",
     "applies_to_images": "safety_applies_to_images",
+    "applies_to_revisions": "safety_applies_to_revisions",
+    "auto_pin_first_revision": "auto_pin_first_revision",
 }
 _INTERNAL_TO_EXTERNAL = {v: k for k, v in _EXTERNAL_TO_INTERNAL.items()}
 
@@ -68,6 +70,8 @@ def _settings_from_system(system: System) -> SystemSafetySettings:
         applies_to_fronts=system.safety_applies_to_fronts,
         applies_to_journals=system.safety_applies_to_journals,
         applies_to_images=system.safety_applies_to_images,
+        applies_to_revisions=system.safety_applies_to_revisions,
+        auto_pin_first_revision=system.auto_pin_first_revision,
     )
 
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -105,6 +105,13 @@ class Settings(BaseSettings):
     # Notice period before a tier downgrade trims revision history.
     tier_downgrade_grace_days: int = 14
 
+    # Pinned-revision caps per tier (per target — i.e. per journal entry or
+    # member bio). 0 = unlimited. Pinned revisions are exempt from the rolling
+    # retention sweep and form a separate budget from the count/day caps above.
+    pinned_revision_max_per_target_free: int = 3
+    pinned_revision_max_per_target_plus: int = 5
+    pinned_revision_max_per_target_selfhosted: int = 10
+
     # Allow external images in bios/descriptions. If False, CSP blocks
     # external image loading — only hosted uploads are displayed.
     allow_external_images: bool = True

--- a/sheaf/models/content_revision.py
+++ b/sheaf/models/content_revision.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from enum import StrEnum
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -63,6 +63,12 @@ class ContentRevision(UUIDMixin, Base):
         nullable=False,
     )
 
+    # NULL = not pinned. NOT NULL timestamp doubles as flag + UI sort.
+    # Pinned revisions are exempt from the rolling retention sweep.
+    pinned_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     __table_args__ = (
         Index(
             "ix_content_revisions_target",
@@ -72,4 +78,11 @@ class ContentRevision(UUIDMixin, Base):
         ),
         Index("ix_content_revisions_created", "created_at"),
         Index("ix_content_revisions_user", "user_id"),
+        Index(
+            "ix_content_revisions_pinned",
+            "target_type",
+            "target_id",
+            "pinned_at",
+            postgresql_where=text("pinned_at IS NOT NULL"),
+        ),
     )

--- a/sheaf/models/pending_action.py
+++ b/sheaf/models/pending_action.py
@@ -17,6 +17,7 @@ class PendingActionType(StrEnum):
     FRONT_DELETE = "front_delete"
     JOURNAL_DELETE = "journal_delete"
     IMAGE_DELETE = "image_delete"
+    REVISION_UNPIN = "revision_unpin"
 
 
 class PendingActionStatus(StrEnum):

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -92,6 +92,17 @@ class System(UUIDMixin, TimestampMixin, Base):
     safety_applies_to_images: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False
     )
+    safety_applies_to_revisions: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+
+    # Auto-pin the first captured revision for each journal entry / member bio.
+    # Independent of safety_applies_to_revisions: even without grace+re-auth on
+    # unpin, an auto-pin defends against the spam-eviction attack because the
+    # rolling retention sweep skips pinned rows.
+    auto_pin_first_revision: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="true", nullable=False
+    )
 
     # Revision-history retention overrides. NULL = use the tier-default cap;
     # a concrete value must be <= the tier max (validated at write time).
@@ -100,6 +111,9 @@ class System(UUIDMixin, TimestampMixin, Base):
         Integer, nullable=True
     )
     journal_max_revision_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+    pinned_revision_max_per_target: Mapped[int | None] = mapped_column(
         Integer, nullable=True
     )
 

--- a/sheaf/schemas/journal.py
+++ b/sheaf/schemas/journal.py
@@ -99,6 +99,7 @@ class ContentRevisionRead(BaseModel):
     title: str | None
     body: str
     created_at: datetime
+    pinned_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 
@@ -109,3 +110,26 @@ class ContentRevisionRead(BaseModel):
 
 class RestoreRevisionRequest(BaseModel):
     revision_id: uuid.UUID
+
+
+class PinRevisionRequest(BaseModel):
+    revision_id: uuid.UUID
+
+
+class UnpinRevisionRequest(BaseModel):
+    revision_id: uuid.UUID
+    password: str | None = None
+    totp_code: str | None = None
+
+
+class UnpinRevisionResponse(BaseModel):
+    """Returned from /unpin-revision.
+
+    `pending_action` is set when the system has revision-safety enabled with
+    a positive grace period. Otherwise the unpin is immediate and `revision`
+    is the now-unpinned row.
+    """
+
+    revision: ContentRevisionRead | None = None
+    pending_action_id: uuid.UUID | None = None
+    finalize_after: datetime | None = None

--- a/sheaf/schemas/system_safety.py
+++ b/sheaf/schemas/system_safety.py
@@ -18,6 +18,8 @@ class SystemSafetySettings(BaseModel):
     applies_to_fronts: bool
     applies_to_journals: bool
     applies_to_images: bool
+    applies_to_revisions: bool
+    auto_pin_first_revision: bool
 
 
 class SystemSafetyUpdate(BaseModel):
@@ -32,6 +34,8 @@ class SystemSafetyUpdate(BaseModel):
     applies_to_fronts: bool | None = None
     applies_to_journals: bool | None = None
     applies_to_images: bool | None = None
+    applies_to_revisions: bool | None = None
+    auto_pin_first_revision: bool | None = None
 
     # Re-auth for loosening changes is checked against the *current* auth tier.
     password: str | None = None

--- a/sheaf/services/journals.py
+++ b/sheaf/services/journals.py
@@ -97,6 +97,10 @@ async def capture_revision(
     image_keys is extracted from the plaintext body, then stored unencrypted
     so orphan cleanup can read it without key access.
 
+    If this is the first revision captured for the target AND the system has
+    `auto_pin_first_revision=True`, the new row is pinned. Defends against
+    spam-eviction even when the destructive-action grace flow is off.
+
     Caller is responsible for then overwriting the target row with the new
     content and committing.
     """
@@ -104,6 +108,14 @@ async def capture_revision(
         target_type.value if isinstance(target_type, ContentRevisionTarget) else target_type
     )
     editor_ids, editor_names = await snapshot_current_fronts(system_id, db)
+
+    existing_count = await revision_count_for(target_type_str, target_id, db)
+    pinned_at: datetime | None = None
+    if existing_count == 0:
+        system = await db.get(System, system_id)
+        if system is not None and system.auto_pin_first_revision:
+            pinned_at = datetime.now(UTC)
+
     revision = ContentRevision(
         target_type=target_type_str,
         target_id=target_id,
@@ -113,8 +125,84 @@ async def capture_revision(
         title=encrypt(title) if title is not None else None,
         body=encrypt(body),
         image_keys=extract_image_keys(body),
+        pinned_at=pinned_at,
     )
     db.add(revision)
+    return revision
+
+
+# ---------------------------------------------------------------------------
+# Pinning
+# ---------------------------------------------------------------------------
+
+
+_TIER_PIN_CAP = {
+    UserTier.FREE: lambda: settings.pinned_revision_max_per_target_free,
+    UserTier.PLUS: lambda: settings.pinned_revision_max_per_target_plus,
+    UserTier.SELF_HOSTED: lambda: settings.pinned_revision_max_per_target_selfhosted,
+}
+
+
+def tier_pin_cap(tier: UserTier | str) -> int:
+    """Per-target pinned-revision cap for a tier. 0 = unlimited."""
+    key = UserTier(tier) if not isinstance(tier, UserTier) else tier
+    return _TIER_PIN_CAP.get(key, lambda: 0)()
+
+
+def effective_pin_cap(user: User, system: System) -> int:
+    """Per-target pinned-revision cap actually in force. 0 = unlimited."""
+    return _combine_cap(tier_pin_cap(user.tier), system.pinned_revision_max_per_target)
+
+
+async def count_pinned_for_target(
+    target_type: ContentRevisionTarget | str,
+    target_id: uuid.UUID,
+    db: AsyncSession,
+) -> int:
+    target_type_str = (
+        target_type.value if isinstance(target_type, ContentRevisionTarget) else target_type
+    )
+    from sqlalchemy import func
+
+    result = await db.execute(
+        select(func.count())
+        .select_from(ContentRevision)
+        .where(
+            ContentRevision.target_type == target_type_str,
+            ContentRevision.target_id == target_id,
+            ContentRevision.pinned_at.is_not(None),
+        )
+    )
+    return int(result.scalar_one())
+
+
+async def pin_revision(
+    *,
+    db: AsyncSession,
+    user: User,
+    system: System,
+    revision: ContentRevision,
+) -> ContentRevision:
+    """Mark a revision as pinned. Raises ValueError if already pinned or at cap."""
+    if revision.pinned_at is not None:
+        raise ValueError("Revision is already pinned")
+    cap = effective_pin_cap(user, system)
+    if cap > 0:
+        current = await count_pinned_for_target(
+            revision.target_type, revision.target_id, db
+        )
+        if current >= cap:
+            raise ValueError(
+                f"Pin cap reached ({current}/{cap}) for this target — "
+                "unpin one first"
+            )
+    revision.pinned_at = datetime.now(UTC)
+    return revision
+
+
+def unpin_revision_immediate(revision: ContentRevision) -> ContentRevision:
+    """Clear the pin flag in-place. Caller commits."""
+    revision.pinned_at = None
     return revision
 
 
@@ -139,6 +227,7 @@ def decrypt_revision_for_read(revision: ContentRevision) -> dict:
         "body": body,
         "image_keys": revision.image_keys,
         "created_at": revision.created_at,
+        "pinned_at": revision.pinned_at,
     }
 
 

--- a/sheaf/services/retention.py
+++ b/sheaf/services/retention.py
@@ -178,6 +178,9 @@ async def _trim_target_group(
 
     `max_revisions=0` means unlimited (no count cap).
     `max_days=0` means unlimited (no age cap).
+
+    Pinned revisions (pinned_at IS NOT NULL) are exempt from both caps. They
+    form a separate budget bounded by the per-target pin cap, not this sweep.
     """
     if max_revisions == 0 and max_days == 0:
         return 0
@@ -187,6 +190,7 @@ async def _trim_target_group(
         .where(
             ContentRevision.target_type == target_type,
             ContentRevision.target_id == target_id,
+            ContentRevision.pinned_at.is_(None),
         )
         .order_by(ContentRevision.created_at.desc())
     )

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.auth.passwords import verify_password
 from sheaf.auth.totp import verify_code
 from sheaf.crypto import decrypt
+from sheaf.models.content_revision import ContentRevision
 from sheaf.models.custom_field import CustomFieldDefinition
 from sheaf.models.front import Front
 from sheaf.models.group import Group
@@ -50,6 +51,7 @@ SAFETY_CATEGORIES: tuple[str, ...] = (
     "fronts",
     "journals",
     "images",
+    "revisions",
 )
 
 _CATEGORY_BY_ACTION: dict[str, str] = {
@@ -60,6 +62,7 @@ _CATEGORY_BY_ACTION: dict[str, str] = {
     PendingActionType.FRONT_DELETE: "fronts",
     PendingActionType.JOURNAL_DELETE: "journals",
     PendingActionType.IMAGE_DELETE: "images",
+    PendingActionType.REVISION_UNPIN: "revisions",
 }
 
 _MODEL_BY_ACTION: dict[str, type] = {
@@ -70,6 +73,7 @@ _MODEL_BY_ACTION: dict[str, type] = {
     PendingActionType.FRONT_DELETE: Front,
     PendingActionType.JOURNAL_DELETE: JournalEntry,
     PendingActionType.IMAGE_DELETE: UploadedFile,
+    PendingActionType.REVISION_UNPIN: ContentRevision,
 }
 
 
@@ -139,7 +143,11 @@ class SafetyChangeSplit:
     deferred: dict[str, Any]
 
 
-_RETENTION_FIELDS = ("journal_max_revisions", "journal_max_revision_days")
+_RETENTION_FIELDS = (
+    "journal_max_revisions",
+    "journal_max_revision_days",
+    "pinned_revision_max_per_target",
+)
 
 
 def split_safety_changes(system: System, updates: dict[str, Any]) -> SafetyChangeSplit:
@@ -175,7 +183,7 @@ def split_safety_changes(system: System, updates: dict[str, Any]) -> SafetyChang
                 deferred[field] = new_value
             else:
                 applied[field] = new_value
-        elif field.startswith("safety_applies_to_"):
+        elif field.startswith("safety_applies_to_") or field == "auto_pin_first_revision":
             if current is True and new_value is False:
                 deferred[field] = new_value
             else:
@@ -287,7 +295,11 @@ def has_pending_action_for_target(
 async def finalize_pending_action(
     pending: PendingAction, db: AsyncSession
 ) -> None:
-    """Execute the queued delete. Idempotent: missing target marks completed."""
+    """Execute the queued action. Idempotent: missing target marks completed.
+
+    Most action types are deletes, with cascade/blob cleanup as needed.
+    REVISION_UNPIN clears the pin flag in place rather than deleting.
+    """
     model = _MODEL_BY_ACTION.get(pending.action_type)
     if model is None:
         pending.status = PendingActionStatus.ERRORED
@@ -297,26 +309,31 @@ async def finalize_pending_action(
 
     target = await db.get(model, pending.target_id)
     if target is not None and await _target_in_scope(target, pending, db):
-        # Polymorphic content_revisions can't FK on target — cascade in app.
-        if pending.action_type == PendingActionType.JOURNAL_DELETE:
-            from sheaf.services.journals import delete_revisions_for
+        if pending.action_type == PendingActionType.REVISION_UNPIN:
+            from sheaf.services.journals import unpin_revision_immediate
 
-            await delete_revisions_for("journal_entry", target.id, db)
-        elif pending.action_type == PendingActionType.MEMBER_DELETE:
-            from sheaf.services.journals import delete_revisions_for
+            unpin_revision_immediate(target)
+        else:
+            # Polymorphic content_revisions can't FK on target — cascade in app.
+            if pending.action_type == PendingActionType.JOURNAL_DELETE:
+                from sheaf.services.journals import delete_revisions_for
 
-            await delete_revisions_for("member_bio", target.id, db)
-        # Image deletes need to drop the storage blob alongside the DB row;
-        # the immediate-delete path does the same. An orphaned blob from a
-        # storage failure is recoverable; a stuck pending action isn't.
-        if pending.action_type == PendingActionType.IMAGE_DELETE:
-            import contextlib
+                await delete_revisions_for("journal_entry", target.id, db)
+            elif pending.action_type == PendingActionType.MEMBER_DELETE:
+                from sheaf.services.journals import delete_revisions_for
 
-            from sheaf.storage import get_storage
+                await delete_revisions_for("member_bio", target.id, db)
+            # Image deletes need to drop the storage blob alongside the DB row;
+            # the immediate-delete path does the same. An orphaned blob from a
+            # storage failure is recoverable; a stuck pending action isn't.
+            if pending.action_type == PendingActionType.IMAGE_DELETE:
+                import contextlib
 
-            with contextlib.suppress(Exception):
-                await get_storage().delete(target.key)
-        await db.delete(target)
+                from sheaf.storage import get_storage
+
+                with contextlib.suppress(Exception):
+                    await get_storage().delete(target.key)
+            await db.delete(target)
 
     pending.status = PendingActionStatus.COMPLETED
     pending.completed_at = datetime.now(UTC)
@@ -328,8 +345,17 @@ async def _target_in_scope(
     """Verify the target still belongs to the system that queued the action.
 
     Most targets carry system_id directly. UploadedFile is user-scoped, so
-    we resolve through the system's user_id.
+    we resolve through the system's user_id. ContentRevision is polymorphic —
+    walk to its target row and read system_id there.
     """
+    if isinstance(target, ContentRevision):
+        if target.target_type == "journal_entry":
+            entry = await db.get(JournalEntry, target.target_id)
+            return entry is not None and entry.system_id == pending.system_id
+        if target.target_type == "member_bio":
+            member = await db.get(Member, target.target_id)
+            return member is not None and member.system_id == pending.system_id
+        return False
     if hasattr(target, "system_id"):
         return target.system_id == pending.system_id
     if hasattr(target, "user_id"):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -155,7 +155,6 @@ def test_secondary_session_mints_independent_session(client: httpx.Client):
     body = secondary_resp.json()
     assert body["access_token"] and body["refresh_token"]
     assert body["session_id"]
-    watch_access = body["access_token"]
     watch_refresh = body["refresh_token"]
 
     # Both sessions show up in /sessions, distinct ids.

--- a/tests/test_revision_pinning.py
+++ b/tests/test_revision_pinning.py
@@ -1,0 +1,430 @@
+"""Tests for revision pinning: per-target caps, unpin grace, GC exemption,
+auto-pin first revision."""
+
+import asyncio
+import os
+import uuid
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Helpers — DB pokes mirror the patterns in test_revision_retention.py
+# ---------------------------------------------------------------------------
+
+
+def _register(client: httpx.Client, prefix: str = "pin") -> str:
+    email = f"{prefix}-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "testpassword123"},
+    )
+    assert resp.status_code == 201
+    client.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+    return email
+
+
+def _run_async(coro):
+    return asyncio.run(coro)
+
+
+def _engine():
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from sheaf.config import settings
+
+    db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+    return create_async_engine(db_url)
+
+
+def _set_user_tier(email: str, tier: str) -> None:
+    from sqlalchemy import select
+
+    from sheaf.crypto import blind_index
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.user import User
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            user = (
+                await db.execute(
+                    select(User).where(User.email_hash == blind_index(email))
+                )
+            ).scalar_one()
+            user.tier = tier
+            await db.commit()
+        await engine.dispose()
+
+    _run_async(_run())
+
+
+def _set_system_fields(email: str, **fields) -> None:
+    from sqlalchemy import select
+
+    from sheaf.crypto import blind_index
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.system import System
+        from sheaf.models.user import User
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            user = (
+                await db.execute(
+                    select(User).where(User.email_hash == blind_index(email))
+                )
+            ).scalar_one()
+            system = (
+                await db.execute(select(System).where(System.user_id == user.id))
+            ).scalar_one()
+            for k, v in fields.items():
+                setattr(system, k, v)
+            await db.commit()
+        await engine.dispose()
+
+    _run_async(_run())
+
+
+def _create_entry_with_revisions(
+    client: httpx.Client, count: int
+) -> tuple[dict, list[dict]]:
+    """Create a journal entry then edit it `count` times. Returns (entry, revisions)."""
+    entry = client.post(
+        "/v1/journals", json={"title": "T0", "body": "B0"}
+    ).json()
+    for i in range(count):
+        client.patch(
+            f"/v1/journals/{entry['id']}",
+            json={"title": f"T{i + 1}", "body": f"B{i + 1}"},
+        )
+    revs = client.get(f"/v1/journals/{entry['id']}/revisions").json()
+    return entry, revs
+
+
+# ---------------------------------------------------------------------------
+# Auto-pin first revision
+# ---------------------------------------------------------------------------
+
+
+def test_auto_pin_first_revision_default_on(auth_client: httpx.Client):
+    """Default auto_pin_first_revision=True — first edit's captured revision is pinned."""
+    entry, revs = _create_entry_with_revisions(auth_client, 1)
+    assert len(revs) == 1
+    assert revs[0]["pinned_at"] is not None
+
+
+def test_auto_pin_disabled_no_pin(client: httpx.Client):
+    email = _register(client, "autopin")
+    _set_system_fields(email, auto_pin_first_revision=False)
+    _, revs = _create_entry_with_revisions(client, 1)
+    assert len(revs) == 1
+    assert revs[0]["pinned_at"] is None
+
+
+def test_auto_pin_only_first_not_subsequent(auth_client: httpx.Client):
+    _, revs = _create_entry_with_revisions(auth_client, 3)
+    pinned = [r for r in revs if r["pinned_at"] is not None]
+    assert len(pinned) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pin endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_pin_unpinned_revision(client: httpx.Client):
+    email = _register(client, "pinok")
+    _set_system_fields(email, auto_pin_first_revision=False)
+    entry, revs = _create_entry_with_revisions(client, 2)
+    target = revs[0]
+    assert target["pinned_at"] is None
+
+    resp = client.post(
+        f"/v1/journals/{entry['id']}/pin-revision",
+        json={"revision_id": target["id"]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["pinned_at"] is not None
+
+
+def test_pin_already_pinned_409(auth_client: httpx.Client):
+    entry, revs = _create_entry_with_revisions(auth_client, 1)
+    pinned = revs[0]
+    resp = auth_client.post(
+        f"/v1/journals/{entry['id']}/pin-revision",
+        json={"revision_id": pinned["id"]},
+    )
+    assert resp.status_code == 409
+
+
+def test_pin_cap_enforced(client: httpx.Client):
+    email = _register(client, "pincap")
+    _set_user_tier(email, "free")  # free cap = 3
+    _set_system_fields(email, auto_pin_first_revision=False)
+    entry, revs = _create_entry_with_revisions(client, 5)
+    # Pin three — should all succeed.
+    for r in revs[:3]:
+        resp = client.post(
+            f"/v1/journals/{entry['id']}/pin-revision",
+            json={"revision_id": r["id"]},
+        )
+        assert resp.status_code == 200, resp.text
+    # Fourth pin — at cap, must reject.
+    resp = client.post(
+        f"/v1/journals/{entry['id']}/pin-revision",
+        json={"revision_id": revs[3]["id"]},
+    )
+    assert resp.status_code == 409
+
+
+def test_pin_revision_from_other_target_404(auth_client: httpx.Client):
+    """Pinning a revision that belongs to a different entry returns 404."""
+    a, a_revs = _create_entry_with_revisions(auth_client, 1)
+    b, _ = _create_entry_with_revisions(auth_client, 1)
+    # Try pinning A's revision via B's pin endpoint.
+    resp = auth_client.post(
+        f"/v1/journals/{b['id']}/pin-revision",
+        json={"revision_id": a_revs[0]["id"]},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Unpin endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_unpin_when_safety_off_immediate(auth_client: httpx.Client):
+    """No safety + auto-pinned first revision → immediate unpin."""
+    entry, revs = _create_entry_with_revisions(auth_client, 1)
+    pinned = revs[0]
+    resp = auth_client.post(
+        f"/v1/journals/{entry['id']}/unpin-revision",
+        json={"revision_id": pinned["id"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["revision"] is not None
+    assert body["revision"]["pinned_at"] is None
+    assert body["pending_action_id"] is None
+
+
+def test_unpin_when_safety_on_queues_pending(client: httpx.Client):
+    email = _register(client, "unpingrace")
+    _set_system_fields(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_revisions=True,
+    )
+    entry, revs = _create_entry_with_revisions(client, 1)
+    pinned = revs[0]
+    resp = client.post(
+        f"/v1/journals/{entry['id']}/unpin-revision",
+        json={"revision_id": pinned["id"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["revision"] is None
+    assert body["pending_action_id"] is not None
+    assert body["finalize_after"] is not None
+
+    # Revision should still be pinned (not yet finalized).
+    after = client.get(f"/v1/journals/{entry['id']}/revisions").json()
+    assert after[0]["pinned_at"] is not None
+
+    # Pending action should appear in the safety endpoint, type revision_unpin.
+    pending = client.get("/v1/system/safety").json()["pending_actions"]
+    assert any(p["action_type"] == "revision_unpin" for p in pending)
+
+
+def test_unpin_unpinned_revision_409(client: httpx.Client):
+    email = _register(client, "unpinnone")
+    _set_system_fields(email, auto_pin_first_revision=False)
+    entry, revs = _create_entry_with_revisions(client, 1)
+    resp = client.post(
+        f"/v1/journals/{entry['id']}/unpin-revision",
+        json={"revision_id": revs[0]["id"]},
+    )
+    assert resp.status_code == 409
+
+
+def test_finalize_pending_unpin_clears_pin():
+    """The PendingAction finalize for REVISION_UNPIN must clear pinned_at, not delete."""
+
+    async def _run() -> None:
+        from datetime import UTC, datetime
+
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.crypto import blind_index
+        from sheaf.models.content_revision import ContentRevision
+        from sheaf.models.pending_action import (
+            PendingAction,
+            PendingActionStatus,
+            PendingActionType,
+        )
+        from sheaf.models.system import System
+        from sheaf.models.user import User
+        from sheaf.services.system_safety import finalize_pending_action
+
+        # Use a separately-registered user.
+        email = f"finalize-{uuid.uuid4().hex[:8]}@sheaf.dev"
+        with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as c:
+            c.post(
+                "/v1/auth/register",
+                json={"email": email, "password": "testpassword123"},
+            )
+            tok = c.post(
+                "/v1/auth/login",
+                json={"email": email, "password": "testpassword123"},
+            ).json()["access_token"]
+            c.headers["Authorization"] = f"Bearer {tok}"
+            entry, revs = _create_entry_with_revisions(c, 1)
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            user = (
+                await db.execute(
+                    select(User).where(User.email_hash == blind_index(email))
+                )
+            ).scalar_one()
+            system = (
+                await db.execute(select(System).where(System.user_id == user.id))
+            ).scalar_one()
+            revision = await db.get(ContentRevision, uuid.UUID(revs[0]["id"]))
+            assert revision.pinned_at is not None
+
+            pending = PendingAction(
+                system_id=system.id,
+                action_type=PendingActionType.REVISION_UNPIN,
+                target_id=revision.id,
+                target_label="test pin",
+                requested_at=datetime.now(UTC),
+                requested_by_user_id=user.id,
+                finalize_after=datetime.now(UTC),
+                fronting_member_ids=[],
+                fronting_member_names=[],
+                status=PendingActionStatus.PENDING,
+            )
+            db.add(pending)
+            await db.commit()
+
+            await finalize_pending_action(pending, db)
+            await db.commit()
+
+            await db.refresh(revision)
+            assert revision.pinned_at is None
+            # Critically — the row itself must NOT be deleted.
+            still_there = await db.get(ContentRevision, revision.id)
+            assert still_there is not None
+        await engine.dispose()
+
+    _run_async(_run())
+
+
+# ---------------------------------------------------------------------------
+# GC sweep exemption
+# ---------------------------------------------------------------------------
+
+
+def test_gc_sweep_skips_pinned():
+    """gc_revisions must not delete pinned rows even when the count cap is exceeded."""
+    # Set up fixture state OUTSIDE the inner async block — the DB pokes use
+    # asyncio.run() internally and can't be called from within a running loop.
+    email = f"gcpin-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as c:
+        c.post(
+            "/v1/auth/register",
+            json={"email": email, "password": "testpassword123"},
+        )
+        tok = c.post(
+            "/v1/auth/login",
+            json={"email": email, "password": "testpassword123"},
+        ).json()["access_token"]
+        c.headers["Authorization"] = f"Bearer {tok}"
+        # Create 6 revisions; the auto-pinned first is pinned.
+        entry, _ = _create_entry_with_revisions(c, 5)
+        entry_id = entry["id"]
+
+    # Drop user to free tier (cap = 10) and tighten override to 2 so the
+    # sweep WILL trim. The pinned first revision must survive.
+    _set_user_tier(email, "free")
+    _set_system_fields(email, journal_max_revisions=2)
+
+    async def _run() -> None:
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.content_revision import ContentRevision
+        from sheaf.services.retention import gc_revisions
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            await gc_revisions(db)
+            await db.commit()
+            # Pinned revision still present.
+            pinned_rows = (
+                await db.execute(
+                    select(ContentRevision).where(
+                        ContentRevision.target_id == uuid.UUID(entry_id),
+                        ContentRevision.pinned_at.is_not(None),
+                    )
+                )
+            ).scalars().all()
+            assert len(pinned_rows) == 1
+            # Total revisions should be: 1 pinned + 2 newest unpinned = 3.
+            all_rows = (
+                await db.execute(
+                    select(ContentRevision).where(
+                        ContentRevision.target_id == uuid.UUID(entry_id),
+                    )
+                )
+            ).scalars().all()
+            assert len(all_rows) == 3
+        await engine.dispose()
+
+    _run_async(_run())
+
+
+# ---------------------------------------------------------------------------
+# Bio (member) pinning — sanity check the polymorphic path
+# ---------------------------------------------------------------------------
+
+
+def test_bio_pin_unpin_round_trip(auth_client: httpx.Client):
+    member = auth_client.post(
+        "/v1/members", json={"name": "Alice", "description": "v0"}
+    ).json()
+    auth_client.patch(
+        f"/v1/members/{member['id']}", json={"description": "v1"}
+    )
+    revs = auth_client.get(f"/v1/members/{member['id']}/revisions").json()
+    assert len(revs) == 1
+    assert revs[0]["pinned_at"] is not None  # auto-pin
+
+    unpin = auth_client.post(
+        f"/v1/members/{member['id']}/unpin-revision",
+        json={"revision_id": revs[0]["id"]},
+    )
+    assert unpin.status_code == 200, unpin.text
+
+    # Re-pin manually.
+    pin = auth_client.post(
+        f"/v1/members/{member['id']}/pin-revision",
+        json={"revision_id": revs[0]["id"]},
+    )
+    assert pin.status_code == 200
+    assert pin.json()["pinned_at"] is not None

--- a/tests/test_revision_retention.py
+++ b/tests/test_revision_retention.py
@@ -317,6 +317,9 @@ def test_on_tier_change_upgrade_cancels_existing_notice():
 def test_gc_revisions_trims_to_count_cap(client: httpx.Client):
     email = _register(client)
     _set_user_tier_via_db(email, "free")  # cap = 10
+    # This test is about the rolling count cap in isolation; opt out of
+    # auto-pin so the trim count matches what the cap would do alone.
+    _set_system_safety_via_db(email, auto_pin_first_revision=False)
 
     # Create one entry and edit it 15 times to generate 15 revisions.
     entry = client.post("/v1/journals", json={"body": "v0"}).json()
@@ -373,8 +376,10 @@ def test_gc_revisions_grace_window_defers_trim():
         assert resp.status_code == 201
         c.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
 
-        # Create 15 revisions while on PLUS (cap 100, no trimming yet)
+        # Create 15 revisions while on PLUS (cap 100, no trimming yet).
+        # Disable auto-pin so we exercise the rolling cap in isolation.
         _set_user_tier_via_db(email, "plus")
+        _set_system_safety_via_db(email, auto_pin_first_revision=False)
         entry = c.post("/v1/journals", json={"body": "v0"}).json()
         for i in range(1, 16):
             c.patch(f"/v1/journals/{entry['id']}", json={"body": f"v{i}"})

--- a/web/src/components/content-revision-list.tsx
+++ b/web/src/components/content-revision-list.tsx
@@ -1,7 +1,14 @@
 import { Suspense, lazy, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { diffLines } from "diff";
-import { History, RotateCcw, Eye, GitCompare } from "lucide-react";
+import {
+  History,
+  RotateCcw,
+  Eye,
+  GitCompare,
+  Pin,
+  PinOff,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,9 +17,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { formatDateTime } from "@/lib/date-format";
-import type { ContentRevision, DateFormat } from "@/types/api";
+import type {
+  ContentRevision,
+  DateFormat,
+  DeleteConfirmation,
+  DestructiveConfirm,
+  UnpinRevisionResponse,
+} from "@/types/api";
 
 const MarkdownPreview = lazy(() =>
   import("@/components/bio-editor").then((m) => ({
@@ -55,6 +70,10 @@ export function ContentRevisionList({
   queryKey,
   list,
   restore,
+  pin,
+  unpin,
+  safetyEnabled,
+  authTier,
   invalidateOnRestore,
   emptyMessage = "No revisions yet. Edits will appear here.",
   dateFormat = "ymd",
@@ -64,6 +83,16 @@ export function ContentRevisionList({
   queryKey: readonly unknown[];
   list: (id: string) => Promise<ContentRevision[]>;
   restore: (id: string, revisionId: string) => Promise<unknown>;
+  pin?: (id: string, revisionId: string) => Promise<unknown>;
+  unpin?: (
+    id: string,
+    revisionId: string,
+    confirm?: DestructiveConfirm,
+  ) => Promise<UnpinRevisionResponse>;
+  /** When true, unpin requires re-auth and queues a PendingAction. */
+  safetyEnabled?: boolean;
+  /** Auth tier in force; only consulted when safetyEnabled. */
+  authTier?: DeleteConfirmation;
   invalidateOnRestore: readonly (readonly unknown[])[];
   emptyMessage?: string;
   dateFormat?: DateFormat;
@@ -79,15 +108,61 @@ export function ContentRevisionList({
     tab: "preview" | "diff";
   } | null>(null);
 
+  const [unpinConfirm, setUnpinConfirm] = useState<ContentRevision | null>(null);
+
+  function invalidateAll() {
+    for (const key of invalidateOnRestore) {
+      qc.invalidateQueries({ queryKey: [...key] });
+    }
+  }
+
   const restoreMut = useMutation({
     mutationFn: (revisionId: string) => restore(targetId, revisionId),
     onSuccess: () => {
-      for (const key of invalidateOnRestore) {
-        qc.invalidateQueries({ queryKey: [...key] });
-      }
+      invalidateAll();
       toast.success("Restored");
     },
   });
+
+  const pinMut = useMutation({
+    mutationFn: (revisionId: string) => pin!(targetId, revisionId),
+    onSuccess: () => {
+      invalidateAll();
+      toast.success("Revision pinned");
+    },
+  });
+
+  const unpinMut = useMutation({
+    mutationFn: ({
+      revisionId,
+      confirm,
+    }: {
+      revisionId: string;
+      confirm?: DestructiveConfirm;
+    }) => unpin!(targetId, revisionId, confirm),
+    onSuccess: (resp) => {
+      invalidateAll();
+      setUnpinConfirm(null);
+      if (resp.pending_action_id && resp.finalize_after) {
+        const when = new Date(resp.finalize_after).toLocaleString();
+        toast.success(`Unpin queued — finalizes ${when}. Cancel from Safety settings.`);
+      } else {
+        toast.success("Revision unpinned");
+      }
+    },
+  });
+
+  // Sort: pinned first, then chronological (newest unpinned first).
+  const sorted = useMemo(() => {
+    if (!data) return [];
+    return [...data].sort((a, b) => {
+      if (a.pinned_at && !b.pinned_at) return -1;
+      if (!a.pinned_at && b.pinned_at) return 1;
+      return b.created_at.localeCompare(a.created_at);
+    });
+  }, [data]);
+
+  const pinnedCount = data?.filter((r) => r.pinned_at).length ?? 0;
 
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Loading revisions…</p>;
@@ -103,61 +178,141 @@ export function ContentRevisionList({
       <div className="flex items-center gap-2 text-sm font-medium">
         <History className="h-4 w-4" />
         Revisions ({data.length})
+        {pinnedCount > 0 && (
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+            <Pin className="h-3 w-3 mr-1" />
+            {pinnedCount} pinned
+          </Badge>
+        )}
       </div>
       <div className="space-y-2">
-        {data.map((rev) => (
-          <div
-            key={rev.id}
-            className="flex flex-wrap items-start gap-3 rounded-md border px-3 py-2 text-sm"
-          >
-            <div className="min-w-0 flex-1 space-y-0.5">
-              <p className="font-medium truncate">
-                {rev.title || "(untitled)"}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {formatDateTime(rev.created_at, dateFormat)}
-                {rev.editor_member_names.length > 0
-                  ? ` · ${rev.editor_member_names.join(", ")}`
-                  : ""}
-              </p>
-            </div>
-            <div className="flex shrink-0 gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs"
-                onClick={() => setPreviewing({ rev, tab: "preview" })}
-              >
-                <Eye className="h-3 w-3 mr-1" />
-                Preview
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs"
-                onClick={() => setPreviewing({ rev, tab: "diff" })}
-              >
-                <GitCompare className="h-3 w-3 mr-1" />
-                Diff
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs"
-                onClick={() => restoreMut.mutate(rev.id)}
-                disabled={
-                  restoreMut.isPending && restoreMut.variables === rev.id
+        {sorted.map((rev, idx) => {
+          const isPinned = rev.pinned_at !== null;
+          const showDivider =
+            idx > 0 &&
+            sorted[idx - 1].pinned_at !== null &&
+            !isPinned;
+          return (
+            <div key={rev.id}>
+              {showDivider && (
+                <div className="my-2 border-t border-dashed" aria-hidden />
+              )}
+              <div
+                className={
+                  "flex flex-wrap items-start gap-3 rounded-md border px-3 py-2 text-sm " +
+                  (isPinned ? "border-primary/40 bg-primary/5" : "")
                 }
               >
-                <RotateCcw className="h-3 w-3 mr-1" />
-                {restoreMut.isPending && restoreMut.variables === rev.id
-                  ? "Restoring…"
-                  : "Restore"}
-              </Button>
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <p className="font-medium truncate flex items-center gap-2">
+                    {isPinned && (
+                      <Pin className="h-3 w-3 shrink-0 text-primary fill-primary" />
+                    )}
+                    <span className="truncate">{rev.title || "(untitled)"}</span>
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {formatDateTime(rev.created_at, dateFormat)}
+                    {rev.editor_member_names.length > 0
+                      ? ` · ${rev.editor_member_names.join(", ")}`
+                      : ""}
+                  </p>
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() => setPreviewing({ rev, tab: "preview" })}
+                  >
+                    <Eye className="h-3 w-3 mr-1" />
+                    Preview
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() => setPreviewing({ rev, tab: "diff" })}
+                  >
+                    <GitCompare className="h-3 w-3 mr-1" />
+                    Diff
+                  </Button>
+                  {pin && unpin && (
+                    isPinned ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs"
+                        onClick={() => {
+                          if (safetyEnabled) {
+                            setUnpinConfirm(rev);
+                          } else {
+                            unpinMut.mutate({ revisionId: rev.id });
+                          }
+                        }}
+                        disabled={
+                          unpinMut.isPending &&
+                          unpinMut.variables?.revisionId === rev.id
+                        }
+                      >
+                        <PinOff className="h-3 w-3 mr-1" />
+                        {unpinMut.isPending &&
+                        unpinMut.variables?.revisionId === rev.id
+                          ? "Unpinning…"
+                          : "Unpin"}
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs"
+                        onClick={() => pinMut.mutate(rev.id)}
+                        disabled={
+                          pinMut.isPending && pinMut.variables === rev.id
+                        }
+                      >
+                        <Pin className="h-3 w-3 mr-1" />
+                        {pinMut.isPending && pinMut.variables === rev.id
+                          ? "Pinning…"
+                          : "Pin"}
+                      </Button>
+                    )
+                  )}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() => restoreMut.mutate(rev.id)}
+                    disabled={
+                      restoreMut.isPending && restoreMut.variables === rev.id
+                    }
+                  >
+                    <RotateCcw className="h-3 w-3 mr-1" />
+                    {restoreMut.isPending && restoreMut.variables === rev.id
+                      ? "Restoring…"
+                      : "Restore"}
+                  </Button>
+                </div>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
+      <DestructiveConfirmDialog
+        open={unpinConfirm !== null}
+        onOpenChange={(open) => !open && setUnpinConfirm(null)}
+        title="Unpin revision?"
+        description={
+          "This pin protects the revision from automatic trim. " +
+          "Unpinning will queue a pending action you can cancel from the Safety settings page."
+        }
+        tier={authTier ?? "none"}
+        actionLabel="Queue unpin"
+        actionLabelLoading="Queuing…"
+        loading={unpinMut.isPending}
+        onConfirm={(confirm) =>
+          unpinConfirm && unpinMut.mutate({ revisionId: unpinConfirm.id, confirm })
+        }
+      />
       <Dialog
         open={previewing !== null}
         onOpenChange={(open) => !open && setPreviewing(null)}

--- a/web/src/components/destructive-confirm-dialog.tsx
+++ b/web/src/components/destructive-confirm-dialog.tsx
@@ -22,6 +22,10 @@ interface Props {
   tier: DeleteConfirmation;
   onConfirm: (confirm?: DestructiveConfirm) => void;
   loading?: boolean;
+  /** Verb shown on the confirm button. Defaults to "Delete". */
+  actionLabel?: string;
+  /** Verb shown on the confirm button while loading. Defaults to "Deleting...". */
+  actionLabelLoading?: string;
 }
 
 export function DestructiveConfirmDialog({
@@ -32,6 +36,8 @@ export function DestructiveConfirmDialog({
   tier,
   onConfirm,
   loading,
+  actionLabel = "Delete",
+  actionLabelLoading = "Deleting...",
 }: Props) {
   const { user } = useAuth();
   const [password, setPassword] = useState("");
@@ -103,7 +109,7 @@ export function DestructiveConfirmDialog({
             onClick={handleConfirm}
             disabled={disabled}
           >
-            {loading ? "Deleting..." : "Delete"}
+            {loading ? actionLabelLoading : actionLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/components/pending-action-row.tsx
+++ b/web/src/components/pending-action-row.tsx
@@ -9,6 +9,7 @@ const actionLabels: Record<PendingActionType, string> = {
   front_delete: "Delete front entry",
   journal_delete: "Delete journal entry",
   image_delete: "Delete image",
+  revision_unpin: "Unpin revision",
 };
 
 function timeRemaining(finalizeAfter: string): string {

--- a/web/src/components/system-safety-card.tsx
+++ b/web/src/components/system-safety-card.tsx
@@ -42,6 +42,7 @@ const categoryLabels: {
   { key: "applies_to_fronts", label: "Front entries", desc: "Deleting a front entry" },
   { key: "applies_to_journals", label: "Journal entries", desc: "Deleting a journal entry" },
   { key: "applies_to_images", label: "Images", desc: "Deleting an uploaded image" },
+  { key: "applies_to_revisions", label: "Revision pins", desc: "Unpinning a protected revision" },
 ];
 
 function changeSummary(changes: Record<string, unknown>): string {
@@ -54,6 +55,8 @@ function changeSummary(changes: Record<string, unknown>): string {
     } else if (k.startsWith("safety_applies_to_")) {
       const cat = k.replace("safety_applies_to_", "");
       parts.push(`disable ${cat}`);
+    } else if (k === "auto_pin_first_revision") {
+      parts.push(v === false ? "disable auto-pin first revision" : "enable auto-pin first revision");
     } else if (k === "journal_max_revisions") {
       parts.push(
         v === null ? "revision count cap → tier default" : `revision count cap → ${v}`,
@@ -231,6 +234,24 @@ function SafetyForm({ settings }: { settings: SystemSafetySettings }) {
           ))}
         </div>
       </div>
+      <div className="space-y-2 border-t pt-3">
+        <Label className="text-sm">Revision pinning</Label>
+        <label className="flex items-start gap-2 text-sm cursor-pointer">
+          <Checkbox
+            checked={draft.auto_pin_first_revision}
+            onCheckedChange={(v) => setField("auto_pin_first_revision", Boolean(v))}
+            className="mt-0.5"
+          />
+          <span>
+            <span className="font-medium">Auto-pin original revision</span>
+            <span className="block text-xs text-muted-foreground">
+              When a journal entry or member bio is first edited, automatically
+              pin the captured original. Pinned revisions are exempt from the
+              rolling history cap.
+            </span>
+          </span>
+        </label>
+      </div>
       {needsReauth && (
         <div className="space-y-3 border-t pt-3">
           <p className="text-sm text-muted-foreground">
@@ -361,11 +382,13 @@ const CATEGORY_KEYS = [
   "applies_to_fronts",
   "applies_to_journals",
   "applies_to_images",
+  "applies_to_revisions",
 ] as const;
 
 function hasDiff(a: SystemSafetySettings, b: SystemSafetySettings): boolean {
   if (a.grace_period_days !== b.grace_period_days) return true;
   if (a.auth_tier !== b.auth_tier) return true;
+  if (a.auto_pin_first_revision !== b.auto_pin_first_revision) return true;
   return CATEGORY_KEYS.some((k) => a[k] !== b[k]);
 }
 
@@ -377,6 +400,8 @@ function diffFields(
   if (current.grace_period_days !== draft.grace_period_days)
     patch.grace_period_days = draft.grace_period_days;
   if (current.auth_tier !== draft.auth_tier) patch.auth_tier = draft.auth_tier;
+  if (current.auto_pin_first_revision !== draft.auto_pin_first_revision)
+    patch.auto_pin_first_revision = draft.auto_pin_first_revision;
   for (const key of CATEGORY_KEYS) {
     if (current[key] !== draft[key]) patch[key] = draft[key];
   }
@@ -396,6 +421,7 @@ function detectLoosening(
 ): boolean {
   if (draft.grace_period_days < current.grace_period_days) return true;
   if (tierStrength[draft.auth_tier] < tierStrength[current.auth_tier]) return true;
+  if (current.auto_pin_first_revision && !draft.auto_pin_first_revision) return true;
   for (const key of CATEGORY_KEYS) {
     if (current[key] && !draft[key]) return true;
   }

--- a/web/src/lib/journals.ts
+++ b/web/src/lib/journals.ts
@@ -7,6 +7,7 @@ import type {
   JournalEntryUpdate,
   JournalEntryWithCount,
   JournalListResponse,
+  UnpinRevisionResponse,
 } from "@/types/api";
 import { apiFetch } from "./api-client";
 
@@ -60,5 +61,23 @@ export function restoreRevision(id: string, revisionId: string) {
   return apiFetch<JournalEntry>(`/v1/journals/${id}/restore-revision`, {
     method: "POST",
     body: JSON.stringify({ revision_id: revisionId }),
+  });
+}
+
+export function pinJournalRevision(id: string, revisionId: string) {
+  return apiFetch<ContentRevision>(`/v1/journals/${id}/pin-revision`, {
+    method: "POST",
+    body: JSON.stringify({ revision_id: revisionId }),
+  });
+}
+
+export function unpinJournalRevision(
+  id: string,
+  revisionId: string,
+  confirm?: DestructiveConfirm,
+) {
+  return apiFetch<UnpinRevisionResponse>(`/v1/journals/${id}/unpin-revision`, {
+    method: "POST",
+    body: JSON.stringify({ revision_id: revisionId, ...(confirm ?? {}) }),
   });
 }

--- a/web/src/lib/members.ts
+++ b/web/src/lib/members.ts
@@ -5,6 +5,7 @@ import type {
   Member,
   MemberCreate,
   MemberUpdate,
+  UnpinRevisionResponse,
 } from "@/types/api";
 import { apiFetch } from "./api-client";
 
@@ -45,5 +46,23 @@ export function restoreMemberBioRevision(id: string, revisionId: string) {
   return apiFetch<Member>(`/v1/members/${id}/restore-revision`, {
     method: "POST",
     body: JSON.stringify({ revision_id: revisionId }),
+  });
+}
+
+export function pinMemberBioRevision(id: string, revisionId: string) {
+  return apiFetch<ContentRevision>(`/v1/members/${id}/pin-revision`, {
+    method: "POST",
+    body: JSON.stringify({ revision_id: revisionId }),
+  });
+}
+
+export function unpinMemberBioRevision(
+  id: string,
+  revisionId: string,
+  confirm?: DestructiveConfirm,
+) {
+  return apiFetch<UnpinRevisionResponse>(`/v1/members/${id}/unpin-revision`, {
+    method: "POST",
+    body: JSON.stringify({ revision_id: revisionId, ...(confirm ?? {}) }),
   });
 }

--- a/web/src/routes/journals.$id.tsx
+++ b/web/src/routes/journals.$id.tsx
@@ -31,7 +31,9 @@ import {
   deleteJournal,
   getJournal,
   listRevisions,
+  pinJournalRevision,
   restoreRevision,
+  unpinJournalRevision,
   updateJournal,
 } from "@/lib/journals";
 import { getSystemSafety } from "@/lib/system-safety";
@@ -161,9 +163,17 @@ export function JournalDetailPage() {
               queryKey={["journal", entry.id, "revisions"]}
               list={listRevisions}
               restore={restoreRevision}
+              pin={pinJournalRevision}
+              unpin={unpinJournalRevision}
+              safetyEnabled={
+                !!safety?.settings.applies_to_revisions &&
+                (safety?.settings.grace_period_days ?? 0) > 0
+              }
+              authTier={safety?.settings.auth_tier ?? "none"}
               invalidateOnRestore={[
                 ["journal", entry.id],
                 ["journal", entry.id, "revisions"],
+                ["system-safety"],
               ]}
               emptyMessage="No revisions yet. Edits to this entry will appear here."
               dateFormat={dateFormat}

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -4,7 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 import { useMembers, useCreateMember, useDeleteMember, useUpdateMember } from "@/hooks/use-members";
 import { useCustomFields, useMemberFieldValues, useSetMemberFieldValues } from "@/hooks/use-custom-fields";
 import { getMySystem } from "@/lib/systems";
-import { listMemberBioRevisions, restoreMemberBioRevision } from "@/lib/members";
+import {
+  listMemberBioRevisions,
+  pinMemberBioRevision,
+  restoreMemberBioRevision,
+  unpinMemberBioRevision,
+} from "@/lib/members";
+import { getSystemSafety } from "@/lib/system-safety";
 import { AvatarUpload } from "@/components/avatar-upload";
 import { ContentRevisionList } from "@/components/content-revision-list";
 
@@ -316,6 +322,7 @@ function MemberView({
   const { data: fields } = useCustomFields();
   const { data: values } = useMemberFieldValues(member.id);
   const { data: system } = useQuery({ queryKey: ["system", "me"], queryFn: getMySystem });
+  const { data: safety } = useQuery({ queryKey: ["system-safety"], queryFn: getSystemSafety });
   const dateFormat = system?.date_format ?? "ymd";
   const [showRevisions, setShowRevisions] = useState(false);
 
@@ -405,9 +412,17 @@ function MemberView({
                 queryKey={["member", member.id, "revisions"]}
                 list={listMemberBioRevisions}
                 restore={restoreMemberBioRevision}
+                pin={pinMemberBioRevision}
+                unpin={unpinMemberBioRevision}
+                safetyEnabled={
+                  !!safety?.settings.applies_to_revisions &&
+                  (safety?.settings.grace_period_days ?? 0) > 0
+                }
+                authTier={safety?.settings.auth_tier ?? "none"}
                 invalidateOnRestore={[
                   ["members"],
                   ["member", member.id, "revisions"],
+                  ["system-safety"],
                 ]}
                 emptyMessage="No bio revisions yet. Edits to the bio will appear here."
                 dateFormat={dateFormat}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -214,7 +214,8 @@ export type PendingActionType =
   | "field_delete"
   | "front_delete"
   | "journal_delete"
-  | "image_delete";
+  | "image_delete"
+  | "revision_unpin";
 
 export type PendingActionStatus =
   | "pending"
@@ -258,6 +259,8 @@ export interface SystemSafetySettings {
   applies_to_fronts: boolean;
   applies_to_journals: boolean;
   applies_to_images: boolean;
+  applies_to_revisions: boolean;
+  auto_pin_first_revision: boolean;
 }
 
 export interface SystemSafetyUpdate {
@@ -270,6 +273,8 @@ export interface SystemSafetyUpdate {
   applies_to_fronts?: boolean;
   applies_to_journals?: boolean;
   applies_to_images?: boolean;
+  applies_to_revisions?: boolean;
+  auto_pin_first_revision?: boolean;
   password?: string;
   totp_code?: string;
 }
@@ -359,6 +364,13 @@ export interface ContentRevision {
   title: string | null;
   body: string;
   created_at: string;
+  pinned_at: string | null;
+}
+
+export interface UnpinRevisionResponse {
+  revision: ContentRevision | null;
+  pending_action_id: string | null;
+  finalize_after: string | null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Allows pinning revisions in text content with edit histories (member bios, journals). 
- Unpin routes through PendingAction with grace period as a destructive action as it may cause an old revision to immediately be GC'd.
- Caps on pins are gated per tier, and are per-target, not global (never run out of pins other than on a specific entry)
- No auto-replace-oldest paradigm, as this allows. Potentially having to wait before *updating* a pinned rev is better than just kicking the can on the whole "malicious member pushes important content off the edit history" issue
- Auto-pin first revision option, defaults to on for baseline protection for people who do not explore settings before use
- Update documentation
