### PR TITLE
Make sidebar collapsible on desktop, drawer on mobile

### DIFF
--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -16,7 +16,11 @@ import {
   Shield,
   BookOpen,
   Bell,
+  PanelLeftClose,
+  PanelLeftOpen,
+  X,
 } from "lucide-react";
+import type { ComponentType } from "react";
 
 const navItems = [
   { to: "/", label: "Dashboard", icon: LayoutDashboard },
@@ -28,146 +32,209 @@ const navItems = [
   { to: "/settings", label: "Settings", icon: Settings },
 ];
 
-export function AppSidebar() {
+const adminItems = [
+  { to: "/admin", label: "Admin", icon: Shield, exact: true, top: true },
+  { to: "/admin/users", label: "Users" },
+  { to: "/admin/approvals", label: "Approvals" },
+  { to: "/admin/invites", label: "Invites" },
+  { to: "/admin/announcements", label: "Announcements" },
+  { to: "/admin/jobs", label: "Jobs" },
+];
+
+export function AppSidebar({
+  collapsed = false,
+  onToggleCollapse,
+  mobileOpen = false,
+  onMobileClose,
+}: {
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
+}) {
   const { user, logout } = useAuth();
   const { theme, toggleTheme } = useTheme();
 
+  // Collapsed-icons-only is a desktop-only convenience. On mobile the
+  // sidebar is shown as a drawer overlay where horizontal space is plentiful,
+  // so always render the full label set there. Forcing isCollapsed=false
+  // whenever the drawer is open (which only happens on mobile, since the
+  // hamburger is md:hidden) handles the case where a user collapsed on
+  // desktop and then opened the same UI on a phone.
+  const isCollapsed = collapsed && !mobileOpen;
+
   return (
-    <aside className="flex h-screen w-56 flex-col border-r bg-sidebar text-sidebar-foreground">
-      <div className="flex h-14 items-center justify-between border-b px-4">
-        <div className="flex items-center gap-2">
-          <Logo className="h-7 w-7 rounded-md" />
-          <span className="text-lg font-semibold tracking-tight">Sheaf</span>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 text-sidebar-foreground/70"
-          onClick={toggleTheme}
-          aria-label="Toggle theme"
-        >
-          {theme === "dark" ? (
-            <Sun className="h-4 w-4" />
-          ) : (
-            <Moon className="h-4 w-4" />
-          )}
-        </Button>
+    <aside
+      className={cn(
+        // Desktop layout: static, in-flow, full height.
+        "flex h-screen flex-col border-r bg-sidebar text-sidebar-foreground transition-[width] duration-150",
+        // Mobile drawer: fixed-positioned overlay, slides in.
+        "fixed inset-y-0 left-0 z-50 md:static",
+        mobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0",
+        "transition-transform md:transition-[width]",
+        isCollapsed ? "w-16" : "w-56",
+      )}
+      aria-hidden={!mobileOpen ? undefined : false}
+    >
+      <div
+        className={cn(
+          "flex h-14 items-center border-b",
+          isCollapsed ? "justify-center px-2" : "justify-between px-4",
+        )}
+      >
+        {!isCollapsed && (
+          <div className="flex items-center gap-2 min-w-0">
+            <Logo className="h-7 w-7 rounded-md shrink-0" />
+            <span className="text-lg font-semibold tracking-tight truncate">
+              Sheaf
+            </span>
+          </div>
+        )}
+        {isCollapsed && <Logo className="h-7 w-7 rounded-md" />}
+        {!isCollapsed && (
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-sidebar-foreground/70"
+              onClick={toggleTheme}
+              aria-label="Toggle theme"
+            >
+              {theme === "dark" ? (
+                <Sun className="h-4 w-4" />
+              ) : (
+                <Moon className="h-4 w-4" />
+              )}
+            </Button>
+            {/* Mobile-only close button */}
+            {onMobileClose && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-sidebar-foreground/70 md:hidden"
+                onClick={onMobileClose}
+                aria-label="Close menu"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        )}
       </div>
-      <nav className="flex-1 space-y-1 p-3">
+      <nav className="flex-1 space-y-1 overflow-y-auto p-3">
         {navItems.map((item) => (
-          <NavLink
+          <SidebarNavLink
             key={item.to}
             to={item.to}
             end={item.to === "/"}
-            className={({ isActive }) =>
-              cn(
-                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                isActive
-                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                  : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
-              )
-            }
-          >
-            <item.icon className="h-4 w-4" />
-            {item.label}
-          </NavLink>
+            label={item.label}
+            icon={item.icon}
+            collapsed={isCollapsed}
+            onClick={onMobileClose}
+          />
         ))}
-        {user?.is_admin && (
-          <>
-            <NavLink
-              to="/admin"
-              end
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
-                )
-              }
-            >
-              <Shield className="h-4 w-4" />
-              Admin
-            </NavLink>
-            <NavLink
-              to="/admin/users"
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md pl-9 pr-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
-                )
-              }
-            >
-              Users
-            </NavLink>
-            <NavLink
-              to="/admin/approvals"
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md pl-9 pr-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
-                )
-              }
-            >
-              Approvals
-            </NavLink>
-            <NavLink
-              to="/admin/invites"
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md pl-9 pr-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
-                )
-              }
-            >
-              Invites
-            </NavLink>
-            <NavLink
-              to="/admin/announcements"
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md pl-9 pr-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
-                )
-              }
-            >
-              Announcements
-            </NavLink>
-            <NavLink
-              to="/admin/jobs"
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md pl-9 pr-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
-                )
-              }
-            >
-              Jobs
-            </NavLink>
-          </>
-        )}
+        {user?.is_admin &&
+          adminItems.map((item) => {
+            // Sub-items are hidden when collapsed: just show the parent
+            // Admin row. Clicking it goes to /admin where the sub-pages
+            // live as tabs anyway.
+            if (isCollapsed && !item.top) return null;
+            return (
+              <SidebarNavLink
+                key={item.to}
+                to={item.to}
+                end={item.exact}
+                label={item.label}
+                icon={item.icon}
+                collapsed={isCollapsed}
+                indented={!item.top}
+                onClick={onMobileClose}
+              />
+            );
+          })}
       </nav>
