### PR TITLE
Bring notification deletes under System Safety

### DIFF
--- a/alembic/versions/s9t0u1v2w3x4_add_notifications_safety.py
+++ b/alembic/versions/s9t0u1v2w3x4_add_notifications_safety.py
@@ -1,0 +1,34 @@
+"""Add safety_applies_to_notifications column on systems
+
+Revision ID: s9t0u1v2w3x4
+Revises: r8s9t0u1v2w3
+Create Date: 2026-05-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "s9t0u1v2w3x4"
+down_revision = "r8s9t0u1v2w3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("systems")}
+    if "safety_applies_to_notifications" not in cols:
+        op.add_column(
+            "systems",
+            sa.Column(
+                "safety_applies_to_notifications",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("systems", "safety_applies_to_notifications")

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -24,12 +24,14 @@ from sheaf.models.notification_channel import (
 )
 from sheaf.models.notification_channel_group_rule import NotificationChannelGroupRule
 from sheaf.models.notification_channel_member_rule import NotificationChannelMemberRule
+from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import PrivacyLevel, System
 from sheaf.models.user import User
 from sheaf.models.watch_token import WatchToken
 from sheaf.schemas.notifications import (
     ChannelCreate,
     ChannelCreateResponse,
+    ChannelDeleteConfirm,
     ChannelRead,
     ChannelUpdate,
     GroupRuleSpec,
@@ -51,6 +53,11 @@ from sheaf.services.notifications.handlers import deliver
 from sheaf.services.notifications.resolution import (
     build_group_name_lookup,
     resolve_member_visibility,
+)
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
 )
 
 router = APIRouter(prefix="", tags=["notifications"])
@@ -412,15 +419,44 @@ async def update_channel(
 
 @router.delete(
     "/channels/{channel_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_scope("notifications:delete"))],
 )
 async def delete_channel(
     channel_id: uuid.UUID,
+    body: ChannelDeleteConfirm | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     channel = await _load_owned_channel(db, user, channel_id)
+    system = await _system_for_user(user, db)
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
+
+    if is_safeguarded(system, PendingActionType.CHANNEL_DELETE):
+        from fastapi.responses import JSONResponse
+
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.CHANNEL_DELETE,
+            target_id=channel.id,
+            target_label=channel.name,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
+        )
+
     await db.delete(channel)
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/sheaf/api/v1/system_safety.py
+++ b/sheaf/api/v1/system_safety.py
@@ -54,6 +54,7 @@ _EXTERNAL_TO_INTERNAL = {
     "applies_to_journals": "safety_applies_to_journals",
     "applies_to_images": "safety_applies_to_images",
     "applies_to_revisions": "safety_applies_to_revisions",
+    "applies_to_notifications": "safety_applies_to_notifications",
     "auto_pin_first_revision": "auto_pin_first_revision",
 }
 _INTERNAL_TO_EXTERNAL = {v: k for k, v in _EXTERNAL_TO_INTERNAL.items()}
@@ -71,6 +72,7 @@ def _settings_from_system(system: System) -> SystemSafetySettings:
         applies_to_journals=system.safety_applies_to_journals,
         applies_to_images=system.safety_applies_to_images,
         applies_to_revisions=system.safety_applies_to_revisions,
+        applies_to_notifications=system.safety_applies_to_notifications,
         auto_pin_first_revision=system.auto_pin_first_revision,
     )
 

--- a/sheaf/api/v1/watch_tokens.py
+++ b/sheaf/api/v1/watch_tokens.py
@@ -12,13 +12,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
 from sheaf.models.notification_channel import NotificationChannel
+from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.models.watch_token import WatchToken
 from sheaf.schemas.notifications import (
     WatchTokenCreate,
     WatchTokenRead,
+    WatchTokenRevokeConfirm,
     WatchTokenUpdate,
+)
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
 )
 
 router = APIRouter(prefix="", tags=["notifications"])
@@ -152,11 +159,11 @@ async def update_watch_token(
 
 @router.delete(
     "/watch-tokens/{token_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(require_scope("notifications:delete"))],
 )
 async def revoke_watch_token(
     token_id: uuid.UUID,
+    body: WatchTokenRevokeConfirm | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
@@ -164,7 +171,41 @@ async def revoke_watch_token(
     them. Owner can revoke and re-issue a fresh token if a recipient
     relationship has gone bad."""
     token = await _load_owned_token(db, user, token_id)
