### PR TITLE
Quiet hours: respect channel timezone instead of UTC-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 - Pushover monthly quota tracking: new `PUSHOVER_MAX_PER_MONTH` setting (default 10000) caps shared-app deliveries deployment-wide per calendar month; usage surfaced on `/admin` and at `GET /v1/admin/pushover-usage`.
 - Per-user-tier Pushover allowance: new `PUSHOVER_USER_MAX_PER_MONTH_{FREE,PLUS,SELF_HOSTED}` settings (defaults 100/1000/0) stop one Sheaf user from monopolising the deployment quota. Surfaced to the user at `GET /v1/notifications/pushover-usage` and shown on their notifications page.
 - Pushover shared-app debounce floor: new `PUSHOVER_SHARED_APP_MIN_DEBOUNCE_SECONDS` setting (default 1800) protects the deployment-wide cap from one chatty system burning everyone's quota. Surfaced to the channel form via `GET /v1/notifications/server-config`. BYO channels are exempt.
+- Quiet hours respect the channel's timezone instead of UTC-only. The QuietHours schema gained an IANA-validated `tz` field (defaults to `UTC`); the dispatcher computes window boundaries with `zoneinfo` so DST transitions move the window correctly. Frontend gains a tz picker populated from `Intl.supportedValuesOf("timeZone")`, defaulting to the recipient's browser timezone for new configs.
 
 ## [v0.1.0] - 2026-04-29
 

--- a/sheaf/schemas/notifications.py
+++ b/sheaf/schemas/notifications.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from typing import Any, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # ---- watch tokens ---------------------------------------------------------
 
@@ -62,7 +63,16 @@ class MemberRuleSpec(BaseModel):
 class QuietHours(BaseModel):
     start: str  # "HH:MM"
     end: str  # "HH:MM"
-    tz: str = "UTC"
+    tz: str = "UTC"  # IANA name, e.g. "Europe/Berlin"
+
+    @field_validator("tz")
+    @classmethod
+    def _validate_tz(cls, v: str) -> str:
+        try:
+            ZoneInfo(v)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(f"unknown IANA timezone: {v!r}") from exc
+        return v
 
 
 class ChannelCreate(BaseModel):

