### PR TITLE
Coalesce contiguous fronting across chained entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Coalesce contiguous fronting
+
+- New `system.coalesce_contiguous_fronts` toggle (default on). When a member appears in a chain of back-to-back front entries (e.g. solo &rarr; cofront via `replace_fronts=true`), their "fronting since" walks back to the earliest entry in the chain instead of resetting on each new entry. Surfaced as `Front.member_since` on `/v1/fronts/current` — a per-member-id map of effective fronting-since timestamps. Existing `front.started_at` is unchanged; coalescing is a derived view, not a rewrite.
+- Settings &rarr; Fronting gains a "Coalesce contiguous fronting" toggle.
+- Dashboard and Fronts page badges now show per-member timers ("Alice 8h", "Bob just now") inside each badge instead of one shared "since" at the front level.
+- Bug fix as a side effect: `replace_fronts=true` previously set the auto-ended front's `ended_at` and the new front's `started_at` from two separate `datetime.now()` calls a few ms apart, leaving a tiny gap that this feature would have noticed even without the toggle. Both timestamps are now strictly equal.
+
 ### Tag membership
 
 - New `PUT /v1/tags/{id}/members` and `PUT /v1/members/{id}/tags` (with `GET` siblings) — symmetric m2m endpoints for managing which members carry which tags. Mirrors the existing groups pattern. Closes a real gap: the `Tag.members` relationship existed in the model and tags were already exported with `member_ids`, but no API surface populated the join (only the Sheaf-import service did, via raw SQL).

