### PR TITLE
Add PluralKit one-shot import (file or live API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### PluralKit import
+
+- New importer accepts both PK data export files (from `pk;export`) and live API pulls using the user's PK token (from `pk;token`). Same preview / options / result schema for both paths so the UI is uniform. Token is forwarded once and never logged or persisted.
+- PK switch events (state-change point-in-time records) are converted to Sheaf front intervals via an oldest-to-newest walk: each switch ends the previous open Front and starts a new one with the resolved member set, with empty member sets handled as "nobody fronting" gaps. Members spanning multiple switches end up in multiple Front records, which the existing coalesce-contiguous-fronts feature reassembles on display.
+- Member migration covers name, display name, color, pronouns, avatar, description, and birthday (including the PK `0004-MM-DD` year-less sentinel collapsed to `MM-DD`). PK's per-field privacy map is collapsed to Sheaf's tri-level `privacy` enum via the overall `visibility` field, falling back to the most-restrictive flag.
+- New nullable `pluralkit_id` column on `members` records each imported member's PK HID, surfaced in the member edit form for users who manually cross-reference between Sheaf and PK.
+- API surface: `POST /v1/import/pluralkit[/preview]` (multipart file) and `POST /v1/import/pluralkit-api[/preview]` (JSON body with token), both gated by the existing `import:write` scope.
+- Frontend: new "Import from PluralKit" card on the import page with a file-or-token sub-flow and switch-range preview.
+
 ### Coalesce contiguous fronting
 
 - New `system.coalesce_contiguous_fronts` toggle (default on). When a member appears in a chain of back-to-back front entries (e.g. solo &rarr; cofront via `replace_fronts=true`), their "fronting since" walks back to the earliest entry in the chain instead of resetting on each new entry. Surfaced as `Front.member_since` on `/v1/fronts/current` — a per-member-id map of effective fronting-since timestamps. Existing `front.started_at` is unchanged; coalescing is a derived view, not a rewrite.

--- a/FAQ.md
+++ b/FAQ.md
@@ -18,6 +18,10 @@ Yes. Sheaf is free and open-source software under the AGPL-3.0 license. You can 
 
 Yes. Export your data from SimplyPlural, then use the import feature in Sheaf. You can choose exactly what to import — specific members, front history, custom fields, groups.
 
+### Can I import from PluralKit?
+
+Yes, both ways: upload a `pk;export` JSON file, or paste the token from `pk;token` to pull live from the PluralKit API. PK's switch log is converted into Sheaf's front-interval model, and each member's PK HID is stored on the imported member so you can keep cross-referencing between the two. Tokens are forwarded once and never stored. See [docs/IMPORT.md](docs/IMPORT.md) for details.
+
 ### Does Sheaf have mobile apps?
 
 Yes, iOS and Android apps are in development.
@@ -88,7 +92,7 @@ Sheaf treats all system data as GDPR Article 9 special category data (data conce
 
 ### What about PluralKit integration?
 
-It's on the roadmap. Bidirectional sync (pushing switches to PK and/or pulling from PK) is planned but needs careful design work.
+One-shot import is supported today (file upload or live API via `pk;token`). Bidirectional sync (pushing switches to PK and/or continuously pulling from PK with conflict resolution) is on the roadmap as a follow-up; it needs careful design work around foreign-ID tracking and merge semantics.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 - **Revision history** — Member bios and journal entries are versioned, with tier-aware retention caps
 - **Revision pinning** — Pin specific revisions to protect them from automatic trim, with optional re-auth + grace on unpin
 - **System Safety** — Optional grace period and re-auth (password / TOTP) on destructive actions (member/journal/group/etc deletion, revision unpin)
-- **SimplyPlural import** — Import your SP export with granular control (select specific members, toggle front history, etc.)
+- **SimplyPlural / PluralKit import** — Import your SP export, your PluralKit export file, or pull live from PluralKit using your `pk;token`. Granular control over what to bring across; PK switch log is converted to Sheaf front intervals. See **[docs/IMPORT.md](docs/IMPORT.md)** for the full migration guide.
 - **File storage** — File uploads with filesystem or S3-compatible backends
 - **Data export** — sync JSON (Article 20 portability), async zip with image bytes, and a separate Article 15 endpoint covering everything we know about your account
 - **2FA** — Optional TOTP with recovery codes
@@ -139,6 +139,8 @@ Key endpoints:
 | `POST /v1/journals/{id}/unpin-revision` | Unpin (immediate or queued behind grace) |
 | `GET/PATCH /v1/system/safety` | System Safety settings + pending actions |
 | `POST /v1/import/simplyplural` | Import SP data |
+| `POST /v1/import/pluralkit` | Import PK export file |
+| `POST /v1/import/pluralkit-api` | Import PK system via token |
 | `POST /v1/import/sheaf` | Import Sheaf export |
 | `GET /v1/export` | Export plural system content (sync JSON) |
 | `POST /v1/export/jobs` | Queue an async backup including image bytes |
@@ -206,6 +208,7 @@ SHEAF_TEST_DB_URL=postgresql+asyncpg://sheaf:<POSTGRES_PASSWORD>@localhost:5432/
 - [ ] CLI similar to [simplyplural-cli](https://github.com/SiteRelEnby/simplyplural-cli)
 - [x] Front-change notifications — web push, webhook (json/discord/slack/plaintext), ntfy, Pushover. Per-channel filters with three-layer member visibility (base + group rules + member overrides), payload sensitivity, debounce, quiet hours.
 - [x] Journals/notes (per-member, encrypted at rest)
+- [x] PluralKit one-shot import (file or live API via `pk;token`)
 - [ ] PluralKit bidirectional sync
 - [ ] Friend/trust system (cross-system visibility controls)
 - [ ] Per-field-per-member privacy overrides

--- a/alembic/versions/v2w3x4y5z6a7_add_pluralkit_id_to_members.py
+++ b/alembic/versions/v2w3x4y5z6a7_add_pluralkit_id_to_members.py
@@ -1,0 +1,29 @@
+"""Add pluralkit_id column on members
+
+Revision ID: v2w3x4y5z6a7
+Revises: u1v2w3x4y5z6
+Create Date: 2026-05-05
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "v2w3x4y5z6a7"
+down_revision = "u1v2w3x4y5z6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("members")}
+    if "pluralkit_id" not in cols:
+        op.add_column(
+            "members",
+            sa.Column("pluralkit_id", sa.String(length=8), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("members", "pluralkit_id")

--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -338,10 +338,18 @@ Uploads can be disabled server-wide (`ALLOW_IMAGE_UPLOADS=false`). When disabled
 
 ### Import/Export
 
+For end-user-facing import documentation (covering how data shapes
+differ between SimplyPlural / PluralKit / Sheaf and what gets mapped
+where), see **[IMPORT.md](IMPORT.md)**.
+
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/import/simplyplural/preview` | Preview SP import |
 | POST | `/import/simplyplural` | Run SP import |
+| POST | `/import/pluralkit/preview` | Preview PK import (file upload) |
+| POST | `/import/pluralkit` | Run PK import (file upload) |
+| POST | `/import/pluralkit-api/preview` | Preview PK import (live API; body `{token}`) |
+| POST | `/import/pluralkit-api` | Run PK import (live API; body `{token, options}`) |
 | POST | `/import/sheaf/preview` | Preview Sheaf import |
 | POST | `/import/sheaf` | Run Sheaf import |
 | GET | `/export` | Export plural system content as JSON (sync, Article 20) |

--- a/docs/IMPORT.md
+++ b/docs/IMPORT.md
@@ -1,0 +1,198 @@
+# Importing data into Sheaf
+
+Sheaf can import from three sources today:
+
+- **SimplyPlural** — JSON export file from your SP account.
+- **PluralKit** — either the JSON file produced by `pk;export`, or a live pull
+  from the PluralKit API using your account token (`pk;token`).
+- **Sheaf** — JSON file produced by `/v1/export`. Use this to restore a backup
+  or migrate between Sheaf instances.
+
+All three flows live at **Settings → Import data** (or directly at `/import`).
+Each one previews what it found before writing anything to your system, so you
+can deselect members or skip front history before committing.
+
+---
+
+## PluralKit import
+
+PluralKit is a Discord-first plural system bot with a different data model
+than SP/Sheaf. The importer reconciles those differences so you can move (or
+mirror) your PK system into Sheaf without losing structure.
+
+### Two ingestion paths
+
+There are two ways to get the data in. Both produce the same result.
+
+**File upload** — DM `pk;export` to PluralKit on Discord. PK replies with a
+JSON attachment. Upload it here. Nothing leaves your browser except the file
+content itself.
+
+**Live API** — Run `pk;token` on Discord. PK DMs you a token. Paste it into
+Sheaf. The token is forwarded once to `api.pluralkit.me`, then dropped:
+
+- It is not written to disk.
+- It is not stored in your browser's localStorage.
+- It is not logged on the server.
+- It is cleared from the import form's React state once the import finishes.
+
+If you'd rather not paste a token at all, use the file upload path instead.
+Both produce the same result.
+
+### What gets imported
+
+| PluralKit data | How it lands in Sheaf |
+|---|---|
+| System name, tag, color, avatar | Filled in **only on fields you've left blank**. Won't overwrite anything you've already set. |
+| Members | Created with name, display name, color, pronouns, avatar URL, description, birthday. Each member's PK HID (e.g. `wyyetr`) is stored in `pluralkit_id` so you can cross-reference between the two. |
+| Member privacy | Collapsed to Sheaf's tri-level `privacy` enum. Uses PK's `visibility` field if present; otherwise falls back to "all-public if every per-field flag is public, else private". |
+| Birthdays with no year | PK uses `0004-MM-DD` as the year-less sentinel. Sheaf collapses these to `MM-DD`. |
+| Groups | Created as Sheaf groups with their member memberships intact. PK groups don't nest, so there's no parent-link pass. |
+| Switches → fronts | The PK switch log is converted to Sheaf front intervals. See below. |
+| Proxy tags | **Not imported.** Sheaf doesn't have a Discord-bridge concept yet; these are PK-bot-only data. |
+| Discord-specific config | Not imported (`tts`, `keep_proxy`, `autoproxy_enabled`, message counts, etc.). |
+| System description | **Not pulled by default.** Sheaf system descriptions are heavily user-styled; silent overwrite at import would be the kind of thing that reads as a bug. Edit it manually if you want PK's description in Sheaf. |
+
+### Switch log → front intervals
+
+PK and Sheaf model fronting differently:
+
+- **PluralKit** records *switches*, point-in-time events that say "from this
+  moment, the fronter set is now {Alice, Bob}". The previous switch is
+  implicitly superseded.
+- **Sheaf** records *front intervals*, each with a `started_at`, optional
+  `ended_at`, and a member set.
+
+The importer walks PK switches **oldest-to-newest** and converts them as
+follows:
+
+```
+PK switches (sorted ascending):
+  09:00  {Alice}
+  10:00  {Alice, Bob}
+  11:00  {Carol}
+  12:00  {}             # nobody fronting
+```
+
+becomes
+
+```
+Sheaf fronts:
+  Front #1: started 09:00, ended 10:00, members [Alice]
+  Front #2: started 10:00, ended 11:00, members [Alice, Bob]
+  Front #3: started 11:00, ended 12:00, members [Carol]
+```
+
+Each new switch closes the previous Front and opens a new one. Empty switches
+(`members: []`) close the previous Front and don't open a new one — they
+preserve "nobody fronting" gaps in your timeline.
+
+A member who fronts continuously across several switches will end up in
+several consecutive Front records. The
+[coalesce-contiguous-fronts](../CHANGELOG.md) feature reassembles them on
+display so the dashboard shows one continuous "fronting since 09:00" rather
+than a fresh start for each switch.
+
+### What you can toggle at import time
+
+The preview screen shows what was found and lets you control:
+
+- **System profile** — copy PK system tag/color/avatar onto Sheaf system if
+  not already set.
+- **Groups** — import groups and their member memberships.
+- **Front history** — off by default. PK switch logs can run thousands of
+  entries; turning this on can take a moment for large systems on the live
+  API path (one paginated request per ~100 switches).
+- **Member selection** — pick exactly which members to bring across. Switches
+  that reference members you deselected are still walked, but those members
+  are silently dropped from the resulting Front records (you'll see a
+  warning).
+
+### Rate limiting & retries
+
+The live API path throttles itself to roughly one paginated request every
+600ms, well under PluralKit's 2 req/sec/token limit. If PK rate-limits us
+anyway (HTTP 429), the import aborts cleanly with an error and nothing is
+written. Retry after a minute.
+
+If your token is rejected (401/403), the importer surfaces a clear error
+without exposing the token in the response.
+
+### Re-running an import
+
+Imports are additive. Running the same import twice will create duplicate
+members, groups, and fronts. There's no de-dup pass against existing
+`pluralkit_id` matches in v1; if you want to refresh from PK, delete the
+old members first or import into a fresh Sheaf system.
+
+A bidirectional PK sync (with conflict resolution and de-dup) is in the
+roadmap as a separate feature on top of one-shot import.
+
+### Things that don't have a PK equivalent
+
+A few Sheaf concepts have no source data in a PK export and stay unset on
+imported members:
+
+- Tags (Sheaf-only; you can add them after).
+- Custom fields and values.
+- Member journals.
+- Member-level "friends" privacy (only public/private maps from PK).
+
+---
+
+## SimplyPlural import
+
+The SP importer parses the JSON file from SP's data export. It supports the
+same preview-then-import flow as PK and covers:
+
+- System profile (name, description, color).
+- Members with avatar, pronouns, color, description, birthday, privacy.
+- Custom fronts (currently imported as members with a description prefix
+  marking them as such — first-class custom-front support is on the roadmap).
+- Custom field definitions and per-member values.
+- Groups with parent hierarchy and member memberships.
+- Front history (off by default; SP exports can be large).
+- Notes are detected but not yet imported (the journal feature has a
+  different data shape; a future migration pass will pull these in).
+
+---
+
+## Sheaf import
+
+For round-trip backups or migrating between instances. Pulls members, fronts,
+groups, tags, custom fields, and journal entries verbatim from a JSON file
+produced by `/v1/export`.
+
+Image bytes are not embedded in the sync JSON export — only S3 keys. A
+re-import on a different instance will keep the keys but won't show the
+images themselves unless those bytes are present in the destination's S3
+bucket. The async `/v1/export/jobs` endpoint produces a zip with image bytes
+included; the import side that consumes those zips is on the roadmap (see
+[CHANGELOG.md](../CHANGELOG.md)).
+
+---
+
+## API surface
+
+All importer endpoints require an authenticated session (or an API key with
+the `import:write` scope) and operate on the caller's own system.
+
+| Method | Path | Body |
+|---|---|---|
+| POST | `/v1/import/simplyplural/preview` | multipart `file` |
+| POST | `/v1/import/simplyplural` | multipart `file` + query options |
+| POST | `/v1/import/pluralkit/preview` | multipart `file` |
+| POST | `/v1/import/pluralkit` | multipart `file` + query options |
+| POST | `/v1/import/pluralkit-api/preview` | JSON `{token}` |
+| POST | `/v1/import/pluralkit-api` | JSON `{token, options}` |
+| POST | `/v1/import/sheaf/preview` | multipart `file` |
+| POST | `/v1/import/sheaf` | multipart `file` + query options |
+
+Each preview endpoint returns a small summary (counts of members, groups,
+switches/fronts, notes; in the PK case also the earliest and latest switch
+timestamps so you can decide whether to opt into front history). The
+non-preview endpoints actually write to the database and return a result
+object with `*_imported` counters and a list of human-readable warnings.
+
+For the option fields supported by each, see the OpenAPI docs at
+`/v1/docs` on your instance.

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -187,6 +187,7 @@ async def export_all(
                 "avatar_url": m.avatar_url,
                 "color": m.color,
                 "birthday": m.birthday,
+                "pluralkit_id": m.pluralkit_id,
                 "privacy": m.privacy.value,
                 "created_at": m.created_at.isoformat(),
             }

--- a/sheaf/api/v1/pk_import.py
+++ b/sheaf/api/v1/pk_import.py
@@ -1,0 +1,192 @@
+"""PluralKit data import endpoints.
+
+Two ingestion paths share a single importer:
+
+  - File: multipart upload of a PK data export JSON. Mirrors SP file import.
+  - API: JSON body containing the user's PK token. We forward the token
+    to PluralKit on a single round of requests, never log it, and never
+    persist it.
+
+Both paths use the same options/preview/result schemas because they
+produce the same canonical PK-shaped dict that the importer consumes.
+"""
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
+from sheaf.models.system import System
+from sheaf.models.user import User
+from sheaf.schemas.pk_import import (
+    PKApiImportRequest,
+    PKApiPreviewRequest,
+    PKImportOptions,
+    PKImportResult,
+    PKPreviewSummary,
+)
+from sheaf.services.pk_api import (
+    PKApiError,
+    fetch_export,
+    fetch_switch_sample,
+)
+from sheaf.services.pk_import import preview as build_preview
+from sheaf.services.pk_import import run_import
+
+logger = logging.getLogger("sheaf.import.pk")
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+MAX_IMPORT_SIZE = 100 * 1024 * 1024  # 100MB — PK exports are tiny but be safe
+
+
+async def _parse_upload(file: UploadFile) -> dict[str, Any]:
+    """Read and parse a PK export JSON file from a multipart upload."""
+    data = await file.read()
+    if len(data) > MAX_IMPORT_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Import file too large. Max 100MB.",
+        )
+    try:
+        parsed = json.loads(data)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid JSON file.",
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Export file does not contain a PluralKit system object.",
+        )
+    return parsed
+
+
+async def _get_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if not system:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Create a system first.",
+        )
+    return system
+
+
+def _options_from_query(
+    system_profile: bool,
+    member_ids: str | None,
+    groups: bool,
+    front_history: bool,
+) -> PKImportOptions:
+    parsed_member_ids: list[str] | None = None
+    if member_ids is not None:
+        parsed_member_ids = [m.strip() for m in member_ids.split(",") if m.strip()]
+    return PKImportOptions(
+        system_profile=system_profile,
+        member_ids=parsed_member_ids,
+        groups=groups,
+        front_history=front_history,
+    )
+
+
+def _api_error_to_http(exc: PKApiError) -> HTTPException:
+    if exc.status_code in (401, 403):
+        return HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc))
+    if exc.status_code == 404:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    if exc.status_code == 429:
+        return HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc))
+    return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+# --- File path ---------------------------------------------------------------
+
+
+@router.post("/pluralkit/preview", response_model=PKPreviewSummary)
+async def preview_file_import(
+    file: UploadFile,
+    _user: User = Depends(get_current_user),
+):
+    """Parse a PK export file and return a summary."""
+    data = await _parse_upload(file)
+    return build_preview(data)
+
+
+@router.post("/pluralkit", response_model=PKImportResult)
+async def do_file_import(
+    file: UploadFile,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    system_profile: bool = True,
+    member_ids: str | None = None,
+    groups: bool = True,
+    front_history: bool = False,
+):
+    """Import data from a PluralKit export file.
+
+    Use the preview endpoint first to see what's in the file and to gather
+    HIDs for the optional member_ids parameter (comma-separated).
+    """
+    data = await _parse_upload(file)
+    system = await _get_system(user, db)
+    options = _options_from_query(system_profile, member_ids, groups, front_history)
+    return await run_import(data, options, system, db)
+
+
+# --- API path ----------------------------------------------------------------
+
+
+@router.post("/pluralkit-api/preview", response_model=PKPreviewSummary)
+async def preview_api_import(
+    body: PKApiPreviewRequest,
+    _user: User = Depends(get_current_user),
+):
+    """Preview an import by reading from the PluralKit API directly.
+
+    The token is request-scoped: we use it for a single round-trip to
+    fetch the system + members + groups + a single page of switches, and
+    drop it on response. Nothing is logged, nothing persisted.
+    """
+    try:
+        # Skip the full-history pull during preview — only one switch page.
+        data = await fetch_export(body.token, include_switches=False)
+        switch_sample, has_more = await fetch_switch_sample(body.token)
+    except PKApiError as exc:
+        raise _api_error_to_http(exc) from exc
+
+    data["switches"] = switch_sample
+    # Surface "100+" via override so the user knows there are more switches
+    # than the preview page sampled.
+    override = len(switch_sample) if not has_more else None
+    summary = build_preview(data, switch_count_override=override)
+    if has_more:
+        # Set the count to the page size; UI will format "100+".
+        summary.switch_count = len(switch_sample)
+    return summary
+
+
+@router.post("/pluralkit-api", response_model=PKImportResult)
+async def do_api_import(
+    body: PKApiImportRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Import a system via the PluralKit API.
+
+    The token is forwarded for the duration of this request and then
+    discarded. Nothing about the token is persisted to the database.
+    """
+    try:
+        data = await fetch_export(body.token, include_switches=body.options.front_history)
+    except PKApiError as exc:
+        raise _api_error_to_http(exc) from exc
+
+    system = await _get_system(user, db)
+    return await run_import(data, body.options, system, db)

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -15,6 +15,7 @@ from sheaf.api.v1 import (
     members,
     notification_channels,
     notifications_public,
+    pk_import,
     retention,
     sheaf_import,
     sp_import,
@@ -92,6 +93,10 @@ v1_router.include_router(
 v1_router.include_router(files.router)
 v1_router.include_router(
     sp_import.router,
+    dependencies=[Depends(require_scope("import:write"))],
+)
+v1_router.include_router(
+    pk_import.router,
     dependencies=[Depends(require_scope("import:write"))],
 )
 v1_router.include_router(

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -78,6 +78,11 @@ class Member(UUIDMixin, TimestampMixin, Base):
     color: Mapped[str | None] = mapped_column(String(7), nullable=True)
     # Stored as "MM-DD" or "YYYY-MM-DD" to support year-optional birthdays
     birthday: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    # PluralKit member HID (5-7 lowercase letters/digits). Stored for users who
+    # cross-reference between Sheaf and PluralKit; populated by the PK import,
+    # editable manually. Not unique within a system; we don't validate against
+    # PluralKit's namespace ourselves.
+    pluralkit_id: Mapped[str | None] = mapped_column(String(8), nullable=True)
     privacy: Mapped[PrivacyLevel] = mapped_column(
         Enum(PrivacyLevel, values_callable=lambda e: [m.value for m in e]),
         default=PrivacyLevel.PRIVATE,

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -20,6 +20,7 @@ class MemberCreate(BaseModel):
     avatar_url: str | None = Field(default=None, max_length=500)
     color: str | None = Field(default=None, max_length=7)
     birthday: str | None = Field(default=None, max_length=10)
+    pluralkit_id: str | None = Field(default=None, max_length=8)
     privacy: PrivacyLevel = PrivacyLevel.PRIVATE
 
     @field_validator("avatar_url", mode="before")
@@ -41,6 +42,7 @@ class MemberUpdate(BaseModel):
     avatar_url: str | None = Field(default=None, max_length=500)
     color: str | None = Field(default=None, max_length=7)
     birthday: str | None = Field(default=None, max_length=10)
+    pluralkit_id: str | None = Field(default=None, max_length=8)
     privacy: PrivacyLevel | None = None
 
     @field_validator("avatar_url", mode="before")
@@ -73,6 +75,7 @@ class MemberRead(BaseModel):
     avatar_url: str | None
     color: str | None
     birthday: str | None
+    pluralkit_id: str | None
     privacy: PrivacyLevel
     created_at: datetime
     updated_at: datetime

--- a/sheaf/schemas/pk_import.py
+++ b/sheaf/schemas/pk_import.py
@@ -1,0 +1,66 @@
+"""Pydantic models for PluralKit data import.
+
+Both ingestion paths (file upload and live API pull) produce the same
+canonical PK-shaped dict, so a single set of schemas describes the
+preview/options/result regardless of source.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class PKImportOptions(BaseModel):
+    """What to import from a PluralKit export."""
+
+    system_profile: bool = True
+    member_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "PK member HIDs to import. None = all. Used to let the user "
+            "deselect specific members on the preview screen."
+        ),
+    )
+    groups: bool = True
+    front_history: bool = False  # Default off — switch logs can run thousands of entries.
+
+
+class PKApiCredentials(BaseModel):
+    """Token-based credentials for the live PluralKit API.
+
+    The token is request-scoped: it lives only for the duration of the
+    request handler and is never logged or persisted. The frontend
+    submits it via HTTPS POST body.
+    """
+
+    token: str = Field(min_length=1, max_length=128)
+
+
+class PKApiPreviewRequest(PKApiCredentials):
+    pass
+
+
+class PKApiImportRequest(PKApiCredentials):
+    options: PKImportOptions = Field(default_factory=PKImportOptions)
+
+
+class PKPreviewMember(BaseModel):
+    id: str  # PK HID
+    name: str
+
+
+class PKPreviewSummary(BaseModel):
+    system_name: str | None = None
+    member_count: int = 0
+    members: list[PKPreviewMember] = []
+    group_count: int = 0
+    switch_count: int = 0
+    earliest_switch: datetime | None = None
+    latest_switch: datetime | None = None
+
+
+class PKImportResult(BaseModel):
+    members_imported: int = 0
+    groups_imported: int = 0
+    fronts_imported: int = 0
+    warnings: list[str] = []

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -49,6 +49,7 @@ def decrypt_member_for_read(member: Member) -> MemberRead:
         "avatar_url": member.avatar_url,
         "color": member.color,
         "birthday": member.birthday,
+        "pluralkit_id": member.pluralkit_id,
         "privacy": member.privacy,
         "created_at": member.created_at,
         "updated_at": member.updated_at,

--- a/sheaf/services/pk_api.py
+++ b/sheaf/services/pk_api.py
@@ -1,0 +1,184 @@
+"""PluralKit live-API fetch.
+
+Pulls a PluralKit system, members, groups, and switches via the public v2
+API and returns them in the same shape as a PK file export, so that the
+single importer in `pk_import.py` can consume either source uniformly.
+
+The supplied token is request-scoped — never logged, never persisted, just
+forwarded to PK on a single request. PK's auth header is the bare token
+(no `Bearer` prefix), per their published API docs.
+
+Rate limiting: PK allows ~2 requests/second per token. We sleep ~600ms
+between page requests to stay comfortably under that, which adds latency
+but avoids the need for any retry/backoff complexity. A system with
+5000 switches paginates as 50 sequential page fetches (~30s); the user
+already understands an "import" can take a moment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from sheaf.config import settings
+
+logger = logging.getLogger("sheaf.import.pk_api")
+
+PK_API_BASE = "https://api.pluralkit.me/v2"
+SWITCHES_PAGE_SIZE = 100
+RATE_LIMIT_DELAY_SECONDS = 0.6
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+class PKApiError(Exception):
+    """Raised when the PluralKit API returns an error or is unreachable."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _user_agent() -> str:
+    # PK asks identifying clients to set a User-Agent. We don't have a
+    # generic instance-contact field, so report Sheaf and link to the
+    # public repo for any abuse follow-up.
+    base_url = getattr(settings, "sheaf_base_url", "") or "https://github.com/sheaf-project/sheaf"
+    return f"Sheaf-PluralKit-Importer ({base_url})"
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": token,
+        "User-Agent": _user_agent(),
+        "Accept": "application/json",
+    }
+
+
+async def _get(client: httpx.AsyncClient, path: str, token: str, **params: Any) -> Any:
+    """Issue one GET against the PK API, mapping HTTP errors to PKApiError."""
+    try:
+        resp = await client.get(
+            f"{PK_API_BASE}{path}",
+            headers=_headers(token),
+            params=params or None,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        raise PKApiError(f"Could not reach PluralKit API: {exc}") from exc
+
+    if resp.status_code == 401:
+        raise PKApiError("PluralKit token rejected (401). Check the token and try again.", 401)
+    if resp.status_code == 403:
+        raise PKApiError("PluralKit denied access (403). The token may lack permission.", 403)
+    if resp.status_code == 404:
+        raise PKApiError("PluralKit returned 404. The system or resource was not found.", 404)
+    if resp.status_code == 429:
+        raise PKApiError("PluralKit rate-limited the import. Try again in a minute.", 429)
+    if resp.status_code >= 500:
+        raise PKApiError(
+            f"PluralKit server error ({resp.status_code}). Try again later.",
+            resp.status_code,
+        )
+    if resp.status_code >= 400:
+        raise PKApiError(
+            f"PluralKit returned {resp.status_code}: {resp.text[:200]}",
+            resp.status_code,
+        )
+
+    try:
+        return resp.json()
+    except ValueError as exc:
+        raise PKApiError("PluralKit returned a non-JSON response.") from exc
+
+
+async def fetch_export(token: str, *, include_switches: bool = True) -> dict:
+    """Pull a complete PK system snapshot, returning it in export-file shape.
+
+    The returned dict has the same top-level keys as a PluralKit data
+    export — `id`, `name`, `members`, `groups`, `switches`, etc. — so the
+    single importer pipeline can consume both file and live-API sources.
+
+    `include_switches=False` skips the (potentially many-paged) switches
+    fetch and is used by the preview endpoint, where we only want a count
+    of pages and a date range. The preview fetches one page and reports
+    `switch_count` as either the exact size when <=100, or "100+" via a
+    flag (see `pk_import.preview`).
+    """
+    async with httpx.AsyncClient() as client:
+        system = await _get(client, "/systems/@me", token)
+        await asyncio.sleep(RATE_LIMIT_DELAY_SECONDS)
+
+        members = await _get(client, "/systems/@me/members", token)
+        await asyncio.sleep(RATE_LIMIT_DELAY_SECONDS)
+
+        groups = await _get(client, "/systems/@me/groups", token, with_members="true")
+        await asyncio.sleep(RATE_LIMIT_DELAY_SECONDS)
+
+        switches: list[dict] = []
+        if include_switches:
+            switches = await _fetch_all_switches(client, token)
+
+    # Reshape into export-file format. PK API returns members/groups/switches
+    # at sibling paths; the export file collapses them into one document.
+    return {
+        **system,
+        "members": members,
+        "groups": groups,
+        "switches": switches,
+        "version": 2,
+    }
+
+
+async def fetch_switch_sample(token: str) -> tuple[list[dict], bool]:
+    """Pull just one page of switches for the preview screen.
+
+    Returns `(switches, has_more)` where `has_more` is true if the page
+    was full (100 entries) and there may be older switches. Lets the
+    preview show "100+" without making the user wait for full pagination.
+    """
+    async with httpx.AsyncClient() as client:
+        page = await _get(
+            client,
+            "/systems/@me/switches",
+            token,
+            limit=SWITCHES_PAGE_SIZE,
+        )
+    if not isinstance(page, list):
+        return [], False
+    return page, len(page) >= SWITCHES_PAGE_SIZE
+
+
+async def _fetch_all_switches(client: httpx.AsyncClient, token: str) -> list[dict]:
+    """Walk PK switch pagination newest-to-oldest until exhausted."""
+    all_switches: list[dict] = []
+    before: str | None = None
+
+    while True:
+        params: dict[str, Any] = {"limit": SWITCHES_PAGE_SIZE}
+        if before is not None:
+            params["before"] = before
+
+        page = await _get(client, "/systems/@me/switches", token, **params)
+        if not isinstance(page, list) or not page:
+            break
+
+        all_switches.extend(page)
+
+        if len(page) < SWITCHES_PAGE_SIZE:
+            break
+
+        # PK pagination: `before` returns switches strictly older than the
+        # given timestamp. The last entry of the current page is the oldest.
+        oldest_ts = page[-1].get("timestamp")
+        if not oldest_ts or oldest_ts == before:
+            # Defensive: if the API ever stops advancing, bail rather than loop.
+            logger.warning("PK switches pagination stalled at %s, stopping.", oldest_ts)
+            break
+        before = oldest_ts
+
+        await asyncio.sleep(RATE_LIMIT_DELAY_SECONDS)
+
+    return all_switches

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -1,0 +1,443 @@
+"""PluralKit data import.
+
+PK exports are JSON documents at the system level. The shape is the same
+for both ingestion paths — uploaded export files and live API pulls —
+because `pk_api.fetch_export` stitches the live response into the export
+file format before handing it to this module.
+
+Top-level keys we use:
+- `name`, `description`, `tag`, `color`, `avatar_url`, `pronouns` — system profile
+- `members` — array of PK member objects (with HID `id`, `uuid`, etc.)
+- `groups` — array of PK group objects (with HIDs and a `members` HID list)
+- `switches` — array of `{timestamp, members: [hid, ...]}` events,
+  newest-first
+
+Switch model conversion is the only non-trivial part. PK records system
+switches as point-in-time events: each switch carries the new fronter set
+and supersedes the previous. Sheaf records front intervals: each Front
+has a started_at, an optional ended_at, and a member set. We walk the
+switch log oldest-to-newest, ending the previous Front at each new
+switch's timestamp and opening a new Front with the new members. Empty
+member sets correspond to "nobody fronting", so they end the previous
+Front without opening a new one. Members spanning multiple consecutive
+switches end up in multiple Front records; the existing
+coalesce-contiguous-fronts feature reassembles them on display.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.crypto import blind_index, encrypt
+from sheaf.models.front import Front
+from sheaf.models.group import Group
+from sheaf.models.member import Member, front_members, group_members
+from sheaf.models.system import PrivacyLevel, System
+from sheaf.schemas.pk_import import (
+    PKImportOptions,
+    PKImportResult,
+    PKPreviewMember,
+    PKPreviewSummary,
+)
+
+logger = logging.getLogger("sheaf.import.pk")
+
+# A PK HID is 5-7 lowercase alphanumeric characters. The String(8) column
+# leaves a byte of slack for any future widening on PK's side.
+_PKID_MAX_LEN = 8
+
+
+def _list(data: dict, key: str) -> list[dict]:
+    """Get a list-typed collection from PK data, defaulting to empty."""
+    value = data.get(key)
+    return value if isinstance(value, list) else []
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Parse a PK ISO-8601 timestamp into an aware datetime, or None."""
+    if not isinstance(value, str):
+        return None
+    try:
+        # PK uses Zulu suffix; fromisoformat accepts +00:00.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def preview(data: dict, *, switch_count_override: int | None = None) -> PKPreviewSummary:
+    """Summarise a PK export for the user before they confirm the import.
+
+    `switch_count_override` lets the live-API preview path inject a
+    minimum-known count when only one page was fetched. The file path
+    leaves it None so the count comes straight from the parsed JSON.
+    """
+    members = _list(data, "members")
+    groups = _list(data, "groups")
+    switches = _list(data, "switches")
+
+    timestamps = [_parse_iso(s.get("timestamp")) for s in switches]
+    timestamps = [t for t in timestamps if t is not None]
+
+    return PKPreviewSummary(
+        system_name=_clean_str(data.get("name")),
+        member_count=len(members),
+        members=[
+            PKPreviewMember(
+                id=str(m.get("id") or ""),
+                name=_clean_str(m.get("name")) or "unnamed",
+            )
+            for m in members
+            if m.get("id")
+        ],
+        group_count=len(groups),
+        switch_count=switch_count_override if switch_count_override is not None else len(switches),
+        earliest_switch=min(timestamps) if timestamps else None,
+        latest_switch=max(timestamps) if timestamps else None,
+    )
+
+
+async def run_import(
+    data: dict,
+    options: PKImportOptions,
+    system: System,
+    db: AsyncSession,
+) -> PKImportResult:
+    """Import a parsed PK export into the user's system."""
+    result = PKImportResult()
+    warnings: list[str] = []
+
+    if options.system_profile:
+        _apply_system_profile(data, system)
+
+    pk_members = _list(data, "members")
+    if options.member_ids is not None:
+        wanted = set(options.member_ids)
+        pk_members = [m for m in pk_members if m.get("id") in wanted]
+
+    hid_to_member: dict[str, Member] = {}
+    for pk_m in pk_members:
+        member = _build_member(pk_m, system.id)
+        if member is None:
+            continue
+        db.add(member)
+        hid = str(pk_m.get("id") or "")
+        if hid:
+            hid_to_member[hid] = member
+        result.members_imported += 1
+
+    await db.flush()
+
+    if options.groups:
+        group_imported = await _import_groups(
+            _list(data, "groups"), system.id, hid_to_member, db
+        )
+        result.groups_imported = group_imported
+
+    if options.front_history:
+        fronts_imported, switch_warnings = await _import_switches(
+            _list(data, "switches"), system.id, hid_to_member, db
+        )
+        result.fronts_imported = fronts_imported
+        warnings.extend(switch_warnings)
+
+    result.warnings = warnings
+    return result
+
+
+# --- System profile ----------------------------------------------------------
+
+
+def _apply_system_profile(data: dict, system: System) -> None:
+    """Copy a few non-destructive fields from the PK system onto Sheaf's.
+
+    We never overwrite a name the user has already set (their Sheaf system
+    name takes priority), but we will fill in optional fields like tag,
+    color, and avatar when they're empty on Sheaf side. PK's `description`
+    is not pulled in by default — Sheaf system descriptions are heavily
+    user-styled and a silent overwrite during import is the kind of thing
+    that reads as a bug. A separate "also import system description"
+    toggle could be added later if anyone asks.
+    """
+    name = _clean_str(data.get("name"))
+    if name and not system.name:
+        system.name = name[:100]
+    tag = _clean_str(data.get("tag"))
+    if tag and not system.tag:
+        system.tag = tag[:8]
+    color = _normalize_color(data.get("color"))
+    if color and not system.color:
+        system.color = color
+    avatar = _clean_str(data.get("avatar_url"))
+    if avatar and not system.avatar_url:
+        system.avatar_url = avatar[:500]
+
+
+# --- Members -----------------------------------------------------------------
+
+
+def _build_member(pk_m: dict, system_id: uuid.UUID) -> Member | None:
+    """Construct a Sheaf Member from a PK member object.
+
+    Returns None if the source row lacks a usable name. Encryption,
+    blind-index, length truncation, and HID truncation all live here.
+    """
+    plaintext_name = _clean_str(pk_m.get("name"))
+    if not plaintext_name:
+        return None
+    plaintext_name = plaintext_name[:100]
+    plaintext_description = _clean_str(pk_m.get("description"))
+
+    pk_hid = _clean_str(pk_m.get("id"))
+
+    return Member(
+        id=uuid.uuid4(),
+        system_id=system_id,
+        name=encrypt(plaintext_name),
+        name_hash=blind_index(plaintext_name),
+        display_name=_truncate(_clean_str(pk_m.get("display_name")), 100),
+        description=encrypt(plaintext_description) if plaintext_description else None,
+        pronouns=_truncate(_clean_str(pk_m.get("pronouns")), 100),
+        avatar_url=_truncate(_clean_str(pk_m.get("avatar_url")), 500),
+        color=_normalize_color(pk_m.get("color")),
+        birthday=_normalize_birthday(pk_m.get("birthday")),
+        pluralkit_id=_truncate(pk_hid, _PKID_MAX_LEN),
+        privacy=_map_privacy(pk_m.get("privacy")),
+    )
+
+
+# --- Groups ------------------------------------------------------------------
+
+
+async def _import_groups(
+    pk_groups: list[dict],
+    system_id: uuid.UUID,
+    hid_to_member: dict[str, Member],
+    db: AsyncSession,
+) -> int:
+    """Create Sheaf Groups from PK groups and wire member associations.
+
+    PK groups don't nest, so there's no parent linking pass. The members
+    list inside each PK group is HIDs; we look them up in hid_to_member
+    and silently drop any that the user deselected during preview.
+    """
+    imported = 0
+    sheaf_groups: list[tuple[dict, Group]] = []
+
+    for pk_g in pk_groups:
+        name = _clean_str(pk_g.get("name"))
+        if not name:
+            continue
+        group = Group(
+            id=uuid.uuid4(),
+            system_id=system_id,
+            name=name[:100],
+            description=_clean_str(pk_g.get("description")),
+            color=_normalize_color(pk_g.get("color")),
+        )
+        db.add(group)
+        sheaf_groups.append((pk_g, group))
+        imported += 1
+
+    if not sheaf_groups:
+        return 0
+
+    await db.flush()
+
+    for pk_g, group in sheaf_groups:
+        # PK exposes group membership in two shapes depending on endpoint:
+        # - The export file inlines `members` as a list of member HIDs.
+        # - The /v2/groups?with_members=true response inlines them as full
+        #   member objects, in which case we still want HIDs.
+        for entry in _list(pk_g, "members"):
+            hid = entry if isinstance(entry, str) else _clean_str(
+                entry.get("id") if isinstance(entry, dict) else None
+            )
+            if not hid:
+                continue
+            member = hid_to_member.get(hid)
+            if not member:
+                continue
+            await db.execute(
+                group_members.insert().values(group_id=group.id, member_id=member.id)
+            )
+
+    return imported
+
+
+# --- Switches → fronts -------------------------------------------------------
+
+
+async def _import_switches(
+    pk_switches: list[dict],
+    system_id: uuid.UUID,
+    hid_to_member: dict[str, Member],
+    db: AsyncSession,
+) -> tuple[int, list[str]]:
+    """Convert PK switch events into Sheaf Front intervals.
+
+    Walking oldest-to-newest, each switch:
+      - ends the previous open Front at this timestamp,
+      - opens a new Front with the resolved member set, unless the switch
+        is empty (= nobody fronting), in which case the gap is preserved.
+
+    Returns `(fronts_imported, warnings)`. The most common warning is
+    "this switch references a member that wasn't imported", typically
+    because the user deselected that member at preview time.
+    """
+    if not pk_switches:
+        return 0, []
+
+    parsed: list[tuple[datetime, list[str]]] = []
+    skipped_no_ts = 0
+    for sw in pk_switches:
+        ts = _parse_iso(sw.get("timestamp"))
+        if ts is None:
+            skipped_no_ts += 1
+            continue
+        members = sw.get("members") or []
+        if not isinstance(members, list):
+            members = []
+        parsed.append((ts, [str(m) for m in members if m]))
+
+    parsed.sort(key=lambda item: item[0])
+
+    warnings: list[str] = []
+    if skipped_no_ts:
+        warnings.append(
+            f"Skipped {skipped_no_ts} switch entries with no timestamp."
+        )
+
+    imported = 0
+    open_front: Front | None = None
+    missing_hids: set[str] = set()
+
+    for ts, hids in parsed:
+        if open_front is not None:
+            open_front.ended_at = ts
+            open_front = None
+
+        if not hids:
+            continue
+
+        members = []
+        for hid in hids:
+            member = hid_to_member.get(hid)
+            if member is None:
+                missing_hids.add(hid)
+                continue
+            members.append(member)
+
+        if not members:
+            # All referenced members were filtered out; treat as "nobody fronting".
+            continue
+
+        front = Front(
+            id=uuid.uuid4(),
+            system_id=system_id,
+            started_at=ts,
+            ended_at=None,
+        )
+        db.add(front)
+        await db.flush()
+        for member in members:
+            await db.execute(
+                front_members.insert().values(front_id=front.id, member_id=member.id)
+            )
+        open_front = front
+        imported += 1
+
+    if missing_hids:
+        warnings.append(
+            f"Skipped {len(missing_hids)} member references in switch history "
+            "that pointed to members not selected for import."
+        )
+
+    return imported, warnings
+
+
+# --- Helpers -----------------------------------------------------------------
+
+
+def _clean_str(value: Any) -> str | None:
+    """Coerce to string, strip whitespace, return None for empty."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    return value or None
+
+
+def _truncate(value: str | None, max_len: int) -> str | None:
+    if value is None:
+        return None
+    return value[:max_len]
+
+
+def _normalize_color(value: Any) -> str | None:
+    """Coerce a PK color (`6c89bb` style) to Sheaf's `#6c89bb` format."""
+    s = _clean_str(value)
+    if not s:
+        return None
+    if s.startswith("#"):
+        s = s[1:]
+    if len(s) != 6:
+        return None
+    if not all(c in "0123456789abcdefABCDEF" for c in s):
+        return None
+    return f"#{s.lower()}"
+
+
+def _normalize_birthday(value: Any) -> str | None:
+    """Accept PK birthday formats (YYYY-MM-DD, possibly 0004-MM-DD as no-year).
+
+    PK uses 0004 as a sentinel year for birthdays where the year is not
+    known. Sheaf supports MM-DD too, so we collapse the sentinel form down.
+    """
+    s = _clean_str(value)
+    if not s:
+        return None
+    # Year-less sentinel: PK stores no-year birthdays as 0004-MM-DD.
+    if s.startswith("0004-") and len(s) == 10:
+        return s[5:]  # MM-DD
+    if len(s) == 10 and s[4] == "-" and s[7] == "-":
+        return s
+    if len(s) == 5 and s[2] == "-":
+        return s
+    return s[:10]
+
+
+def _map_privacy(privacy: Any) -> PrivacyLevel:
+    """Collapse PK's per-field privacy map to Sheaf's tri-level enum.
+
+    PK has fine-grained `name_privacy`, `description_privacy`, etc., each
+    `public` or `private`. Sheaf has a single `privacy` field on the
+    member with three values. We use PK's `visibility` field (the
+    overall member-level flag) when present, falling back to the
+    most-restrictive field-level value if not. Anything that isn't
+    explicitly `public` is treated as private — PK's middle ground
+    `friends_only`-style states don't exist there, so we don't need to
+    map onto Sheaf's `friends` value automatically.
+    """
+    if not isinstance(privacy, dict):
+        # PK export defaults to "private" historically when no privacy
+        # block is present.
+        return PrivacyLevel.PRIVATE
+    visibility = privacy.get("visibility")
+    if visibility == "public":
+        return PrivacyLevel.PUBLIC
+    if visibility == "private":
+        return PrivacyLevel.PRIVATE
+    # Fallback: most-restrictive of the field-level flags.
+    flags = [
+        v for k, v in privacy.items()
+        if k.endswith("_privacy") and isinstance(v, str)
+    ]
+    if flags and all(v == "public" for v in flags):
+        return PrivacyLevel.PUBLIC
+    return PrivacyLevel.PRIVATE

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -141,6 +141,7 @@ async def run_import(
             avatar_url=_trunc(m_data.get("avatar_url"), 500),
             color=_trunc(m_data.get("color"), 7),
             birthday=_trunc(m_data.get("birthday"), 10),
+            pluralkit_id=_trunc(m_data.get("pluralkit_id"), 8),
             privacy=_privacy(m_data.get("privacy")),
         )
         db.add(member)

--- a/tests/fixtures/pk_export_sample.json
+++ b/tests/fixtures/pk_export_sample.json
@@ -1,0 +1,114 @@
+{
+  "version": 2,
+  "id": "exsysa",
+  "uuid": "11111111-1111-1111-1111-111111111111",
+  "name": "Test PK System",
+  "description": "Imported via test fixture.",
+  "tag": "tst",
+  "color": "ffaa00",
+  "avatar_url": "https://cdn.pluralkit.example/sys/exsysa.webp",
+  "pronouns": null,
+  "banner": null,
+  "created": "2024-01-01T00:00:00Z",
+  "privacy": {
+    "name_privacy": "public",
+    "avatar_privacy": "public",
+    "description_privacy": "public",
+    "banner_privacy": "public",
+    "pronoun_privacy": "public",
+    "member_list_privacy": "public",
+    "group_list_privacy": "public",
+    "front_privacy": "public",
+    "front_history_privacy": "public"
+  },
+  "config": {},
+  "accounts": [],
+  "webhook_url": null,
+  "members": [
+    {
+      "id": "alice",
+      "uuid": "22222222-2222-2222-2222-222222222222",
+      "name": "Alice",
+      "display_name": "Alice the First",
+      "color": "ff0000",
+      "birthday": "1990-04-15",
+      "pronouns": "she/her",
+      "avatar_url": "https://cdn.pluralkit.example/m/alice.webp",
+      "description": "First test member.",
+      "created": "2024-01-01T00:00:00Z",
+      "proxy_tags": [{"prefix": "a:", "suffix": null}],
+      "privacy": {
+        "visibility": "public",
+        "name_privacy": "public",
+        "description_privacy": "public",
+        "birthday_privacy": "public",
+        "pronoun_privacy": "public",
+        "avatar_privacy": "public",
+        "metadata_privacy": "public",
+        "proxy_privacy": "public"
+      }
+    },
+    {
+      "id": "bobxyz",
+      "uuid": "33333333-3333-3333-3333-333333333333",
+      "name": "Bob",
+      "display_name": null,
+      "color": "00ff00",
+      "birthday": "0004-07-20",
+      "pronouns": "he/him",
+      "avatar_url": null,
+      "description": null,
+      "created": "2024-01-02T00:00:00Z",
+      "proxy_tags": [],
+      "privacy": {
+        "visibility": "private",
+        "name_privacy": "private",
+        "description_privacy": "private"
+      }
+    },
+    {
+      "id": "carol1",
+      "uuid": "44444444-4444-4444-4444-444444444444",
+      "name": "Carol",
+      "display_name": null,
+      "color": "0000ff",
+      "birthday": null,
+      "pronouns": null,
+      "avatar_url": null,
+      "description": null,
+      "created": "2024-01-03T00:00:00Z",
+      "proxy_tags": [],
+      "privacy": {
+        "visibility": "public"
+      }
+    }
+  ],
+  "groups": [
+    {
+      "id": "grp001",
+      "uuid": "55555555-5555-5555-5555-555555555555",
+      "name": "Inner Circle",
+      "description": "A small group.",
+      "color": "888888",
+      "members": ["alice", "bobxyz"]
+    }
+  ],
+  "switches": [
+    {
+      "timestamp": "2025-01-04T12:00:00.000000Z",
+      "members": []
+    },
+    {
+      "timestamp": "2025-01-04T11:00:00.000000Z",
+      "members": ["carol1"]
+    },
+    {
+      "timestamp": "2025-01-04T10:00:00.000000Z",
+      "members": ["alice", "bobxyz"]
+    },
+    {
+      "timestamp": "2025-01-04T09:00:00.000000Z",
+      "members": ["alice"]
+    }
+  ]
+}

--- a/tests/test_pk_import.py
+++ b/tests/test_pk_import.py
@@ -1,0 +1,251 @@
+"""Integration tests for the PluralKit data importer.
+
+These tests cover the file-upload path end-to-end via the public HTTP
+API. The live-API path (which would forward a real PK token to
+api.pluralkit.me) is not exercised here — that path's behaviour is
+tested at the unit level in test_pk_import_unit.py.
+
+The fixture in tests/fixtures/pk_export_sample.json is a small, synthetic
+PK export designed to cover:
+  - mixed public/private members
+  - a member with a year-less PK birthday (0004-MM-DD sentinel)
+  - a group referencing two of the three members
+  - a switch log that exercises join, leave, replace, and "nobody fronting"
+    transitions
+"""
+
+import json
+import pathlib
+
+import httpx
+import pytest
+
+FIXTURE_PATH = pathlib.Path(__file__).parent / "fixtures" / "pk_export_sample.json"
+
+
+@pytest.fixture
+def pk_export_bytes() -> bytes:
+    return FIXTURE_PATH.read_bytes()
+
+
+@pytest.fixture
+def pk_export() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _upload(client: httpx.Client, path: str, payload: bytes, **params):
+    return client.post(
+        path,
+        files={"file": ("pk_export.json", payload, "application/json")},
+        params=params,
+    )
+
+
+# --- Preview path ------------------------------------------------------------
+
+
+def test_preview_summarises_export(auth_client: httpx.Client, pk_export_bytes: bytes):
+    resp = _upload(auth_client, "/v1/import/pluralkit/preview", pk_export_bytes)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["system_name"] == "Test PK System"
+    assert data["member_count"] == 3
+    assert data["group_count"] == 1
+    assert data["switch_count"] == 4
+    hids = {m["id"] for m in data["members"]}
+    assert hids == {"alice", "bobxyz", "carol1"}
+
+
+def test_preview_rejects_invalid_json(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/import/pluralkit/preview",
+        files={"file": ("not_json.json", b"this is not json", "application/json")},
+    )
+    assert resp.status_code == 400
+
+
+def test_preview_rejects_non_object(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/import/pluralkit/preview",
+        files={"file": ("array.json", b"[1, 2, 3]", "application/json")},
+    )
+    assert resp.status_code == 400
+
+
+# --- Default import (members + groups; no front history by default) ---------
+
+
+def test_import_default_creates_members_and_groups(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    resp = _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
+    assert resp.status_code == 200, resp.text
+    result = resp.json()
+    assert result["members_imported"] == 3
+    assert result["groups_imported"] == 1
+    assert result["fronts_imported"] == 0  # front_history default is False
+    assert result["warnings"] == []
+
+    members = auth_client.get("/v1/members").json()
+    by_name = {m["name"]: m for m in members}
+    assert set(by_name) == {"Alice", "Bob", "Carol"}
+
+
+def test_import_populates_pluralkit_id(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
+    members = auth_client.get("/v1/members").json()
+    by_name = {m["name"]: m for m in members}
+    assert by_name["Alice"]["pluralkit_id"] == "alice"
+    assert by_name["Bob"]["pluralkit_id"] == "bobxyz"
+    assert by_name["Carol"]["pluralkit_id"] == "carol1"
+
+
+def test_import_maps_per_field_data(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
+    members = auth_client.get("/v1/members").json()
+    alice = next(m for m in members if m["name"] == "Alice")
+    assert alice["display_name"] == "Alice the First"
+    assert alice["pronouns"] == "she/her"
+    assert alice["color"] == "#ff0000"
+    assert alice["birthday"] == "1990-04-15"
+    assert alice["privacy"] == "public"
+
+
+def test_import_collapses_year_less_birthday(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    """PK uses 0004-MM-DD as the year-less sentinel; we collapse to MM-DD."""
+    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
+    members = auth_client.get("/v1/members").json()
+    bob = next(m for m in members if m["name"] == "Bob")
+    assert bob["birthday"] == "07-20"
+
+
+def test_import_resolves_visibility_to_privacy_enum(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
+    members = auth_client.get("/v1/members").json()
+    by_name = {m["name"]: m for m in members}
+    assert by_name["Alice"]["privacy"] == "public"
+    assert by_name["Bob"]["privacy"] == "private"
+    assert by_name["Carol"]["privacy"] == "public"
+
+
+def test_import_groups_link_correct_members(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
+    groups = auth_client.get("/v1/groups").json()
+    assert len(groups) == 1
+    inner = groups[0]
+    assert inner["name"] == "Inner Circle"
+    members = auth_client.get(f"/v1/groups/{inner['id']}/members").json()
+    names = sorted(m["name"] for m in members)
+    assert names == ["Alice", "Bob"]
+
+
+# --- Front history path ------------------------------------------------------
+
+
+def test_import_with_front_history_emits_intervals(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    """The four-switch fixture should produce three intervals once converted.
+
+    Switch log oldest-to-newest:
+      09:00  alice
+      10:00  alice + bobxyz   <- Front #1 (alice solo) ends here, Front #2 starts
+      11:00  carol1            <- Front #2 ends here, Front #3 starts
+      12:00  []                <- Front #3 ends here (nobody fronting)
+    """
+    resp = _upload(
+        auth_client,
+        "/v1/import/pluralkit",
+        pk_export_bytes,
+        front_history="true",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["fronts_imported"] == 3
+
+    fronts = auth_client.get("/v1/fronts").json()
+    members = auth_client.get("/v1/members").json()
+    name_by_id = {m["id"]: m["name"] for m in members}
+
+    fronts_sorted = sorted(fronts, key=lambda f: f["started_at"])
+    assert len(fronts_sorted) == 3
+
+    first, second, third = fronts_sorted
+    assert {name_by_id[mid] for mid in first["member_ids"]} == {"Alice"}
+    assert first["ended_at"] is not None  # closed by next switch
+
+    assert {name_by_id[mid] for mid in second["member_ids"]} == {"Alice", "Bob"}
+    assert second["ended_at"] is not None
+
+    assert {name_by_id[mid] for mid in third["member_ids"]} == {"Carol"}
+    # Last switch was "nobody fronting", so the third Front is closed too.
+    assert third["ended_at"] is not None
+
+
+# --- Selective import (member_ids filter) ------------------------------------
+
+
+def test_member_ids_filter_drops_unselected(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    resp = _upload(
+        auth_client,
+        "/v1/import/pluralkit",
+        pk_export_bytes,
+        member_ids="alice,carol1",
+    )
+    assert resp.status_code == 200
+    result = resp.json()
+    assert result["members_imported"] == 2
+
+    names = sorted(m["name"] for m in auth_client.get("/v1/members").json())
+    assert names == ["Alice", "Carol"]
+
+
+def test_filter_warns_when_switches_reference_dropped_members(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    """Switches mentioning Bob should produce a warning, not a hard error,
+    when Bob was deselected at preview time."""
+    resp = _upload(
+        auth_client,
+        "/v1/import/pluralkit",
+        pk_export_bytes,
+        member_ids="alice,carol1",
+        front_history="true",
+    )
+    assert resp.status_code == 200
+    result = resp.json()
+    # The Alice + Bob switch becomes effectively Alice-only after filtering,
+    # which means we still get three intervals; only the warning differs.
+    assert any("not selected" in w.lower() for w in result["warnings"])
+
+
+# --- System-profile copy -----------------------------------------------------
+
+
+def test_system_profile_does_not_overwrite_existing_name(
+    auth_client: httpx.Client, pk_export_bytes: bytes
+):
+    """If the user already named their Sheaf system, leave it alone."""
+    auth_client.patch("/v1/systems/me", json={"name": "Existing Name"})
+    _upload(
+        auth_client,
+        "/v1/import/pluralkit",
+        pk_export_bytes,
+        system_profile="true",
+    )
+    system = auth_client.get("/v1/systems/me").json()
+    assert system["name"] == "Existing Name"
+    # The PK tag/color did fill in (since they were unset).
+    assert system["tag"] == "tst"
+    assert system["color"] == "#ffaa00"

--- a/tests/test_pk_import_unit.py
+++ b/tests/test_pk_import_unit.py
@@ -1,0 +1,127 @@
+"""Unit tests for PluralKit import helpers.
+
+These exercise the pure-Python normalisation and switch-conversion
+helpers without needing a running server or database. The integration
+tests in test_pk_import.py cover the full end-to-end path.
+"""
+
+from datetime import UTC, datetime
+
+from sheaf.models.system import PrivacyLevel
+from sheaf.services.pk_import import (
+    _map_privacy,
+    _normalize_birthday,
+    _normalize_color,
+    _parse_iso,
+    preview,
+)
+
+
+def test_normalize_color_strips_hash_and_lowercases():
+    assert _normalize_color("FF00AA") == "#ff00aa"
+    assert _normalize_color("#abcdef") == "#abcdef"
+    assert _normalize_color("  6c89bb  ") == "#6c89bb"
+
+
+def test_normalize_color_rejects_invalid():
+    assert _normalize_color("nope") is None
+    assert _normalize_color("12345") is None  # Too short
+    assert _normalize_color("zzzzzz") is None  # Non-hex
+    assert _normalize_color("") is None
+    assert _normalize_color(None) is None
+
+
+def test_normalize_birthday_collapses_year_less_sentinel():
+    assert _normalize_birthday("0004-07-20") == "07-20"
+
+
+def test_normalize_birthday_passes_through_full_date():
+    assert _normalize_birthday("1990-04-15") == "1990-04-15"
+
+
+def test_normalize_birthday_passes_through_md_only():
+    assert _normalize_birthday("04-15") == "04-15"
+
+
+def test_normalize_birthday_truncates_garbage():
+    assert _normalize_birthday("totally not a date string") == "totally no"
+    assert _normalize_birthday("") is None
+    assert _normalize_birthday(None) is None
+
+
+def test_map_privacy_uses_visibility_when_present():
+    assert _map_privacy({"visibility": "public"}) == PrivacyLevel.PUBLIC
+    assert _map_privacy({"visibility": "private"}) == PrivacyLevel.PRIVATE
+
+
+def test_map_privacy_falls_back_to_field_flags_when_no_visibility():
+    # All fields public => member is public
+    privacy = {
+        "name_privacy": "public",
+        "description_privacy": "public",
+    }
+    assert _map_privacy(privacy) == PrivacyLevel.PUBLIC
+
+    # Mixed => private (most-restrictive wins)
+    privacy = {
+        "name_privacy": "public",
+        "description_privacy": "private",
+    }
+    assert _map_privacy(privacy) == PrivacyLevel.PRIVATE
+
+
+def test_map_privacy_defaults_to_private_for_missing_block():
+    # No privacy info at all => assume private (PK historical default).
+    assert _map_privacy(None) == PrivacyLevel.PRIVATE
+    assert _map_privacy({}) == PrivacyLevel.PRIVATE
+
+
+def test_parse_iso_accepts_zulu_and_offset():
+    expected = datetime(2025, 1, 4, 12, 0, tzinfo=UTC)
+    assert _parse_iso("2025-01-04T12:00:00Z") == expected
+    assert _parse_iso("2025-01-04T12:00:00+00:00") == expected
+
+
+def test_parse_iso_returns_none_for_garbage():
+    assert _parse_iso(None) is None
+    assert _parse_iso("not-a-timestamp") is None
+    assert _parse_iso(123) is None
+
+
+def test_preview_summarises_minimal_export():
+    data = {
+        "name": "Tiny",
+        "members": [{"id": "alpha", "name": "Alpha"}],
+        "groups": [],
+        "switches": [
+            {"timestamp": "2025-01-01T10:00:00Z", "members": ["alpha"]},
+            {"timestamp": "2025-01-01T11:00:00Z", "members": []},
+        ],
+    }
+    summary = preview(data)
+    assert summary.system_name == "Tiny"
+    assert summary.member_count == 1
+    assert summary.members[0].id == "alpha"
+    assert summary.members[0].name == "Alpha"
+    assert summary.switch_count == 2
+    assert summary.earliest_switch == datetime(2025, 1, 1, 10, 0, tzinfo=UTC)
+    assert summary.latest_switch == datetime(2025, 1, 1, 11, 0, tzinfo=UTC)
+
+
+def test_preview_handles_missing_collections():
+    data = {"name": "Empty"}
+    summary = preview(data)
+    assert summary.system_name == "Empty"
+    assert summary.member_count == 0
+    assert summary.group_count == 0
+    assert summary.switch_count == 0
+    assert summary.earliest_switch is None
+    assert summary.latest_switch is None
+
+
+def test_preview_count_override_respects_paged_api_preview():
+    """The live-API preview path can pass an explicit override when only
+    a single page of switches was sampled."""
+    data = {"switches": [{"timestamp": "2025-01-01T10:00:00Z", "members": []}]}
+    summary = preview(data, switch_count_override=42)
+    assert summary.switch_count == 42

--- a/web/src/components/settings/data-import-card.tsx
+++ b/web/src/components/settings/data-import-card.tsx
@@ -10,7 +10,8 @@ export function DataImportCard() {
       </CardHeader>
       <CardContent>
         <p className="text-sm text-muted-foreground mb-3">
-          Supported formats: SimplyPlural, Sheaf
+          Supported sources: SimplyPlural (export file), PluralKit (export file
+          or live API via your <code>pk;token</code>), Sheaf (export file).
         </p>
         <Link to="/import">
           <Button variant="outline">Import data</Button>

--- a/web/src/lib/pk-import.ts
+++ b/web/src/lib/pk-import.ts
@@ -1,0 +1,83 @@
+import { apiFetch } from "./api-client";
+
+export interface PKPreviewMember {
+  id: string;
+  name: string;
+}
+
+export interface PKPreviewSummary {
+  system_name: string | null;
+  member_count: number;
+  members: PKPreviewMember[];
+  group_count: number;
+  switch_count: number;
+  earliest_switch: string | null;
+  latest_switch: string | null;
+}
+
+export interface PKImportResult {
+  members_imported: number;
+  groups_imported: number;
+  fronts_imported: number;
+  warnings: string[];
+}
+
+export interface PKImportOptions {
+  system_profile: boolean;
+  member_ids: string[] | null;
+  groups: boolean;
+  front_history: boolean;
+}
+
+// --- File path ---------------------------------------------------------------
+
+export async function previewImportFromFile(file: File): Promise<PKPreviewSummary> {
+  const form = new FormData();
+  form.append("file", file);
+  return apiFetch<PKPreviewSummary>("/v1/import/pluralkit/preview", {
+    method: "POST",
+    headers: {},
+    body: form,
+  });
+}
+
+export async function runImportFromFile(
+  file: File,
+  options: PKImportOptions,
+): Promise<PKImportResult> {
+  const params = new URLSearchParams();
+  params.set("system_profile", String(options.system_profile));
+  params.set("groups", String(options.groups));
+  params.set("front_history", String(options.front_history));
+  if (options.member_ids !== null) {
+    params.set("member_ids", options.member_ids.join(","));
+  }
+
+  const form = new FormData();
+  form.append("file", file);
+
+  return apiFetch<PKImportResult>(`/v1/import/pluralkit?${params.toString()}`, {
+    method: "POST",
+    headers: {},
+    body: form,
+  });
+}
+
+// --- API path ----------------------------------------------------------------
+
+export async function previewImportFromApi(token: string): Promise<PKPreviewSummary> {
+  return apiFetch<PKPreviewSummary>("/v1/import/pluralkit-api/preview", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  });
+}
+
+export async function runImportFromApi(
+  token: string,
+  options: PKImportOptions,
+): Promise<PKImportResult> {
+  return apiFetch<PKImportResult>("/v1/import/pluralkit-api", {
+    method: "POST",
+    body: JSON.stringify({ token, options }),
+  });
+}

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -17,9 +17,19 @@ import {
   previewSheafImport,
   runSheafImport,
 } from "@/lib/sheaf-import";
+import {
+  type PKPreviewSummary,
+  type PKImportResult,
+  previewImportFromFile as previewPKFile,
+  runImportFromFile as runPKFile,
+  previewImportFromApi as previewPKApi,
+  runImportFromApi as runPKApi,
+} from "@/lib/pk-import";
+import { Input } from "@/components/ui/input";
 
-type Source = "choose" | "sheaf" | "sp";
+type Source = "choose" | "sheaf" | "sp" | "pk";
 type Step = "upload" | "preview" | "importing" | "done";
+type PKMethod = "choose" | "file" | "api";
 
 export function ImportPage() {
   const [source, setSource] = useState<Source>("choose");
@@ -33,6 +43,9 @@ export function ImportPage() {
       )}
       {source === "sp" && (
         <SPImportFlow onBack={() => setSource("choose")} />
+      )}
+      {source === "pk" && (
+        <PKImportFlow onBack={() => setSource("choose")} />
       )}
     </>
   );
@@ -65,6 +78,20 @@ function SourcePicker({ onSelect }: { onSelect: (s: Source) => void }) {
         <CardContent>
           <p className="text-sm text-muted-foreground">
             Import from a SimplyPlural data export (JSON).
+          </p>
+        </CardContent>
+      </Card>
+      <Card
+        className="cursor-pointer hover:border-primary transition-colors"
+        onClick={() => onSelect("pk")}
+      >
+        <CardHeader>
+          <CardTitle className="text-base">Import from PluralKit</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Pull from your PluralKit account using a token (the same one you
+            use for <code>pk;token</code>), or upload a PK data export file.
           </p>
         </CardContent>
       </Card>
@@ -452,6 +479,304 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
               )}
               {result.custom_fields_imported > 0 && (
                 <div>Custom fields: <strong>{result.custom_fields_imported}</strong></div>
+              )}
+            </div>
+            <Warnings warnings={result.warnings} />
+            <Button onClick={() => navigate("/members")} className="w-full">
+              View members
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PluralKit import flow
+// ---------------------------------------------------------------------------
+
+function PKImportFlow({ onBack }: { onBack: () => void }) {
+  const navigate = useNavigate();
+  const [method, setMethod] = useState<PKMethod>("choose");
+  const [step, setStep] = useState<Step>("upload");
+  const [file, setFile] = useState<File | null>(null);
+  // Token lives only in component state; we never persist it. Kept in a
+  // ref-discipline mental model: read on submit, then implicitly discarded
+  // when the user navigates away or finishes the flow.
+  const [token, setToken] = useState<string>("");
+  const [preview, setPreview] = useState<PKPreviewSummary | null>(null);
+  const [result, setResult] = useState<PKImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [systemProfile, setSystemProfile] = useState(true);
+  const [allMembers, setAllMembers] = useState(true);
+  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set());
+  const [groups, setGroups] = useState(true);
+  const [frontHistory, setFrontHistory] = useState(false);
+
+  async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+    setError(null);
+    try {
+      const p = await previewPKFile(f);
+      setPreview(p);
+      setStep("preview");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to parse file");
+    }
+  }
+
+  async function handleApiPreview() {
+    if (!token.trim()) {
+      setError("Enter your PluralKit token first.");
+      return;
+    }
+    setError(null);
+    try {
+      const p = await previewPKApi(token);
+      setPreview(p);
+      setStep("preview");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not reach PluralKit");
+    }
+  }
+
+  async function handleImport() {
+    setStep("importing");
+    setError(null);
+    const options = {
+      system_profile: systemProfile,
+      member_ids: allMembers ? null : Array.from(selectedMembers),
+      groups,
+      front_history: frontHistory,
+    };
+    try {
+      const r =
+        method === "file" && file
+          ? await runPKFile(file, options)
+          : await runPKApi(token, options);
+      setResult(r);
+      setStep("done");
+      // Token has served its purpose; clear it so it's not lingering on the
+      // page for the rest of the session.
+      setToken("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Import failed");
+      setStep("preview");
+    }
+  }
+
+  function toggleMember(id: string) {
+    setSelectedMembers((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <>
+      {error && <ErrorBanner message={error} />}
+
+      {method === "choose" && (
+        <div className="grid gap-4 max-w-lg">
+          <Card
+            className="cursor-pointer hover:border-primary transition-colors"
+            onClick={() => setMethod("api")}
+          >
+            <CardHeader>
+              <CardTitle className="text-base">Connect with a token</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Use your PluralKit token (run <code>pk;token</code> in any
+                Discord server PluralKit is in to get one). Sheaf forwards it
+                once to fetch your system, then drops it. Nothing is stored.
+              </p>
+            </CardContent>
+          </Card>
+          <Card
+            className="cursor-pointer hover:border-primary transition-colors"
+            onClick={() => setMethod("file")}
+          >
+            <CardHeader>
+              <CardTitle className="text-base">Upload an export file</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Use the JSON file from <code>pk;export</code> if you'd rather
+                not paste a token.
+              </p>
+            </CardContent>
+          </Card>
+          <Button variant="outline" size="sm" onClick={onBack} className="w-fit">
+            Back
+          </Button>
+        </div>
+      )}
+
+      {method === "file" && step === "upload" && (
+        <Card className="max-w-lg">
+          <CardHeader>
+            <CardTitle className="text-base">Upload PluralKit export file</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Run <code>pk;export</code> on Discord, then upload the JSON
+              attachment PluralKit DMs you.
+            </p>
+            <input
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileSelect}
+              className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+            />
+            <Button variant="outline" size="sm" onClick={() => setMethod("choose")}>
+              Back
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {method === "api" && step === "upload" && (
+        <Card className="max-w-lg">
+          <CardHeader>
+            <CardTitle className="text-base">Connect to PluralKit</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Paste the token from <code>pk;token</code>. We use it once to
+              fetch your system data and discard it. The token is never
+              stored on the server or in your browser.
+            </p>
+            <div className="space-y-2">
+              <Label htmlFor="pk-token">PluralKit token</Label>
+              <Input
+                id="pk-token"
+                type="password"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="abcd1234..."
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={handleApiPreview} disabled={!token.trim()}>
+                Continue
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setToken("");
+                  setMethod("choose");
+                }}
+              >
+                Back
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "preview" && preview && (
+        <div className="grid gap-4 max-w-2xl">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Preview
+                {preview.system_name && (
+                  <span className="ml-2 font-normal text-muted-foreground">
+                    {preview.system_name}
+                  </span>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-3 text-sm">
+              <div>Members: <strong>{preview.member_count}</strong></div>
+              <div>Groups: <strong>{preview.group_count}</strong></div>
+              <div>
+                Switches:{" "}
+                <strong>
+                  {method === "api" && preview.switch_count >= 100
+                    ? "100+"
+                    : preview.switch_count.toLocaleString()}
+                </strong>
+              </div>
+              {preview.earliest_switch && preview.latest_switch && (
+                <div className="col-span-2 text-xs text-muted-foreground">
+                  Switch range: {new Date(preview.earliest_switch).toLocaleDateString()}
+                  {" "}to{" "}
+                  {new Date(preview.latest_switch).toLocaleDateString()}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Import options</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Checkbox
+                label="System profile (tag, color, avatar — only fills in fields you've left blank)"
+                checked={systemProfile}
+                onChange={setSystemProfile}
+              />
+              <Checkbox
+                label="Groups"
+                checked={groups}
+                onChange={setGroups}
+              />
+              <Checkbox
+                label={
+                  method === "api" && preview.switch_count >= 100
+                    ? "Front history (full pull, may take a moment for large logs)"
+                    : `Front history (${preview.switch_count.toLocaleString()} switches)`
+                }
+                checked={frontHistory}
+                onChange={setFrontHistory}
+              />
+
+              <MemberSelector
+                members={preview.members}
+                totalCount={preview.member_count}
+                allMembers={allMembers}
+                setAllMembers={setAllMembers}
+                selectedMembers={selectedMembers}
+                toggleMember={toggleMember}
+              />
+
+              <Button onClick={handleImport} className="w-full">
+                Import
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {step === "importing" && <ImportingCard />}
+
+      {step === "done" && result && (
+        <Card className="max-w-lg">
+          <CardHeader>
+            <CardTitle className="text-base">Import complete</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {result.members_imported > 0 && (
+                <div>Members: <strong>{result.members_imported}</strong></div>
+              )}
+              {result.groups_imported > 0 && (
+                <div>Groups: <strong>{result.groups_imported}</strong></div>
+              )}
+              {result.fronts_imported > 0 && (
+                <div>Fronts: <strong>{result.fronts_imported}</strong></div>
               )}
             </div>
             <Warnings warnings={result.warnings} />

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -67,6 +67,7 @@ function MemberForm({
   const [color, setColor] = useState(initial?.color ?? "#6366f1");
   const [description, setDescription] = useState(initial?.description ?? "");
   const [birthday, setBirthday] = useState(initial?.birthday ?? "");
+  const [pluralkitId, setPluralkitId] = useState(initial?.pluralkit_id ?? "");
   const [privacy, setPrivacy] = useState<PrivacyLevel>(initial?.privacy ?? "private");
 
   function handleSubmit(e: FormEvent) {
@@ -79,6 +80,7 @@ function MemberForm({
       color: color || null,
       description: description || null,
       birthday: birthday || null,
+      pluralkit_id: pluralkitId.trim() || null,
       privacy,
     });
   }
@@ -143,6 +145,20 @@ function MemberForm({
         <Suspense fallback={<div className="h-[120px] rounded-md border border-input" />}>
           <BioEditor value={description} onChange={setDescription} />
         </Suspense>
+      </div>
+      <div className="space-y-2">
+        <Label>PluralKit ID</Label>
+        <Input
+          value={pluralkitId}
+          onChange={(e) => setPluralkitId(e.target.value)}
+          placeholder="Optional, e.g. wyyetr"
+          maxLength={8}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p className="text-xs text-muted-foreground">
+          The 5-7 character HID PluralKit assigned this member, if you cross-reference between the two.
+        </p>
       </div>
       <div className="space-y-2">
         <Label>Privacy</Label>
@@ -506,6 +522,11 @@ function MemberView({
               )}
               {member.birthday && (
                 <p className="text-sm text-muted-foreground">{member.birthday}</p>
+              )}
+              {member.pluralkit_id && (
+                <p className="text-xs text-muted-foreground font-mono">
+                  PK: {member.pluralkit_id}
+                </p>
               )}
             </div>
           </div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -79,6 +79,7 @@ export interface Member {
   avatar_url: string | null;
   color: string | null;
   birthday: string | null;
+  pluralkit_id: string | null;
   privacy: PrivacyLevel;
   created_at: string;
   updated_at: string;
@@ -92,6 +93,7 @@ export interface MemberCreate {
   avatar_url?: string | null;
   color?: string | null;
   birthday?: string | null;
+  pluralkit_id?: string | null;
   privacy?: PrivacyLevel;
 }
 
@@ -103,6 +105,7 @@ export interface MemberUpdate {
   avatar_url?: string | null;
   color?: string | null;
   birthday?: string | null;
+  pluralkit_id?: string | null;
   privacy?: PrivacyLevel;
 }
 


### PR DESCRIPTION
Two ingestion paths share a single importer:

- File upload of a `pk;export` JSON. Mirrors the SP file flow.
- Live API pull using the user's `pk;token`. Token is forwarded once to api.pluralkit.me and dropped immediately. Not logged, not persisted, not stashed in browser storage. Cleared from form state once the import completes.

PK's switch log (point-in-time fronter-set events) is converted to Sheaf's front-interval model by walking switches oldest-to-newest: each switch ends the previous open Front and opens a new one with the resolved member set. Empty switches preserve "nobody fronting" gaps. A member spanning multiple consecutive switches lands in multiple Front records, which the existing coalesce-contiguous-fronts display feature reassembles.

Member migration covers name, display name, color, pronouns, avatar, description, and birthday (including PK's 0004-MM-DD year-less sentinel collapsed to MM-DD). Privacy is collapsed from PK's per-field map to Sheaf's tri-level enum via the overall visibility flag, with a most-restrictive fallback. Groups carry their member memberships across.

Adds a nullable pluralkit_id column on members for cross-reference, populated by the importer and editable manually in the member form. Surfaced on the member view dialog.

Live API path throttles to ~600ms between paginated requests, well under PK's 2 req/sec/token limit. Imports abort cleanly on 401/403/ 429/5xx with no token leaked into error responses.

User-facing docs in docs/IMPORT.md cover both PK paths plus how SP and Sheaf imports compare, including the switch -> Front conversion worked through an example and a list of what's deliberately not imported (proxy tags, Discord-only config, system description).