--- a/sheaf/services/notifications/dispatcher.py
+++ b/sheaf/services/notifications/dispatcher.py
@@ -19,6 +19,7 @@ import asyncio
 import logging
 import uuid
 from datetime import UTC, datetime, time, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -329,10 +330,14 @@ async def _drop(
 
 def _quiet_hours_end(quiet_hours: dict | None, now: datetime) -> datetime | None:
     """If `now` is inside the channel's quiet-hours window, return the next
-    timestamp at which dispatch is allowed. Else None.
+    UTC timestamp at which dispatch is allowed. Else None.
 
-    Window format: `{"start": "22:00", "end": "07:00", "tz": "UTC"}`.
-    Crosses-midnight is allowed (start > end). Timezone defaults to UTC.
+    Window format: `{"start": "22:00", "end": "07:00", "tz": "Europe/Berlin"}`.
+    Comparisons happen in the channel's tz so DST shifts move the window
+    correctly (a "10 PM to 7 AM Berlin" channel keeps doing the right
+    thing across the spring/autumn changeovers). Returned timestamp is
+    converted back to UTC for the outbox row's deliver_after column.
+    Crosses-midnight is allowed (start > end).
     """
     if not quiet_hours:
         return None
@@ -346,23 +351,32 @@ def _quiet_hours_end(quiet_hours: dict | None, now: datetime) -> datetime | None
     except ValueError:
         return None
 
-    # All comparisons in UTC for v1.
-    now_utc = now.astimezone(UTC)
-    today = now_utc.date()
-    start_dt = datetime.combine(today, start_t, tzinfo=UTC)
-    end_dt = datetime.combine(today, end_t, tzinfo=UTC)
+    tz_name = quiet_hours.get("tz") or "UTC"
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        # Bad tz somehow stored despite the schema validator (or older row
+        # written before validation existed). Don't crash dispatch — fall
+        # back to UTC so we still respect SOME window boundary.
+        logger.warning("quiet_hours has unknown tz %r; falling back to UTC", tz_name)
+        tz = UTC
+
+    now_local = now.astimezone(tz)
+    today = now_local.date()
+    start_dt = datetime.combine(today, start_t, tzinfo=tz)
+    end_dt = datetime.combine(today, end_t, tzinfo=tz)
 
     if start_t <= end_t:
         # Same-day window.
-        if start_dt <= now_utc < end_dt:
-            return end_dt
+        if start_dt <= now_local < end_dt:
+            return end_dt.astimezone(UTC)
         return None
 
-    # Crosses midnight: e.g. 22:00 → 07:00 means [22:00, 24:00) U [00:00, 07:00).
-    if now_utc >= start_dt:
+    # Crosses midnight: e.g. 22:00 -> 07:00 means [22:00, 24:00) U [00:00, 07:00).
+    if now_local >= start_dt:
         # In the late-evening half; window ends tomorrow at end_t.
-        return end_dt + timedelta(days=1)
-    if now_utc < end_dt:
+        return (end_dt + timedelta(days=1)).astimezone(UTC)
+    if now_local < end_dt:
         # In the early-morning half; window ends today at end_t.
-        return end_dt
+        return end_dt.astimezone(UTC)
     return None

--- a/tests/test_notifications_quiet_hours.py
+++ b/tests/test_notifications_quiet_hours.py
@@ -1,0 +1,160 @@
+"""Quiet-hours window math, with timezone awareness.
+
+Pure-function tests over `_quiet_hours_end`. The dispatcher uses this to
+decide whether an outbox row is deliverable now or should be requeued
+past the end of the channel's quiet window. Comparisons happen in the
+channel's timezone (zoneinfo, so DST boundaries are honoured) and the
+returned timestamp is always UTC for storage.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from sheaf.schemas.notifications import QuietHours
+from sheaf.services.notifications.dispatcher import _quiet_hours_end
+
+# ---------------------------------------------------------------------------
+# UTC behaviour preserved (the v1 default)
+# ---------------------------------------------------------------------------
+
+
+def test_utc_inside_same_day_window():
+    """22:00-23:00 UTC; now is 22:30 UTC -> requeue to 23:00 UTC."""
+    qh = {"start": "22:00", "end": "23:00", "tz": "UTC"}
+    now = datetime(2026, 5, 2, 22, 30, tzinfo=UTC)
+    end = _quiet_hours_end(qh, now)
+    assert end == datetime(2026, 5, 2, 23, 0, tzinfo=UTC)
+
+
+def test_utc_outside_window_returns_none():
+    qh = {"start": "22:00", "end": "23:00", "tz": "UTC"}
+    now = datetime(2026, 5, 2, 12, 0, tzinfo=UTC)
+    assert _quiet_hours_end(qh, now) is None
+
+
+def test_utc_cross_midnight_late_evening_half():
+    """22:00-07:00 UTC, now is 23:30 UTC -> requeue to 07:00 next day UTC."""
+    qh = {"start": "22:00", "end": "07:00", "tz": "UTC"}
+    now = datetime(2026, 5, 2, 23, 30, tzinfo=UTC)
+    end = _quiet_hours_end(qh, now)
+    assert end == datetime(2026, 5, 3, 7, 0, tzinfo=UTC)
+
+
+def test_utc_cross_midnight_early_morning_half():
+    """22:00-07:00 UTC, now is 03:00 UTC -> requeue to 07:00 same day."""
+    qh = {"start": "22:00", "end": "07:00", "tz": "UTC"}
+    now = datetime(2026, 5, 2, 3, 0, tzinfo=UTC)
+    end = _quiet_hours_end(qh, now)
+    assert end == datetime(2026, 5, 2, 7, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Non-UTC: window is interpreted in the channel's local time
+# ---------------------------------------------------------------------------
+
+
+def test_berlin_inside_window_returns_local_end_in_utc():
+    """Berlin in May = CEST (+02:00). Quiet 22:00-07:00 Berlin local.
+    Now is 23:00 Berlin = 21:00 UTC. End is 07:00 next day Berlin =
+    05:00 UTC."""
+    qh = {"start": "22:00", "end": "07:00", "tz": "Europe/Berlin"}
+    now = datetime(2026, 5, 2, 21, 0, tzinfo=UTC)  # 23:00 Berlin
+    end = _quiet_hours_end(qh, now)
+    assert end == datetime(2026, 5, 3, 5, 0, tzinfo=UTC)
+
+
+def test_la_outside_window_returns_none():
+    """LA in May = PDT (-07:00). Quiet 22:00-07:00 LA local. Now is
+    14:00 LA = 21:00 UTC. Outside the window."""
+    qh = {"start": "22:00", "end": "07:00", "tz": "America/Los_Angeles"}
+    now = datetime(2026, 5, 2, 21, 0, tzinfo=UTC)  # 14:00 LA
+    assert _quiet_hours_end(qh, now) is None
+
+
+def test_tokyo_inside_window_returns_local_end_in_utc():
+    """Tokyo (JST, no DST). Quiet 23:00-06:00 Tokyo. Now is 02:00 Tokyo
+    = 17:00 UTC previous day. End is 06:00 Tokyo same Tokyo-day =
+    21:00 UTC previous day."""
+    qh = {"start": "23:00", "end": "06:00", "tz": "Asia/Tokyo"}
+    now = datetime(2026, 5, 2, 17, 0, tzinfo=UTC)  # 02:00 next day Tokyo
+    end = _quiet_hours_end(qh, now)
+    # end should be 06:00 Tokyo on May 3 = 21:00 UTC on May 2.
+    assert end == datetime(2026, 5, 2, 21, 0, tzinfo=UTC)
+
+
+def test_dst_spring_forward_window_still_anchored_to_local_clock():
+    """US DST springs forward 2026-03-08 02:00 -> 03:00 EDT.
+    Quiet 22:00-07:00 New York. Caller is at 06:30 EDT = 10:30 UTC on
+    2026-03-08. Window should requeue to 07:00 EDT = 11:00 UTC, i.e.
+    the local clock is what matters, not the wall-clock-elapsed time."""
+    qh = {"start": "22:00", "end": "07:00", "tz": "America/New_York"}
+    now = datetime(2026, 3, 8, 10, 30, tzinfo=UTC)  # 06:30 EDT
+    end = _quiet_hours_end(qh, now)
+    assert end == datetime(2026, 3, 8, 11, 0, tzinfo=UTC)  # 07:00 EDT
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tz_falls_back_to_utc():
+    """Bad tz somehow stored should not crash dispatch — fall back to UTC
+    so we still respect SOME window boundary."""
+    qh = {"start": "22:00", "end": "07:00", "tz": "Mars/Olympus_Mons"}
+    now = datetime(2026, 5, 2, 22, 30, tzinfo=UTC)
+    end = _quiet_hours_end(qh, now)
+    # Treated as UTC: 22:30 UTC inside 22-07 window -> 07:00 next day UTC.
+    assert end == datetime(2026, 5, 3, 7, 0, tzinfo=UTC)
+
+
+def test_empty_quiet_hours_returns_none():
+    assert _quiet_hours_end(None, datetime.now(UTC)) is None
+    assert _quiet_hours_end({}, datetime.now(UTC)) is None
+
+
+def test_malformed_time_returns_none():
+    qh = {"start": "not-a-time", "end": "07:00", "tz": "UTC"}
+    assert _quiet_hours_end(qh, datetime.now(UTC)) is None
+
+
+# ---------------------------------------------------------------------------
+# Schema validator
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_hours_schema_accepts_iana_zone():
+    qh = QuietHours(start="22:00", end="07:00", tz="Europe/Berlin")
+    assert qh.tz == "Europe/Berlin"
+
+
+def test_quiet_hours_schema_accepts_utc_default():
+    qh = QuietHours(start="22:00", end="07:00")
+    assert qh.tz == "UTC"
+
+
+def test_quiet_hours_schema_rejects_unknown_zone():
+    with pytest.raises(ValueError, match="unknown IANA timezone"):
+        QuietHours(start="22:00", end="07:00", tz="Mars/Olympus_Mons")
+
+
+def test_quiet_hours_schema_rejects_offset_string():
+    """Reject `+02:00`-style offsets — IANA names only, since DST handling
+    needs the rule set, not just a current offset."""
+    with pytest.raises(ValueError, match="unknown IANA timezone"):
+        QuietHours(start="22:00", end="07:00", tz="+02:00")
+
+
+def test_quiet_hours_returned_value_is_always_utc():
+    """Every non-None return must be a UTC datetime — outbox rows store
+    deliver_after as UTC."""
+    qh = {"start": "22:00", "end": "07:00", "tz": "Asia/Tokyo"}
+    end = _quiet_hours_end(
+        qh, datetime(2026, 5, 2, 17, 0, tzinfo=UTC)
+    )
+    assert end is not None
+    assert end.utcoffset() == ZoneInfo("UTC").utcoffset(end)

--- a/web/src/components/notifications/delivery-card.tsx
+++ b/web/src/components/notifications/delivery-card.tsx
@@ -37,7 +37,30 @@ export function DeliveryCard({
       : 0;
 
   const quietEnabled = !!channel.quiet_hours;
-  const qh = channel.quiet_hours ?? { start: "22:00", end: "07:00", tz: "UTC" };
+  // Default new quiet-hours configs to the recipient's browser timezone —
+  // the most useful guess. Existing channels keep whatever's stored.
+  const browserTz = (() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    } catch {
+      return "UTC";
+    }
+  })();
+  const qh =
+    channel.quiet_hours ?? { start: "22:00", end: "07:00", tz: browserTz };
+
+  // Full IANA list, alphabetised. Modern browsers all support
+  // supportedValuesOf("timeZone"); older ones get a small fallback.
+  const tzList = (() => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fn = (Intl as any).supportedValuesOf;
+      if (typeof fn === "function") return fn("timeZone") as string[];
+    } catch {
+      // fall through
+    }
+    return ["UTC", browserTz];
+  })();
 
   return (
     <Card>
@@ -162,9 +185,29 @@ export function DeliveryCard({
                   }
                 />
               </div>
+              <div className="col-span-2 space-y-1">
+                <Label className="text-xs">Timezone</Label>
+                <Select
+                  value={qh.tz}
+                  onValueChange={(v) =>
+                    onChange({ quiet_hours: { ...qh, tz: v } })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="max-h-72">
+                    {tzList.map((tz) => (
+                      <SelectItem key={tz} value={tz}>
+                        {tz}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
               <p className="col-span-2 text-xs text-muted-foreground">
-                In UTC for v1. Events landing inside the window are deferred to
-                the end time.
+                Events landing inside the window are deferred to the end
+                time. DST transitions in the chosen timezone are honoured.
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary
- The QuietHours schema already had a tz field but the dispatcher hard-coded UTC for window comparisons and the frontend never let the recipient pick. "Quiet 22:00-07:00" meant 22:00 UTC for everyone, which is useless when your bedtime isn't in London.
- Wires the tz through end-to-end. Window math now happens in the channel's local time via zoneinfo (so DST is handled by stdlib), and the recipient gets a tz picker defaulting to their browser's timezone.

## Changes
- **Schema validator** (`sheaf/schemas/notifications.py`) — `tz` must parse as `zoneinfo.ZoneInfo`. Rejects offset strings like `"+02:00"` since DST needs rule sets, not just current offsets. Defaults to `"UTC"` so existing channels keep working.
- **Dispatcher** (`sheaf/services/notifications/dispatcher.py:_quiet_hours_end`) — converts `now` to the channel's tz, compares in local time, returns the requeue timestamp normalised back to UTC. Bad tz somehow stored falls back to UTC with a logged warning instead of crashing.
- **Frontend** (`web/src/components/notifications/delivery-card.tsx`) — `Select` populated from `Intl.supportedValuesOf("timeZone")` (~400 zones). New configs default to `Intl.DateTimeFormat().resolvedOptions().timeZone`. Older browsers without `supportedValuesOf` get a UTC + browser-tz fallback.
- **Tests** (`tests/test_notifications_quiet_hours.py`) — 16 covering UTC behaviour preservation, non-UTC zones (Berlin / LA / Tokyo), DST spring-forward in New York, schema rejection of bogus zones + offset strings, and the always-returns-UTC contract.

## Test plan
- [ ] `ruff check sheaf/` passes
- [ ] `cd web && npm run lint && npx tsc --noEmit` passes
- [ ] `pytest tests/test_notifications_quiet_hours.py` passes
- [ ] Set quiet hours 22:00-07:00 in your local tz; verify a front change at 23:00 local gets requeued to 07:00 local (not 07:00 UTC)

## Security / privacy impact
None. The tz is operator-set channel config, not personal data; the picker is purely client-side and the value is stored in the same JSON column as before.