### PR TITLE
Tag membership: API endpoints, member-side picker, picker filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Tag membership
+
+- New `PUT /v1/tags/{id}/members` and `PUT /v1/members/{id}/tags` (with `GET` siblings) — symmetric m2m endpoints for managing which members carry which tags. Mirrors the existing groups pattern. Closes a real gap: the `Tag.members` relationship existed in the model and tags were already exported with `member_ids`, but no API surface populated the join (only the Sheaf-import service did, via raw SQL).
+- Settings → Members: tag chips on the member view with inline editing.
+- Member picker (start-front dialog and friends): tag filter chips alongside the existing group filter; AND together so you can pick e.g. "everyone in Core *and* tagged creative".
+- Seed script (`scripts/seed_bulk_system.py`) now scatters tags across members.
+
 ### Account & data exports
 
 - `/v1/export` (Article 20, data portability) now includes journal entries, content revisions (bio + journal edit history), system safety settings, retention overrides, system preferences, watch tokens with their notification channels (config only; per-instance state and webhook secrets omitted), and a file inventory listing every uploaded blob's key + size + content type. Bumped to version `2`. Re-importable into another Sheaf instance via the existing import flow.

--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -309,6 +309,10 @@ All resource endpoints require authentication. With API keys, the appropriate sc
 | POST | `/tags` | `tags:write` |
 | PATCH | `/tags/{id}` | `tags:write` |
 | DELETE | `/tags/{id}` | `tags:delete` |
+| GET | `/tags/{id}/members` | `tags:read` |
+| PUT | `/tags/{id}/members` | `tags:write` |
+| GET | `/members/{id}/tags` | `tags:read` |
+| PUT | `/members/{id}/tags` | `tags:write` |
 | GET | `/fields` | `fields:read` |
 | POST | `/fields` | `fields:write` |
 | PATCH | `/fields/{id}` | `fields:write` |