-      <div className="border-t p-3">
+      <div className="border-t p-3 space-y-1">
+        {/* Desktop-only collapse toggle */}
+        {onToggleCollapse && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "hidden md:flex w-full text-sidebar-foreground/70",
+              isCollapsed ? "justify-center px-0" : "justify-start gap-3",
+            )}
+            onClick={onToggleCollapse}
+            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          >
+            {isCollapsed ? (
+              <PanelLeftOpen className="h-4 w-4" />
+            ) : (
+              <>
+                <PanelLeftClose className="h-4 w-4" />
+                Collapse
+              </>
+            )}
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"
-          className="w-full justify-start gap-3 text-sidebar-foreground/70"
+          className={cn(
+            "w-full text-sidebar-foreground/70",
+            isCollapsed ? "justify-center px-0" : "justify-start gap-3",
+          )}
           onClick={logout}
+          aria-label="Log out"
+          title="Log out"
         >
           <LogOut className="h-4 w-4" />
-          Log out
+          {!isCollapsed && "Log out"}
         </Button>
       </div>
     </aside>
+  );
+}
+
+function SidebarNavLink({
+  to,
+  end,
+  label,
+  icon: Icon,
+  collapsed,
+  indented,
+  onClick,
+}: {
+  to: string;
+  end?: boolean;
+  label: string;
+  icon?: ComponentType<{ className?: string }>;
+  collapsed: boolean;
+  indented?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      onClick={onClick}
+      title={collapsed ? label : undefined}
+      className={({ isActive }) =>
+        cn(
+          "flex items-center rounded-md text-sm font-medium transition-colors",
+          collapsed
+            ? "justify-center px-2 py-2"
+            : indented
+              ? "gap-3 pl-9 pr-3 py-2"
+              : "gap-3 px-3 py-2",
+          isActive
+            ? "bg-sidebar-accent text-sidebar-accent-foreground"
+            : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
+        )
+      }
+    >
+      {Icon && <Icon className="h-4 w-4 shrink-0" />}
+      {!collapsed && <span className="truncate">{label}</span>}
+    </NavLink>
   );
 }