--- a/alembic/versions/u1v2w3x4y5z6_add_coalesce_contiguous_fronts.py
+++ b/alembic/versions/u1v2w3x4y5z6_add_coalesce_contiguous_fronts.py
@@ -1,0 +1,34 @@
+"""Add coalesce_contiguous_fronts column on systems
+
+Revision ID: u1v2w3x4y5z6
+Revises: t0u1v2w3x4y5
+Create Date: 2026-05-05
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "u1v2w3x4y5z6"
+down_revision = "t0u1v2w3x4y5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("systems")}
+    if "coalesce_contiguous_fronts" not in cols:
+        op.add_column(
+            "systems",
+            sa.Column(
+                "coalesce_contiguous_fronts",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("systems", "coalesce_contiguous_fronts")

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
 from sheaf.models.front import Front
-from sheaf.models.member import Member
+from sheaf.models.member import Member, front_members
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
@@ -37,14 +37,115 @@ async def _get_user_system(user: User, db: AsyncSession) -> System:
     return system
 
 
-def _front_to_read(front: Front) -> FrontRead:
+def _front_to_read(
+    front: Front,
+    *,
+    member_since: dict[str, datetime] | None = None,
+    member_since_capped: list[str] | None = None,
+) -> FrontRead:
+    """Project a Front row to its API shape.
+
+    `member_since` is the per-member effective "fronting since" map.
+    When omitted, defaults to {member_id: front.started_at} for each
+    member — the literal-entry view used by history endpoints and any
+    caller that doesn't want to pay for the walk-back.
+
+    `member_since_capped` lists member ids whose chain hit the
+    walk-back depth limit; the returned timestamp is a lower bound,
+    not the true chain start. Frontends should render those with a
+    "> X ago" prefix to be honest about precision.
+    """
+    if member_since is None:
+        member_since = {str(m.id): front.started_at for m in front.members}
     return FrontRead(
         id=front.id,
         system_id=front.system_id,
         started_at=front.started_at,
         ended_at=front.ended_at,
         member_ids=[m.id for m in front.members],
+        member_since=member_since,
+        member_since_capped=member_since_capped or [],
     )
+
+
+# Walk-back depth cap: pathological cycles aside, real chains are
+# typically 1-3 entries. 500 is a generous bound that prevents a
+# corrupted-data edge case from running unbounded queries while still
+# covering anyone who switches every few minutes for many hours.
+# When the cap *is* hit, the response flags the affected member so the
+# UI can render "> X ago" instead of silently under-reporting. Easy to
+# raise later if the flag actually starts surfacing in real usage.
+_COALESCE_MAX_DEPTH = 500
+
+
+async def _coalesced_started_at(
+    db: AsyncSession,
+    *,
+    system_id: uuid.UUID,
+    member_id: uuid.UUID,
+    starting_at: datetime,
+) -> tuple[datetime, bool]:
+    """Walk back through contiguous front entries for a member.
+
+    A "contiguous chain" links Front rows where member M appears in
+    both, AND the previous front's ended_at exactly matches the next
+    front's started_at. Any gap (or member absence) breaks the chain.
+    Returns (earliest_started_at, capped) — `capped` is True if the
+    walk-back hit the depth limit (chain was longer than the cap and
+    the returned timestamp is a lower bound, not the true chain start).
+    """
+    cursor = starting_at
+    seen: set[uuid.UUID] = set()
+    for _ in range(_COALESCE_MAX_DEPTH):
+        result = await db.execute(
+            select(Front)
+            .join(front_members, front_members.c.front_id == Front.id)
+            .where(
+                Front.system_id == system_id,
+                Front.ended_at == cursor,
+                front_members.c.member_id == member_id,
+            )
+            .limit(1)
+        )
+        prev = result.scalar_one_or_none()
+        if prev is None or prev.id in seen:
+            return cursor, False
+        seen.add(prev.id)
+        cursor = prev.started_at
+    # Loop finished without finding the chain start — there's at least
+    # one more entry beyond what we walked. Caller should display the
+    # timestamp as a lower bound (e.g. "> 8h ago").
+    return cursor, True
+
+
+async def _build_coalesced_member_since(
+    db: AsyncSession, system: System, fronts: list[Front]
+) -> dict[uuid.UUID, tuple[dict[str, datetime], list[str]]]:
+    """For each given front, build (since_map, capped_member_ids).
+
+    When `system.coalesce_contiguous_fronts` is False, returns the
+    literal-entry view for each member with no capped members.
+    Otherwise walks back per member to find the earliest chain start.
+    """
+    out: dict[uuid.UUID, tuple[dict[str, datetime], list[str]]] = {}
+    for front in fronts:
+        per_member: dict[str, datetime] = {}
+        capped: list[str] = []
+        for member in front.members:
+            if system.coalesce_contiguous_fronts:
+                ts, hit_cap = await _coalesced_started_at(
+                    db,
+                    system_id=system.id,
+                    member_id=member.id,
+                    starting_at=front.started_at,
+                )
+                per_member[str(member.id)] = ts
+                if hit_cap:
+                    capped.append(str(member.id))
+            else:
+                per_member[str(member.id)] = front.started_at
+        out[front.id] = (per_member, capped)
+    return out
 
 
 @router.get("", response_model=list[FrontRead])
@@ -78,7 +179,16 @@ async def get_current_fronts(
         .where(Front.system_id == system.id, Front.ended_at.is_(None))
         .order_by(Front.started_at.desc())
     )
-    return [_front_to_read(f) for f in result.scalars().all()]
+    fronts = list(result.scalars().all())
+    member_since_map = await _build_coalesced_member_since(db, system, fronts)
+    return [
+        _front_to_read(
+            f,
+            member_since=member_since_map[f.id][0],
+            member_since_capped=member_since_map[f.id][1],
+        )
+        for f in fronts
+    ]
 
 
 @router.post(
@@ -110,6 +220,14 @@ async def create_front(
 
     before_state = await snapshot_front_state(db, system.id)
 
+    # Compute the new front's started_at up-front so we can use it as the
+    # boundary timestamp for any auto-ended fronts. Strict equality between
+    # f_old.ended_at and f_new.started_at is what `coalesce_contiguous_fronts`
+    # relies on to walk a member back through chained entries — if these
+    # were two separate datetime.now() calls a few ms apart the chain
+    # would always break.
+    new_started_at = body.started_at or datetime.now(UTC)
+
     # Resolve replace_fronts: explicit value beats system default
     should_replace = (
         body.replace_fronts if body.replace_fronts is not None else system.replace_fronts_default
@@ -119,9 +237,8 @@ async def create_front(
             select(Front)
             .where(Front.system_id == system.id, Front.ended_at.is_(None))
         )
-        now = datetime.now(UTC)
         for f in open_fronts.scalars().all():
-            f.ended_at = now
+            f.ended_at = new_started_at
     else:
         # Block exact-set duplicates: if an open front already has this exact
         # member set, two fronts with the same composition has no useful
@@ -147,7 +264,7 @@ async def create_front(
 
     front = Front(
         system_id=system.id,
-        started_at=body.started_at or datetime.now(UTC),
+        started_at=new_started_at,
         members=members,
     )
     db.add(front)

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -65,6 +65,13 @@ class System(UUIDMixin, TimestampMixin, Base):
     replace_fronts_default: Mapped[bool] = mapped_column(
         Boolean, default=True, server_default="true", nullable=False
     )
+    # Display preference: when a member appears in a chain of back-to-back
+    # front entries (e.g. solo -> cofront via replace_fronts), treat their
+    # "fronting since" as the start of the earliest contiguous entry rather
+    # than the literal current entry. Computed read-time, no schema impact.
+    coalesce_contiguous_fronts: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="true", nullable=False
+    )
 
     # System Safety — grace period + per-category toggles for destructive actions.
     # 0 days means no grace; paired with all category toggles off by default.

--- a/sheaf/schemas/front.py
+++ b/sheaf/schemas/front.py
@@ -21,5 +21,18 @@ class FrontRead(BaseModel):
     started_at: datetime
     ended_at: datetime | None
     member_ids: list[uuid.UUID]
+    # Per-member effective "fronting since" timestamp, keyed by member id
+    # (string form). When the system has `coalesce_contiguous_fronts` on
+    # AND the member appears in a chain of back-to-back front entries
+    # ending in this one, this is the earliest started_at in the chain.
+    # Otherwise it's the literal `started_at` of this entry. Only walked
+    # back for open fronts on /v1/fronts/current; closed fronts (history)
+    # always carry the literal value.
+    member_since: dict[str, datetime] = {}
+    # Members whose walk-back hit the safety depth cap. The corresponding
+    # `member_since` entry is a lower bound, not the true chain start.
+    # UIs should render these with a "> X ago" prefix. Empty in the
+    # overwhelming majority of cases — chains are typically 1-3 entries.
+    member_since_capped: list[str] = []
 
     model_config = {"from_attributes": True}

--- a/sheaf/schemas/system.py
+++ b/sheaf/schemas/system.py
@@ -40,6 +40,7 @@ class SystemUpdate(BaseModel):
     privacy: PrivacyLevel | None = None
     date_format: DateFormat | None = None
     replace_fronts_default: bool | None = None
+    coalesce_contiguous_fronts: bool | None = None
 
     @field_validator("avatar_url", mode="before")
     @classmethod
@@ -63,6 +64,7 @@ class SystemRead(BaseModel):
     delete_confirmation: DeleteConfirmation
     date_format: DateFormat
     replace_fronts_default: bool
+    coalesce_contiguous_fronts: bool
     created_at: datetime
     updated_at: datetime
 

--- a/tests/test_fronts_coalesce.py
+++ b/tests/test_fronts_coalesce.py
@@ -1,0 +1,257 @@
+"""Coalesce contiguous fronting: per-member effective fronting-since.
+
+When a member appears in a chain of back-to-back front entries (each
+entry's `ended_at` exactly matches the next entry's `started_at`),
+`/v1/fronts/current` returns each open front with `member_since[mid]`
+set to the earliest started_at in that chain — not the literal entry's
+own started_at.
+
+The toggle lives on `system.coalesce_contiguous_fronts` (default True).
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+
+
+def _create_member(client: httpx.Client, name: str) -> str:
+    r = client.post("/v1/members", json={"name": name})
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _current(client: httpx.Client) -> list[dict]:
+    r = client.get("/v1/fronts/current")
+    assert r.status_code == 200
+    return r.json()
+
+
+def _set_coalesce(client: httpx.Client, on: bool) -> None:
+    r = client.patch(
+        "/v1/systems/me", json={"coalesce_contiguous_fronts": on}
+    )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Single-front baseline: member_since == front.started_at
+# ---------------------------------------------------------------------------
+
+
+def test_single_front_member_since_equals_started_at(auth_client: httpx.Client):
+    a = _create_member(auth_client, "Alice")
+    auth_client.post("/v1/fronts", json={"member_ids": [a]})
+
+    fronts = _current(auth_client)
+    assert len(fronts) == 1
+    front = fronts[0]
+    assert front["member_since"][a] == front["started_at"]
+
+
+# ---------------------------------------------------------------------------
+# Chain across solo -> cofront (replace_fronts=True): coalesce kicks in
+# ---------------------------------------------------------------------------
+
+
+def test_solo_then_cofront_coalesces_for_persisting_member(
+    auth_client: httpx.Client,
+):
+    a = _create_member(auth_client, "Alice")
+    b = _create_member(auth_client, "Bob")
+
+    # Front 1: Alice solo. Capture its started_at.
+    f1 = auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": True}
+    ).json()
+    f1_started = f1["started_at"]
+
+    # Brief sleep so the second front has a clearly later started_at —
+    # otherwise we can't distinguish coalesced (= f1) from literal (= f2).
+    time.sleep(0.05)
+
+    # Front 2: replace_fronts ends f1 at the new started_at, then opens
+    # {Alice, Bob}.
+    auth_client.post(
+        "/v1/fronts",
+        json={"member_ids": [a, b], "replace_fronts": True},
+    )
+
+    fronts = _current(auth_client)
+    assert len(fronts) == 1
+    front = fronts[0]
+
+    # Alice was in both, contiguously: her since walks back to f1.
+    assert front["member_since"][a] == f1_started
+    # Bob is new in this entry; his since is the entry's own started_at.
+    assert front["member_since"][b] == front["started_at"]
+    assert front["member_since"][b] != f1_started
+
+
+def test_chain_extends_past_two_entries(auth_client: httpx.Client):
+    a = _create_member(auth_client, "Alice")
+    b = _create_member(auth_client, "Bob")
+    c = _create_member(auth_client, "Cara")
+
+    f1 = auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": True}
+    ).json()
+    f1_started = f1["started_at"]
+    time.sleep(0.05)
+    auth_client.post(
+        "/v1/fronts",
+        json={"member_ids": [a, b], "replace_fronts": True},
+    )
+    time.sleep(0.05)
+    auth_client.post(
+        "/v1/fronts",
+        json={"member_ids": [a, b, c], "replace_fronts": True},
+    )
+
+    fronts = _current(auth_client)
+    front = fronts[0]
+    # Alice walked through all three -> chain start.
+    assert front["member_since"][a] == f1_started
+    # Bob entered at f2 -> his since is f2's started_at, NOT f1.
+    assert front["member_since"][b] != f1_started
+    assert front["member_since"][b] != front["started_at"]  # he's persisted
+    # Cara just joined -> entry's started_at.
+    assert front["member_since"][c] == front["started_at"]
+
+
+# ---------------------------------------------------------------------------
+# Chain breaks on gap (member leaves and rejoins)
+# ---------------------------------------------------------------------------
+
+
+def test_gap_breaks_chain(auth_client: httpx.Client):
+    """Front 1: Alice. Front 1 ends explicitly (no immediate replacement).
+    Then Front 2: Alice. The gap between f1.ended_at and f2.started_at
+    means no contiguous chain — Alice's since is just f2.started_at."""
+    a = _create_member(auth_client, "Alice")
+
+    f1 = auth_client.post("/v1/fronts", json={"member_ids": [a]}).json()
+    # End f1 explicitly via PATCH (creates a gap before f2).
+    auth_client.patch(
+        f"/v1/fronts/{f1['id']}", json={"ended_at": f1["started_at"]}
+    )
+    time.sleep(0.05)
+
+    f2 = auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": True}
+    ).json()
+
+    fronts = _current(auth_client)
+    front = fronts[0]
+    # No chain — since is f2's own started_at.
+    assert front["member_since"][a] == f2["started_at"]
+
+
+# ---------------------------------------------------------------------------
+# Toggle off: literal entry started_at every time
+# ---------------------------------------------------------------------------
+
+
+def test_toggle_off_disables_coalesce(auth_client: httpx.Client):
+    a = _create_member(auth_client, "Alice")
+    b = _create_member(auth_client, "Bob")
+
+    auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": True}
+    )
+    time.sleep(0.05)
+    auth_client.post(
+        "/v1/fronts",
+        json={"member_ids": [a, b], "replace_fronts": True},
+    )
+
+    # Toggle off — Alice's since should now equal the entry's started_at,
+    # not the chain start.
+    _set_coalesce(auth_client, False)
+
+    fronts = _current(auth_client)
+    front = fronts[0]
+    assert front["member_since"][a] == front["started_at"]
+    assert front["member_since"][b] == front["started_at"]
+
+
+# ---------------------------------------------------------------------------
+# History endpoint: literal entry times always
+# ---------------------------------------------------------------------------
+
+
+def test_history_endpoint_uses_literal_started_at(auth_client: httpx.Client):
+    """The /v1/fronts list endpoint returns historical entries with
+    member_since[mid] == front.started_at — no walk-back. Coalescing
+    is a 'currently fronting' display thing, not a history rewrite."""
+    a = _create_member(auth_client, "Alice")
+    b = _create_member(auth_client, "Bob")
+
+    auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": True}
+    )
+    time.sleep(0.05)
+    auth_client.post(
+        "/v1/fronts",
+        json={"member_ids": [a, b], "replace_fronts": True},
+    )
+
+    history = auth_client.get("/v1/fronts").json()
+    for f in history:
+        for mid, since in f["member_since"].items():
+            assert since == f["started_at"], (
+                f"History endpoint should not coalesce; "
+                f"front {f['id']} member {mid} got {since}, "
+                f"expected {f['started_at']}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Schema field round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_system_read_includes_coalesce_field(auth_client: httpx.Client):
+    sys = auth_client.get("/v1/systems/me").json()
+    assert "coalesce_contiguous_fronts" in sys
+    # Default is True for new systems.
+    assert sys["coalesce_contiguous_fronts"] is True
+
+
+def test_system_patch_round_trips_coalesce_field(auth_client: httpx.Client):
+    auth_client.patch(
+        "/v1/systems/me", json={"coalesce_contiguous_fronts": False}
+    )
+    sys = auth_client.get("/v1/systems/me").json()
+    assert sys["coalesce_contiguous_fronts"] is False
+
+
+# ---------------------------------------------------------------------------
+# replace_fronts auto-ended timestamp alignment (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_replace_fronts_auto_end_aligns_with_new_started_at(
+    auth_client: httpx.Client,
+):
+    """Strict equality between an auto-ended front's `ended_at` and the
+    new front's `started_at` is what coalesce_contiguous_fronts relies on
+    to detect a chain. Earlier code used two separate `datetime.now()`
+    calls, leaving a ms-scale gap that always broke the chain."""
+    a = _create_member(auth_client, "Alice")
+
+    f1_resp = auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": True}
+    )
+    assert f1_resp.status_code == 201
+    f1_id = f1_resp.json()["id"]
+
+    f2 = auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": True}
+    ).json()
+
+    # Find f1 in history with its (now-set) ended_at.
+    history = auth_client.get("/v1/fronts").json()
+    f1 = next(f for f in history if f["id"] == f1_id)
+    assert f1["ended_at"] == f2["started_at"]

