### PR TITLE
Make pin/unpin button icon-only to stop squashing the row

### DIFF
--- a/web/src/components/content-revision-list.tsx
+++ b/web/src/components/content-revision-list.tsx
@@ -241,7 +241,14 @@ export function ContentRevisionList({
                       <Button
                         size="sm"
                         variant="outline"
-                        className="h-7 text-xs"
+                        className="h-7 w-7 p-0"
+                        title={
+                          unpinMut.isPending &&
+                          unpinMut.variables?.revisionId === rev.id
+                            ? "Unpinning…"
+                            : "Unpin"
+                        }
+                        aria-label="Unpin"
                         onClick={() => {
                           if (safetyEnabled) {
                             setUnpinConfirm(rev);
@@ -254,26 +261,25 @@ export function ContentRevisionList({
                           unpinMut.variables?.revisionId === rev.id
                         }
                       >
-                        <PinOff className="h-3 w-3 mr-1" />
-                        {unpinMut.isPending &&
-                        unpinMut.variables?.revisionId === rev.id
-                          ? "Unpinning…"
-                          : "Unpin"}
+                        <PinOff className="h-3 w-3" />
                       </Button>
                     ) : (
                       <Button
                         size="sm"
                         variant="outline"
-                        className="h-7 text-xs"
+                        className="h-7 w-7 p-0"
+                        title={
+                          pinMut.isPending && pinMut.variables === rev.id
+                            ? "Pinning…"
+                            : "Pin"
+                        }
+                        aria-label="Pin"
                         onClick={() => pinMut.mutate(rev.id)}
                         disabled={
                           pinMut.isPending && pinMut.variables === rev.id
                         }
                       >
-                        <Pin className="h-3 w-3 mr-1" />
-                        {pinMut.isPending && pinMut.variables === rev.id
-                          ? "Pinning…"
-                          : "Pin"}
+                        <Pin className="h-3 w-3" />
                       </Button>
                     )
                   )}


### PR DESCRIPTION
Adding a fourth labelled button to revision rows pushed the title + date + editor info into a narrow column that wrapped awkwardly. Pin / unpin is fundamentally a toggle, so an icon button with title + aria-label is the same affordance with ~50px less width. The other three actions (Preview / Diff / Restore) keep their labels.

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of the main changes -->

-
-

## Testing

<!-- How was this tested? -->

- [ ] `ruff check sheaf/` passes
- [ ] `cd web && npm run lint && npx tsc --noEmit` passes
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Tested manually

## Security / privacy impact

<!--
Sheaf handles GDPR Article 9 data. If this PR touches authentication,
authorisation, encryption, data storage, or anything user-facing, describe
the impact here. Otherwise, write "none".
-->

## Screenshots

<!-- If this changes the UI, include before/after screenshots -->