-    if token.revoked_at is None:
-        token.revoked_at = datetime.now(UTC)
+    system = await _get_user_system(user, db)
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
+
+    # Already revoked -> idempotent 204 regardless of safety state. Skipping
+    # the safeguard branch here means re-revoking doesn't queue a duplicate
+    # pending action and doesn't lock the owner out of the no-op call.
+    if token.revoked_at is not None:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    if is_safeguarded(system, PendingActionType.WATCH_TOKEN_REVOKE):
+        from fastapi.responses import JSONResponse
+
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.WATCH_TOKEN_REVOKE,
+            target_id=token.id,
+            target_label=token.label or f"Watcher {token.id}",
+        )
         await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
+        )
+
+    token.revoked_at = datetime.now(UTC)
+    await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/sheaf/models/pending_action.py
+++ b/sheaf/models/pending_action.py
@@ -18,6 +18,8 @@ class PendingActionType(StrEnum):
     JOURNAL_DELETE = "journal_delete"
     IMAGE_DELETE = "image_delete"
     REVISION_UNPIN = "revision_unpin"
+    WATCH_TOKEN_REVOKE = "watch_token_revoke"
+    CHANNEL_DELETE = "channel_delete"
 
 
 class PendingActionStatus(StrEnum):

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -95,6 +95,9 @@ class System(UUIDMixin, TimestampMixin, Base):
     safety_applies_to_revisions: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False
     )
+    safety_applies_to_notifications: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
 
     # Auto-pin the first captured revision for each journal entry / member bio.
     # Independent of safety_applies_to_revisions: even without grace+re-auth on

--- a/sheaf/schemas/notifications.py
+++ b/sheaf/schemas/notifications.py
@@ -23,6 +23,11 @@ class WatchTokenUpdate(BaseModel):
     label: str | None = Field(default=None, max_length=120)
 
 
+class WatchTokenRevokeConfirm(BaseModel):
+    password: str | None = None
+    totp_code: str | None = None
+
+
 class WatchTokenRead(BaseModel):
     id: uuid.UUID
     system_id: uuid.UUID
