### PR TITLE
Pushover: BYO app token, per-user + deployment caps, debounce floor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,8 +185,33 @@ IMAGE_SERVING=signed
 # --- Pushover -----------------------------------------------------------------
 # Register a Pushover application at https://pushover.net/apps and put the
 # resulting app token here. The recipient's user_key is supplied per channel
-# at create time. Empty = Pushover destination type is rejected with 501.
+# at create time. Empty = Pushover destination type is rejected with 501,
+# UNLESS the channel supplies its own destination_config.app_token (BYO mode).
 # PUSHOVER_APP_TOKEN=
+
+# Monthly cap on shared-app Pushover deliveries. As of May 2026 Pushover
+# gives each account a pooled 10000 messages/month free across all apps it
+# owns, with paid upgrades at $50/10k, $115/25k, $200/50k, $300/100k,
+# $1000/500k. Sheaf runs one app per instance, so one instance = one
+# account's quota. Sheaf tracks deployment-wide usage in Redis and
+# transient-fails shared-app deliveries once the cap is hit. Channels with
+# destination_config.app_token (BYO) bypass this counter entirely. Set to
+# 0 to disable Sheaf-side tracking and let Pushover-side enforcement be
+# the only ceiling.
+# PUSHOVER_MAX_PER_MONTH=10000
+
+# Minimum debounce_seconds enforced on shared-app Pushover channels. Without
+# this, one chatty system can burn the whole monthly cap for everyone on the
+# instance — 30 minutes is a reasonable floor that still lets active users
+# get reasonably timely pings without runaway. BYO channels are exempt.
+# PUSHOVER_SHARED_APP_MIN_DEBOUNCE_SECONDS=1800
+
+# Per-Sheaf-user monthly Pushover allowance on the shared app, by tier. Stops
+# one user from monopolising the deployment quota. 0 = unlimited per-user
+# (only the deployment-wide cap applies). BYO channels bypass this too.
+# PUSHOVER_USER_MAX_PER_MONTH_FREE=100
+# PUSHOVER_USER_MAX_PER_MONTH_PLUS=1000
+# PUSHOVER_USER_MAX_PER_MONTH_SELF_HOSTED=0
 
 # --- Discord webhook display --------------------------------------------------
 # Owners can set destination_type=webhook + format=discord. These two settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 - Recipient-side capability URL for unsubscribe; account-bound subscriptions tighten to require the redeemer's session for management.
 - System Safety integration: channel deletion and watcher revocation can be safeguarded with grace + re-auth, matching every other destructive action.
 - API keys: dedicated `notifications:read|write|delete` scopes (separate from `members`); journals also moved to their own `journals:*` scopes.
+- Pushover BYO app token: recipients can paste their own Pushover application token into the channel's "Advanced" config to bypass all shared-app limits — they hit their own Pushover quota instead.
+- Pushover monthly quota tracking: new `PUSHOVER_MAX_PER_MONTH` setting (default 10000) caps shared-app deliveries deployment-wide per calendar month; usage surfaced on `/admin` and at `GET /v1/admin/pushover-usage`.
+- Per-user-tier Pushover allowance: new `PUSHOVER_USER_MAX_PER_MONTH_{FREE,PLUS,SELF_HOSTED}` settings (defaults 100/1000/0) stop one Sheaf user from monopolising the deployment quota. Surfaced to the user at `GET /v1/notifications/pushover-usage` and shown on their notifications page.
+- Pushover shared-app debounce floor: new `PUSHOVER_SHARED_APP_MIN_DEBOUNCE_SECONDS` setting (default 1800) protects the deployment-wide cap from one chatty system burning everyone's quota. Surfaced to the channel form via `GET /v1/notifications/server-config`. BYO channels are exempt.
 
 ## [v0.1.0] - 2026-04-29
 

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -248,6 +248,42 @@ PUSHOVER_APP_TOKEN=axxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 Each recipient supplies their own user_key per channel at create time. Without `PUSHOVER_APP_TOKEN`, the destination type is rejected with 501.
 
