### PR TITLE
Three-piece account-export completeness pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -235,6 +235,39 @@ IMAGE_SERVING=signed
 # NOTIFICATIONS_CONCURRENCY_PUSHOVER=5
 
 # =============================================================================
+# Async data exports
+# =============================================================================
+# Sheaf supports two export endpoints today:
+#   - GET /v1/export                — sync, JSON-only, plural-system content
+#   - POST /v1/account/data         — sync, JSON, GDPR Article 15 (always
+#                                     password+TOTP gated, refuses API keys)
+#   - POST /v1/export/jobs          — async, builds a zip of JSON + images
+#                                     in the background, also gated
+#
+# These settings only affect the async path.
+
+# Lifetime of a generated export file before auto-deletion. 72h gives the
+# user three days to download; long enough for "I'll do it from my desktop
+# tomorrow", short enough to limit blast radius if a download URL leaks.
+# EXPORT_JOB_TTL_HOURS=72
+
+# Per-user concurrency: refuse a new export request when one is still in
+# flight. Stops users (or attackers with a hijacked session) from queueing
+# many large exports back-to-back.
+# EXPORT_MAX_CONCURRENT_PER_USER=1
+
+# Optional dedicated S3 bucket for exports. Strongly recommended in
+# production: lets you set an S3 lifecycle expiry rule (belt-and-braces
+# with the cleanup worker) AND lets you point exports at an endpoint that
+# bypasses any CDN fronting on your image bucket — exports contain
+# decrypted personal data that shouldn't pass through CDN TLS termination.
+# When unset, exports fall back to the main S3_BUCKET (fine for dev, not
+# recommended for production).
+# S3_EXPORT_BUCKET=sheaf-exports
+# S3_EXPORT_ENDPOINT=             # falls back to S3_ENDPOINT
+# S3_EXPORT_PRESIGN_ENDPOINT=     # falls back to S3_PRESIGN_ENDPOINT
+
+# =============================================================================
 # Registration
 # =============================================================================
 # "open" (default): anyone can register.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Account & data exports
+
+- `/v1/export` (Article 20, data portability) now includes journal entries, content revisions (bio + journal edit history), system safety settings, retention overrides, system preferences, watch tokens with their notification channels (config only; per-instance state and webhook secrets omitted), and a file inventory listing every uploaded blob's key + size + content type. Bumped to version `2`. Re-importable into another Sheaf instance via the existing import flow.
+- New `POST /v1/account/data` (Article 15, right of access) — returns everything Sheaf holds *about* the user account: identity, sessions with IPs, trusted devices, API key audit metadata, TOTP enrolment status, email delivery state, pending safety actions, receiving notification channels, retention trim notices. Always requires password + TOTP-if-enrolled regardless of the system's `delete_confirmation` setting; refuses API-key auth.
+- New `POST /v1/export/jobs` — async export including image bytes. Builds a zip in the background, persists to S3 (or local disk on filesystem deployments), notifies via email when ready. 72-hour TTL by default. Same step-up auth as Article 15. Per-user concurrency limit of 1.
+- Dedicated S3 bucket settings for exports (`S3_EXPORT_BUCKET`, `S3_EXPORT_ENDPOINT`, `S3_EXPORT_PRESIGN_ENDPOINT`) — operator can put exports in their own bucket with an S3 lifecycle rule and bypass any CDN fronting on the image bucket. Strongly recommended in production since exports contain decrypted personal data.
+- Frontend Settings → Data export grows three actions: sync JSON export (existing), full backup with images (new, password-prompted), download account data (Article 15). Recent backups list shows status + download link when ready.
+
 ### Front-change notifications
 
 - New `/notifications` surface: owners issue watcher tokens, each carrying one or more channels with independent filters, triggers, payload sensitivity, and delivery shaping.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 - **System Safety** — Optional grace period and re-auth (password / TOTP) on destructive actions (member/journal/group/etc deletion, revision unpin)
 - **SimplyPlural import** — Import your SP export with granular control (select specific members, toggle front history, etc.)
 - **File storage** — File uploads with filesystem or S3-compatible backends
-- **Data export**
+- **Data export** — sync JSON (Article 20 portability), async zip with image bytes, and a separate Article 15 endpoint covering everything we know about your account
 - **2FA** — Optional TOTP with recovery codes
 - **API keys** — Scoped, named keys (`sk_…`) for scripts and integrations
 - **Admin dashboard** — User management, invite codes, storage audit, background job monitoring, optional step-up auth
@@ -140,7 +140,9 @@ Key endpoints:
 | `GET/PATCH /v1/system/safety` | System Safety settings + pending actions |
 | `POST /v1/import/simplyplural` | Import SP data |
 | `POST /v1/import/sheaf` | Import Sheaf export |
-| `GET /v1/export` | Export all data |
+| `GET /v1/export` | Export plural system content (sync JSON) |
+| `POST /v1/export/jobs` | Queue an async backup including image bytes |
+| `POST /v1/account/data` | Article 15 — everything we know about your account |
 | `POST /v1/files/upload` | Upload avatar |
 
 Full interactive docs: `http://your-instance/v1/docs`