@@ -135,6 +140,11 @@ class ChannelRead(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class ChannelDeleteConfirm(BaseModel):
+    password: str | None = None
+    totp_code: str | None = None
 
 
 class ChannelCreateResponse(BaseModel):

--- a/sheaf/schemas/system_safety.py
+++ b/sheaf/schemas/system_safety.py
@@ -19,6 +19,7 @@ class SystemSafetySettings(BaseModel):
     applies_to_journals: bool
     applies_to_images: bool
     applies_to_revisions: bool
+    applies_to_notifications: bool
     auto_pin_first_revision: bool
 
 
@@ -35,6 +36,7 @@ class SystemSafetyUpdate(BaseModel):
     applies_to_journals: bool | None = None
     applies_to_images: bool | None = None
     applies_to_revisions: bool | None = None
+    applies_to_notifications: bool | None = None
     auto_pin_first_revision: bool | None = None
 
     # Re-auth for loosening changes is checked against the *current* auth tier.

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -27,6 +27,7 @@ from sheaf.models.front import Front
 from sheaf.models.group import Group
 from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
+from sheaf.models.notification_channel import NotificationChannel
 from sheaf.models.pending_action import (
     PendingAction,
     PendingActionStatus,
@@ -40,6 +41,7 @@ from sheaf.models.system import DeleteConfirmation, System
 from sheaf.models.tag import Tag
 from sheaf.models.uploaded_file import UploadedFile
 from sheaf.models.user import User
+from sheaf.models.watch_token import WatchToken
 
 # Categories that safety can apply to — kept in one place so the API,
 # schemas, and finalize dispatcher all agree on the set.
@@ -52,6 +54,7 @@ SAFETY_CATEGORIES: tuple[str, ...] = (
     "journals",
     "images",
     "revisions",
+    "notifications",
 )
 
 _CATEGORY_BY_ACTION: dict[str, str] = {
@@ -63,6 +66,8 @@ _CATEGORY_BY_ACTION: dict[str, str] = {
     PendingActionType.JOURNAL_DELETE: "journals",
     PendingActionType.IMAGE_DELETE: "images",
     PendingActionType.REVISION_UNPIN: "revisions",
+    PendingActionType.WATCH_TOKEN_REVOKE: "notifications",
+    PendingActionType.CHANNEL_DELETE: "notifications",
 }
 
 _MODEL_BY_ACTION: dict[str, type] = {
@@ -74,6 +79,8 @@ _MODEL_BY_ACTION: dict[str, type] = {
     PendingActionType.JOURNAL_DELETE: JournalEntry,
     PendingActionType.IMAGE_DELETE: UploadedFile,
     PendingActionType.REVISION_UNPIN: ContentRevision,
+    PendingActionType.WATCH_TOKEN_REVOKE: WatchToken,
+    PendingActionType.CHANNEL_DELETE: NotificationChannel,
 }
 
 
@@ -313,6 +320,11 @@ async def finalize_pending_action(
             from sheaf.services.journals import unpin_revision_immediate
 
             unpin_revision_immediate(target)
+        elif pending.action_type == PendingActionType.WATCH_TOKEN_REVOKE:
+            # Soft-revoke: matches the immediate revoke path, channels stay in
+            # DB but the dispatcher skips them. Idempotent if already revoked.
+            if target.revoked_at is None:
+                target.revoked_at = datetime.now(UTC)
         else:
             # Polymorphic content_revisions can't FK on target — cascade in app.
             if pending.action_type == PendingActionType.JOURNAL_DELETE:
@@ -356,6 +368,10 @@ async def _target_in_scope(
             member = await db.get(Member, target.target_id)
             return member is not None and member.system_id == pending.system_id
         return False
+    if isinstance(target, NotificationChannel):
+        # Channels don't carry system_id directly; resolve via watch token.
+        token = await db.get(WatchToken, target.watch_token_id)
+        return token is not None and token.system_id == pending.system_id
     if hasattr(target, "system_id"):
         return target.system_id == pending.system_id
     if hasattr(target, "user_id"):

--- a/tests/test_notifications_safety.py
+++ b/tests/test_notifications_safety.py
@@ -1,0 +1,168 @@
+"""System Safety integration for notification channel + watch token deletes."""
+
+import asyncio
+import os
+import uuid
+
+import httpx
+
+
+def _set_system_safety_via_db(user_email: str, **fields) -> None:
+    from sqlalchemy import select
+
+    from sheaf.crypto import blind_index
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.system import System
+        from sheaf.models.user import User
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            email_hash = blind_index(user_email)
+            user = (
+                await db.execute(select(User).where(User.email_hash == email_hash))
+            ).scalar_one()
+            system = (
+                await db.execute(select(System).where(System.user_id == user.id))
+            ).scalar_one()
+            for k, v in fields.items():
+                setattr(system, k, v)
+            await db.commit()
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def _register(client: httpx.Client) -> str:
+    email = f"notifsafety-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "testpassword123"},
+    )
+    assert resp.status_code == 201
+    client.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+    return email
+
+
+def _create_token(client: httpx.Client) -> dict:
+    sid = client.get("/v1/systems/me").json()["id"]
+    resp = client.post(
+        f"/v1/systems/{sid}/watch-tokens", json={"label": "test"}
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _create_ntfy_channel(client: httpx.Client, token_id: str) -> dict:
+    resp = client.post(
+        f"/v1/watch-tokens/{token_id}/channels",
+        json={
+            "name": "safety-test",
+            "destination_type": "ntfy",
+            "destination_config": {
+                "server_url": "https://ntfy.sh",
+                "topic": f"safety-{uuid.uuid4().hex[:8]}",
+            },
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["channel"]
+
+
+# ---------------------------------------------------------------------------
+# Channel delete
+# ---------------------------------------------------------------------------
+
+
+def test_channel_delete_immediate_when_off(auth_client: httpx.Client):
+    tok = _create_token(auth_client)
+    chan = _create_ntfy_channel(auth_client, tok["id"])
+
+    resp = auth_client.request("DELETE", f"/v1/channels/{chan['id']}")
+    assert resp.status_code == 204, resp.text
+    assert auth_client.get(f"/v1/channels/{chan['id']}").status_code == 404
+
+
+def test_channel_delete_queues_when_safeguarded(client: httpx.Client):
+    email = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_notifications=True,
+    )
+    tok = _create_token(client)
+    chan = _create_ntfy_channel(client, tok["id"])
+
+    resp = client.request("DELETE", f"/v1/channels/{chan['id']}")
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert "pending_action_id" in body
+    assert "finalize_after" in body
+
+    # Channel still exists during grace.
+    assert client.get(f"/v1/channels/{chan['id']}").status_code == 200
+
+    # Pending action surfaces in /system/safety.
+    pending = client.get("/v1/system/safety").json()["pending_actions"]
+    assert any(p["action_type"] == "channel_delete" for p in pending)
+
+
+# ---------------------------------------------------------------------------
+# Watch token revoke
+# ---------------------------------------------------------------------------
+
+
+def test_watch_token_revoke_immediate_when_off(auth_client: httpx.Client):
+    tok = _create_token(auth_client)
+    resp = auth_client.request("DELETE", f"/v1/watch-tokens/{tok['id']}")
+    assert resp.status_code == 204, resp.text
+    fresh = auth_client.get(f"/v1/watch-tokens/{tok['id']}").json()
+    assert fresh["revoked_at"] is not None
+
+
+def test_watch_token_revoke_queues_when_safeguarded(client: httpx.Client):
+    email = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_notifications=True,
+    )
+    tok = _create_token(client)
+
+    resp = client.request("DELETE", f"/v1/watch-tokens/{tok['id']}")
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert "pending_action_id" in body
+
+    # Token NOT yet revoked during grace.
+    fresh = client.get(f"/v1/watch-tokens/{tok['id']}").json()
+    assert fresh["revoked_at"] is None
+
+    pending = client.get("/v1/system/safety").json()["pending_actions"]
+    assert any(p["action_type"] == "watch_token_revoke" for p in pending)
+
+
+def test_watch_token_revoke_idempotent_when_already_revoked(
+    client: httpx.Client,
+):
+    """Re-revoking an already-revoked token should not 202-queue under safety,
+    just no-op 204. Otherwise toggling safety on after revocation would let
+    the user accidentally queue a meaningless action."""
+    email = _register(client)
+    tok = _create_token(client)
+    # Revoke once (safety off).
+    client.request("DELETE", f"/v1/watch-tokens/{tok['id']}")
+    # Now revoke again with safety on.
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_notifications=True,
+    )
+    resp = client.request("DELETE", f"/v1/watch-tokens/{tok['id']}")
+    assert resp.status_code == 204

--- a/web/src/components/notifications/watch-token-card.tsx
+++ b/web/src/components/notifications/watch-token-card.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { Pause, Play, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
+import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -9,8 +12,10 @@ import {
   useRevokeWatchToken,
   useToggleChannel,
 } from "@/hooks/use-notifications";
+import { getMySystem } from "@/lib/systems";
 import type {
   ChannelCreateResponse,
+  DestructiveConfirm,
   NotificationChannel,
   WatchToken,
 } from "@/types/api";
@@ -45,8 +50,13 @@ export function WatchTokenCard({
   systemId: string;
 }) {
   const { data: channels } = useChannels(token.id);
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+  });
   const revoke = useRevokeWatchToken(systemId);
   const [showNew, setShowNew] = useState(false);
+  const [showRevoke, setShowRevoke] = useState(false);
   const [activationModal, setActivationModal] =
     useState<ChannelCreateResponse | null>(null);
 
@@ -79,15 +89,7 @@ export function WatchTokenCard({
                 size="icon"
                 variant="ghost"
                 aria-label="Revoke watcher"
-                onClick={() => {
-                  if (
-                    confirm(
-                      `Revoke "${token.label ?? "this watcher"}"? Existing channels stop delivering immediately. This is reversible by editing the watcher's revoked state.`,
-                    )
-                  ) {
-                    revoke.mutate(token.id);
-                  }
-                }}
+                onClick={() => setShowRevoke(true)}
               >
                 <Trash2 className="h-4 w-4 text-destructive" />
               </Button>
@@ -124,6 +126,35 @@ export function WatchTokenCard({
         url={activationModal?.activation_url ?? null}
         expiresAt={activationModal?.activation_expires_at ?? null}
         channelName={activationModal?.channel.name ?? "the recipient"}
+      />
+      <DestructiveConfirmDialog
+        open={showRevoke}
+        onOpenChange={setShowRevoke}
+        title="Revoke watcher"
+        description={`Revoke "${token.label ?? "this watcher"}"? Channels stop delivering. This is reversible by clearing revoked_at.`}
+        tier={system?.delete_confirmation ?? "none"}
+        loading={revoke.isPending}
+        actionLabel="Revoke"
+        actionLabelLoading="Revoking..."
+        onConfirm={(confirm?: DestructiveConfirm) => {
+          revoke.mutate(
+            { id: token.id, confirm },
+            {
+              onSuccess: (resp) => {
+                setShowRevoke(false);
+                if (
+                  resp &&
+                  typeof resp === "object" &&
+                  "pending_action_id" in resp
+                ) {
+                  toast.success(
+                    "Revocation queued. Cancel from System Safety before it finalizes.",
+                  );
+                }
+              },
+            },
+          );
+        }}
       />
     </Card>
   );

--- a/web/src/components/pending-action-row.tsx
+++ b/web/src/components/pending-action-row.tsx
@@ -10,6 +10,8 @@ const actionLabels: Record<PendingActionType, string> = {
   journal_delete: "Delete journal entry",
   image_delete: "Delete image",
   revision_unpin: "Unpin revision",
+  watch_token_revoke: "Revoke watcher",
+  channel_delete: "Delete notification channel",
 };
 
 function timeRemaining(finalizeAfter: string): string {

--- a/web/src/components/system-safety-card.tsx
+++ b/web/src/components/system-safety-card.tsx
@@ -43,6 +43,11 @@ const categoryLabels: {
   { key: "applies_to_journals", label: "Journal entries", desc: "Deleting a journal entry" },
   { key: "applies_to_images", label: "Images", desc: "Deleting an uploaded image" },
   { key: "applies_to_revisions", label: "Revision pins", desc: "Unpinning a protected revision" },
+  {
+    key: "applies_to_notifications",
+    label: "Notifications",
+    desc: "Deleting a channel or revoking a watcher",
+  },
 ];
 
 function changeSummary(changes: Record<string, unknown>): string {
@@ -383,6 +388,7 @@ const CATEGORY_KEYS = [
   "applies_to_journals",
   "applies_to_images",
   "applies_to_revisions",
+  "applies_to_notifications",
 ] as const;
 
 function hasDiff(a: SystemSafetySettings, b: SystemSafetySettings): boolean {

--- a/web/src/hooks/use-notifications.ts
+++ b/web/src/hooks/use-notifications.ts
@@ -56,10 +56,17 @@ export function useUpdateWatchToken(systemId: string | undefined) {
 export function useRevokeWatchToken(systemId: string | undefined) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.revokeWatchToken(id),
+    mutationFn: ({
+      id,
+      confirm,
+    }: {
+      id: string;
+      confirm?: { password?: string; totp_code?: string };
+    }) => api.revokeWatchToken(id, confirm),
     onSuccess: () => {
       if (systemId) {
         qc.invalidateQueries({ queryKey: notificationKeys.tokens(systemId) });
+        qc.invalidateQueries({ queryKey: ["system-safety"] });
       }
       toast.success("Watcher revoked");
     },
@@ -114,9 +121,16 @@ export function useUpdateChannel(channelId: string | undefined) {
 export function useDeleteChannel() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (channelId: string) => api.deleteChannel(channelId),
+    mutationFn: ({
+      channelId,
+      confirm,
+    }: {
+      channelId: string;
+      confirm?: { password?: string; totp_code?: string };
+    }) => api.deleteChannel(channelId, confirm),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["channels"] });
+      qc.invalidateQueries({ queryKey: ["system-safety"] });
       toast.success("Channel deleted");
     },
   });

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -2,6 +2,8 @@ import type {
   ChannelCreate,
   ChannelCreateResponse,
   ChannelUpdate,
+  DeleteResult,
+  DestructiveConfirm,
   GroupRuleSpec,
   MemberRuleSpec,
   NotificationChannel,
@@ -39,8 +41,14 @@ export function updateWatchToken(tokenId: string, data: WatchTokenUpdate) {
   });
 }
 
-export function revokeWatchToken(tokenId: string) {
-  return apiFetch<void>(`/v1/watch-tokens/${tokenId}`, { method: "DELETE" });
+export function revokeWatchToken(
+  tokenId: string,
+  confirm?: DestructiveConfirm,
+) {
+  return apiFetch<DeleteResult>(`/v1/watch-tokens/${tokenId}`, {
+    method: "DELETE",
+    ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
 }
 
 // ---- channels ------------------------------------------------------------
@@ -69,8 +77,14 @@ export function updateChannel(channelId: string, data: ChannelUpdate) {
   });
 }
 
-export function deleteChannel(channelId: string) {
-  return apiFetch<void>(`/v1/channels/${channelId}`, { method: "DELETE" });
+export function deleteChannel(
+  channelId: string,
+  confirm?: DestructiveConfirm,
+) {
+  return apiFetch<DeleteResult>(`/v1/channels/${channelId}`, {
+    method: "DELETE",
+    ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
 }
 
 export function enableChannel(channelId: string) {

--- a/web/src/routes/notifications.$channelId.tsx
+++ b/web/src/routes/notifications.$channelId.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router";
 import { ArrowLeft, Copy, Pause, Play, RefreshCw, Send, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
+import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { ActivationLinkModal } from "@/components/notifications/activation-link-modal";
 import { DeliveryCard } from "@/components/notifications/delivery-card";
 import { DestinationIcon } from "@/components/notifications/destination-icon";
@@ -27,9 +29,11 @@ import {
   useToggleChannel,
   useUpdateChannel,
 } from "@/hooks/use-notifications";
+import { getMySystem } from "@/lib/systems";
 import type {
   ChannelCreateResponse,
   ChannelUpdate,
+  DestructiveConfirm,
   NotificationChannel,
 } from "@/types/api";
 
@@ -84,10 +88,16 @@ export function NotificationChannelPage() {
   const sendTest = useSendTest();
   const toggle = useToggleChannel();
 
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+  });
+
   const [draftState, setDraftState] = useState<{
     channelUpdatedAt: string | null;
     draft: ChannelUpdate;
   }>({ channelUpdatedAt: null, draft: {} });
+  const [showDelete, setShowDelete] = useState(false);
   const [activationModal, setActivationModal] =
     useState<ChannelCreateResponse | null>(null);
   const [reissueModal, setReissueModal] = useState<{
@@ -199,17 +209,7 @@ export function NotificationChannelPage() {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => {
-            if (
-              confirm(
-                `Delete channel "${channel.name}"? This stops deliveries immediately and removes the channel.`,
-              )
-            ) {
-              del.mutate(channel.id, {
-                onSuccess: () => navigate("/notifications"),
-              });
-            }
-          }}
+          onClick={() => setShowDelete(true)}
         >
           <Trash2 className="mr-1 h-4 w-4 text-destructive" />
           Delete
@@ -301,6 +301,34 @@ export function NotificationChannelPage() {
         url={reissueModal?.url ?? null}
         expiresAt={reissueModal?.expires ?? null}
         channelName={channel.name}
+      />
+      <DestructiveConfirmDialog
+        open={showDelete}
+        onOpenChange={setShowDelete}
+        title="Delete channel"
+        description={`Delete channel "${channel.name}"? This stops deliveries immediately and removes the channel.`}
+        tier={system?.delete_confirmation ?? "none"}
+        loading={del.isPending}
+        onConfirm={(confirm?: DestructiveConfirm) => {
+          del.mutate(
+            { channelId: channel.id, confirm },
+            {
+              onSuccess: (resp) => {
+                setShowDelete(false);
+                if (
+                  resp &&
+                  typeof resp === "object" &&
+                  "pending_action_id" in resp
+                ) {
+                  toast.success(
+                    "Deletion queued. Cancel from System Safety before it finalizes.",
+                  );
+                }
+                navigate("/notifications");
+              },
+            },
+          );
+        }}
       />
     </>
   );

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -215,7 +215,9 @@ export type PendingActionType =
   | "front_delete"
   | "journal_delete"
   | "image_delete"
-  | "revision_unpin";
+  | "revision_unpin"
+  | "watch_token_revoke"
+  | "channel_delete";
 
 export type PendingActionStatus =
   | "pending"
@@ -260,6 +262,7 @@ export interface SystemSafetySettings {
   applies_to_journals: boolean;
   applies_to_images: boolean;
   applies_to_revisions: boolean;
+  applies_to_notifications: boolean;
   auto_pin_first_revision: boolean;
 }
 
@@ -274,6 +277,7 @@ export interface SystemSafetyUpdate {
   applies_to_journals?: boolean;
   applies_to_images?: boolean;
   applies_to_revisions?: boolean;
+  applies_to_notifications?: boolean;
   auto_pin_first_revision?: boolean;
   password?: string;
   totp_code?: string;


### PR DESCRIPTION
## Summary
- Notifications were the one owner-facing destructive surface that ignored System Safety. A compromised session could silently delete every channel or revoke every watcher even when grace+re-auth was configured. Brings them under the same protections every other delete already has.
- New `notifications` safety category covering both `DELETE /v1/channels/{id}` (hard delete, cascade) and `DELETE /v1/watch-tokens/{id}` (soft-revoke). Channel disable is intentionally left out — reversible from the UI and visible on the dashboard, so it doesn't match the same threat model.
- Frontend swaps the browser `confirm()` prompts for the existing `DestructiveConfirmDialog`. When the action queues you get a toast pointing back at System Safety; otherwise it's a normal 204.

## Changes
- `safety_applies_to_notifications` column on `systems` (alembic `s9t0u1v2w3x4`).
- Two new `PendingActionType` values: `watch_token_revoke`, `channel_delete`. Watch-token revoke gets a special-case in `finalize_pending_action` that sets `revoked_at` instead of `db.delete` (matching the soft-revoke behaviour). Channel delete uses the default cascade path.
- `_target_in_scope` walks `NotificationChannel -> WatchToken -> system_id` since channels don't carry `system_id` directly.
- Re-revoking an already-revoked token short-circuits to 204 regardless of safety, so toggling safety on later doesn't queue a meaningless action.
- New "Notifications" row in System Safety settings; `PendingActionType` union and pending-action labels grow two entries.
- Five new tests covering immediate vs queued for both endpoints + the idempotent re-revoke case.

## Test plan
- [ ] `ruff check sheaf/` passes
- [ ] `cd web && npm run lint && npx tsc --noEmit` passes
- [ ] `pytest tests/test_notifications_safety.py` passes
- [ ] Existing notifications + system-safety tests still pass
- [ ] End-to-end: enable notifications safety, delete a channel -> 202 with pending_action_id; revoke a watcher -> 202; cancel from System Safety; verify channel/watcher still exist

## Security / privacy impact
This is a security improvement. Owner-facing destructive notification ops were silently outside System Safety's grace-period + re-auth guarantees; this brings them in line with members/fronts/groups/journals/etc. No new data is collected or exposed. The recipient-side management URL flow (capability tokens, no auth) is unchanged.