--- a/scripts/seed_bulk_system.py
+++ b/scripts/seed_bulk_system.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Seed a demo account with realistic content for reviewers.
+
+Originally just generated members + groups for UI scale-testing; expanded to
+populate everything a Google Play reviewer (or anyone evaluating Sheaf for
+the first time) would want to navigate: system profile, members with
+markdown bios + pronouns + birthdays + privacy mix, groups, tags, custom
+fields with values on a subset of members, ~30 days of front history, and
+a handful of journals with edit history.
+
+Usage:
+    python3 scripts/seed_bulk_system.py
+
+Environment overrides:
+    SHEAF_URL        default http://localhost:8000
+    SEED_EMAIL       default bulktest@demo.sheaf.sh
+    SEED_PASSWORD    default testing-password-123
+
+If the target instance has REGISTRATION_MODE=approval or EMAIL_VERIFICATION=required,
+approve/verify the account first:
+    docker exec sheaf-db-1 psql -U sheaf -d sheaf -c \\
+        "UPDATE users SET account_status='active', email_verified=true \\
+         WHERE email_hash = (SELECT email_hash FROM users \\
+                             WHERE account_status='pending_approval' \\
+                             ORDER BY created_at DESC LIMIT 1);"
+then re-run the script to populate content.
+"""
+import json
+import os
+import random
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime, timedelta
+
+BASE = os.environ.get("SHEAF_URL", "http://localhost:8000")
+EMAIL = os.environ.get("SEED_EMAIL", "bulktest@demo.sheaf.sh")
+PASSWORD = os.environ.get("SEED_PASSWORD", "testing-password-123")
+
+# Deterministic-ish output so re-runs against a fresh DB produce the same
+# story. Reviewers see consistent state across resets.
+random.seed(0xDEAD)
+
+
+def request(method, path, body=None, token=None):
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(BASE + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            payload = resp.read()
+            return json.loads(payload) if payload else None
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"ERROR {method} {path}: {e.code} {body}", file=sys.stderr)
+        raise
+
+
+def iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Content templates
+# ---------------------------------------------------------------------------
+
+NAMES = [
+    "Alder", "Birch", "Cedar", "Dogwood", "Elm", "Fir", "Ginkgo", "Hazel",
+    "Iris", "Juniper", "Koa", "Linden", "Maple", "Nyssa", "Oak", "Pine",
+    "Quince", "Rowan", "Sumac", "Thuja", "Ulmus", "Vine", "Willow", "Xylia",
+    "Yew", "Zelkova", "Ash", "Beech", "Cypress", "Dahlia", "Ebony", "Fern",
+    "Holly", "Ivy", "Jade", "Kudzu", "Mint", "Nettle",
+    "Orchid", "Poppy", "Quill", "Reed", "Sage", "Tansy",
+]
+
+PRONOUNS_POOL = [
+    "she/her", "he/him", "they/them", "she/they", "he/they",
+    "they/she", "they/he", "xe/xem", "it/its", None, None, None,
+]
+
+BIO_TEMPLATES = [
+    "Bookish, drinks too much tea. Likes maps and well-organised spice racks.",
+    "Loud one. Will pick a fight with a vending machine and lose with style.",
+    "The careful one. Reads instructions, double-checks doors, "
+    "remembers everyone's birthdays.",
+    "**Plant nerd.** Knows every leaf in a five-mile radius by name.\n\n"
+    "Currently obsessed with: ferns, terrariums, the smell of soil.",
+    "Gentle. Soft voice, soft hands, *very* sharp opinions about pasta.",
+    "Loves a long walk. Will tell you about birds whether you asked or not.",
+    "Night owl. Best ideas arrive between 1 and 4 AM, in *exactly that order*.",
+    "The cook. Will feed you whether you're hungry or not.\n\n"
+    "Specialty: anything braised, slowly, on a Sunday.",
+    "Quiet, but the kind of quiet that's listening.",
+    "Energetic morning person. Sorry.",
+    "Studious. Three half-finished journals on the bedside table at any time.",
+    "The protective one. Watches the door, keeps the keys, "
+    "remembers the locksmith's number.",
+    "Whimsical. Believes in the personhood of houseplants.",
+    "Fixer. If something's broken in the house, this one's already on it.",
+]
+
+BIRTHDAY_FORMATS = ["1991-03-14", "1988-11-22", "1995-07-04", None, None, None]
+PRIVACY_LEVELS = [
+    "public", "private", "private", "private",  # bias toward private
+    "friends",
+]
+
+GROUP_SPECS = [
+    ("Core", "#7c3aed", "Members who front regularly.", 12),
+    ("Introjects", "#10b981", "Members based on outside sources.", 8),
+    ("Protectors", "#ef4444", "Members who front during stress / "
+        "emotional intensity.", 6),
+    ("Guests", "#f59e0b", "Members who front rarely or in unusual "
+        "circumstances.", 5),
+    ("Archivists", "#3b82f6", "Members who keep our memory and history.", 7),
+]
+
+TAG_SPECS = [
+    ("primary-fronter", "#7c3aed"),
+    ("rare-fronter", "#94a3b8"),
+    ("co-conscious", "#10b981"),
+    ("trauma-holder", "#ef4444"),
+    ("creative", "#ec4899"),
+    ("logical", "#3b82f6"),
+]
+
+CUSTOM_FIELDS = [
+    ("Role", "text", None),
+    ("Age", "text", None),
+    ("Favourite food", "text", None),
+    (
+        "Comfort level",
+        "select",
+        {"choices": ["high", "medium", "low", "varies"]},
+    ),
+    ("Out to family?", "boolean", None),
+]
+
+ROLE_VALUES = [
+    "host", "co-host", "protector", "caretaker", "child", "scholar",
+    "creative", "fixer", "watcher", "trickster", "guide",
+]
+AGE_VALUES = ["~12", "~16", "~20", "~25", "~30", "~35", "~50", "ageless"]
+FOOD_VALUES = [
+    "ramen", "sourdough", "miso soup", "roasted vegetables", "pho",
+    "chocolate", "fresh bread", "iced coffee", "tea + biscuits",
+]
+
+
+SYSTEM_PROFILE = {
+    "name": "The Sheaf Demo",
+    "description": (
+        "Demo account for evaluating Sheaf. Populated with synthetic "
+        "members, fronts, and journals. Nothing here is real personal "
+        "data — fronters are tree species and bios are templated."
+    ),
+    "tag": "DEMO",
+    "color": "#7c3aed",
+    "privacy": "private",
+    "date_format": "ymd",
+    "replace_fronts_default": True,
+}
+
+
+JOURNAL_ENTRIES = [
+    {
+        "title": "Welcome to the demo",
+        "body": (
+            "## Welcome\n\n"
+            "This is the demo account. Browse around — we've populated "
+            "members, groups, fronts, and journals with synthetic data so "
+            "every screen has something to look at.\n\n"
+            "Try:\n\n"
+            "- The **Members** list with privacy filters\n"
+            "- The **Fronts** screen — there's about a month of switch history\n"
+            "- The **Journals** tab on individual members\n"
+            "- **Settings → System Safety** — see the destructive-action "
+            "grace period in action\n"
+        ),
+        "edits": [
+            "## Welcome\n\nThis is the demo account.",
+            "## Welcome\n\nThis is the demo account. Browse around.",
+        ],
+    },
+    {
+        "title": "Notes on cofronting",
+        "body": (
+            "Two of us today, and the world's a bit louder than usual.\n\n"
+            "It's like having a stereo on — neither voice is wrong, they "
+            "just both want to talk."
+        ),
+    },
+    {
+        "title": "Sleep cycle finally syncing",
+        "body": (
+            "Three weeks of going to bed at a reasonable hour and we're "
+            "finally feeling it. Mornings are no longer the enemy."
+        ),
+    },
+]
+
+
+PER_MEMBER_JOURNAL_TEMPLATES = [
+    "Quiet day. Nothing in particular to report — just here.",
+    "Worked on the garden. The mint is winning the battle for the box "
+    "but we're letting it.",
+    "Long walk this morning. Saw a heron. Took it as a sign.",
+    "Reading that book the others started last week. Not sure I'm a fan "
+    "of the protagonist.",
+    "Finally finished the bookshelf. Photo for the journal would be ideal "
+    "but I forgot to take one.",
+]
+
+
+# ---------------------------------------------------------------------------
+# Front history generation
+# ---------------------------------------------------------------------------
+
+
+def generate_front_history(member_ids: list[str], days: int = 30):
+    """Produce a list of (started_at, member_ids) tuples, in chronological
+    order, for `days` days ending at "now". Mix of solo and cofront.
+
+    The most recent entry is left open (currently fronting) so the front
+    screen has a meaningful "now" state.
+    """
+    events: list[tuple[datetime, list[str]]] = []
+    cursor = datetime.now(UTC) - timedelta(days=days)
+
+    while cursor < datetime.now(UTC) - timedelta(minutes=20):
+        # Switch every 1.5–10 hours
+        gap_hours = random.uniform(1.5, 10)
+        cursor += timedelta(hours=gap_hours)
+
+        # 65% solo, 30% cofront-of-2, 5% cofront-of-3
+        roll = random.random()
+        if roll < 0.65:
+            count = 1
+        elif roll < 0.95:
+            count = 2
+        else:
+            count = 3
+        members = random.sample(member_ids, count)
+        events.append((cursor, members))
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    try:
+        auth = request(
+            "POST",
+            "/v1/auth/register",
+            {"email": EMAIL, "password": PASSWORD, "newsletter_opt_in": False},
+        )
+        print(f"Registered {EMAIL}")
+    except urllib.error.HTTPError:
+        auth = request(
+            "POST",
+            "/v1/auth/login",
+            {"email": EMAIL, "password": PASSWORD},
+        )
+        print(f"Logged in existing {EMAIL}")
+
+    token = auth["access_token"]
+
+    # System profile
+    request("PATCH", "/v1/systems/me", SYSTEM_PROFILE, token)
+    print(f"System profile set: {SYSTEM_PROFILE['name']}")
+
+    # Members
+    member_ids: list[str] = []
+    for i, name in enumerate(NAMES):
+        m = request(
+            "POST",
+            "/v1/members",
+            {
+                "name": name,
+                "description": random.choice(BIO_TEMPLATES),
+                "pronouns": random.choice(PRONOUNS_POOL),
+                "color": random.choice(
+                    [
+                        "#7c3aed", "#10b981", "#f59e0b", "#ef4444",
+                        "#3b82f6", "#ec4899", "#14b8a6", "#f97316",
+                    ]
+                ),
+                "birthday": random.choice(BIRTHDAY_FORMATS),
+                "privacy": random.choice(PRIVACY_LEVELS),
+            },
+            token,
+        )
+        member_ids.append(m["id"])
+        if (i + 1) % 10 == 0:
+            print(f"  ...{i + 1}/{len(NAMES)} members")
+    print(f"Created {len(member_ids)} members")
+
+    # Groups
+    for gname, gcolor, gdesc, count in GROUP_SPECS:
+        g = request(
+            "POST",
+            "/v1/groups",
+            {"name": gname, "color": gcolor, "description": gdesc},
+            token,
+        )
+        chosen = random.sample(member_ids, count)
+        request(
+            "PUT",
+            f"/v1/groups/{g['id']}/members",
+            {"member_ids": chosen},
+            token,
+        )
+        print(f"Group '{gname}' with {count} members")
+
+    # Tags + memberships
+    tag_ids: list[str] = []
+    for tname, tcolor in TAG_SPECS:
+        t = request(
+            "POST",
+            "/v1/tags",
+            {"name": tname, "color": tcolor},
+            token,
+        )
+        tag_ids.append(t["id"])
+    # Scatter ~30-50% of members into each tag, with overlap so tags
+    # behave like real ad-hoc labels rather than partitions.
+    for tag_id in tag_ids:
+        share = random.randint(len(member_ids) // 4, len(member_ids) // 2)
+        chosen = random.sample(member_ids, share)
+        request(
+            "PUT",
+            f"/v1/tags/{tag_id}/members",
+            {"member_ids": chosen},
+            token,
+        )
+    print(f"Created {len(TAG_SPECS)} tags with member assignments")
+
+    # Custom fields + values
+    field_ids: dict[str, str] = {}
+    for order, (fname, ftype, foptions) in enumerate(CUSTOM_FIELDS):
+        body = {
+            "name": fname,
+            "field_type": ftype,
+            "order": order,
+            "privacy": "private",
+        }
+        if foptions:
+            body["options"] = foptions
+        f = request("POST", "/v1/fields", body, token)
+        field_ids[fname] = f["id"]
+    print(f"Created {len(field_ids)} custom fields")
+
+    # Set values on a random ~half of members
+    populated = random.sample(member_ids, len(member_ids) // 2)
+    for mid in populated:
+        values = [
+            {"field_id": field_ids["Role"], "value": random.choice(ROLE_VALUES)},
+            {"field_id": field_ids["Age"], "value": random.choice(AGE_VALUES)},
+            {
+                "field_id": field_ids["Favourite food"],
+                "value": random.choice(FOOD_VALUES),
+            },
+            {
+                "field_id": field_ids["Comfort level"],
+                "value": random.choice(["high", "medium", "low", "varies"]),
+            },
+            {
+                "field_id": field_ids["Out to family?"],
+                "value": random.choice([True, False]),
+            },
+        ]
+        request("PUT", f"/v1/members/{mid}/fields", values, token)
+    print(f"Populated custom-field values on {len(populated)} members")
+
+    # Front history
+    events = generate_front_history(member_ids, days=30)
+    for started_at, mids in events:
+        request(
+            "POST",
+            "/v1/fronts",
+            {
+                "member_ids": mids,
+                "started_at": iso(started_at),
+                "replace_fronts": True,
+            },
+            token,
+        )
+    print(
+        f"Created {len(events)} front events over the last 30 days "
+        f"(latest is currently open)"
+    )
+
+    # Journals — system-wide first
+    for entry in JOURNAL_ENTRIES:
+        j = request(
+            "POST",
+            "/v1/journals",
+            {"title": entry["title"], "body": entry["body"]},
+            token,
+        )
+        # Replay edits to build revision history. The first edit creates
+        # the auto-pinned original, subsequent ones accumulate.
+        for older_body in entry.get("edits", []):
+            request(
+                "PATCH",
+                f"/v1/journals/{j['id']}",
+                {"body": older_body},
+                token,
+            )
+            # Edit it back to the canonical version so the "current" view
+            # matches `body` and the revisions tail captures the journey.
+            request(
+                "PATCH",
+                f"/v1/journals/{j['id']}",
+                {"body": entry["body"]},
+                token,
+            )
+    print(f"Created {len(JOURNAL_ENTRIES)} system-wide journal entries")
+
+    # A few per-member journals on randomly chosen members
+    journaling_members = random.sample(member_ids, 6)
+    for mid in journaling_members:
+        request(
+            "POST",
+            "/v1/journals",
+            {
+                "member_id": mid,
+                "title": None,
+                "body": random.choice(PER_MEMBER_JOURNAL_TEMPLATES),
+            },
+            token,
+        )
+    print(f"Created per-member journals on {len(journaling_members)} members")
+
+    print()
+    print(f"Login: {EMAIL} / {PASSWORD}")
+    print(f"  at: {BASE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.config import settings
@@ -13,6 +14,7 @@ from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
+from sheaf.models.tag import Tag
 from sheaf.models.user import User, UserTier
 from sheaf.schemas.journal import (
     ContentRevisionRead,
@@ -21,7 +23,14 @@ from sheaf.schemas.journal import (
     UnpinRevisionRequest,
     UnpinRevisionResponse,
 )
-from sheaf.schemas.member import MemberCreate, MemberDeleteConfirm, MemberRead, MemberUpdate
+from sheaf.schemas.member import (
+    MemberCreate,
+    MemberDeleteConfirm,
+    MemberRead,
+    MemberTagUpdate,
+    MemberUpdate,
+)
+from sheaf.schemas.tag import TagRead
 from sheaf.services.journals import (
     capture_revision,
     decrypt_revision_for_read,
@@ -228,6 +237,77 @@ async def delete_member(
     await db.delete(member)
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/{member_id}/tags", response_model=list[TagRead])
+async def get_member_tags(
+    member_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the tags this member is currently labelled with."""
+    system = await _get_user_system(user, db)
+    result = await db.execute(
+        select(Member)
+        .options(selectinload(Member.tags))
+        .where(Member.id == member_id, Member.system_id == system.id)
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Member not found"
+        )
+    return sorted(member.tags, key=lambda t: t.name.casefold())
+
+
+@router.put(
+    "/{member_id}/tags",
+    response_model=list[TagRead],
+    dependencies=[Depends(require_scope("tags:write"))],
+)
+async def set_member_tags(
+    member_id: uuid.UUID,
+    body: MemberTagUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Replace this member's full tag set with the body-supplied list.
+
+    Mirrors `PUT /v1/tags/{tag_id}/members` from the other side. Either
+    endpoint can be used to manage the m2m; pick whichever matches the
+    UI you're in (member-edit form vs tag-management page).
+    """
+    system = await _get_user_system(user, db)
+    result = await db.execute(
+        select(Member)
+        .options(selectinload(Member.tags))
+        .where(Member.id == member_id, Member.system_id == system.id)
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Member not found"
+        )
+
+    if body.tag_ids:
+        tag_result = await db.execute(
+            select(Tag).where(
+                Tag.id.in_(body.tag_ids),
+                Tag.system_id == system.id,
+            )
+        )
+        tags = list(tag_result.scalars().all())
+        if len(tags) != len(set(body.tag_ids)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="One or more tag IDs are invalid",
+            )
+    else:
+        tags = []
+
+    member.tags = tags
+    await db.commit()
+    return sorted(tags, key=lambda t: t.name.casefold())
 
 
 @router.get(

--- a/sheaf/api/v1/tags.py
+++ b/sheaf/api/v1/tags.py
@@ -4,15 +4,18 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
+from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
 from sheaf.models.user import User
-from sheaf.schemas.member import MemberDeleteConfirm
-from sheaf.schemas.tag import TagCreate, TagRead, TagUpdate
+from sheaf.schemas.member import MemberDeleteConfirm, MemberRead
+from sheaf.schemas.tag import TagCreate, TagMemberUpdate, TagRead, TagUpdate
+from sheaf.services.members import decrypt_member_for_read
 from sheaf.services.system_safety import (
     is_safeguarded,
     queue_pending_action,
@@ -102,6 +105,73 @@ async def update_tag(
     await db.commit()
     await db.refresh(tag)
     return tag
+
+
+@router.get("/{tag_id}/members", response_model=list[MemberRead])
+async def get_tag_members(
+    tag_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    result = await db.execute(
+        select(Tag)
+        .options(selectinload(Tag.members))
+        .where(Tag.id == tag_id, Tag.system_id == system.id)
+    )
+    tag = result.scalar_one_or_none()
+    if tag is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Tag not found"
+        )
+    return [decrypt_member_for_read(m) for m in tag.members]
+
+
+@router.put(
+    "/{tag_id}/members",
+    response_model=list[MemberRead],
+    dependencies=[Depends(require_scope("tags:write"))],
+)
+async def set_tag_members(
+    tag_id: uuid.UUID,
+    body: TagMemberUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Replace the tag's full member set with the body-supplied list.
+
+    Mirrors `PUT /v1/groups/{group_id}/members` — full-replace semantics
+    keep the API symmetric and avoid subtle bugs around partial updates.
+    For a single add/remove, the caller should fetch first and re-PUT.
+    """
+    system = await _get_user_system(user, db)
+    result = await db.execute(
+        select(Tag)
+        .options(selectinload(Tag.members))
+        .where(Tag.id == tag_id, Tag.system_id == system.id)
+    )
+    tag = result.scalar_one_or_none()
+    if tag is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Tag not found"
+        )
+
+    member_result = await db.execute(
+        select(Member).where(
+            Member.id.in_(body.member_ids),
+            Member.system_id == system.id,
+        )
+    )
+    members = list(member_result.scalars().all())
+    if len(members) != len(set(body.member_ids)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more member IDs are invalid",
+        )
+
+    tag.members = members
+    await db.commit()
+    return [decrypt_member_for_read(m) for m in members]
 
 
 @router.delete(

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -59,6 +59,10 @@ class MemberDeleteConfirm(BaseModel):
     totp_code: str | None = None
 
 
+class MemberTagUpdate(BaseModel):
+    tag_ids: list[uuid.UUID]
+
+
 class MemberRead(BaseModel):
     id: uuid.UUID
     system_id: uuid.UUID

--- a/sheaf/schemas/tag.py
+++ b/sheaf/schemas/tag.py
@@ -23,3 +23,7 @@ class TagRead(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class TagMemberUpdate(BaseModel):
+    member_ids: list[uuid.UUID]

--- a/tests/test_groups_tags.py
+++ b/tests/test_groups_tags.py
@@ -66,3 +66,110 @@ def test_tag_crud(auth_client: httpx.Client):
 
     resp = auth_client.get(f"/v1/tags/{tag_id}")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tag membership (tag-side and member-side endpoints — symmetric m2m)
+# ---------------------------------------------------------------------------
+
+
+def test_set_tag_members(auth_client: httpx.Client):
+    m1 = _create_member(auth_client, "TagMem1")
+    m2 = _create_member(auth_client, "TagMem2")
+    tag_id = auth_client.post("/v1/tags", json={"name": "creative"}).json()["id"]
+
+    resp = auth_client.put(
+        f"/v1/tags/{tag_id}/members",
+        json={"member_ids": [m1, m2]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()) == 2
+
+    listed = auth_client.get(f"/v1/tags/{tag_id}/members")
+    assert listed.status_code == 200
+    assert {m["id"] for m in listed.json()} == {m1, m2}
+
+
+def test_set_tag_members_replaces(auth_client: httpx.Client):
+    """PUT semantics — body replaces the full set, not additive."""
+    m1 = _create_member(auth_client, "TagReplace1")
+    m2 = _create_member(auth_client, "TagReplace2")
+    tag_id = auth_client.post("/v1/tags", json={"name": "label"}).json()["id"]
+
+    auth_client.put(f"/v1/tags/{tag_id}/members", json={"member_ids": [m1, m2]})
+    auth_client.put(f"/v1/tags/{tag_id}/members", json={"member_ids": [m1]})
+
+    listed = auth_client.get(f"/v1/tags/{tag_id}/members").json()
+    assert {m["id"] for m in listed} == {m1}
+
+
+def test_set_tag_members_rejects_unknown_member(auth_client: httpx.Client):
+    import uuid
+
+    tag_id = auth_client.post("/v1/tags", json={"name": "bad"}).json()["id"]
+    resp = auth_client.put(
+        f"/v1/tags/{tag_id}/members",
+        json={"member_ids": [str(uuid.uuid4())]},
+    )
+    assert resp.status_code == 400
+
+
+def test_set_tag_members_clears_with_empty_list(auth_client: httpx.Client):
+    m1 = _create_member(auth_client, "TagClear1")
+    tag_id = auth_client.post("/v1/tags", json={"name": "temp"}).json()["id"]
+
+    auth_client.put(f"/v1/tags/{tag_id}/members", json={"member_ids": [m1]})
+    auth_client.put(f"/v1/tags/{tag_id}/members", json={"member_ids": []})
+
+    listed = auth_client.get(f"/v1/tags/{tag_id}/members").json()
+    assert listed == []
+
+
+def test_member_side_tag_endpoints(auth_client: httpx.Client):
+    """The /v1/members/{id}/tags endpoint is the symmetric counterpart of
+    /v1/tags/{id}/members. Setting from one side should be visible from
+    the other."""
+    member_id = _create_member(auth_client, "MemberTagSide")
+    t1 = auth_client.post("/v1/tags", json={"name": "primary"}).json()["id"]
+    t2 = auth_client.post("/v1/tags", json={"name": "creative"}).json()["id"]
+
+    # Initially no tags.
+    initial = auth_client.get(f"/v1/members/{member_id}/tags").json()
+    assert initial == []
+
+    # Set both via member-side PUT.
+    resp = auth_client.put(
+        f"/v1/members/{member_id}/tags",
+        json={"tag_ids": [t1, t2]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert {t["id"] for t in resp.json()} == {t1, t2}
+
+    # Visible from tag-side GET on either tag.
+    t1_members = auth_client.get(f"/v1/tags/{t1}/members").json()
+    assert any(m["id"] == member_id for m in t1_members)
+
+    # Clear from member side.
+    auth_client.put(
+        f"/v1/members/{member_id}/tags", json={"tag_ids": []}
+    )
+    assert auth_client.get(f"/v1/members/{member_id}/tags").json() == []
+
+    # Set from tag side; member-side GET picks it up.
+    auth_client.put(
+        f"/v1/tags/{t1}/members", json={"member_ids": [member_id]}
+    )
+    assert {t["id"] for t in auth_client.get(
+        f"/v1/members/{member_id}/tags"
+    ).json()} == {t1}
+
+
+def test_member_side_tag_set_rejects_unknown_tag(auth_client: httpx.Client):
+    import uuid
+
+    member_id = _create_member(auth_client, "BadTagSet")
+    resp = auth_client.put(
+        f"/v1/members/{member_id}/tags",
+        json={"tag_ids": [str(uuid.uuid4())]},
+    )
+    assert resp.status_code == 400

--- a/web/src/components/member-select.tsx
+++ b/web/src/components/member-select.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMembers } from "@/hooks/use-members";
 import { useAllGroupMembers, useGroups } from "@/hooks/use-groups";
+import { useAllTagMembers, useTags } from "@/hooks/use-tags";
 import { ColorDot } from "./color-dot";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -21,9 +22,12 @@ export function MemberSelect({
 }: Props) {
   const { data: members } = useMembers();
   const { data: groups } = useGroups();
+  const { data: tags } = useTags();
   const groupMemberMap = useAllGroupMembers();
+  const tagMemberMap = useAllTagMembers();
   const [search, setSearch] = useState("");
   const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+  const [activeTagId, setActiveTagId] = useState<string | null>(null);
 
   if (!members) return null;
 
@@ -37,10 +41,14 @@ export function MemberSelect({
 
   const activeGroupMembers =
     activeGroupId !== null ? groupMemberMap.get(activeGroupId) : null;
+  const activeTagMembers =
+    activeTagId !== null ? tagMemberMap.get(activeTagId) : null;
   const searchLower = search.trim().toLowerCase();
 
   const filtered = members.filter((m) => {
+    // Group + tag filters AND together — "in this group AND tagged this".
     if (activeGroupMembers && !activeGroupMembers.has(m.id)) return false;
+    if (activeTagMembers && !activeTagMembers.has(m.id)) return false;
     if (searchLower) {
       return (
         m.name.toLowerCase().includes(searchLower) ||
@@ -51,6 +59,7 @@ export function MemberSelect({
   });
 
   const hasGroups = showGroupFilter && (groups?.length ?? 0) > 0;
+  const hasTags = showGroupFilter && (tags?.length ?? 0) > 0;
 
   return (
     <div className={cn("space-y-2", className)}>
@@ -61,7 +70,7 @@ export function MemberSelect({
             className="cursor-pointer select-none"
             onClick={() => setActiveGroupId(null)}
           >
-            All
+            All groups
           </Badge>
           {groups!.map((g) => (
             <Badge
@@ -74,6 +83,30 @@ export function MemberSelect({
             >
               {g.color && <ColorDot color={g.color} />}
               {g.name}
+            </Badge>
+          ))}
+        </div>
+      )}
+      {hasTags && (
+        <div className="flex flex-wrap gap-1.5">
+          <Badge
+            variant={activeTagId === null ? "default" : "outline"}
+            className="cursor-pointer select-none"
+            onClick={() => setActiveTagId(null)}
+          >
+            All tags
+          </Badge>
+          {tags!.map((t) => (
+            <Badge
+              key={t.id}
+              variant={activeTagId === t.id ? "default" : "outline"}
+              className="cursor-pointer select-none gap-1.5"
+              onClick={() =>
+                setActiveTagId(activeTagId === t.id ? null : t.id)
+              }
+            >
+              {t.color && <ColorDot color={t.color} />}
+              {t.name}
             </Badge>
           ))}
         </div>

--- a/web/src/hooks/use-tags.ts
+++ b/web/src/hooks/use-tags.ts
@@ -1,4 +1,10 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   isDeleteQueued,
@@ -10,12 +16,51 @@ import * as api from "@/lib/tags";
 
 export const tagKeys = {
   all: ["tags"] as const,
+  members: (id: string) => ["tags", id, "members"] as const,
 };
 
 export function useTags() {
   return useQuery({
     queryKey: tagKeys.all,
     queryFn: api.listTags,
+  });
+}
+
+export function useTagMembers(id: string) {
+  return useQuery({
+    queryKey: tagKeys.members(id),
+    queryFn: () => api.getTagMembers(id),
+  });
+}
+
+export function useAllTagMembers(): Map<string, Set<string>> {
+  const { data: tags } = useTags();
+  const queries = useQueries({
+    queries: (tags ?? []).map((t) => ({
+      queryKey: tagKeys.members(t.id),
+      queryFn: () => api.getTagMembers(t.id),
+    })),
+  });
+  return useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    (tags ?? []).forEach((t, i) => {
+      const members = queries[i]?.data;
+      if (members) map.set(t.id, new Set(members.map((m) => m.id)));
+    });
+    return map;
+  }, [tags, queries]);
+}
+
+export function useSetTagMembers() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, memberIds }: { id: string; memberIds: string[] }) =>
+      api.setTagMembers(id, memberIds),
+    onSuccess: (_, vars) => {
+      qc.invalidateQueries({ queryKey: tagKeys.members(vars.id) });
+      // Member-side tag list is the symmetric view; invalidate broadly.
+      qc.invalidateQueries({ queryKey: ["member"] });
+    },
   });
 }
 

--- a/web/src/lib/members.ts
+++ b/web/src/lib/members.ts
@@ -5,6 +5,7 @@ import type {
   Member,
   MemberCreate,
   MemberUpdate,
+  Tag,
   UnpinRevisionResponse,
 } from "@/types/api";
 import { apiFetch } from "./api-client";
@@ -64,5 +65,16 @@ export function unpinMemberBioRevision(
   return apiFetch<UnpinRevisionResponse>(`/v1/members/${id}/unpin-revision`, {
     method: "POST",
     body: JSON.stringify({ revision_id: revisionId, ...(confirm ?? {}) }),
+  });
+}
+
+export function getMemberTags(id: string) {
+  return apiFetch<Tag[]>(`/v1/members/${id}/tags`);
+}
+
+export function setMemberTags(id: string, tagIds: string[]) {
+  return apiFetch<Tag[]>(`/v1/members/${id}/tags`, {
+    method: "PUT",
+    body: JSON.stringify({ tag_ids: tagIds }),
   });
 }

--- a/web/src/lib/tags.ts
+++ b/web/src/lib/tags.ts
@@ -1,6 +1,7 @@
 import type {
   DeleteResult,
   DestructiveConfirm,
+  Member,
   Tag,
   TagCreate,
   TagUpdate,
@@ -29,5 +30,16 @@ export function deleteTag(id: string, confirm?: DestructiveConfirm) {
   return apiFetch<DeleteResult>(`/v1/tags/${id}`, {
     method: "DELETE",
     ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
+}
+
+export function getTagMembers(id: string) {
+  return apiFetch<Member[]>(`/v1/tags/${id}/members`);
+}
+
+export function setTagMembers(id: string, memberIds: string[]) {
+  return apiFetch<Member[]>(`/v1/tags/${id}/members`, {
+    method: "PUT",
+    body: JSON.stringify({ member_ids: memberIds }),
   });
 }

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -5,14 +5,21 @@ import { useMembers, useCreateMember, useDeleteMember, useUpdateMember } from "@
 import { useCustomFields, useMemberFieldValues, useSetMemberFieldValues } from "@/hooks/use-custom-fields";
 import { getMySystem } from "@/lib/systems";
 import {
+  getMemberTags,
   listMemberBioRevisions,
   pinMemberBioRevision,
   restoreMemberBioRevision,
+  setMemberTags,
   unpinMemberBioRevision,
 } from "@/lib/members";
+import { listTags } from "@/lib/tags";
 import { getSystemSafety } from "@/lib/system-safety";
 import { AvatarUpload } from "@/components/avatar-upload";
+import { Badge } from "@/components/ui/badge";
+import { ColorDot } from "@/components/color-dot";
 import { ContentRevisionList } from "@/components/content-revision-list";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 const BioEditor = lazy(() => import("@/components/bio-editor").then(m => ({ default: m.BioEditor })));
 const MarkdownPreview = lazy(() => import("@/components/bio-editor").then(m => ({ default: m.MarkdownPreview })));
@@ -310,6 +317,115 @@ function DeleteMemberDialog({
   );
 }
 
+function MemberTagsEditor({ memberId }: { memberId: string }) {
+  const qc = useQueryClient();
+  const { data: allTags } = useQuery({ queryKey: ["tags"], queryFn: listTags });
+  const { data: memberTags } = useQuery({
+    queryKey: ["member", memberId, "tags"],
+    queryFn: () => getMemberTags(memberId),
+  });
+  const setTags = useMutation({
+    mutationFn: (tagIds: string[]) => setMemberTags(memberId, tagIds),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["member", memberId, "tags"] });
+      // Tag-side member lists may now disagree with what's on the server,
+      // since editing here is the symmetric counterpart of /v1/tags/{id}/members.
+      qc.invalidateQueries({ queryKey: ["tags"] });
+      setEditing(false);
+      toast.success("Tags updated");
+    },
+    onError: (err) =>
+      toast.error(err instanceof Error ? err.message : "Failed to update tags"),
+  });
+  const [editing, setEditing] = useState(false);
+  const [draftIds, setDraftIds] = useState<string[]>([]);
+
+  const currentIds = memberTags?.map((t) => t.id) ?? [];
+
+  function startEdit() {
+    setDraftIds(currentIds);
+    setEditing(true);
+  }
+
+  function toggle(tagId: string) {
+    setDraftIds((d) =>
+      d.includes(tagId) ? d.filter((id) => id !== tagId) : [...d, tagId],
+    );
+  }
+
+  if (!allTags || allTags.length === 0) {
+    return null; // No tags configured — hide the section entirely.
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs text-muted-foreground">Tags</Label>
+        {!editing ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 text-xs"
+            onClick={startEdit}
+          >
+            Edit
+          </Button>
+        ) : (
+          <div className="flex gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-xs"
+              onClick={() => setEditing(false)}
+              disabled={setTags.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              className="h-6 text-xs"
+              onClick={() => setTags.mutate(draftIds)}
+              disabled={setTags.isPending}
+            >
+              {setTags.isPending ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {editing
+          ? allTags.map((t) => {
+              const selected = draftIds.includes(t.id);
+              return (
+                <Badge
+                  key={t.id}
+                  variant={selected ? "default" : "outline"}
+                  className="cursor-pointer gap-1.5"
+                  onClick={() => toggle(t.id)}
+                >
+                  <ColorDot color={t.color} />
+                  {t.name}
+                </Badge>
+              );
+            })
+          : memberTags && memberTags.length > 0
+            ? memberTags.map((t) => (
+                <Badge key={t.id} variant="outline" className="gap-1.5">
+                  <ColorDot color={t.color} />
+                  {t.name}
+                </Badge>
+              ))
+            : (
+              <span className="text-xs text-muted-foreground">
+                No tags assigned.
+              </span>
+            )}
+      </div>
+    </div>
+  );
+}
+
+
 function MemberView({
   member,
   onEdit,
@@ -441,6 +557,9 @@ function MemberView({
               ))}
             </div>
           )}
+
+          {/* Tags */}
+          <MemberTagsEditor memberId={member.id} />
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- The `Tag.members` m2m relationship existed in the model and tags were already exported with `member_ids`, but no API surface populated the join — only the Sheaf-import service did, via raw SQL. Tags were effectively decorative:
you could create/name/colour them and they showed up nowhere.
- Adds symmetric tag-membership endpoints (mirroring the existing groups pattern), plus the missing UI affordances.

## Changes

### Backend
- `PUT /v1/tags/{id}/members` and `GET /v1/tags/{id}/members` — tag-side full-replace + listing.
- `PUT /v1/members/{id}/tags` and `GET /v1/members/{id}/tags` — member-side, symmetric. Either side can manage the m2m; pick whichever fits the UI you're in.
- Both write endpoints validate IDs are scoped to the caller's system and reject unknown IDs with 400. Both gated by `tags:write`.

### Frontend
- `MemberView` dialog grows a `MemberTagsEditor` section: chips when read-only, multi-select badges when editing. Hides entirely if the system has no tags.
- `MemberSelect` (start-front dialog, etc.) gains an "All tags" filter row alongside the existing "All groups" row. Group + tag filters AND together — pick e.g. "everyone in Core *and* tagged creative".
- `use-tags.ts` hooks mirror the groups pattern (`useTagMembers`, `useAllTagMembers`, `useSetTagMembers`).

### Seed + tests + docs
- `scripts/seed_bulk_system.py` scatters 25-50% of members into each tag with overlap.
- 6 new tests in `test_groups_tags.py` covering both sides + cross-side visibility + clearing + invalid-ID rejection.
- `CLIENT_DESIGN.md` lists the four new endpoints + scopes.


## Testing

<!-- How was this tested? -->

- [x] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Tested manually