--- a/web/src/routes/_layout.tsx
+++ b/web/src/routes/_layout.tsx
@@ -1,17 +1,44 @@
+import { useEffect, useState } from "react";
 import { Navigate, Outlet } from "react-router";
+import { Menu } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { AppSidebar } from "@/components/app-sidebar";
 import { AccountPending } from "@/components/account-pending";
 import { AnnouncementBanners } from "@/components/announcement-banners";
 import { DeletionBanner } from "@/components/deletion-banner";
 import { LegalFooter } from "@/components/legal-footer";
+import { Logo } from "@/components/logo";
 import { RetentionTrimNoticeBanner } from "@/components/retention-trim-notice-banner";
 import { SystemSafetyBanner } from "@/components/system-safety-banner";
 import { OnboardingPrompt } from "@/components/onboarding-prompt";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+
+const SIDEBAR_COLLAPSED_KEY = "sheaf:sidebarCollapsed";
 
 export function AppLayout() {
   const { user, loading } = useAuth();
+
+  // Mobile drawer state — closed by default. Resets on every page nav
+  // via the onClick handlers passed into the sidebar nav items.
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  // Desktop collapsed-icons state — persisted so it sticks across reloads.
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+    } catch {
+      // localStorage unavailable (private mode etc); just don't persist.
+    }
+  }, [collapsed]);
 
   if (loading) {
     return (
@@ -32,13 +59,40 @@ export function AppLayout() {
 
   return (
     <div className="flex h-screen">
-      <AppSidebar />
+      <AppSidebar
+        collapsed={collapsed}
+        onToggleCollapse={() => setCollapsed((c) => !c)}
+        mobileOpen={mobileOpen}
+        onMobileClose={() => setMobileOpen(false)}
+      />
+      {/* Mobile backdrop — clicking dismisses the drawer */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={() => setMobileOpen(false)}
+          aria-hidden="true"
+        />
+      )}
       <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Mobile-only top bar with hamburger */}
+        <header className="flex h-12 items-center gap-2 border-b bg-background px-3 md:hidden">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={() => setMobileOpen(true)}
+            aria-label="Open menu"
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+          <Logo className="h-6 w-6 rounded-md" />
+          <span className="font-semibold tracking-tight">Sheaf</span>
+        </header>
         <AnnouncementBanners />
         {user.account_status === "pending_deletion" && <DeletionBanner />}
         <SystemSafetyBanner />
         <RetentionTrimNoticeBanner />
-        <main className="flex-1 overflow-auto p-6">
+        <main className="flex-1 overflow-auto p-4 md:p-6">
           <Outlet />
         </main>
         <LegalFooter />


### PR DESCRIPTION
## Summary

The sidebar previously took a fixed 224px regardless of viewport, which made the app borderline unusable on phone widths. This adds:

- A desktop collapse toggle (icons-only at w-16, full at w-56), with the choice persisted in localStorage so it sticks across reloads.
- A mobile drawer pattern: at <md the sidebar is fixed-positioned and off-canvas by default, opened via a hamburger in a new mobile-only top bar, dismissed by the backdrop, an X button, or any nav click.
- Forced full-width labels whenever the drawer is open, so a user who collapsed on desktop and then loads the app on a phone still gets a legible drawer rather than a 64px strip of icons.

Admin sub-items are hidden when collapsed on desktop (only the parent Admin row remains); clicking it lands on /admin where the sub-pages already live as tabs.

## Testing

<!-- How was this tested? -->

- [ ] `ruff check sheaf/` passes
- [x] `cd web && npm run lint && npx tsc --noEmit` passes
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Tested manually

## Security / privacy impact

<!--
Sheaf handles GDPR Article 9 data. If this PR touches authentication,
authorisation, encryption, data storage, or anything user-facing, describe
the impact here. Otherwise, write "none".
-->

## Screenshots

<!-- If this changes the UI, include before/after screenshots -->
