### PR TITLE
Commit api keys at create time, not via the get_db post-yield hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run test suite
-        run: ./run_tests.sh || ./run_tests.sh --no-build
+        run: ./run_tests.sh
 
   docker:
     runs-on: ubuntu-latest

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -1533,7 +1533,8 @@ async def create_api_key(
         expires_at=body.expires_at,
     )
     db.add(api_key)
-    await db.flush()
+    await db.commit()
+    await db.refresh(api_key)
 
     return ApiKeyCreated(
         id=str(api_key.id),


### PR DESCRIPTION
create_api_key did db.add() + db.flush() and relied on get_db()'s post-yield commit to persist the row. That commit runs after the HTTP response goes out, so under load a follow-up request from the same client (typically DELETE on the just-returned id) can land before the INSERT is visible to other sessions, returning 404. This surfaced as an intermittent CI failure on test_revoke_key when more API key tests ran in the same job.

Switch to explicit commit + refresh inside the handler so the response is only sent after the row is durable, matching the pattern every other create endpoint in this module already uses.

Drop the `|| run_tests.sh --no-build` retry from CI - that was added specifically to paper over this flake, and there's no reason to keep masking real flakes once the underlying race is fixed.