--- a/web/src/components/settings/front-preferences-card.tsx
+++ b/web/src/components/settings/front-preferences-card.tsx
@@ -3,15 +3,17 @@ import { getMySystem, updateMySystem } from "@/lib/systems";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import type { SystemUpdate } from "@/types/api";
 import { toast } from "sonner";
 
 export function FrontPreferencesCard() {
   const qc = useQueryClient();
   const { data: system } = useQuery({ queryKey: ["system", "me"], queryFn: getMySystem });
   const update = useMutation({
-    mutationFn: (replace_fronts_default: boolean) => updateMySystem({ replace_fronts_default }),
+    mutationFn: (patch: SystemUpdate) => updateMySystem(patch),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["system", "me"] });
+      qc.invalidateQueries({ queryKey: ["fronts"] });
       toast.success("Front preferences saved");
     },
   });
@@ -23,12 +25,14 @@ export function FrontPreferencesCard() {
       <CardHeader>
         <CardTitle className="text-base">Fronting</CardTitle>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
         <div className="flex items-start gap-3">
           <Checkbox
             id="replace-fronts-default"
             checked={system.replace_fronts_default}
-            onCheckedChange={(v) => update.mutate(v === true)}
+            onCheckedChange={(v) =>
+              update.mutate({ replace_fronts_default: v === true })
+            }
             disabled={update.isPending}
           />
           <div>
@@ -38,6 +42,31 @@ export function FrontPreferencesCard() {
             <p className="text-xs text-muted-foreground mt-0.5">
               This is the default for the "End all current fronts" checkbox in the start front dialog.
               You can override it per front.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="coalesce-contiguous-fronts"
+            checked={system.coalesce_contiguous_fronts}
+            onCheckedChange={(v) =>
+              update.mutate({ coalesce_contiguous_fronts: v === true })
+            }
+            disabled={update.isPending}
+          />
+          <div>
+            <Label
+              htmlFor="coalesce-contiguous-fronts"
+              className="text-sm font-medium cursor-pointer"
+            >
+              Coalesce contiguous fronting
+            </Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Show "fronting since" per member instead of per front entry.
+              When a member is in a chain of back-to-back front entries
+              (e.g. solo &rarr; cofront), their timer reflects the
+              earliest entry rather than resetting on each one.
             </p>
           </div>
         </div>

--- a/web/src/routes/dashboard.tsx
+++ b/web/src/routes/dashboard.tsx
@@ -53,16 +53,20 @@ export function DashboardPage() {
                     <div className="flex flex-wrap items-center gap-2">
                       {front.member_ids.map((mid) => {
                         const m = memberMap.get(mid);
+                        const since =
+                          front.member_since?.[mid] ?? front.started_at;
+                        const capped =
+                          front.member_since_capped?.includes(mid) ?? false;
                         return (
                           <Badge key={mid} variant="secondary" className="gap-1.5">
                             <ColorDot color={m?.color ?? null} />
                             {m?.display_name ?? m?.name ?? "Unknown"}
+                            <span className="text-muted-foreground">
+                              · {capped ? "> " : ""}{timeAgo(since)}
+                            </span>
                           </Badge>
                         );
                       })}
-                      <span className="text-xs text-muted-foreground">
-                        {timeAgo(front.started_at)}
-                      </span>
                     </div>
                     <Button
                       size="sm"

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -16,7 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
-import { formatDateTime } from "@/lib/utils";
+import { formatDateTime, timeAgo } from "@/lib/utils";
 import { getMySystem } from "@/lib/systems";
 
 export function FrontsPage() {
@@ -35,13 +35,24 @@ export function FrontsPage() {
     updateFront.mutate({ id, data: { ended_at: new Date().toISOString() } });
   }
 
-  function renderMembers(memberIds: string[]) {
+  function renderMembers(
+    memberIds: string[],
+    memberSince?: Record<string, string>,
+    cappedIds?: string[],
+  ) {
     return memberIds.map((mid) => {
       const m = memberMap.get(mid);
+      const since = memberSince?.[mid];
+      const capped = cappedIds?.includes(mid) ?? false;
       return (
         <Badge key={mid} variant="secondary" className="gap-1.5">
           <ColorDot color={m?.color ?? null} />
           {m?.display_name ?? m?.name ?? "Unknown"}
+          {since && (
+            <span className="text-muted-foreground">
+              · {capped ? "> " : ""}{timeAgo(since)}
+            </span>
+          )}
         </Badge>
       );
     });
@@ -69,10 +80,11 @@ export function FrontsPage() {
                   className="flex items-center justify-between rounded-md border p-3"
                 >
                   <div className="flex flex-wrap items-center gap-2">
-                    {renderMembers(front.member_ids)}
-                    <span className="text-xs text-muted-foreground">
-                      since {formatDateTime(front.started_at)}
-                    </span>
+                    {renderMembers(
+                      front.member_ids,
+                      front.member_since,
+                      front.member_since_capped,
+                    )}
                   </div>
                   <Button
                     size="sm"

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -52,6 +52,7 @@ export interface System {
   delete_confirmation: DeleteConfirmation;
   date_format: DateFormat;
   replace_fronts_default: boolean;
+  coalesce_contiguous_fronts: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -65,6 +66,7 @@ export interface SystemUpdate {
   privacy?: PrivacyLevel;
   date_format?: DateFormat;
   replace_fronts_default?: boolean;
+  coalesce_contiguous_fronts?: boolean;
 }
 
 export interface Member {
@@ -110,6 +112,18 @@ export interface Front {
   started_at: string;
   ended_at: string | null;
   member_ids: string[];
+  // Per-member effective "fronting since" timestamp, keyed by member id.
+  // For open fronts on /v1/fronts/current with the system's
+  // coalesce_contiguous_fronts toggle on, this walks back through
+  // contiguous front entries (each ending exactly when the next began)
+  // so a member who went solo -> cofront keeps their original
+  // fronting-since instead of resetting on the new entry. Closed-front
+  // history endpoints always return the literal entry started_at here.
+  member_since: Record<string, string>;
+  // Members whose walk-back hit the safety depth cap. The corresponding
+  // `member_since` entry is a lower bound, not the true chain start —
+  // render with a "> X ago" prefix.
+  member_since_capped: string[];
 }
 
 export interface FrontCreate {


### PR DESCRIPTION
## Summary
- When a member appears in a chain of back-to-back front entries (e.g. solo → cofront via `replace_fronts=true`), their "fronting since" used to reset on each new entry. So adding Bob to Alice's front flipped Alice from "8h ago" to "just now" — wrong; she's been here all along.
- Adds `system.coalesce_contiguous_fronts` (default on). The new `Front.member_since` map on `/v1/fronts/current` walks back per member to find the earliest contiguous-chain start. `front.started_at` itself is unchanged — this is a derived view, not a history rewrite.
- Side fix: `replace_fronts=true` previously set the auto-ended front's `ended_at` and the new front's `started_at` from two separate `datetime.now()` calls a few ms apart. Both now come from the same value, so the strict-equality chain link this feature relies on actually holds.

## Changes
- **Backend.** `Front.member_since` is a `dict[member_id_str, datetime]`. `member_since_capped` is the (rare) set of member ids whose walk-back hit the safety depth cap (500) and whose timestamp is therefore a lower bound. Walk-back uses the `front_members` join + strict-equality match on `ended_at`. Toggle off bypasses the walk and returns literal entry timestamps.
- **Frontend.** Settings → Fronting gains the toggle. Dashboard + Fronts page badges show per-member `· timeAgo(since)` inline with a `> ` prefix when capped. History page unchanged.
- **Migration** `u1v2w3x4y5z6` adds the column with `default true`, so existing systems get the new behaviour automatically (which seems clearly correct — old timer behaviour was confusing).

## Test plan
- [ ] `ruff check sheaf/` passes
- [ ] `cd web && npm run lint && npx tsc --noEmit` passes
- [ ] `pytest tests/test_fronts_coalesce.py` passes
- [ ] Start a solo front, then add another member with "End current fronts" checked. Original member's timer should not reset.
- [ ] Toggle off in Settings → Fronting; same scenario should show timer reset on the new entry.
- [ ] End a front explicitly (via Patch), wait, then start a new one with the same member. Timer resets (gap broke the chain).

## Security / privacy impact
None new. Coalescing is a server-side computation over data the user already owns; no new data collected, no new endpoints.