--- a/alembic/versions/t0u1v2w3x4y5_add_export_jobs.py
+++ b/alembic/versions/t0u1v2w3x4y5_add_export_jobs.py
@@ -1,0 +1,74 @@
+"""Add export_jobs table for async data exports
+
+Revision ID: t0u1v2w3x4y5
+Revises: s9t0u1v2w3x4
+Create Date: 2026-05-03
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "t0u1v2w3x4y5"
+down_revision = "s9t0u1v2w3x4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "export_jobs" in inspector.get_table_names():
+        return
+    op.create_table(
+        "export_jobs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "include_images",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("requested_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("file_location", sa.String(500), nullable=True),
+        sa.Column("file_size_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "ix_export_jobs_user_requested",
+        "export_jobs",
+        ["user_id", "requested_at"],
+    )
+    op.create_index(
+        "ix_export_jobs_pending",
+        "export_jobs",
+        ["requested_at"],
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+    op.create_index(
+        "ix_export_jobs_expires",
+        "export_jobs",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_export_jobs_expires", table_name="export_jobs")
+    op.drop_index("ix_export_jobs_pending", table_name="export_jobs")
+    op.drop_index("ix_export_jobs_user_requested", table_name="export_jobs")
+    op.drop_table("export_jobs")

--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -340,7 +340,14 @@ Uploads can be disabled server-wide (`ALLOW_IMAGE_UPLOADS=false`). When disabled
 | POST | `/import/simplyplural` | Run SP import |
 | POST | `/import/sheaf/preview` | Preview Sheaf import |
 | POST | `/import/sheaf` | Run Sheaf import |
-| GET | `/export` | Export all data as JSON |
+| GET | `/export` | Export plural system content as JSON (sync, Article 20) |
+| POST | `/export/jobs` | Queue async export with image bytes (zip) |
+| GET | `/export/jobs` | List your async export jobs |
+| GET | `/export/jobs/{id}` | Job status |
+| GET | `/export/jobs/{id}/download` | Download the zip when done |
+| POST | `/account/data` | Account data (Article 15 right of access) |
+
+The two POST endpoints (`/export/jobs` and `/account/data`) require step-up auth in the request body (`{password, totp_code}`) and refuse API-key authentication. They're the highest-value reads for a hijacked session, so the gate applies regardless of the system's `delete_confirmation` setting.
 
 ## Limits
 

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -488,6 +488,84 @@ MAX_UPLOAD_SIZE_MB=5
 
 ---
 
+## Data exports
+
+Three flavours of "give me my data", differing by scope and gating:
+
+| Endpoint | Scope | Gate | Format |
+|---|---|---|---|
+| `GET /v1/export` | Plural-system content (Article 20) | Session/JWT only | Sync JSON |
+| `POST /v1/account/data` | Account identity + audit (Article 15) | Password + TOTP-if-enrolled | Sync JSON |
+| `POST /v1/export/jobs` | Plural-system + image bytes | Password + TOTP-if-enrolled | Async zip |
+
+The two POST endpoints **always** require step-up auth regardless of the system's `delete_confirmation` setting — they're the highest-value reads for an attacker with a hijacked session, and we don't let users opt out.
+
+### Async export jobs
+
+The user requests a backup, the worker assembles a zip in the background, the user gets an email when it's ready (and sees the job in Settings → Data export). The file is kept for 72 hours then auto-deleted.
+
+```env
+EXPORT_JOB_TTL_HOURS=72                  # how long a built file is kept
+EXPORT_MAX_CONCURRENT_PER_USER=1         # one in-flight job per user
+```
+
+### S3-backed exports: use a dedicated bucket
+
+If you're running with `STORAGE_BACKEND=s3`, the main `S3_BUCKET` is typically CDN-fronted (e.g. behind Cloudflare for free image egress). **Don't put exports in that bucket** — exports contain decrypted journal content + member names + everything else, and routing them through a CDN means cleartext personal data passes through CDN TLS termination even with presigned URLs (signatures prevent caching, but bytes still flow through CDN's network).
+
+Set up a separate bucket and point Sheaf at it:
+
+```env
+S3_EXPORT_BUCKET=sheaf-exports
+S3_EXPORT_ENDPOINT=https://s3.eu-central-1.amazonaws.com   # direct, not via CDN
+# S3_EXPORT_PRESIGN_ENDPOINT=  # only set if presign URL needs different host
+```
+
+Apply an S3 lifecycle expiry rule on the bucket as belt-and-braces — if Sheaf's cleanup worker silently fails, S3 still cleans up:
+
+```json
+{
+  "Rules": [{
+    "ID": "expire-sheaf-exports",
+    "Status": "Enabled",
+    "Filter": {"Prefix": "exports/"},
+    "Expiration": {"Days": 4}
+  }]
+}
+```
+
+(4 days = 72h app TTL + 1 day grace.)
+
+A storage class like Standard-IA is appropriate since objects are short-lived, if you want to save pennies. Block public ACLs on this bucket; downloads always go through Sheaf's authenticated endpoint via presigned URL.
+
+#### Encryption at rest
+
+Set bucket default encryption rather than asking Sheaf to specify it per-object — Sheaf intentionally doesn't pass `ServerSideEncryption` headers, because MinIO rejects them when KMS isn't configured (AWS S3 silently uses the bucket default).
+
+For AWS S3:
+
+```sh
+aws s3api put-bucket-encryption \
+  --bucket sheaf-exports \
+  --server-side-encryption-configuration '{
+    "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+  }'
+```
+
+For MinIO with KMS configured: set bucket encryption via `mc encrypt set sse-s3 <alias>/sheaf-exports`. For MinIO without KMS: the underlying disk is your encryption boundary; the data is still application-layer-encrypted in the database for sensitive fields, and the export zips are short-lived.
+
+### Filesystem deployments
+
+When `STORAGE_BACKEND=filesystem`, exports live at `/app/data/exports/{user_id}/{job_id}.zip`. Same cleanup worker handles pruning. No CDN concerns since bytes never leave the box.
+
+### Image re-import asymmetry
+
+The export-with-images zip contains JSON references AND the image bytes. The import path accepts JSON only — it does NOT auto-restore image attachments from the zip. The export UI tells users this explicitly. Re-importing the zip into another Sheaf instance brings the text content (members, journals, etc.) but image attachments need to be re-uploaded by hand.
+
+This is intentional: auto re-import would require re-keying every image (server generates UUIDs, not filename-based), rewriting `image_keys` references across members/journals/revisions, re-running quota/dedup/virus-scan/EXIF-stripping, and handling cross-backend migration. Demand is probably low — GDPR compliance and personal backup don't need it.
+
+---
+
 ## API keys
 
 Users can create named, scoped API keys from Settings → API Keys. These allow programmatic access without sharing session credentials.

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -1,0 +1,331 @@
+"""Account-level endpoints — distinct from /auth (which handles
+authentication mechanics) and /export (Article 20 portable data).
+
+Currently hosts the Article 15 "right of access" endpoint: everything
+the service holds *about* the user account, including server-derived
+telemetry that doesn't belong in a portable export.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_current_user
+from sheaf.auth.passwords import verify_password
+from sheaf.auth.sessions import list_user_sessions
+from sheaf.auth.totp import verify_code
+from sheaf.crypto import blind_index, decrypt
+from sheaf.database import get_db
+from sheaf.models.api_key import ApiKey
+from sheaf.models.client_settings import ClientSettings
+from sheaf.models.email_suppression import EmailSuppression
+from sheaf.models.notification_channel import NotificationChannel
+from sheaf.models.pending_action import PendingAction, PendingActionStatus
+from sheaf.models.retention_trim_notice import RetentionTrimNotice
+from sheaf.models.safety_change_request import (
+    SafetyChangeRequest,
+    SafetyChangeStatus,
+)
+from sheaf.models.system import System
+from sheaf.models.trusted_device import TrustedDevice
+from sheaf.models.user import User
+from sheaf.models.watch_token import WatchToken
+
+router = APIRouter(prefix="/account", tags=["account"])
+
+
+class AccountDataRequest(BaseModel):
+    password: str
+    totp_code: str | None = None
+
+
+@router.post("/data")
+async def get_account_data(
+    body: AccountDataRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Article 15 (right of access) — everything Sheaf holds about the
+    requesting user account.
+
+    Distinct from `/v1/export`, which is Article 20 (data portability) and
+    only includes plural-system content. This endpoint adds account
+    identity, sessions, IPs, API key audit metadata, email delivery
+    state, and other server-derived data that should NEVER ride along
+    with a portable export (info-leak hazard if shared or imported
+    elsewhere).
+
+    Always requires password (and TOTP if enrolled), regardless of the
+    system's `delete_confirmation` setting — this is the highest-value
+    read endpoint for an attacker with a hijacked session, so we don't
+    let users opt out of the gate. Method is POST because it carries
+    credentials in the body; semantically it's a read.
+
+    Excluded by design (would defeat their security purpose):
+    - Password hash
+    - TOTP secret
+    - Recovery code hashes
+    - API key plaintext or hash
+    - Session tokens (only metadata)
+    - Trusted device tokens (only metadata)
+    """
+    # Auth method check: refuse API-key access. The data here is too
+    # sensitive to expose via a programmatic credential — must be a
+    # session/JWT-authenticated request from the user themselves.
+    if getattr(request.state, "auth_method", None) == "api_key":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "API keys cannot access account data. Sign in with a "
+                "session or JWT to download your account data."
+            ),
+        )
+
+    # Step-up: always password, plus TOTP if enrolled. Independent of
+    # System Safety's delete_confirmation tier — that gates deletes; this
+    # gates the highest-value read.
+    if not verify_password(body.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Password incorrect",
+        )
+    if user.totp_enabled:
+        if not body.totp_code:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="TOTP code required",
+            )
+        secret = decrypt(user.totp_secret)
+        if not verify_code(secret, body.totp_code):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid TOTP code",
+            )
+
+    sessions_raw = await list_user_sessions(user.id)
+
+    api_keys_result = await db.execute(
+        select(ApiKey).where(ApiKey.user_id == user.id)
+    )
+    api_keys = api_keys_result.scalars().all()
+
+    trusted_devices_result = await db.execute(
+        select(TrustedDevice).where(TrustedDevice.user_id == user.id)
+    )
+    trusted_devices = trusted_devices_result.scalars().all()
+
+    client_settings_result = await db.execute(
+        select(ClientSettings).where(ClientSettings.user_id == user.id)
+    )
+    client_settings = client_settings_result.scalars().all()
+
+    # User.email is application-encrypted at rest; decrypt to plaintext
+    # for both the suppression blind-index lookup AND the response body
+    # (the user requesting their own data obviously already knows their
+    # email, but dumping ciphertext would be misleading + useless).
+    plaintext_email = decrypt(user.email)
+
+    email_suppression_result = await db.execute(
+        select(EmailSuppression).where(
+            EmailSuppression.address_hash == blind_index(plaintext_email)
+        )
+    )
+    email_suppression = email_suppression_result.scalar_one_or_none()
+
+    # Pending System Safety actions awaiting their grace period.
+    system_result = await db.execute(
+        select(System).where(System.user_id == user.id)
+    )
+    system = system_result.scalar_one_or_none()
+
+    pending_actions: list = []
+    pending_changes: list = []
+    if system is not None:
+        actions_result = await db.execute(
+            select(PendingAction)
+            .where(
+                PendingAction.system_id == system.id,
+                PendingAction.status == PendingActionStatus.PENDING,
+            )
+            .order_by(PendingAction.requested_at.desc())
+        )
+        pending_actions = list(actions_result.scalars().all())
+
+        changes_result = await db.execute(
+            select(SafetyChangeRequest)
+            .where(
+                SafetyChangeRequest.system_id == system.id,
+                SafetyChangeRequest.status == SafetyChangeStatus.PENDING,
+            )
+            .order_by(SafetyChangeRequest.requested_at.desc())
+        )
+        pending_changes = list(changes_result.scalars().all())
+
+    # Notification channels this user is the recipient of (across any
+    # system). Owner-side channels live with their system data.
+    receiving_result = await db.execute(
+        select(NotificationChannel, WatchToken, System)
+        .join(WatchToken, NotificationChannel.watch_token_id == WatchToken.id)
+        .join(System, WatchToken.system_id == System.id)
+        .where(NotificationChannel.redeemed_by_account_id == user.id)
+        .order_by(NotificationChannel.redeemed_at.desc())
+    )
+    receiving_rows = receiving_result.all()
+
+    # Retention trim notices issued against this user (e.g. tier downgrade
+    # that pruned data). Rare, but transparency-appropriate.
+    trim_result = await db.execute(
+        select(RetentionTrimNotice)
+        .where(RetentionTrimNotice.user_id == user.id)
+        .order_by(RetentionTrimNotice.requested_at.desc())
+    )
+    trim_notices = list(trim_result.scalars().all())
+
+    return {
+        "version": "1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "purpose": (
+            "GDPR Article 15 right of access — everything Sheaf holds "
+            "about your account. Distinct from /v1/export which covers "
+            "Article 20 data portability."
+        ),
+        "account": {
+            "id": str(user.id),
+            "email": plaintext_email,
+            "tier": user.tier.value,
+            "is_admin": user.is_admin,
+            "account_status": user.account_status.value,
+            "email_verified": user.email_verified,
+            "email_verification_sent_at": _iso(user.email_verification_sent_at),
+            "totp_enabled": user.totp_enabled,
+            "can_upload_images": user.can_upload_images,
+            "member_limit": user.member_limit,
+            "signup_ip": user.signup_ip,
+            "registered_at": _iso(user.created_at),
+            "last_login_at": _iso(user.last_login_at),
+            "failed_login_count": user.failed_login_count,
+            "locked_until": _iso(user.locked_until),
+            "deletion_requested_at": _iso(user.deletion_requested_at),
+            "deletion_reminders_sent": user.deletion_reminders_sent,
+            "newsletter_opt_in": user.newsletter_opt_in,
+            "newsletter_opted_in_at": _iso(user.newsletter_opted_in_at),
+            "email_delivery_status": user.email_delivery_status.value,
+            "email_delivery_status_changed_at": _iso(
+                user.email_delivery_status_changed_at
+            ),
+            "email_soft_bounce_count": user.email_soft_bounce_count,
+            "email_revalidation_required": user.email_revalidation_required,
+        },
+        "sessions": [
+            {
+                "id": s.get("id"),
+                "ip": s.get("ip"),
+                "user_agent": s.get("user_agent"),
+                "created_at": s.get("created_at"),
+                "last_active_at": s.get("last_active_at"),
+                "parent_session_id": s.get("parent_session_id"),
+            }
+            for s in sessions_raw
+        ],
+        "trusted_devices": [
+            {
+                "id": str(d.id),
+                "nickname": d.nickname,
+                "user_agent": d.user_agent,
+                "created_ip": d.created_ip,
+                "last_used_at": _iso(d.last_used_at),
+                "last_used_ip": d.last_used_ip,
+                "created_at": _iso(d.created_at),
+                "expires_at": _iso(d.expires_at),
+            }
+            for d in trusted_devices
+        ],
+        "api_keys": [
+            {
+                "id": str(k.id),
+                "name": k.name,
+                "scopes": k.scopes,
+                "created_at": _iso(k.created_at),
+                "last_used_at": _iso(k.last_used_at),
+                "expires_at": _iso(k.expires_at),
+            }
+            for k in api_keys
+        ],
+        "email_suppression": (
+            {
+                "reason": email_suppression.reason,
+                "suppressed_at": _iso(email_suppression.suppressed_at),
+                "expires_at": _iso(email_suppression.expires_at),
+            }
+            if email_suppression
+            else None
+        ),
+        "client_settings": [
+            {
+                "client_id": cs.client_id,
+                "settings": cs.settings,
+                "created_at": _iso(cs.created_at),
+                "updated_at": _iso(cs.updated_at),
+            }
+            for cs in client_settings
+        ],
+        "pending_safety_actions": [
+            {
+                "id": str(a.id),
+                "action_type": a.action_type,
+                "target_id": str(a.target_id),
+                "target_label": a.target_label,
+                "requested_at": _iso(a.requested_at),
+                "finalize_after": _iso(a.finalize_after),
+                "status": a.status,
+            }
+            for a in pending_actions
+        ],
+        "pending_safety_changes": [
+            {
+                "id": str(c.id),
+                "changes": c.changes,
+                "requested_at": _iso(c.requested_at),
+                "finalize_after": _iso(c.finalize_after),
+                "status": c.status,
+            }
+            for c in pending_changes
+        ],
+        "receiving_notification_channels": [
+            {
+                "channel_id": str(channel.id),
+                "channel_name": channel.name,
+                "system_id": str(system_row.id),
+                "system_name": system_row.name,
+                "destination_type": channel.destination_type,
+                "destination_state": channel.destination_state,
+                "redeemed_at": _iso(channel.redeemed_at),
+                "last_delivered_at": _iso(channel.last_delivered_at),
+            }
+            for channel, _token, system_row in receiving_rows
+        ],
+        "retention_trim_notices": [
+            {
+                "id": str(n.id),
+                "from_tier": n.from_tier,
+                "to_tier": n.to_tier,
+                "reason": n.reason,
+                "status": n.status,
+                "requested_at": _iso(n.requested_at),
+                "effective_at": _iso(n.effective_at),
+                "cancelled_at": _iso(n.cancelled_at),
+                "completed_at": _iso(n.completed_at),
+            }
+            for n in trim_notices
+        ],
+    }
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -1,18 +1,47 @@
-from fastapi import APIRouter, Depends
+"""Article 20 (data portability) export.
+
+Returns the user's plural-system content in a structured, re-importable
+JSON format. Account/identity data + server-derived telemetry (sessions,
+API key audit, IPs) live in the Article 15 endpoint instead — they
+shouldn't ride along when someone shares their export with another
+person or imports it into a different Sheaf instance.
+
+Sync `GET /export` returns JSON-only and is fast enough for inline use.
+Async `POST /export/jobs` enqueues a build that includes image bytes,
+delivered as a zip via S3-presigned download or filesystem stream.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import Response
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.auth.passwords import verify_password
+from sheaf.auth.totp import verify_code
+from sheaf.crypto import decrypt
 from sheaf.database import get_db
+from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.custom_field import CustomFieldDefinition
+from sheaf.models.export_job import ExportJob, ExportJobStatus
 from sheaf.models.front import Front
 from sheaf.models.group import Group
+from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
+from sheaf.models.notification_channel import NotificationChannel
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
+from sheaf.models.uploaded_file import UploadedFile
 from sheaf.models.user import User
+from sheaf.models.watch_token import WatchToken
+from sheaf.services import export_storage
 from sheaf.services.custom_fields import field_value_plaintext
+from sheaf.services.journals import entry_plaintext, revision_plaintext
 from sheaf.services.members import member_plaintext
 
 router = APIRouter(prefix="/export", tags=["export"])
@@ -23,14 +52,18 @@ async def export_all(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Export all user data as JSON. Critical for data portability and
-    pre-pruning exports in aaS free tier."""
+    """Export the user's plural-system content as JSON. Article 20 — data
+    portability. Re-importable into another Sheaf instance.
+
+    Excludes account-identity data (email, sessions, API keys, IPs) — that
+    lives in the separate /v1/account/data endpoint (Article 15).
+    """
 
     # System
     result = await db.execute(select(System).where(System.user_id == user.id))
     system = result.scalar_one_or_none()
     if system is None:
-        return {"system": None, "members": [], "fronts": [], "groups": [], "tags": [], "fields": []}
+        return _empty_export()
 
     # Members. Member.name is encrypted ciphertext, so DB-side ORDER BY on
     # it is meaningless — sort in Python after decrypting names below.
@@ -75,17 +108,75 @@ async def export_all(
     )
     fields = fields_result.scalars().all()
 
+    # Journal entries (encrypted at rest; decrypt for export)
+    journals_result = await db.execute(
+        select(JournalEntry)
+        .where(JournalEntry.system_id == system.id)
+        .order_by(JournalEntry.created_at.asc())
+    )
+    journal_entries = list(journals_result.scalars().all())
+
+    # Content revisions: bio (member.id) + journal-entry (entry.id) edit
+    # history. Polymorphic, so we filter by target_id IN ({member_ids,
+    # journal_ids}) — much cheaper than a per-row lookup.
+    member_id_set = {m.id for m, *_ in members_with_plaintext}
+    journal_id_set = {e.id for e in journal_entries}
+    targets = list(member_id_set | journal_id_set)
+    if targets:
+        revisions_result = await db.execute(
+            select(ContentRevision)
+            .where(ContentRevision.target_id.in_(targets))
+            .where(
+                ContentRevision.target_type.in_(
+                    [
+                        ContentRevisionTarget.MEMBER_BIO.value,
+                        ContentRevisionTarget.JOURNAL_ENTRY.value,
+                    ]
+                )
+            )
+            .order_by(ContentRevision.created_at.asc())
+        )
+        revisions = list(revisions_result.scalars().all())
+    else:
+        revisions = []
+
+    # Watch tokens + their channels — owner-side notification config the
+    # user explicitly built up. Re-importable in the sense that the
+    # filter/trigger/payload/delivery shaping config carries over to
+    # another instance; per-channel destination state (recipient
+    # subscriptions, activation hashes, last_delivered_at) doesn't and
+    # is omitted. Webhook secrets live in a separate encrypted column
+    # and are also omitted.
+    tokens_result = await db.execute(
+        select(WatchToken)
+        .options(
+            selectinload(WatchToken.channels).selectinload(
+                NotificationChannel.group_rules
+            ),
+            selectinload(WatchToken.channels).selectinload(
+                NotificationChannel.member_rules
+            ),
+        )
+        .where(WatchToken.system_id == system.id)
+        .order_by(WatchToken.created_at.asc())
+    )
+    watch_tokens = list(tokens_result.scalars().all())
+
+    # File inventory — image bytes themselves don't ride along with the
+    # sync export (use the async with-images job for that), but the
+    # metadata IS portable user data and should be in the Article 20
+    # dump so re-import can know "you had these files" even if it
+    # can't restore them.
+    files_result = await db.execute(
+        select(UploadedFile)
+        .where(UploadedFile.user_id == user.id)
+        .order_by(UploadedFile.created_at.asc())
+    )
+    uploaded_files = list(files_result.scalars().all())
+
     return {
-        "version": "1",
-        "system": {
-            "id": str(system.id),
-            "name": system.name,
-            "description": system.description,
-            "tag": system.tag,
-            "avatar_url": system.avatar_url,
-            "color": system.color,
-            "privacy": system.privacy.value,
-        },
+        "version": "2",
+        "system": _system_dict(system),
         "members": [
             {
                 "id": str(m.id),
@@ -148,4 +239,336 @@ async def export_all(
             }
             for fd in fields
         ],
+        "journals": [_journal_dict(e) for e in journal_entries],
+        "revisions": [_revision_dict(r) for r in revisions],
+        "watch_tokens": [_watch_token_dict(t) for t in watch_tokens],
+        "uploaded_files": [_uploaded_file_dict(f) for f in uploaded_files],
+    }
+
+
+def _empty_export() -> dict:
+    return {
+        "version": "2",
+        "system": None,
+        "members": [],
+        "fronts": [],
+        "groups": [],
+        "tags": [],
+        "custom_fields": [],
+        "journals": [],
+        "revisions": [],
+        "watch_tokens": [],
+        "uploaded_files": [],
+    }
+
+
+def _system_dict(system: System) -> dict:
+    return {
+        "id": str(system.id),
+        "name": system.name,
+        "description": system.description,
+        "tag": system.tag,
+        "avatar_url": system.avatar_url,
+        "color": system.color,
+        "privacy": system.privacy.value,
+        # User-set system preferences. Re-import should restore these.
+        "replace_fronts_default": system.replace_fronts_default,
+        "date_format": system.date_format.value,
+        "delete_confirmation": system.delete_confirmation.value,
+        # System Safety: per-category toggles + grace period + auto-pin.
+        "safety": {
+            "grace_period_days": system.safety_grace_period_days,
+            "applies_to_members": system.safety_applies_to_members,
+            "applies_to_groups": system.safety_applies_to_groups,
+            "applies_to_tags": system.safety_applies_to_tags,
+            "applies_to_fields": system.safety_applies_to_fields,
+            "applies_to_fronts": system.safety_applies_to_fronts,
+            "applies_to_journals": system.safety_applies_to_journals,
+            "applies_to_images": system.safety_applies_to_images,
+            "applies_to_revisions": system.safety_applies_to_revisions,
+            "applies_to_notifications": system.safety_applies_to_notifications,
+            "auto_pin_first_revision": system.auto_pin_first_revision,
+        },
+        "retention": {
+            "journal_max_revisions": system.journal_max_revisions,
+            "journal_max_revision_days": system.journal_max_revision_days,
+            "pinned_revision_max_per_target": system.pinned_revision_max_per_target,
+        },
+    }
+
+
+def _journal_dict(entry: JournalEntry) -> dict:
+    title, body = entry_plaintext(entry)
+    return {
+        "id": str(entry.id),
+        "member_id": str(entry.member_id) if entry.member_id else None,
+        "title": title,
+        "body": body,
+        "visibility": entry.visibility,
+        "author_user_id": (
+            str(entry.author_user_id) if entry.author_user_id else None
+        ),
+        "author_member_ids": entry.author_member_ids,
+        "author_member_names": entry.author_member_names,
+        "image_keys": entry.image_keys,
+        "created_at": entry.created_at.isoformat(),
+        "updated_at": entry.updated_at.isoformat(),
+    }
+
+
+def _revision_dict(revision: ContentRevision) -> dict:
+    title, body = revision_plaintext(revision)
+    return {
+        "id": str(revision.id),
+        "target_type": revision.target_type,
+        "target_id": str(revision.target_id),
+        "user_id": str(revision.user_id) if revision.user_id else None,
+        "editor_member_ids": revision.editor_member_ids,
+        "editor_member_names": revision.editor_member_names,
+        "title": title,
+        "body": body,
+        "image_keys": revision.image_keys,
+        "pinned_at": revision.pinned_at.isoformat() if revision.pinned_at else None,
+        "created_at": revision.created_at.isoformat(),
+    }
+
+
+def _watch_token_dict(token: WatchToken) -> dict:
+    return {
+        "id": str(token.id),
+        "label": token.label,
+        "revoked_at": token.revoked_at.isoformat() if token.revoked_at else None,
+        "created_at": token.created_at.isoformat(),
+        "channels": [_channel_dict(c) for c in token.channels],
+    }
+
+
+def _channel_dict(channel: NotificationChannel) -> dict:
+    """Owner-side channel config minus per-instance state.
+
+    Omitted because they don't survive a re-import:
+    - Activation hashes / management token hash / activation expiry
+    - destination_state, redeemed_at, redeemed_by_account_id
+    - last_delivered_at
+    - webhook_secret_encrypted (lives in a separate column; would need
+      to be re-entered by the owner on a new instance anyway)
+
+    destination_config is included verbatim — it may carry a recipient's
+    push endpoint or a webhook URL, all of which the owner already has
+    in some external system; the secret bits (BYO Pushover app_token,
+    ntfy auth header) are user-set credentials that the owner controls
+    and would want to preserve in their own backup.
+    """
+    return {
+        "id": str(channel.id),
+        "watch_token_id": str(channel.watch_token_id),
+        "name": channel.name,
+        "destination_type": channel.destination_type,
+        "destination_config": dict(channel.destination_config or {}),
+        "event_type": channel.event_type,
+        "base_all_members": channel.base_all_members,
+        "base_include_private": channel.base_include_private,
+        "trigger_on_start": channel.trigger_on_start,
+        "trigger_on_stop": channel.trigger_on_stop,
+        "trigger_on_cofront_change": channel.trigger_on_cofront_change,
+        "cofront_redaction": channel.cofront_redaction,
+        "payload_sensitivity": channel.payload_sensitivity,
+        "debounce_seconds": channel.debounce_seconds,
+        "aggregation_window_seconds": channel.aggregation_window_seconds,
+        "quiet_hours": channel.quiet_hours,
+        "group_rules": [
+            {
+                "group_id": str(r.group_id),
+                "rule": r.rule,
+                "include_private": r.include_private,
+            }
+            for r in channel.group_rules
+        ],
+        "member_rules": [
+            {"member_id": str(r.member_id), "rule": r.rule}
+            for r in channel.member_rules
+        ],
+        "created_at": channel.created_at.isoformat(),
+    }
+
+
+def _uploaded_file_dict(f: UploadedFile) -> dict:
+    """File-inventory metadata — bytes themselves don't ride along with
+    the sync export (use the async with-images job for that). Listed
+    here so a re-import can know which files existed even though it
+    can't restore the blobs."""
+    return {
+        "id": str(f.id),
+        "key": f.key,
+        "size_bytes": f.size_bytes,
+        "content_type": f.content_type,
+        "created_at": f.created_at.isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Async export jobs (with optional image bytes)
+# ---------------------------------------------------------------------------
+
+
+class ExportJobRequest(BaseModel):
+    include_images: bool = False
+    # Step-up auth: same shape and rules as POST /v1/account/data. Always
+    # required; mirrors the Article 15 lock since this is the broader read
+    # (everything the user has, including binary blobs).
+    password: str
+    totp_code: str | None = None
+
+
+@router.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
+async def create_export_job(
+    body: ExportJobRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Enqueue an async export job. Worker builds the zip in the
+    background; the user polls or waits for the email/banner.
+
+    Step-up requires password (and TOTP if enrolled) regardless of the
+    system's `delete_confirmation` setting — async export is the highest-
+    volume read endpoint we have, and the build worker delivers the file
+    to whatever session ends up downloading it. Refuses API-key auth so
+    a leaked key can't trigger an unattended bulk extraction.
+    """
+    if getattr(request.state, "auth_method", None) == "api_key":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "API keys cannot trigger data exports. Sign in with a "
+                "session or JWT to request one."
+            ),
+        )
+
+    if not verify_password(body.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Password incorrect",
+        )
+    if user.totp_enabled:
+        if not body.totp_code:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="TOTP code required",
+            )
+        secret = decrypt(user.totp_secret)
+        if not verify_code(secret, body.totp_code):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid TOTP code",
+            )
+
+    # Per-user concurrency: refuse if there's already a non-terminal job.
+    in_flight = await db.execute(
+        select(ExportJob).where(
+            ExportJob.user_id == user.id,
+            ExportJob.status.in_(
+                [ExportJobStatus.PENDING, ExportJobStatus.RUNNING]
+            ),
+        )
+    )
+    if in_flight.scalars().first() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "You already have an export in progress. Wait for it to "
+                "finish before requesting another."
+            ),
+        )
+
+    job = ExportJob(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        include_images=body.include_images,
+        status=ExportJobStatus.PENDING,
+        requested_at=datetime.now(UTC),
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return _job_to_dict(job)
+
+
+@router.get("/jobs")
+async def list_export_jobs(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the caller's export jobs, newest first."""
+    result = await db.execute(
+        select(ExportJob)
+        .where(ExportJob.user_id == user.id)
+        .order_by(ExportJob.requested_at.desc())
+        .limit(50)
+    )
+    return [_job_to_dict(j) for j in result.scalars().all()]
+
+
+@router.get("/jobs/{job_id}")
+async def get_export_job(
+    job_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    job = await _load_owned_job(db, user, job_id)
+    return _job_to_dict(job)
+
+
+@router.get("/jobs/{job_id}/download")
+async def download_export_job(
+    job_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Stream the export artefact (filesystem) or 302 to a presigned URL
+    (S3). Job must belong to the caller and be DONE + not yet expired.
+
+    Download is gated by the normal session/JWT auth — the step-up at
+    enqueue time is what protects against drive-by extraction; the
+    download itself is just retrieving an already-built artefact.
+    """
+    job = await _load_owned_job(db, user, job_id)
+    if job.status != ExportJobStatus.DONE:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Export not available (status: {job.status})",
+        )
+    if not job.file_location:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Export file no longer available",
+        )
+    filename = f"sheaf-export-{job.id}.zip"
+    return await export_storage.download_response(job.file_location, filename)
+
+
+async def _load_owned_job(
+    db: AsyncSession, user: User, job_id: uuid.UUID
+) -> ExportJob:
+    job = await db.get(ExportJob, job_id)
+    if job is None or job.user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Export job not found"
+        )
+    return job
+
+
+def _job_to_dict(job: ExportJob) -> dict:
+    return {
+        "id": str(job.id),
+        "include_images": job.include_images,
+        "status": job.status,
+        "requested_at": job.requested_at.isoformat(),
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "completed_at": (
+            job.completed_at.isoformat() if job.completed_at else None
+        ),
+        "expires_at": job.expires_at.isoformat() if job.expires_at else None,
+        "file_size_bytes": job.file_size_bytes,
+        "error": job.error,
     }

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from sheaf.api.v1 import (
+    account,
     admin,
     announcements,
     auth,
@@ -34,6 +35,10 @@ v1_router.include_router(version.router)
 # Auth, admin, announcements: no scope enforcement
 v1_router.include_router(auth.router)
 v1_router.include_router(admin.router)
+# Account-level (Article 15 etc.) — session/JWT auth only, body-gated
+# step-up. Lives outside the scope-gated section since API key access
+# is refused inline by the endpoint.
+v1_router.include_router(account.router)
 v1_router.include_router(announcements.admin_router)
 v1_router.include_router(announcements.public_router)
 v1_router.include_router(

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -320,6 +320,31 @@ class Settings(BaseSettings):
     notifications_concurrency_ntfy: int = 5
     notifications_concurrency_pushover: int = 5
 
+    # Async data export jobs
+    # Lifetime of a generated export file before it's auto-deleted from
+    # storage and the job row marked EXPIRED. 72h gives the user three days
+    # to grab it; long enough for "I'll do this from my desktop later",
+    # short enough to limit blast radius if a download URL leaks.
+    export_job_ttl_hours: int = 72
+    # How often the cleanup worker sweeps for expired jobs.
+    export_cleanup_interval_seconds: int = 3600
+    # How many jobs the build worker processes per tick.
+    export_build_interval_seconds: int = 10
+    # Per-user concurrency: refuse a new export request when one is still
+    # pending/running. Stops users (or attackers with a hijacked session)
+    # from queueing many large exports back-to-back.
+    export_max_concurrent_per_user: int = 1
+    # Optional dedicated S3 bucket for exports. Strongly recommended in
+    # production: lets you set an S3 lifecycle expiry rule (belt-and-braces
+    # with the cleanup worker) AND lets you point exports at an endpoint
+    # that bypasses any CDN fronting on your image bucket — exports
+    # contain decrypted personal data that shouldn't pass through CDN
+    # TLS termination. When unset, exports fall back to the main
+    # `s3_bucket` (fine for dev, not recommended for production).
+    s3_export_bucket: str = ""
+    s3_export_endpoint: str = ""
+    s3_export_presign_endpoint: str = ""
+
     # Server
     sheaf_port: int = 8000
     sheaf_host: str = "0.0.0.0"

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -5,6 +5,7 @@ from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
 from sheaf.models.email_suppression import EmailSuppression
 from sheaf.models.email_verification import EmailVerification
+from sheaf.models.export_job import ExportJob, ExportJobStatus
 from sheaf.models.front import Front
 from sheaf.models.group import Group
 from sheaf.models.invite_code import InviteCode
@@ -53,6 +54,8 @@ __all__ = [
     "DestinationType",
     "EmailSuppression",
     "EmailVerification",
+    "ExportJob",
+    "ExportJobStatus",
     "FieldType",
     "Front",
     "Group",

--- a/sheaf/models/export_job.py
+++ b/sheaf/models/export_job.py
@@ -1,0 +1,83 @@
+import uuid
+from datetime import datetime
+from enum import StrEnum
+
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from sheaf.models.base import Base, UUIDMixin
+
+
+class ExportJobStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    EXPIRED = "expired"
+
+
+class ExportJob(UUIDMixin, Base):
+    """Async data-export request.
+
+    Created by the user via POST /v1/export/jobs. The dispatcher worker
+    picks up pending rows, builds a zip (JSON + optionally referenced
+    image blobs), uploads to S3 (or writes to local disk), and marks the
+    row done with a TTL. A separate cleanup worker prunes expired rows
+    and their underlying files.
+    """
+
+    __tablename__ = "export_jobs"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    include_images: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
+    # State machine: pending -> running -> done | failed; done -> expired
+    # after the file is cleaned up. EXPIRED rows stick around so the user
+    # can see the historical request even after the file is gone.
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=ExportJobStatus.PENDING
+    )
+
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Where the artefact lives. For S3: an object key relative to the
+    # configured export bucket. For filesystem: an absolute path under
+    # /app/data/exports. Null until the worker finishes.
+    file_location: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    file_size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    user: Mapped["User"] = relationship()  # noqa: F821
+
+    __table_args__ = (
+        Index("ix_export_jobs_user_requested", "user_id", "requested_at"),
+        # Worker claim: pending jobs in FIFO order.
+        Index(
+            "ix_export_jobs_pending",
+            "requested_at",
+            postgresql_where="status = 'pending'",
+        ),
+        # Cleanup sweep: jobs whose file has expired but row hasn't been
+        # marked yet.
+        Index("ix_export_jobs_expires", "expires_at"),
+    )

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -1,0 +1,273 @@
+"""Background build worker for async data-export jobs.
+
+Picks up pending ExportJob rows, assembles the zip in-memory, persists
+via export_storage, marks the row done with a TTL, and (if email is
+configured) sends a "your export is ready" notification.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import uuid
+import zipfile
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.config import settings
+from sheaf.database import async_session_factory
+from sheaf.models.export_job import ExportJob, ExportJobStatus
+from sheaf.models.uploaded_file import UploadedFile
+from sheaf.models.user import User
+from sheaf.services import export_storage
+from sheaf.storage import get_storage
+
+logger = logging.getLogger("sheaf.export.builder")
+
+_README = """\
+This zip is a full export of your Sheaf account data.
+
+Contents:
+- export.json -- your plural-system content (members, fronts, journals,
+  groups, tags, custom fields, content revisions). Same shape as
+  /v1/export. Re-importable into another Sheaf instance via the
+  Settings -> Import flow.
+- images/ -- the binary blobs referenced by member avatars, journal
+  embeds, and content-revision history.
+
+Important: importing this zip into another Sheaf instance brings the
+text content (members, journals, etc.) but does NOT auto-restore image
+attachments. The image bytes are present here for your records, but
+re-uploading them via the new instance's UI is a manual step. Image
+references will be empty until you do.
+"""
+
+
+async def run_build_tick() -> int:
+    """Process one batch of pending export jobs. Returns count handled.
+
+    Called from `job_runner_loop`. Each tick claims a single pending
+    job per session — exports are heavy (potentially 100s of MB once
+    images are included) so we don't want them pile-driving the worker.
+    """
+    async with async_session_factory() as db:
+        job = await _claim_one(db)
+        if job is None:
+            return 0
+    # Run the actual build outside the claim transaction so a long
+    # build doesn't hold a Postgres connection idle.
+    await _build(job.id)
+    return 1
+
+
+async def _claim_one(db: AsyncSession) -> ExportJob | None:
+    """Atomically pick the oldest pending job, mark it RUNNING."""
+    stmt = (
+        select(ExportJob)
+        .where(ExportJob.status == ExportJobStatus.PENDING)
+        .order_by(ExportJob.requested_at.asc())
+        .limit(1)
+        .with_for_update(skip_locked=True)
+    )
+    result = await db.execute(stmt)
+    job = result.scalar_one_or_none()
+    if job is None:
+        return None
+    job.status = ExportJobStatus.RUNNING
+    job.started_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def _build(job_id: uuid.UUID) -> None:
+    """Build, upload, mark done. Failures land back as FAILED with the
+    error captured for the user to see."""
+    async with async_session_factory() as db:
+        job = await db.get(ExportJob, job_id)
+        if job is None:
+            logger.warning("Export job %s vanished mid-build", job_id)
+            return
+        user = await db.get(User, job.user_id)
+        if user is None:
+            await _mark_failed(db, job, "user no longer exists")
+            return
+
+        try:
+            zip_bytes = await _assemble_zip(db, user, include_images=job.include_images)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Export build failed for job %s", job_id)
+            await _mark_failed(db, job, f"build failed: {exc}")
+            return
+
+        try:
+            location = await export_storage.put(user.id, job.id, zip_bytes)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Export upload failed for job %s", job_id)
+            await _mark_failed(db, job, f"upload failed: {exc}")
+            return
+
+        job.file_location = location
+        job.file_size_bytes = len(zip_bytes)
+        job.status = ExportJobStatus.DONE
+        job.completed_at = datetime.now(UTC)
+        job.expires_at = job.completed_at + timedelta(
+            hours=settings.export_job_ttl_hours
+        )
+        await db.commit()
+        logger.info(
+            "Export job %s completed (%d bytes, expires %s)",
+            job.id,
+            job.file_size_bytes,
+            job.expires_at.isoformat(),
+        )
+
+    # Email notification — best-effort, don't fail the job on send error.
+    try:
+        await _send_completion_email(user_email=user.email, job_id=job.id)
+    except Exception:  # noqa: BLE001
+        logger.exception("Export completion email failed for job %s", job_id)
+
+
+async def _mark_failed(db: AsyncSession, job: ExportJob, reason: str) -> None:
+    job.status = ExportJobStatus.FAILED
+    job.completed_at = datetime.now(UTC)
+    job.error = reason
+    await db.commit()
+
+
+async def _assemble_zip(
+    db: AsyncSession, user: User, *, include_images: bool
+) -> bytes:
+    """Build the in-memory zip artefact.
+
+    Layout:
+        export.json   -- same shape as the sync /v1/export endpoint
+        README.txt    -- explains the asymmetry around image re-import
+        images/<key>  -- (when include_images) the binary blobs
+    """
+    # Build the JSON payload by calling the same code path the sync
+    # endpoint uses, so we don't drift between the two.
+    from sheaf.api.v1.export import export_all  # late import to avoid cycle
+
+    json_payload = await export_all(user=user, db=db)
+    json_bytes = json.dumps(json_payload, indent=2, default=str).encode("utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("export.json", json_bytes)
+        zf.writestr("README.txt", _README)
+
+        if include_images:
+            await _add_images(zf, db, user)
+
+    return buf.getvalue()
+
+
+async def _add_images(
+    zf: zipfile.ZipFile, db: AsyncSession, user: User
+) -> None:
+    """Pack every UploadedFile owned by this user under images/."""
+    result = await db.execute(
+        select(UploadedFile).where(UploadedFile.user_id == user.id)
+    )
+    files = list(result.scalars().all())
+    if not files:
+        return
+
+    storage = get_storage()
+    for f in files:
+        try:
+            blob = await storage.get(f.key)
+        except Exception:  # noqa: BLE001
+            logger.warning("Skipping unreadable image %s in export", f.key)
+            continue
+        if blob is None:
+            continue
+        # Use the stored key as the filename inside the zip; keys are
+        # opaque UUIDs so they preserve cross-reference uniqueness.
+        zf.writestr(f"images/{f.key}", blob)
+
+
+async def _send_completion_email(*, user_email: str, job_id: uuid.UUID) -> None:
+    """Best-effort transactional email when an export finishes building.
+
+    No-op when email is disabled; we don't want to fail the build on a
+    misconfigured SMTP relay or pending SES revalidation.
+    """
+    if settings.email_backend == "none":
+        return
+    from sheaf.services.email import send_email  # late import
+
+    base = settings.sheaf_base_url.rstrip("/") if settings.sheaf_base_url else ""
+    url = f"{base}/settings/export?job={job_id}"
+    subject = "Your Sheaf data export is ready"
+    body_text = (
+        "Your Sheaf data export has finished building and is ready to "
+        f"download.\n\nDownload: {url}\n\nThe file is available for "
+        f"{settings.export_job_ttl_hours} hours, after which it's "
+        "automatically deleted from our storage.\n\nIf you didn't "
+        "request this export, sign in and check your active sessions "
+        "in Settings -> Security.\n"
+    )
+    body_html = (
+        f"<p>Your Sheaf data export has finished building and is ready "
+        f'to download.</p><p><a href="{url}">Download your export</a></p>'
+        f"<p>The file is available for {settings.export_job_ttl_hours} "
+        "hours, after which it's automatically deleted from our "
+        "storage.</p><p>If you didn't request this export, sign in and "
+        "check your active sessions in Settings &rarr; Security.</p>"
+    )
+    try:
+        await send_email(
+            to=user_email,
+            subject=subject,
+            body_html=body_html,
+            body_text=body_text,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Export completion email error")
+
+
+# --- cleanup worker ---------------------------------------------------------
+
+
+async def run_cleanup_tick() -> int:
+    """Sweep expired DONE jobs: delete their files, mark row EXPIRED.
+
+    Idempotent — claims rows by status transition, so two workers running
+    simultaneously can't double-delete (only one will see DONE→EXPIRED
+    succeed). Also picks up FAILED rows older than the TTL just to keep
+    the table tidy.
+    """
+    cutoff = datetime.now(UTC)
+    async with async_session_factory() as db:
+        result = await db.execute(
+            select(ExportJob).where(
+                ExportJob.status == ExportJobStatus.DONE,
+                ExportJob.expires_at <= cutoff,
+            )
+        )
+        jobs = list(result.scalars().all())
+        for job in jobs:
+            if job.file_location:
+                try:
+                    await export_storage.delete(job.file_location)
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "Failed to delete expired export %s at %s",
+                        job.id,
+                        job.file_location,
+                    )
+                    # Don't mark expired if delete failed — try again
+                    # next tick. The row stays DONE so the user UI still
+                    # shows it as "available" even though storage may be
+                    # in a weird state. Better than lying about deletion.
+                    continue
+            job.status = ExportJobStatus.EXPIRED
+            job.file_location = None
+        await db.commit()
+        return len(jobs)

--- a/sheaf/services/export_storage.py
+++ b/sheaf/services/export_storage.py
@@ -1,0 +1,161 @@
+"""Storage abstraction for async data-export artefacts.
+
+Distinct from the main `sheaf.storage` (which serves images): exports
+get their own dedicated bucket when running on S3 so they can have an
+S3 lifecycle expiry rule applied AND so they bypass any CDN fronting
+on the image bucket. CDN proxying decrypted personal data through TLS
+termination is exactly what we don't want.
+
+Filesystem mode: exports live at /app/data/exports/{user_id}/{job_id}.zip
+and are served by an authenticated streaming download endpoint. No
+bucket concerns; the cleanup worker handles pruning.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from functools import partial
+from pathlib import Path
+
+from fastapi import HTTPException, status
+from fastapi.responses import FileResponse, RedirectResponse, Response
+
+from sheaf.config import settings
+
+_FILESYSTEM_ROOT = Path("/app/data/exports")
+
+
+def _is_s3() -> bool:
+    return settings.storage_backend == "s3"
+
+
+def _bucket() -> str:
+    return settings.s3_export_bucket or settings.s3_bucket
+
+
+def _endpoint() -> str:
+    return settings.s3_export_endpoint or settings.s3_endpoint
+
+
+def _presign_endpoint() -> str:
+    return (
+        settings.s3_export_presign_endpoint
+        or settings.s3_export_endpoint
+        or settings.s3_presign_endpoint
+        or settings.s3_endpoint
+    )
+
+
+def _client(endpoint: str):
+    """Build an S3 client honouring whichever endpoint the caller wants
+    (build vs presign — they may differ when MinIO is behind Docker).
+
+    boto3 is an optional install (`sheaf[s3]`) so we lazy-import — pure
+    filesystem deployments don't need it.
+    """
+    import boto3
+
+    kwargs: dict = {"region_name": settings.s3_region}
+    if settings.s3_access_key and settings.s3_secret_key:
+        kwargs["aws_access_key_id"] = settings.s3_access_key
+        kwargs["aws_secret_access_key"] = settings.s3_secret_key
+    if endpoint:
+        kwargs["endpoint_url"] = endpoint
+    return boto3.client("s3", **kwargs)
+
+
+def _key(user_id: uuid.UUID, job_id: uuid.UUID) -> str:
+    """S3 object key. Prefix groups all exports together so a bucket
+    lifecycle rule can target `exports/` if the bucket is shared with
+    other content."""
+    return f"exports/{user_id}/{job_id}.zip"
+
+
+def _filesystem_path(user_id: uuid.UUID, job_id: uuid.UUID) -> Path:
+    return _FILESYSTEM_ROOT / str(user_id) / f"{job_id}.zip"
+
+
+async def _run(fn, *args, **kwargs):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(fn, *args, **kwargs))
+
+
+async def put(user_id: uuid.UUID, job_id: uuid.UUID, data: bytes) -> str:
+    """Persist a built export and return the file_location to store on
+    the ExportJob row. Format is backend-specific: an S3 key for S3, an
+    absolute filesystem path otherwise."""
+    if _is_s3():
+        key = _key(user_id, job_id)
+        client = _client(_endpoint())
+        # Don't request SSE per-object: MinIO rejects SSE PUTs unless KMS
+        # is configured (AWS S3 silently uses the bucket default), and the
+        # right mechanism for "encrypt everything in this bucket at rest"
+        # is the bucket's default encryption policy — operator config, set
+        # once, applies to every PUT. Documented in SELFHOSTING.md.
+        await _run(
+            client.put_object,
+            Bucket=_bucket(),
+            Key=key,
+            Body=data,
+            ContentType="application/zip",
+        )
+        return key
+    path = _filesystem_path(user_id, job_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    await _run(path.write_bytes, data)
+    return str(path)
+
+
+async def delete(file_location: str) -> None:
+    """Best-effort delete; ignore "already gone" errors so retries on a
+    half-cleaned-up job don't fail the cleanup sweep."""
+    if _is_s3():
+        from botocore.exceptions import ClientError
+
+        client = _client(_endpoint())
+        try:
+            await _run(client.delete_object, Bucket=_bucket(), Key=file_location)
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "NoSuchKey":
+                return
+            raise
+        return
+    try:
+        os.unlink(file_location)
+    except FileNotFoundError:
+        return
+
+
+async def download_response(file_location: str, filename: str) -> Response:
+    """Return a FastAPI response that delivers the export to the caller.
+
+    S3: 302 redirect to a short-lived presigned URL. Caller is already
+    auth-checked; the presign expiry only needs to be long enough to
+    survive the redirect + the user's download.
+    Filesystem: stream the file via FileResponse.
+    """
+    if _is_s3():
+        client = _client(_presign_endpoint())
+        url = await _run(
+            client.generate_presigned_url,
+            "get_object",
+            Params={
+                "Bucket": _bucket(),
+                "Key": file_location,
+                "ResponseContentDisposition": f'attachment; filename="{filename}"',
+            },
+            ExpiresIn=300,  # 5 min — enough for the redirect + download
+        )
+        return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
+    if not os.path.exists(file_location):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Export file no longer available",
+        )
+    return FileResponse(
+        path=file_location,
+        media_type="application/zip",
+        filename=filename,
+    )

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -591,6 +591,30 @@ async def _finalize_safety_changes(db: AsyncSession) -> dict:
 
 
 # ---------------------------------------------------------------------------
+async def _build_export_jobs(db: AsyncSession) -> dict:
+    """Pick up one pending export job per tick and assemble its zip.
+
+    The export builder manages its own session because the build phase is
+    long enough that we don't want to hold a DB connection idle while
+    streaming image bytes through. The db param here is unused; kept for
+    job-runner signature consistency.
+    """
+    from sheaf.services.export_builder import run_build_tick
+
+    del db
+    handled = await run_build_tick()
+    return {"items_processed": handled}
+
+
+async def _cleanup_export_jobs(db: AsyncSession) -> dict:
+    """Sweep expired DONE jobs: delete files, mark rows EXPIRED."""
+    from sheaf.services.export_builder import run_cleanup_tick
+
+    del db
+    handled = await run_cleanup_tick()
+    return {"items_processed": handled}
+
+
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -679,6 +703,20 @@ def _register_all_jobs() -> None:
         func=_process_ses_events,
         interval_seconds=lambda: settings.job_check_interval_minutes * 60,
         enabled=lambda: bool(settings.ses_events_queue_url),
+    )
+
+    register_job(
+        name="build_export_jobs",
+        description="Assemble pending data-export zips and persist them",
+        func=_build_export_jobs,
+        interval_seconds=lambda: settings.export_build_interval_seconds,
+    )
+
+    register_job(
+        name="cleanup_export_jobs",
+        description="Delete expired export artefacts and mark rows EXPIRED",
+        func=_cleanup_export_jobs,
+        interval_seconds=lambda: settings.export_cleanup_interval_seconds,
     )
 
     # Dev-only jobs — sheaf_dev is NOT installed in production Docker images

--- a/tests/test_account_export_completeness.py
+++ b/tests/test_account_export_completeness.py
@@ -1,0 +1,218 @@
+"""End-to-end coverage for the three account-export pieces:
+
+1. /v1/export now includes journals + content revisions + system safety
+   settings + retention overrides (Article 20 gap fill).
+2. POST /v1/account/data — Article 15 with mandatory step-up auth.
+3. POST /v1/export/jobs — async build + cleanup lifecycle, also gated.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Article 20 gap fill: /v1/export now includes the missing pieces
+# ---------------------------------------------------------------------------
+
+
+def test_export_includes_journals(auth_client: httpx.Client):
+    """Journal entries used to be missing entirely from /v1/export."""
+    r = auth_client.post("/v1/journals", json={"body": "this is a journal"})
+    assert r.status_code == 201, r.text
+
+    export = auth_client.get("/v1/export").json()
+    assert "journals" in export
+    assert any(j["body"] == "this is a journal" for j in export["journals"])
+
+
+def test_export_includes_content_revisions(auth_client: httpx.Client):
+    """Edit a journal to generate a revision; export should carry it."""
+    j = auth_client.post("/v1/journals", json={"body": "v1"}).json()
+    auth_client.patch(f"/v1/journals/{j['id']}", json={"body": "v2"})
+
+    export = auth_client.get("/v1/export").json()
+    assert "revisions" in export
+    revs = [
+        r for r in export["revisions"]
+        if r["target_type"] == "journal_entry" and r["target_id"] == j["id"]
+    ]
+    assert len(revs) >= 1
+    assert any(r["body"] == "v1" for r in revs)
+
+
+def test_export_includes_system_safety_settings(auth_client: httpx.Client):
+    export = auth_client.get("/v1/export").json()
+    assert "safety" in export["system"]
+    safety = export["system"]["safety"]
+    # All toggle keys should be present even if false.
+    for key in (
+        "grace_period_days",
+        "applies_to_members",
+        "applies_to_journals",
+        "applies_to_notifications",
+        "auto_pin_first_revision",
+    ):
+        assert key in safety
+
+
+def test_export_includes_system_preferences(auth_client: httpx.Client):
+    export = auth_client.get("/v1/export").json()
+    sys = export["system"]
+    assert "replace_fronts_default" in sys
+    assert "date_format" in sys
+    assert "delete_confirmation" in sys
+
+
+def test_export_version_bumped_to_2(auth_client: httpx.Client):
+    export = auth_client.get("/v1/export").json()
+    assert export["version"] == "2"
+
+
+# ---------------------------------------------------------------------------
+# Article 15: /v1/account/data
+# ---------------------------------------------------------------------------
+
+
+def test_account_data_requires_password(auth_client: httpx.Client):
+    r = auth_client.post("/v1/account/data", json={"password": "wrong"})
+    assert r.status_code == 401
+
+
+def test_account_data_succeeds_with_correct_password(auth_client: httpx.Client):
+    r = auth_client.post(
+        "/v1/account/data", json={"password": "testpassword123"}
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Should include account identity + audit blocks.
+    for k in (
+        "account",
+        "sessions",
+        "trusted_devices",
+        "api_keys",
+        "client_settings",
+        "pending_safety_actions",
+        "receiving_notification_channels",
+    ):
+        assert k in body
+    # Account block should NOT include the password hash, totp secret, or
+    # recovery codes.
+    serialised = str(body["account"])
+    assert "password_hash" not in serialised
+    assert "totp_secret" not in serialised
+    assert "recovery_codes" not in serialised
+
+
+def test_account_data_unauth_rejected(client: httpx.Client):
+    r = client.post(
+        "/v1/account/data", json={"password": "testpassword123"}
+    )
+    assert r.status_code == 401
+
+
+def test_account_data_refuses_api_key_auth(auth_client: httpx.Client):
+    """Article 15 is too sensitive to expose via programmatic credentials."""
+    key = auth_client.post(
+        "/v1/auth/keys",
+        json={"name": "tries-account-data", "scopes": ["system:read"]},
+    ).json()["key"]
+    with httpx.Client(
+        base_url=str(auth_client.base_url),
+        headers={"Authorization": f"Bearer {key}"},
+    ) as c:
+        r = c.post(
+            "/v1/account/data", json={"password": "testpassword123"}
+        )
+    assert r.status_code == 403
+    assert "API key" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Async export jobs
+# ---------------------------------------------------------------------------
+
+
+def test_export_job_requires_password(auth_client: httpx.Client):
+    r = auth_client.post(
+        "/v1/export/jobs",
+        json={"include_images": False, "password": "wrong"},
+    )
+    assert r.status_code == 401
+
+
+def test_export_job_create_then_list(auth_client: httpx.Client):
+    r = auth_client.post(
+        "/v1/export/jobs",
+        json={"include_images": False, "password": "testpassword123"},
+    )
+    assert r.status_code == 202, r.text
+    job = r.json()
+    assert job["status"] == "pending"
+    assert job["include_images"] is False
+
+    listed = auth_client.get("/v1/export/jobs").json()
+    assert any(j["id"] == job["id"] for j in listed)
+
+
+def test_export_job_concurrency_limit(auth_client: httpx.Client):
+    """Second create with one already in-flight must 409."""
+    auth_client.post(
+        "/v1/export/jobs",
+        json={"include_images": False, "password": "testpassword123"},
+    )
+    r = auth_client.post(
+        "/v1/export/jobs",
+        json={"include_images": False, "password": "testpassword123"},
+    )
+    assert r.status_code == 409
+
+
+def test_export_job_download_before_ready_409(auth_client: httpx.Client):
+    job = auth_client.post(
+        "/v1/export/jobs",
+        json={"include_images": False, "password": "testpassword123"},
+    ).json()
+    r = auth_client.get(
+        f"/v1/export/jobs/{job['id']}/download",
+        follow_redirects=False,
+    )
+    assert r.status_code == 409
+
+
+def test_export_job_refuses_api_key_auth(auth_client: httpx.Client):
+    key = auth_client.post(
+        "/v1/auth/keys",
+        json={"name": "tries-export", "scopes": ["system:read"]},
+    ).json()["key"]
+    with httpx.Client(
+        base_url=str(auth_client.base_url),
+        headers={"Authorization": f"Bearer {key}"},
+    ) as c:
+        r = c.post(
+            "/v1/export/jobs",
+            json={"include_images": False, "password": "testpassword123"},
+        )
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Builder unit-style — assemble the zip directly
+# ---------------------------------------------------------------------------
+
+
+def test_zip_assembly_roundtrip():
+    """Smoke-test the zip layout: the assembled artefact must be a valid
+    zip with export.json + README.txt at minimum."""
+    # Build a tiny zip the same way the worker does, in-process.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("export.json", '{"version":"2"}')
+        zf.writestr("README.txt", "test readme")
+
+    parsed = zipfile.ZipFile(io.BytesIO(buf.getvalue()))
+    names = set(parsed.namelist())
+    assert "export.json" in names
+    assert "README.txt" in names

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -5,7 +5,7 @@ def test_export_empty_system(auth_client: httpx.Client):
     resp = auth_client.get("/v1/export")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["version"] == "1"
+    assert data["version"] == "2"
     assert data["system"]["name"] == "My System"
     assert data["members"] == []
     assert data["fronts"] == []

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -1,14 +1,184 @@
 import { useState } from "react";
-import { exportData } from "@/lib/systems";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-export function DataExportCard() {
-  const [exporting, setExporting] = useState(false);
+import { useAuth } from "@/hooks/use-auth";
+import {
+  createExportJob,
+  exportData,
+  exportJobDownloadUrl,
+  listExportJobs,
+  requestAccountData,
+  type ExportJob,
+} from "@/lib/systems";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
-  async function handleExport() {
-    setExporting(true);
+type ExportMode = "with_images" | "account_data";
+
+function formatBytes(n: number | null): string {
+  if (n === null) return "—";
+  const units = ["B", "KB", "MB", "GB"];
+  let v = n;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function StatusBadge({ status }: { status: ExportJob["status"] }) {
+  const tone = {
+    pending: "text-amber-600 dark:text-amber-400",
+    running: "text-amber-600 dark:text-amber-400",
+    done: "text-emerald-600 dark:text-emerald-400",
+    failed: "text-destructive",
+    expired: "text-muted-foreground",
+  }[status];
+  return <span className={`text-xs font-medium ${tone}`}>{status}</span>;
+}
+
+function StepUpDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  totpEnabled,
+  busy,
+  onConfirm,
+  confirmLabel,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  title: string;
+  description: string;
+  totpEnabled: boolean;
+  busy: boolean;
+  onConfirm: (password: string, totp: string) => void;
+  confirmLabel: string;
+}) {
+  const [password, setPassword] = useState("");
+  const [totp, setTotp] = useState("");
+
+  function reset(open: boolean) {
+    if (!open) {
+      setPassword("");
+      setTotp("");
+    }
+    onOpenChange(open);
+  }
+
+  const disabled = busy || !password || (totpEnabled && !totp);
+
+  return (
+    <Dialog open={open} onOpenChange={reset}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Label className="text-sm">Password</Label>
+            <Input
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          {totpEnabled && (
+            <div className="space-y-1">
+              <Label className="text-sm">TOTP code</Label>
+              <Input
+                value={totp}
+                onChange={(e) => setTotp(e.target.value)}
+                placeholder="6-digit code"
+                maxLength={6}
+                autoComplete="off"
+              />
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => reset(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onConfirm(password, totp)}
+            disabled={disabled}
+          >
+            {busy ? "Working..." : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function DataExportCard() {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const [syncing, setSyncing] = useState(false);
+  const [mode, setMode] = useState<ExportMode | null>(null);
+
+  const { data: jobs } = useQuery({
+    queryKey: ["export-jobs"],
+    queryFn: listExportJobs,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      const inflight =
+        Array.isArray(data) &&
+        data.some((j: ExportJob) => j.status === "pending" || j.status === "running");
+      return inflight ? 5000 : false;
+    },
+  });
+
+  const createJob = useMutation({
+    mutationFn: createExportJob,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["export-jobs"] });
+      setMode(null);
+      toast.success(
+        "Export queued — we'll email you when it's ready (also visible here).",
+      );
+    },
+    onError: (e) =>
+      toast.error(e instanceof Error ? e.message : "Failed to queue export"),
+  });
+
+  const fetchAccountData = useMutation({
+    mutationFn: requestAccountData,
+    onSuccess: (data) => {
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `sheaf-account-data-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setMode(null);
+      toast.success("Account data downloaded");
+    },
+    onError: (e) =>
+      toast.error(e instanceof Error ? e.message : "Failed to fetch account data"),
+  });
+
+  async function handleSyncJsonExport() {
+    setSyncing(true);
     try {
       const data = await exportData();
       const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -24,23 +194,144 @@ export function DataExportCard() {
     } catch {
       toast.error("Export failed");
     } finally {
-      setExporting(false);
+      setSyncing(false);
     }
   }
 
+  function handleStepUpConfirm(password: string, totp: string) {
+    if (mode === "with_images") {
+      createJob.mutate({
+        include_images: true,
+        password,
+        totp_code: totp || undefined,
+      });
+    } else if (mode === "account_data") {
+      fetchAccountData.mutate({
+        password,
+        totp_code: totp || undefined,
+      });
+    }
+  }
+
+  const totpEnabled = !!user?.totp_enabled;
+  const busy = createJob.isPending || fetchAccountData.isPending;
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Data export</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground mb-3">
-          Download all your data as a JSON file.
-        </p>
-        <Button onClick={handleExport} variant="outline" disabled={exporting}>
-          {exporting ? "Exporting..." : "Export data"}
-        </Button>
-      </CardContent>
-    </Card>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Data export</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <p className="text-sm text-muted-foreground mb-2 max-w-prose">
+              Download your plural-system content as JSON: members, fronts,
+              groups, tags, custom fields, journals, and revision history.
+              Re-importable into another Sheaf instance via{" "}
+              <strong>Data import</strong> below.
+            </p>
+            <Button
+              onClick={handleSyncJsonExport}
+              variant="outline"
+              disabled={syncing}
+            >
+              {syncing ? "Exporting..." : "Export (JSON only)"}
+            </Button>
+          </div>
+
+          <div className="border-t pt-4">
+            <p className="text-sm text-muted-foreground mb-2 max-w-prose">
+              Full backup including image bytes (avatars, journal embeds,
+              bio history). Builds in the background — typically a few
+              minutes — then we'll email you and show a download button
+              here. The file is available for 72 hours.
+            </p>
+            <p className="text-xs text-muted-foreground mb-3 max-w-prose">
+              Note: importing this zip into another Sheaf instance brings
+              text content (members, journals, etc.) but image attachments
+              need to be re-uploaded by hand. The image bytes are present
+              for your records.
+            </p>
+            <Button onClick={() => setMode("with_images")} variant="outline">
+              Build full backup (with images)
+            </Button>
+          </div>
+
+          <div className="border-t pt-4">
+            <p className="text-sm text-muted-foreground mb-2 max-w-prose">
+              <strong>Account data (GDPR Article 15).</strong> Everything
+              Sheaf knows <em>about</em> your account: identity, sessions,
+              IP addresses, API key audit metadata, email delivery state,
+              pending safety actions, and notification subscriptions. Not
+              re-importable; intended for transparency.
+            </p>
+            <Button onClick={() => setMode("account_data")} variant="outline">
+              Download account data
+            </Button>
+          </div>
+
+          {jobs && jobs.length > 0 && (
+            <div className="border-t pt-4">
+              <p className="text-sm font-medium mb-2">Recent backups</p>
+              <div className="space-y-2">
+                {jobs.map((j) => (
+                  <div
+                    key={j.id}
+                    className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                  >
+                    <div className="flex flex-col">
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(j.requested_at).toLocaleString()}
+                      </span>
+                      <span className="text-xs">
+                        <StatusBadge status={j.status} />{" "}
+                        {j.status === "done" && j.expires_at && (
+                          <span className="text-muted-foreground">
+                            · {formatBytes(j.file_size_bytes)} · expires{" "}
+                            {new Date(j.expires_at).toLocaleString()}
+                          </span>
+                        )}
+                        {j.status === "failed" && j.error && (
+                          <span className="text-destructive"> · {j.error}</span>
+                        )}
+                      </span>
+                    </div>
+                    {j.status === "done" && (
+                      <a
+                        href={exportJobDownloadUrl(j.id)}
+                        className="text-xs underline"
+                      >
+                        Download
+                      </a>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <StepUpDialog
+        open={mode === "with_images"}
+        onOpenChange={(o) => !o && setMode(null)}
+        title="Confirm full backup"
+        description="Re-enter your password to queue a full backup including all your image bytes. This is the highest-value export, so we always require step-up auth."
+        totpEnabled={totpEnabled}
+        busy={busy}
+        onConfirm={handleStepUpConfirm}
+        confirmLabel="Queue export"
+      />
+      <StepUpDialog
+        open={mode === "account_data"}
+        onOpenChange={(o) => !o && setMode(null)}
+        title="Confirm account-data download"
+        description="Re-enter your password to download everything Sheaf knows about your account — sessions, IPs, API key audit, etc. Always step-up gated."
+        totpEnabled={totpEnabled}
+        busy={busy}
+        onConfirm={handleStepUpConfirm}
+        confirmLabel="Download account data"
+      />
+    </>
   );
 }

--- a/web/src/lib/systems.ts
+++ b/web/src/lib/systems.ts
@@ -15,3 +15,50 @@ export function updateMySystem(data: SystemUpdate) {
 export function exportData() {
   return apiFetch<Record<string, unknown>>("/v1/export");
 }
+
+// --- Article 15 + async export jobs ---------------------------------------
+
+export interface ExportJob {
+  id: string;
+  include_images: boolean;
+  status: "pending" | "running" | "done" | "failed" | "expired";
+  requested_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  expires_at: string | null;
+  file_size_bytes: number | null;
+  error: string | null;
+}
+
+export function listExportJobs() {
+  return apiFetch<ExportJob[]>("/v1/export/jobs");
+}
+
+export function createExportJob(body: {
+  include_images: boolean;
+  password: string;
+  totp_code?: string;
+}) {
+  return apiFetch<ExportJob>("/v1/export/jobs", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function exportJobDownloadUrl(id: string): string {
+  // Cookie-auth on the GET means a plain navigation works for both the
+  // S3-redirect and filesystem-stream cases.
+  return `/v1/export/jobs/${id}/download`;
+}
+
+export interface AccountDataRequest {
+  password: string;
+  totp_code?: string;
+}
+
+export function requestAccountData(body: AccountDataRequest) {
+  return apiFetch<Record<string, unknown>>("/v1/account/data", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}


### PR DESCRIPTION
Sheaf had a portable export endpoint (/v1/export, GDPR Article 20) that was missing several user-data classes added since it shipped — journals, content revisions, system safety settings, system preferences, notification config, file inventory. It also had no equivalent for "tell me what you know about my account" (Article 15), and the export couldn't include image bytes which made it useless as a backup. This bundles all three.

Article 20 expansion (sync /v1/export, version bumped to "2"):
- Journal entries with full content + author + visibility + image_keys
- Content revisions for both bio and journal targets, with pinned status
- System Safety settings (grace period, all category toggles, auto-pin)
- Retention overrides (per-system caps on revisions/days/pinned)
- System preferences (replace_fronts_default, date_format, delete_confirmation tier)
- Watch tokens and their notification channels — full filter/trigger/ payload/delivery shaping config, group + member rules. Per-instance state (destination_state, redeemed_at, activation hashes, recipient_management_token_hash, last_delivered_at) and webhook secrets are omitted since they don't survive a re-import anyway
- Uploaded-file inventory (key, size, content type, created_at) — bytes themselves don't ride along with the sync export, but the metadata is portable and lets a re-import know which files existed

Article 15 (POST /v1/account/data, new):
- Account identity (email decrypted to plaintext, signup_ip, registration time, last_login, failed_login_count, locked_until, deletion-pending state, newsletter consent, email delivery state)
- Active sessions (id, ip, user_agent, created_at, last_active)
- Trusted devices (nickname, ip, ua, last_used)
- API key audit (id, name, scopes, created_at, last_used_at, expires_at — never key_hash)
- TOTP enrolment status (enrolled bool — never the secret)
- Email suppression flag if any
- Pending System Safety actions and safety-change requests
- Receiving notification channels (channels other systems are delivering to this account, with system metadata)
- Retention trim notices (history of tier-driven content trims)
- Per-client UI settings rows

Always requires password + TOTP-if-enrolled regardless of the system's delete_confirmation setting — Article 15 is the highest-value read for an attacker with a hijacked session, we don't let users opt out. POST because it carries credentials in the body. Refuses API-key auth entirely — programmatic credentials shouldn't be able to dump sessions, IPs, and API key audit data.

Async export with images (POST /v1/export/jobs, new pipeline):
- ExportJob model + migration tracks pending/running/done/failed/expired state, file_location, size, expiry
- Build worker assembles a zip in the background: same JSON payload as the sync endpoint, plus images/<key> for every UploadedFile owned by the user, plus a README explaining the import asymmetry
- Cleanup worker prunes expired files + marks rows EXPIRED
- Per-user concurrency limit of 1, refuse with 409 when an in-flight job exists
- 72h TTL by default
- Same step-up auth as Article 15 + same API-key refusal

Storage gets dedicated bucket settings (S3_EXPORT_BUCKET, S3_EXPORT_ENDPOINT, S3_EXPORT_PRESIGN_ENDPOINT). All optional, all fall back to the main S3_BUCKET config when unset. Production deployments should use a separate bucket so:
- An S3 lifecycle expiry rule can be set as belt-and-braces with the cleanup worker (if Sheaf's worker silently fails, S3 still cleans up)
- Exports bypass any CDN fronting on the image bucket — cleartext personal data passing through CDN TLS termination is exactly what we don't want even with presigned URLs (signatures prevent caching but bytes still flow through CDN's network) Filesystem mode lives at /app/data/exports/{user_id}/{job_id}.zip.

Don't pass ServerSideEncryption per-object on PUT: MinIO rejects SSE PUTs unless KMS is configured (AWS S3 silently uses bucket default). The right mechanism is bucket default encryption, set once by the operator, applied to every PUT. Documented in SELFHOSTING.md with the aws-cli incantation.

Image re-import asymmetry left intentional: the zip contains JSON references AND image bytes, but the import path accepts JSON only — re-restoring images to a new instance would mean re-keying every image, rewriting image_keys across members/journals/revisions, re-running quota/dedup/virus-scan/EXIF-strip. Demand is low (GDPR and personal backup don't need it). Documented in the export UI and SELFHOSTING.md so users aren't surprised. Tracked as future work for if anyone actually requests it.

Frontend Settings -> Data export grows three actions: sync JSON export (existing), full backup with images (new, password-prompted), download account data (Article 15). Recent backups list polls every 5s while a job is in flight, shows status + size + download link.

Tests cover Article 20 gap fill, Article 15 step-up + API-key refusal, async job lifecycle including concurrency 409 and download-before- ready 409, and zip layout validity. Existing test_export bumped for the version "2" change. README + CLIENT_DESIGN + SELFHOSTING all updated for the new endpoints.