+#### Cost shape
+
+As of May 2026, [Pushover gives each account a pooled 10,000 messages/month free](https://blog.pushover.net/posts/2026/4/app-limits) across all apps the account owns. Paid upgrades are one-off purchases at $50/10k, $115/25k, $200/50k, $300/100k, $1000/500k, applied at the account level.
+
+Sheaf runs one app per instance, so one Sheaf instance = one Pushover account's quota. If you expect to push past 10k/month, the simplest option is a one-off upgrade — they apply automatically since the account quota is what we hit.
+
+[Pushover for Teams](https://pushover.net/teams) is a separate $5/user/month subscription product for organizations; team accounts get a 25k/month free limit instead of 10k, but the team subscription only makes sense if you also need its user-management features. For pure quota expansion an individual one-off upgrade is much cheaper.
+
+Three sets of settings cap shared-app exposure:
+
+```env
+PUSHOVER_MAX_PER_MONTH=10000                     # deployment-wide ceiling
+PUSHOVER_SHARED_APP_MIN_DEBOUNCE_SECONDS=1800    # 30-min minimum debounce
+PUSHOVER_USER_MAX_PER_MONTH_FREE=100             # per-Sheaf-user, by tier
+PUSHOVER_USER_MAX_PER_MONTH_PLUS=1000
+PUSHOVER_USER_MAX_PER_MONTH_SELF_HOSTED=0        # 0 = unlimited for that tier
+```
+
+Three checks happen for every shared-app Pushover delivery:
+
+1. **Per-user tier cap.** Each Sheaf user has a monthly allowance based on their tier. 0 disables the per-user check for that tier. Hitting the user's cap transient-fails their deliveries until the next calendar month. Counter at `pushover:usage:user:{user_id}:YYYY-MM`. Surfaced to the user via `GET /v1/notifications/pushover-usage` and shown on their notifications page.
+2. **Deployment-wide cap.** `PUSHOVER_MAX_PER_MONTH` caps total instance usage. Counter at `pushover:usage:YYYY-MM`. Surfaced on `/admin` and at `GET /v1/admin/pushover-usage`. Set to 0 to disable Sheaf-side tracking entirely (Pushover's own 429s become the only ceiling).
+3. **Debounce floor.** `PUSHOVER_SHARED_APP_MIN_DEBOUNCE_SECONDS` is enforced at channel create/update time, so users can't configure under it. Without this floor, one chatty system could burn the whole instance quota in a day. 30 minutes is the default. Surfaced via `GET /v1/notifications/server-config` so the UI can render the floor in the channel form.
+
+All three apply only to channels using the deployment's shared `PUSHOVER_APP_TOKEN`. BYO channels (recipient-supplied `destination_config.app_token`) bypass all of them.
+
+#### BYO Pushover app (recipient-side)
+
+Recipients who want their own Pushover quota (or just don't want to compete for the shared one) can create a free Pushover account, register an application at <https://pushover.net/apps/build>, and paste its API token into the channel's "Advanced" config:
+
+- The channel uses the BYO app token instead of the deployment's
+- Counts toward the recipient's own account quota (10k/month free, pooled across any other Pushover apps they run), not yours
+- Both `PUSHOVER_MAX_PER_MONTH` and `PUSHOVER_SHARED_APP_MIN_DEBOUNCE_SECONDS` no longer apply — the recipient sets debounce wherever they want
+
+This is the pressure-relief valve when you start hitting the shared cap regularly. Document it for power users.
+
 ### Discord webhook display
 
 Owners can choose `format=discord` on a webhook channel. These two settings control how the bot renders in Discord:

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -131,6 +131,28 @@ async def get_stats(
     }
 
 
+@router.get("/pushover-usage")
+async def get_pushover_usage(_: User = Depends(get_admin_user)):
+    """Current month's shared-app Pushover delivery count vs the configured
+    monthly cap. Channels with a BYO destination_config.app_token aren't
+    counted here — they hit the recipient's own Pushover quota."""
+    from datetime import UTC, datetime
+
+    from sheaf.services.notifications.pushover_counter import (
+        get_monthly_count,
+    )
+
+    count = await get_monthly_count()
+    cap = settings.pushover_max_per_month
+    return {
+        "month": datetime.now(UTC).strftime("%Y-%m"),
+        "count": count,
+        "cap": cap,
+        # Convenience: when cap=0 we don't enforce, surface that explicitly.
+        "enforced": cap > 0,
+    }
+
+
 # ---------------------------------------------------------------------------
 # User management
 # ---------------------------------------------------------------------------

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -4,6 +4,7 @@ send-test + live preview."""
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select
@@ -213,6 +214,31 @@ def _validate_direct_config(body_type: str, config: dict) -> None:
         )
 
 
+def _validate_pushover_debounce(
+    destination_type: str, destination_config: dict, debounce_seconds: int
+) -> None:
+    """Reject Pushover channels using the shared deployment app token if
+    they're configured below the floor. BYO-app channels are exempt — the
+    recipient is on their own quota.
+    """
+    if destination_type != DestinationType.PUSHOVER.value:
+        return
+    if (destination_config or {}).get("app_token"):
+        return  # BYO mode: no floor.
+    floor = settings.pushover_shared_app_min_debounce_seconds
+    if floor > 0 and debounce_seconds < floor:
+        minutes = round(floor / 60)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"This instance requires at least {minutes} minutes "
+                f"between deliveries on the shared Pushover app. "
+                f"Raise the debounce, or set your own Pushover app token "
+                f"in the channel's Advanced config to bypass this limit."
+            ),
+        )
+
+
 # ---------- create / list / read / update / delete -------------------------
 
 
@@ -238,6 +264,11 @@ async def create_channel(
     _validate_destination(body.destination_type)
     if body.destination_type in _DIRECT_TYPES:
         _validate_direct_config(body.destination_type, body.destination_config)
+    _validate_pushover_debounce(
+        body.destination_type,
+        body.destination_config or {},
+        body.debounce_seconds,
+    )
 
     channel = NotificationChannel(
         id=uuid.uuid4(),
@@ -367,6 +398,20 @@ async def update_channel(
                 detail="webhook_secret only valid for webhook channels",
             )
         channel.webhook_secret_encrypted = encrypt(body.webhook_secret)
+    # Re-check the pushover debounce floor against the merged config +
+    # whichever debounce ends up applying after this PATCH. Either could
+    # change independently — caller might raise debounce while keeping the
+    # shared app, or add a BYO app_token while lowering debounce.
+    final_debounce = (
+        body.debounce_seconds
+        if body.debounce_seconds is not None
+        else channel.debounce_seconds
+    )
+    _validate_pushover_debounce(
+        channel.destination_type,
+        channel.destination_config or {},
+        final_debounce,
+    )
     for field in (
         "base_all_members",
         "base_include_private",
@@ -841,6 +886,52 @@ async def remove_member_rule(
 # account, the channel binds to their user_id. These endpoints let that user
 # see and manage every channel they're receiving (across all systems they
 # subscribe to) without juggling per-channel capability URLs.
+
+
+@router.get("/notifications/server-config")
+async def get_notifications_server_config():
+    """Public-shape config the channel-creation UI needs to render correctly.
+
+    Surfaces the shared-app debounce floor + whether a deployment-wide
+    Pushover app token is configured. The UI uses this to set the
+    debounce_seconds input's minimum and decide whether to require a BYO
+    app_token. No secrets here — just operator-set policy that recipients
+    will hit at submit time anyway.
+    """
+    return {
+        "pushover": {
+            "shared_app_available": bool(settings.pushover_app_token),
+            "shared_app_min_debounce_seconds": (
+                settings.pushover_shared_app_min_debounce_seconds
+            ),
+        },
+    }
+
+
+@router.get("/notifications/pushover-usage")
+async def get_my_pushover_usage(
+    user: User = Depends(get_current_user),
+):
+    """Current month's shared-app Pushover usage for the calling user.
+
+    Counts only deliveries that hit the deployment's shared app token.
+    BYO channels (recipient supplied their own destination_config.app_token)
+    aren't tracked here — they're on the recipient's own Pushover quota.
+    """
+    from sheaf.services.notifications.pushover_counter import (
+        cap_for_tier,
+        get_user_monthly_count,
+    )
+
+    count = await get_user_monthly_count(user.id)
+    cap = cap_for_tier(user.tier)
+    return {
+        "month": datetime.now(UTC).strftime("%Y-%m"),
+        "tier": user.tier,
+        "count": count,
+        "cap": cap,
+        "enforced": cap > 0,
+    }
 
 
 @router.get("/notifications/receiving", response_model=list[ReceivingChannelView])

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -278,9 +278,33 @@ class Settings(BaseSettings):
     # Contact URI for push services (mailto:ops@example.com or https://...).
     # Required when web push is enabled.
     vapid_subject: str = ""
-    # Pushover app token (issued by pushover.net). Empty = Pushover destination
-    # type is rejected with 501.
+    # Pushover app token (issued by pushover.net) used for the shared,
+    # deployment-wide Pushover app. Empty = Pushover destination type is
+    # rejected with 501 unless a recipient supplies their own app_token via
+    # the channel's destination_config (BYO mode bypasses both the absent
+    # default and the monthly cap).
     pushover_app_token: str = ""
+    # Monthly cap on shared-app Pushover deliveries. Pushover charges per app
+    # per month: 10000 free, then $50/10k extra (one-off, not subscription).
+    # Sheaf tracks deployment-wide usage in Redis keyed by YYYY-MM and
+    # transient-fails shared-app deliveries once the cap is hit. Channels
+    # with BYO app_token bypass this counter entirely. Set to 0 to disable
+    # tracking and let Pushover-side enforcement be the only ceiling.
+    pushover_max_per_month: int = 10000
+    # Minimum debounce_seconds for shared-app Pushover channels. One chatty
+    # system can otherwise burn the whole monthly cap for everyone on the
+    # instance — 30 minutes is a reasonable baseline that still lets active
+    # users get reasonably timely pings without budget runaway. BYO channels
+    # are exempt; they get whatever debounce the recipient configured.
+    pushover_shared_app_min_debounce_seconds: int = 1800
+    # Per-user-tier monthly Pushover allowance on the shared app. Stops one
+    # Sheaf user from burning everyone else's allotment within the global
+    # cap. 0 = unlimited (per-user check skipped for that tier; the
+    # deployment-wide cap is the only ceiling). BYO channels bypass this
+    # too — they're on the recipient's own Pushover quota, not ours.
+    pushover_user_max_per_month_free: int = 100
+    pushover_user_max_per_month_plus: int = 1000
+    pushover_user_max_per_month_self_hosted: int = 0
     # Username + avatar URL Discord renders for our webhook deliveries.
     # avatar URL must be publicly reachable PNG/JPEG (Discord rejects SVG).
     # Empty avatar = falls back to the webhook's default avatar; empty

--- a/sheaf/services/notifications/dispatcher.py
+++ b/sheaf/services/notifications/dispatcher.py
@@ -195,9 +195,17 @@ async def _process_row(
             await _drop(db, row, f"no handler for {channel.destination_type}")
             return
 
+        # Resolve channel owner for handlers that need per-user accounting
+        # (currently just Pushover's per-user monthly cap on the shared app).
+        owner_user_id, owner_tier = await _resolve_channel_owner(db, channel)
+
         async with sem:
             outcome = await deliver(
-                channel, message, event_id=str(row.event_id)
+                channel,
+                message,
+                event_id=str(row.event_id),
+                owner_user_id=owner_user_id,
+                owner_tier=owner_tier,
             )
 
         if outcome.ok:
@@ -241,6 +249,29 @@ async def _load_channel(
         )
     )
     return result.scalar_one_or_none()
+
+
+async def _resolve_channel_owner(
+    db: AsyncSession, channel: NotificationChannel
+) -> tuple[uuid.UUID | None, str | None]:
+    """Walk channel -> watch_token -> system -> user to surface (user_id,
+    tier) for handlers that enforce per-user quotas. Returns (None, None)
+    if any link is missing — handlers should treat that as "skip the
+    per-user check, fall back to deployment cap only"."""
+    from sheaf.models.system import System
+    from sheaf.models.user import User
+
+    if channel.watch_token is None:
+        return None, None
+    result = await db.execute(
+        select(User.id, User.tier)
+        .join(System, System.user_id == User.id)
+        .where(System.id == channel.watch_token.system_id)
+    )
+    row = result.first()
+    if row is None:
+        return None, None
+    return row.id, row.tier
 
 
 async def _resolve_members(

--- a/sheaf/services/notifications/handlers.py
+++ b/sheaf/services/notifications/handlers.py
@@ -12,6 +12,7 @@ import hmac
 import json
 import logging
 import time
+import uuid
 from dataclasses import dataclass
 from hashlib import sha256
 
@@ -53,8 +54,20 @@ def permanent(error: str) -> DeliveryResult:
 
 
 async def deliver(
-    channel: NotificationChannel, message: RenderedMessage, *, event_id: str
+    channel: NotificationChannel,
+    message: RenderedMessage,
+    *,
+    event_id: str,
+    owner_user_id: uuid.UUID | None = None,
+    owner_tier: str | None = None,
 ) -> DeliveryResult:
+    """Dispatch a rendered message via the channel's destination handler.
+
+    `owner_user_id` + `owner_tier` are only used by Pushover for per-user
+    monthly cap enforcement on the shared deployment app token. Pass them
+    on real dispatcher-driven deliveries; pass None for synthetic test
+    sends (which still hit the deployment cap but skip the per-user one).
+    """
     dtype = DestinationType(channel.destination_type)
     if dtype == DestinationType.WEB_PUSH:
         return await _deliver_web_push(channel, message)
@@ -63,7 +76,9 @@ async def deliver(
     if dtype == DestinationType.NTFY:
         return await _deliver_ntfy(channel, message)
     if dtype == DestinationType.PUSHOVER:
-        return await _deliver_pushover(channel, message)
+        return await _deliver_pushover(
+            channel, message, owner_user_id=owner_user_id, owner_tier=owner_tier
+        )
     return permanent(f"unsupported destination type {dtype}")
 
 
@@ -264,21 +279,61 @@ async def _deliver_ntfy(
 
 
 async def _deliver_pushover(
-    channel: NotificationChannel, message: RenderedMessage
+    channel: NotificationChannel,
+    message: RenderedMessage,
+    *,
+    owner_user_id: uuid.UUID | None = None,
+    owner_tier: str | None = None,
 ) -> DeliveryResult:
-    if not settings.pushover_app_token:
-        # Server config issue: transient so the channel doesn't get
-        # auto-disabled before the operator notices.
-        return transient("Pushover app token not configured")
-
     cfg = channel.destination_config or {}
     user_key = cfg.get("user_key")
     if not user_key:
         return permanent("missing pushover user_key")
 
+    # BYO mode: recipient supplies their own Pushover application token.
+    # That bypasses both shared-app caps (deployment-wide and per-user) and
+    # the operator's debounce floor — the recipient is on their own quota.
+    byo_token = cfg.get("app_token")
+    using_shared = not byo_token
+    app_token = byo_token or settings.pushover_app_token
+
+    if not app_token:
+        # No token at all (BYO empty AND server not configured). Transient
+        # so a later config fix lets pending deliveries through without
+        # auto-disabling the channel.
+        return transient("Pushover app token not configured")
+
+    if using_shared:
+        from sheaf.services.notifications.pushover_counter import (
+            increment_monthly_count,
+            increment_user_monthly_count,
+            is_over_cap,
+            is_user_over_cap,
+        )
+
+        # Per-user cap first: a user who's already over their own allotment
+        # shouldn't even be charged against the deployment counter, since
+        # their delivery is going to fail anyway.
+        if owner_user_id is not None and await is_user_over_cap(
+            owner_user_id, owner_tier
+        ):
+            return transient(
+                "your monthly Pushover allotment on this instance is "
+                "reached; the operator can raise your tier's cap, or you "
+                "can set destination_config.app_token to your own Pushover "
+                "application to bypass the shared-app limit"
+            )
+
+        if await is_over_cap():
+            return transient(
+                "shared Pushover app monthly cap reached; "
+                "ask the operator or set destination_config.app_token "
+                "to your own Pushover app to bypass"
+            )
+
     url = "https://api.pushover.net/1/messages.json"
     data = {
-        "token": settings.pushover_app_token,
+        "token": app_token,
         "user": user_key,
         "title": message.title,
         "message": message.body,
@@ -293,6 +348,17 @@ async def _deliver_pushover(
             return transient(f"pushover network error: {exc}")
 
     if 200 <= resp.status_code < 300:
+        # Only count toward the caps on successful shared-app deliveries,
+        # so retries of a failed call don't burn budget twice.
+        if using_shared:
+            from sheaf.services.notifications.pushover_counter import (
+                increment_monthly_count,
+                increment_user_monthly_count,
+            )
+
+            await increment_monthly_count()
+            if owner_user_id is not None:
+                await increment_user_monthly_count(owner_user_id)
         return SUCCESS
     if resp.status_code == 400:
         # Pushover returns 400 for invalid user/app keys: permanent.

--- a/sheaf/services/notifications/pushover_counter.py
+++ b/sheaf/services/notifications/pushover_counter.py
@@ -1,0 +1,117 @@
+"""Per-month counters for shared-app Pushover deliveries.
+
+Two tiers of counter:
+
+- **Deployment-wide** (`pushover:usage:YYYY-MM`) — protects the operator's
+  Pushover account quota from total runaway. Set by `PUSHOVER_MAX_PER_MONTH`.
+- **Per-Sheaf-user** (`pushover:usage:user:{user_id}:YYYY-MM`) — stops one
+  user from monopolising the deployment quota; capped per their Sheaf tier
+  via `PUSHOVER_USER_MAX_PER_MONTH_{FREE,PLUS,SELF_HOSTED}`.
+
+Both counters increment on the same shared-app delivery. BYO-app channels
+(recipient supplies their own app_token) bypass both — they're on the
+recipient's own Pushover quota, not ours. Keys auto-expire 45 days after
+first write so old counters self-clean.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sheaf.auth.sessions import get_redis
+from sheaf.config import settings
+from sheaf.models.user import UserTier
+
+
+def _month_suffix(now: datetime | None = None) -> str:
+    return (now or datetime.now(UTC)).strftime("%Y-%m")
+
+
+def _deployment_key(now: datetime | None = None) -> str:
+    return f"pushover:usage:{_month_suffix(now)}"
+
+
+def _user_key(user_id: uuid.UUID, now: datetime | None = None) -> str:
+    return f"pushover:usage:user:{user_id}:{_month_suffix(now)}"
+
+
+def _ttl_seconds() -> int:
+    """Long enough that the counter survives the entire current month plus
+    a safety margin into the next, so we never roll over to a 0 count from
+    an early eviction."""
+    return 45 * 24 * 3600  # 45 days
+
+
+def cap_for_tier(tier: str | None) -> int:
+    """Resolve the per-user monthly cap for a Sheaf tier. Returns 0 for
+    unknown tiers and for explicitly-unlimited tiers — the dispatcher
+    treats 0 as "skip the check, only the deployment cap applies"."""
+    if tier == UserTier.FREE.value:
+        return settings.pushover_user_max_per_month_free
+    if tier == UserTier.PLUS.value:
+        return settings.pushover_user_max_per_month_plus
+    if tier == UserTier.SELF_HOSTED.value:
+        return settings.pushover_user_max_per_month_self_hosted
+    return 0
+
+
+# --- Deployment-wide counter -------------------------------------------------
+
+
+async def get_monthly_count(now: datetime | None = None) -> int:
+    r = await get_redis()
+    val = await r.get(_deployment_key(now))
+    return int(val) if val is not None else 0
+
+
+async def increment_monthly_count(now: datetime | None = None) -> int:
+    r = await get_redis()
+    key = _deployment_key(now)
+    new = await r.incr(key)
+    if new == 1:
+        await r.expire(key, _ttl_seconds())
+    return int(new)
+
+
+async def is_over_cap(now: datetime | None = None) -> bool:
+    """True if shared-app Pushover deliveries should be paused for the
+    current month deployment-wide. cap=0 disables the check."""
+    cap = settings.pushover_max_per_month
+    if cap <= 0:
+        return False
+    return await get_monthly_count(now) >= cap
+
+
+# --- Per-user counter --------------------------------------------------------
+
+
+async def get_user_monthly_count(
+    user_id: uuid.UUID, now: datetime | None = None
+) -> int:
+    r = await get_redis()
+    val = await r.get(_user_key(user_id, now))
+    return int(val) if val is not None else 0
+
+
+async def increment_user_monthly_count(
+    user_id: uuid.UUID, now: datetime | None = None
+) -> int:
+    r = await get_redis()
+    key = _user_key(user_id, now)
+    new = await r.incr(key)
+    if new == 1:
+        await r.expire(key, _ttl_seconds())
+    return int(new)
+
+
+async def is_user_over_cap(
+    user_id: uuid.UUID, tier: str | None, now: datetime | None = None
+) -> bool:
+    """True if this user has exhausted their per-tier monthly Pushover
+    allowance on the shared app. cap=0 disables the per-user check for
+    that tier (e.g. self_hosted has no per-user limit by default)."""
+    cap = cap_for_tier(tier)
+    if cap <= 0:
+        return False
+    return await get_user_monthly_count(user_id, now) >= cap

--- a/tests/test_pushover_improvements.py
+++ b/tests/test_pushover_improvements.py
@@ -1,0 +1,212 @@
+"""Pushover BYO + monthly quota + min debounce floor.
+
+API-level tests against the running test stack. The handler-level branching
+(BYO short-circuits the counter; shared-app increments on success) is also
+exercised here because the dispatcher's behaviour is what users observe.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def _system_id(client: httpx.Client) -> str:
+    return client.get("/v1/systems/me").json()["id"]
+
+
+def _create_token(client: httpx.Client) -> dict:
+    sid = _system_id(client)
+    resp = client.post(
+        f"/v1/systems/{sid}/watch-tokens", json={"label": "pushover-tests"}
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _create_pushover_channel(
+    client: httpx.Client,
+    token_id: str,
+    *,
+    user_key: str = "u_test",
+    app_token: str | None = None,
+    debounce_seconds: int = 1800,
+) -> tuple[int, dict]:
+    cfg: dict = {"user_key": user_key}
+    if app_token is not None:
+        cfg["app_token"] = app_token
+    resp = client.post(
+        f"/v1/watch-tokens/{token_id}/channels",
+        json={
+            "name": "pushover test",
+            "destination_type": "pushover",
+            "destination_config": cfg,
+            "debounce_seconds": debounce_seconds,
+        },
+    )
+    return resp.status_code, resp.json() if resp.content else {}
+
+
+# ---------------------------------------------------------------------------
+# Min-debounce floor on shared-app channels
+# ---------------------------------------------------------------------------
+
+
+def test_shared_app_below_floor_rejected(auth_client: httpx.Client):
+    tok = _create_token(auth_client)
+    code, body = _create_pushover_channel(
+        auth_client, tok["id"], debounce_seconds=60
+    )
+    assert code == 400
+    detail = body.get("detail", "")
+    # User-facing message: should explain the minimum and point at the
+    # BYO escape hatch; doesn't need to leak the raw setting name.
+    assert "minutes" in detail.lower()
+    assert "shared pushover" in detail.lower() or "shared pushover app" in detail.lower()
+
+
+def test_shared_app_at_floor_accepted(auth_client: httpx.Client):
+    tok = _create_token(auth_client)
+    code, _ = _create_pushover_channel(
+        auth_client, tok["id"], debounce_seconds=1800
+    )
+    assert code == 201
+
+
+def test_byo_app_token_bypasses_floor(auth_client: httpx.Client):
+    """A recipient with their own Pushover app is on their own quota; the
+    operator's debounce floor doesn't apply."""
+    tok = _create_token(auth_client)
+    code, _ = _create_pushover_channel(
+        auth_client,
+        tok["id"],
+        app_token="a-30-char-byo-app-token-aaaa",
+        debounce_seconds=30,
+    )
+    assert code == 201
+
+
+def test_patch_lowering_debounce_below_floor_rejected(auth_client: httpx.Client):
+    """Channel created at the floor; PATCH that would drop debounce below
+    floor (without adding a BYO token) gets rejected."""
+    tok = _create_token(auth_client)
+    code, body = _create_pushover_channel(
+        auth_client, tok["id"], debounce_seconds=1800
+    )
+    assert code == 201
+    cid = body["channel"]["id"]
+    resp = auth_client.patch(
+        f"/v1/channels/{cid}", json={"debounce_seconds": 60}
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_patch_adding_byo_app_token_unlocks_lower_debounce(
+    auth_client: httpx.Client,
+):
+    """Owner adds BYO token AND lowers debounce in one PATCH — should pass."""
+    tok = _create_token(auth_client)
+    code, body = _create_pushover_channel(
+        auth_client, tok["id"], debounce_seconds=1800
+    )
+    assert code == 201
+    cid = body["channel"]["id"]
+    resp = auth_client.patch(
+        f"/v1/channels/{cid}",
+        json={
+            "destination_config": {"app_token": "a-30-char-byo-token-aaaaaaaa"},
+            "debounce_seconds": 60,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoint surfaces usage
+# ---------------------------------------------------------------------------
+
+
+def test_admin_pushover_usage_endpoint(admin_client: httpx.Client):
+    resp = admin_client.get("/v1/admin/pushover-usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "month" in body
+    assert "count" in body
+    assert "cap" in body
+    assert "enforced" in body
+    assert isinstance(body["count"], int)
+    assert isinstance(body["cap"], int)
+
+
+def test_admin_pushover_usage_requires_admin(auth_client: httpx.Client):
+    resp = auth_client.get("/v1/admin/pushover-usage")
+    assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# BYO mode skips the counter — verify via the admin endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_byo_delivery_does_not_increment_counter(
+    auth_client: httpx.Client, admin_client: httpx.Client
+):
+    """Sending a test through a BYO channel must not move the shared-app
+    counter. We can't actually deliver to Pushover here (no live recipient),
+    but the test send-path goes through the same handler and would INCR if
+    BYO detection were broken."""
+    before = admin_client.get("/v1/admin/pushover-usage").json()["count"]
+
+    tok = _create_token(auth_client)
+    code, body = _create_pushover_channel(
+        auth_client,
+        tok["id"],
+        app_token="a-30-char-byo-token-aaaaaaaa",
+        debounce_seconds=30,
+    )
+    assert code == 201
+    cid = body["channel"]["id"]
+    # Send-test will fail at Pushover (fake user_key) but that's a 4xx
+    # response from Pushover, NOT a SUCCESS. Counter only moves on success.
+    auth_client.post(f"/v1/channels/{cid}/test")
+
+    after = admin_client.get("/v1/admin/pushover-usage").json()["count"]
+    assert after == before
+
+
+# ---------------------------------------------------------------------------
+# Server-config endpoint surfaces the floor + shared-app availability
+# ---------------------------------------------------------------------------
+
+
+def test_server_config_surfaces_min_debounce(auth_client: httpx.Client):
+    resp = auth_client.get("/v1/notifications/server-config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "pushover" in body
+    assert "shared_app_min_debounce_seconds" in body["pushover"]
+    assert "shared_app_available" in body["pushover"]
+    assert isinstance(body["pushover"]["shared_app_available"], bool)
+    assert isinstance(body["pushover"]["shared_app_min_debounce_seconds"], int)
+
+
+# ---------------------------------------------------------------------------
+# Per-user usage endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_my_pushover_usage_endpoint(auth_client: httpx.Client):
+    resp = auth_client.get("/v1/notifications/pushover-usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "month" in body
+    assert "tier" in body
+    assert "count" in body
+    assert "cap" in body
+    assert "enforced" in body
+    # Fresh user starts at 0.
+    assert body["count"] == 0
+
+
+def test_my_pushover_usage_requires_auth(client: httpx.Client):
+    resp = client.get("/v1/notifications/pushover-usage")
+    assert resp.status_code == 401

--- a/web/src/components/notifications/delivery-card.tsx
+++ b/web/src/components/notifications/delivery-card.tsx
@@ -1,3 +1,5 @@
+import { useQuery } from "@tanstack/react-query";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -9,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { getNotificationsServerConfig } from "@/lib/notifications";
 import type { NotificationChannel, PayloadSensitivity } from "@/types/api";
 
 export function DeliveryCard({
@@ -18,6 +21,21 @@ export function DeliveryCard({
   channel: NotificationChannel;
   onChange: (patch: Partial<NotificationChannel>) => void;
 }) {
+  const { data: serverCfg } = useQuery({
+    queryKey: ["notifications", "server-config"],
+    queryFn: getNotificationsServerConfig,
+  });
+  // Pushover channels using the shared deployment app token can't drop
+  // debounce below the operator's floor — surface that here so the user
+  // doesn't get rejected at save time.
+  const usingSharedPushover =
+    channel.destination_type === "pushover" &&
+    !(channel.destination_config?.app_token);
+  const debounceFloor =
+    usingSharedPushover
+      ? (serverCfg?.pushover.shared_app_min_debounce_seconds ?? 0)
+      : 0;
+
   const quietEnabled = !!channel.quiet_hours;
   const qh = channel.quiet_hours ?? { start: "22:00", end: "07:00", tz: "UTC" };
 
@@ -57,16 +75,35 @@ export function DeliveryCard({
             <Label>Debounce (seconds)</Label>
             <Input
               type="number"
-              min={0}
+              min={debounceFloor}
               max={86400}
               value={channel.debounce_seconds}
+              aria-invalid={
+                debounceFloor > 0 && channel.debounce_seconds < debounceFloor
+              }
               onChange={(e) =>
                 onChange({ debounce_seconds: Number(e.target.value || 0) })
               }
             />
-            <p className="text-xs text-muted-foreground">
-              Minimum gap between deliveries on this channel.
-            </p>
+            {debounceFloor > 0 && channel.debounce_seconds < debounceFloor ? (
+              <p className="text-xs text-destructive">
+                This instance requires at least {debounceFloor} seconds (
+                {Math.round(debounceFloor / 60)} min) between deliveries on
+                the shared Pushover app. Raise this value, or set your own
+                Pushover app token to bypass the shared-app limit.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Minimum gap between deliveries on this channel.
+                {debounceFloor > 0 && (
+                  <>
+                    {" "}
+                    Shared Pushover app requires at least{" "}
+                    {Math.round(debounceFloor / 60)} min.
+                  </>
+                )}
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/web/src/components/notifications/new-channel-dialog.tsx
+++ b/web/src/components/notifications/new-channel-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useCreateChannel } from "@/hooks/use-notifications";
+import { getNotificationsServerConfig } from "@/lib/notifications";
 import type { ChannelCreate, ChannelCreateResponse, DestinationType } from "@/types/api";
 
 export function NewChannelDialog({
@@ -32,6 +34,13 @@ export function NewChannelDialog({
   onCreated?: (resp: ChannelCreateResponse) => void;
 }) {
   const create = useCreateChannel(tokenId);
+  const { data: serverCfg } = useQuery({
+    queryKey: ["notifications", "server-config"],
+    queryFn: getNotificationsServerConfig,
+  });
+  const minDebounce =
+    serverCfg?.pushover.shared_app_min_debounce_seconds ?? 0;
+  const sharedAppAvailable = serverCfg?.pushover.shared_app_available ?? true;
 
   const [name, setName] = useState("");
   const [type, setType] = useState<DestinationType>("web_push");
@@ -43,6 +52,8 @@ export function NewChannelDialog({
   const [ntfyServer, setNtfyServer] = useState("https://ntfy.sh");
   const [ntfyTopic, setNtfyTopic] = useState("");
   const [pushoverUserKey, setPushoverUserKey] = useState("");
+  const [pushoverAppToken, setPushoverAppToken] = useState("");
+  const [pushoverAdvanced, setPushoverAdvanced] = useState(false);
 
   function reset() {
     setName("");
@@ -53,6 +64,8 @@ export function NewChannelDialog({
     setNtfyServer("https://ntfy.sh");
     setNtfyTopic("");
     setPushoverUserKey("");
+    setPushoverAppToken("");
+    setPushoverAdvanced(false);
   }
 
   function handleSubmit(e: FormEvent) {
@@ -63,6 +76,12 @@ export function NewChannelDialog({
       base_all_members: true,
       trigger_on_start: true,
     };
+    // For shared-app Pushover channels, start at the operator's floor so
+    // the user doesn't get rejected on create with the schema default of
+    // 30s. BYO channels skip this — they're on the recipient's own quota.
+    if (type === "pushover" && !pushoverAppToken.trim() && minDebounce > 0) {
+      data.debounce_seconds = minDebounce;
+    }
     if (type === "webhook") {
       data.destination_config = { url: webhookUrl, format: webhookFormat };
       // HMAC only meaningful for json/plaintext; the discord/slack endpoints
@@ -76,7 +95,11 @@ export function NewChannelDialog({
     } else if (type === "ntfy") {
       data.destination_config = { server_url: ntfyServer, topic: ntfyTopic };
     } else if (type === "pushover") {
-      data.destination_config = { user_key: pushoverUserKey };
+      const cfg: Record<string, string> = { user_key: pushoverUserKey };
+      if (pushoverAppToken.trim()) {
+        cfg.app_token = pushoverAppToken.trim();
+      }
+      data.destination_config = cfg;
     }
 
     create.mutate(data, {
@@ -199,15 +222,67 @@ export function NewChannelDialog({
           )}
 
           {type === "pushover" && (
-            <div className="space-y-2">
-              <Label>User key</Label>
-              <Input
-                value={pushoverUserKey}
-                onChange={(e) => setPushoverUserKey(e.target.value)}
-                placeholder="From your Pushover dashboard"
-                required
-              />
-            </div>
+            <>
+              <div className="space-y-2">
+                <Label>User key</Label>
+                <Input
+                  value={pushoverUserKey}
+                  onChange={(e) => setPushoverUserKey(e.target.value)}
+                  placeholder="From your Pushover dashboard"
+                  required
+                />
+              </div>
+              {!sharedAppAvailable && !pushoverAppToken && (
+                <p className="text-xs text-destructive">
+                  This instance has no shared Pushover app configured —
+                  you'll need to bring your own app token below.
+                </p>
+              )}
+              <div className="space-y-2 rounded-md border bg-muted/30 px-3 py-2">
+                <button
+                  type="button"
+                  onClick={() => setPushoverAdvanced((v) => !v)}
+                  className="flex w-full items-center justify-between text-left text-sm font-medium"
+                >
+                  <span>Advanced: bring your own Pushover app</span>
+                  <span className="text-xs text-muted-foreground">
+                    {pushoverAdvanced ? "−" : "+"}
+                  </span>
+                </button>
+                {pushoverAdvanced && (
+                  <>
+                    <p className="text-xs text-muted-foreground">
+                      Pushover gives each account a 10,000 messages/month
+                      free quota across all the apps it owns. This instance
+                      shares one app across all recipients, so it caps
+                      total monthly traffic, applies per-user allowances by
+                      tier, and enforces a longer minimum debounce
+                      {minDebounce > 0
+                        ? ` (${Math.round(minDebounce / 60)} min)`
+                        : ""}
+                      . Create your own free Pushover application at{" "}
+                      <a
+                        href="https://pushover.net/apps/build"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline"
+                      >
+                        pushover.net/apps/build
+                      </a>{" "}
+                      and paste its API token below to bypass all of those
+                      — you'll hit your own account's 10k/month free pool
+                      instead.
+                    </p>
+                    <Label className="text-xs">App token (optional)</Label>
+                    <Input
+                      value={pushoverAppToken}
+                      onChange={(e) => setPushoverAppToken(e.target.value)}
+                      placeholder="a-30-char-pushover-app-token"
+                    />
+                  </>
+                )}
+              </div>
+            </>
           )}
 
           {type === "web_push" && (

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -85,6 +85,17 @@ export function getStorageStats() {
   return apiFetch<{ total_bytes: number; total_files: number; users_with_files: number }>("/v1/admin/storage/stats");
 }
 
+export interface PushoverUsage {
+  month: string;
+  count: number;
+  cap: number;
+  enforced: boolean;
+}
+
+export function getPushoverUsage() {
+  return apiFetch<PushoverUsage>("/v1/admin/pushover-usage");
+}
+
 export function getPendingApprovals() {
   return apiFetch<PendingUser[]>("/v1/admin/approvals");
 }

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -154,6 +154,31 @@ export function removeMemberRule(channelId: string, memberId: string) {
   );
 }
 
+// ---- server config + per-user usage --------------------------------------
+
+export interface NotificationsServerConfig {
+  pushover: {
+    shared_app_available: boolean;
+    shared_app_min_debounce_seconds: number;
+  };
+}
+
+export function getNotificationsServerConfig() {
+  return apiFetch<NotificationsServerConfig>("/v1/notifications/server-config");
+}
+
+export interface MyPushoverUsage {
+  month: string;
+  tier: string;
+  count: number;
+  cap: number;
+  enforced: boolean;
+}
+
+export function getMyPushoverUsage() {
+  return apiFetch<MyPushoverUsage>("/v1/notifications/pushover-usage");
+}
+
 // ---- receiving (recipient-side, account-bound) ---------------------------
 
 export function listReceiving() {

--- a/web/src/routes/admin/index.tsx
+++ b/web/src/routes/admin/index.tsx
@@ -3,7 +3,12 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { PageHeader } from "@/components/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { getAdminStats, runRetention, runCleanup } from "@/lib/admin";
+import {
+  getAdminStats,
+  getPushoverUsage,
+  runCleanup,
+  runRetention,
+} from "@/lib/admin";
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B";
@@ -47,6 +52,10 @@ function MaintenanceButton({
 
 export function AdminDashboard() {
   const { data: stats } = useQuery({ queryKey: ["admin", "stats"], queryFn: getAdminStats });
+  const { data: pushover } = useQuery({
+    queryKey: ["admin", "pushover-usage"],
+    queryFn: getPushoverUsage,
+  });
   const [retentionResult, setRetentionResult] = useState<string | null>(null);
   const [cleanupResult, setCleanupResult] = useState<string | null>(null);
   const retention = useMutation({
@@ -77,6 +86,46 @@ export function AdminDashboard() {
             }
           />
         </div>
+
+        {pushover && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Pushover (shared app) usage
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p className="text-sm">
+                <span className="font-medium">
+                  {pushover.count.toLocaleString()}
+                </span>{" "}
+                {pushover.enforced ? (
+                  <>
+                    /{" "}
+                    <span className="font-medium">
+                      {pushover.cap.toLocaleString()}
+                    </span>{" "}
+                    deliveries this month ({pushover.month}).
+                  </>
+                ) : (
+                  <>deliveries this month ({pushover.month}). No cap enforced.</>
+                )}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Counts deliveries that used the deployment-wide Pushover app
+                token. Recipients with a BYO token in their channel config
+                aren't tracked here — they hit their own Pushover quota.
+              </p>
+              {pushover.enforced && pushover.count >= pushover.cap && (
+                <p className="text-xs text-destructive">
+                  Cap reached. Shared-app deliveries are paused until the
+                  next calendar month or until you raise{" "}
+                  <code>PUSHOVER_MAX_PER_MONTH</code>.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardHeader>

--- a/web/src/routes/notifications.$channelId.tsx
+++ b/web/src/routes/notifications.$channelId.tsx
@@ -29,6 +29,7 @@ import {
   useToggleChannel,
   useUpdateChannel,
 } from "@/hooks/use-notifications";
+import { getNotificationsServerConfig } from "@/lib/notifications";
 import { getMySystem } from "@/lib/systems";
 import type {
   ChannelCreateResponse,
@@ -92,6 +93,10 @@ export function NotificationChannelPage() {
     queryKey: ["system", "me"],
     queryFn: getMySystem,
   });
+  const { data: serverCfg } = useQuery({
+    queryKey: ["notifications", "server-config"],
+    queryFn: getNotificationsServerConfig,
+  });
 
   const [draftState, setDraftState] = useState<{
     channelUpdatedAt: string | null;
@@ -119,6 +124,21 @@ export function NotificationChannelPage() {
     () => (channel ? isDraftDirty(channel, draft) : false),
     [channel, draft],
   );
+
+  // Pre-flight: a Pushover channel on the shared deployment app token must
+  // satisfy the operator's debounce floor. Catch this client-side so the
+  // user gets a friendly inline message instead of the backend's 400.
+  const debounceFloorViolation = useMemo(() => {
+    if (!channel || channel.destination_type !== "pushover") return null;
+    if (channel.destination_config?.app_token) return null; // BYO is exempt
+    const floor = serverCfg?.pushover.shared_app_min_debounce_seconds ?? 0;
+    if (floor <= 0) return null;
+    const effective =
+      draft.debounce_seconds !== undefined
+        ? draft.debounce_seconds
+        : channel.debounce_seconds;
+    return effective < floor ? floor : null;
+  }, [channel, draft.debounce_seconds, serverCfg]);
 
   if (isLoading || !channel) {
     return (
@@ -277,13 +297,24 @@ export function NotificationChannelPage() {
         <LivePreviewCard channel={channel} draft={draft} />
       </div>
 
-      <div className="sticky bottom-0 mt-6 flex items-center justify-end gap-2 border-t bg-background/95 backdrop-blur px-4 py-3 -mx-4">
+      <div className="sticky bottom-0 mt-6 flex flex-wrap items-center justify-end gap-2 border-t bg-background/95 backdrop-blur px-4 py-3 -mx-4">
+        {debounceFloorViolation !== null && (
+          <p className="mr-auto text-xs text-destructive">
+            Debounce must be at least {debounceFloorViolation}s on the
+            shared Pushover app.
+          </p>
+        )}
         {dirty && (
           <Button variant="ghost" onClick={reset}>
             Discard changes
           </Button>
         )}
-        <Button disabled={!dirty || update.isPending} onClick={save}>
+        <Button
+          disabled={
+            !dirty || update.isPending || debounceFloorViolation !== null
+          }
+          onClick={save}
+        >
           {update.isPending ? "Saving..." : "Save changes"}
         </Button>
       </div>

--- a/web/src/routes/notifications.tsx
+++ b/web/src/routes/notifications.tsx
@@ -20,6 +20,7 @@ import {
   useCreateWatchToken,
   useWatchTokens,
 } from "@/hooks/use-notifications";
+import { getMyPushoverUsage } from "@/lib/notifications";
 import { getMySystem } from "@/lib/systems";
 
 export function NotificationsPage() {
@@ -28,6 +29,10 @@ export function NotificationsPage() {
     queryFn: getMySystem,
   });
   const { data: tokens, isLoading } = useWatchTokens(system?.id);
+  const { data: pushoverUsage } = useQuery({
+    queryKey: ["notifications", "my-pushover-usage"],
+    queryFn: getMyPushoverUsage,
+  });
   const createToken = useCreateWatchToken(system?.id);
   const [showNew, setShowNew] = useState(false);
   const [label, setLabel] = useState("");
@@ -67,6 +72,33 @@ export function NotificationsPage() {
             and each channel has its own filters &mdash; you control what each
             recipient is allowed to see, per-member.
           </p>
+
+          {pushoverUsage && pushoverUsage.enforced && (
+            <div className="mb-4 max-w-prose rounded-md border bg-muted/30 px-3 py-2 text-xs">
+              <p>
+                <strong>Pushover (shared app):</strong>{" "}
+                <span
+                  className={
+                    pushoverUsage.count >= pushoverUsage.cap
+                      ? "text-destructive"
+                      : ""
+                  }
+                >
+                  {pushoverUsage.count.toLocaleString()} /{" "}
+                  {pushoverUsage.cap.toLocaleString()}
+                </span>{" "}
+                deliveries this month ({pushoverUsage.month}, {pushoverUsage.tier} tier).
+                {pushoverUsage.count >= pushoverUsage.cap && (
+                  <>
+                    {" "}
+                    Cap reached &mdash; further Pushover deliveries are paused
+                    until next month, or until you paste your own Pushover app
+                    token in a channel's Advanced config.
+                  </>
+                )}
+              </p>
+            </div>
+          )}
 
           {isLoading ? (
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- The shared deployment Pushover app sits on a single 10k/month free quota. One chatty system can drain it for everyone, and there was no way to bound per-user exposure within the deployment ceiling.
- Adds three layers of protection (per-user tier cap → deployment cap → debounce floor) plus a recipient-side BYO escape hatch.
- BYO channels (recipient supplies their own \`destination_config.app_token\`) bypass every shared-app limit; they're on their own Pushover account quota.

## Changes
- **Per-user-tier monthly cap** — \`PUSHOVER_USER_MAX_PER_MONTH_{FREE,PLUS,SELF_HOSTED}\` (defaults 100/1000/0). Counter at \`pushover:usage:user:{user_id}:YYYY-MM\`. Surfaced via \`GET /v1/notifications/pushover-usage\` and shown as a usage badge on the user's notifications page.
- **Deployment-wide cap** — \`PUSHOVER_MAX_PER_MONTH\` (default 10000). Counter at \`pushover:usage:YYYY-MM\`. Surfaced on \`/admin\` and at \`GET /v1/admin/pushover-usage\`.
- **Shared-app debounce floor** — \`PUSHOVER_SHARED_APP_MIN_DEBOUNCE_SECONDS\` (default 1800). Enforced at channel create + update; surfaced via \`GET /v1/notifications/server-config\` so the UI can render the floor before submit. BYO channels exempt.
- **BYO app token** — recipients paste their own Pushover app token in the channel's "Advanced" expander. UI explainer links to pushover.net/apps/build.
- Backend dispatcher does both checks before sending and INCRs both counters only on successful shared-app delivery (retries don't burn budget twice).
- Frontend pre-empts the validation rejection: Save disabled with inline message when debounce below floor; create dialog auto-defaults shared-Pushover channels to the floor; backend rejection wording rewritten from raw setting names to a user-facing sentence for non-UI API consumers.

## Test plan
- [x] \`ruff check sheaf/\` passes
- [x] \`cd web && npm run lint && npx tsc --noEmit\` passes
- [x] \`pytest tests/test_pushover_improvements.py\` passes
- [x] Create a shared-Pushover channel with default settings → debounce auto-set to 1800s, accepted
- [x] Try to lower debounce on existing channel → Save button disabled, inline red message
- [x] Add a BYO app_token via PATCH alongside the lower debounce → Save unlocks, accepted
- [x] \`/admin\` shows deployment counter; user notifications page shows their own counter
- [x] BYO send-test does not increment shared counter

## Security / privacy impact
None new. The new endpoints (\`/v1/notifications/server-config\`, \`/v1/notifications/pushover-usage\`, \`/v1/admin/pushover-usage\`) only return operator-set policy + the caller's own usage; no recipient data and no BYO token values surface anywhere. Counters live in Redis under namespaced keys with 45-day TTLs.