### PR TITLE
Custom fronts, member emoji, and front custom status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Custom fronts, member emoji, custom status on fronts
+
+A bundle of three small SimplyPlural-parity additions to the member and front data models:
+
+- **Custom fronts** — new `is_custom_front` boolean on `members`. Marks a Member as a non-counting fronting entity ("Asleep", "Away", "Lost time"). Custom fronts behave like members for fronting/groups/notifications, but are excluded from member-headcount statistics and listed in their own section on the Members page. The SP importer now sets the flag instead of prefixing imported `frontStatuses` with `[Imported SP custom front]` in the description.
+- **Member emoji** — new optional `emoji` String(8) on `members`. Surfaced alongside the avatar fallback in compact lists and as a prefix on member badges in the dashboard, fronts page, and notification picker.
+- **Custom status on fronts** — new optional `custom_status` Text column on `fronts`. Encrypted at rest (matching the precedent set by member descriptions and journal bodies). Lets you annotate a fronting period with context like "during a job interview" without amending the bio. Surfaced inline on the dashboard and fronts pages, editable via the start-front dialog. PATCH semantics: omit the field to keep, send `null` to clear, send a string to replace.
+
 ### PluralKit import
 
 - New importer accepts both PK data export files (from `pk;export`) and live API pulls using the user's PK token (from `pk;token`). Same preview / options / result schema for both paths so the UI is uniform. Token is forwarded once and never logged or persisted.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 
 ## Features
 
-- **Members** — Profiles with name, pronouns, description, colour, birthday, avatar, privacy levels
-- **Front tracking** — Log switches, including cofronters and custom fronts
+- **Members** — Profiles with name, pronouns, description, colour, birthday, avatar, emoji, privacy levels, optional PluralKit ID
+- **Custom fronts** — Mark non-counting fronting entities like "Asleep" or "Away" so they show up in the fronter list without inflating member counts
+- **Front tracking** — Log switches with cofronters and an optional encrypted free-text status per fronting period
 - **Groups** — Organize members into groups with nesting (subsystems)
 - **Tags** — Flexible member tagging
 - **Custom fields** — Define your own fields (text, number, date, boolean, select) with per-field privacy

--- a/alembic/versions/w3x4y5z6a7b8_sp_gap_bundle.py
+++ b/alembic/versions/w3x4y5z6a7b8_sp_gap_bundle.py
@@ -1,0 +1,60 @@
+"""Add custom-front flag, member emoji, and front custom status
+
+Revision ID: w3x4y5z6a7b8
+Revises: v2w3x4y5z6a7
+Create Date: 2026-05-06
+
+Three small additive columns introduced as one bundle:
+
+- members.is_custom_front (boolean, default false): marks a Member row as
+  a non-counting fronting entity ("Asleep", "Away", "Lost time"). Excluded
+  from member headcount but still selectable on the front start dialog and
+  shown in the fronter list.
+- members.emoji (varchar(8) nullable): a short visual identifier surfaced
+  alongside or instead of the avatar fallback in badges and lists.
+- fronts.custom_status (text nullable): per-fronting-period free-text
+  annotation, e.g. "during a job interview". Doesn't replace bio edits.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "w3x4y5z6a7b8"
+down_revision = "v2w3x4y5z6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    member_cols = {c["name"] for c in inspector.get_columns("members")}
+    if "is_custom_front" not in member_cols:
+        op.add_column(
+            "members",
+            sa.Column(
+                "is_custom_front",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+    if "emoji" not in member_cols:
+        op.add_column(
+            "members",
+            sa.Column("emoji", sa.String(length=8), nullable=True),
+        )
+
+    front_cols = {c["name"] for c in inspector.get_columns("fronts")}
+    if "custom_status" not in front_cols:
+        op.add_column(
+            "fronts",
+            sa.Column("custom_status", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("fronts", "custom_status")
+    op.drop_column("members", "emoji")
+    op.drop_column("members", "is_custom_front")

--- a/docs/IMPORT.md
+++ b/docs/IMPORT.md
@@ -147,8 +147,9 @@ same preview-then-import flow as PK and covers:
 
 - System profile (name, description, color).
 - Members with avatar, pronouns, color, description, birthday, privacy.
-- Custom fronts (currently imported as members with a description prefix
-  marking them as such — first-class custom-front support is on the roadmap).
+- Custom fronts (imported as Members with `is_custom_front=true`, so they
+  show up in the fronter list and groups but are excluded from member-count
+  statistics and listed separately on the Members page).
 - Custom field definitions and per-member values.
 - Groups with parent hierarchy and member memberships.
 - Front history (off by default; SP exports can be large).

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -188,6 +188,8 @@ async def export_all(
                 "color": m.color,
                 "birthday": m.birthday,
                 "pluralkit_id": m.pluralkit_id,
+                "emoji": m.emoji,
+                "is_custom_front": m.is_custom_front,
                 "privacy": m.privacy.value,
                 "created_at": m.created_at.isoformat(),
             }
@@ -199,6 +201,9 @@ async def export_all(
                 "started_at": f.started_at.isoformat(),
                 "ended_at": f.ended_at.isoformat() if f.ended_at else None,
                 "member_ids": [str(m.id) for m in f.members],
+                "custom_status": (
+                    decrypt(f.custom_status) if f.custom_status else None
+                ),
             }
             for f in fronts
         ],

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user, require_scope
+from sheaf.crypto import decrypt, encrypt
 from sheaf.database import get_db
 from sheaf.models.front import Front
 from sheaf.models.member import Member, front_members
@@ -63,6 +64,7 @@ def _front_to_read(
         started_at=front.started_at,
         ended_at=front.ended_at,
         member_ids=[m.id for m in front.members],
+        custom_status=decrypt(front.custom_status) if front.custom_status else None,
         member_since=member_since,
         member_since_capped=member_since_capped or [],
     )
@@ -265,6 +267,7 @@ async def create_front(
     front = Front(
         system_id=system.id,
         started_at=new_started_at,
+        custom_status=encrypt(body.custom_status) if body.custom_status else None,
         members=members,
     )
     db.add(front)
@@ -305,6 +308,14 @@ async def update_front(
 
     if body.ended_at is not None:
         front.ended_at = body.ended_at
+
+    # custom_status uses presence-in-body to distinguish "omit" from
+    # "explicitly clear". model_fields_set is Pydantic v2's per-instance
+    # set of field names that were actually supplied in the input.
+    if "custom_status" in body.model_fields_set:
+        front.custom_status = (
+            encrypt(body.custom_status) if body.custom_status else None
+        )
 
     if body.member_ids is not None:
         member_result = await db.execute(

--- a/sheaf/models/front.py
+++ b/sheaf/models/front.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index
+from sqlalchemy import DateTime, ForeignKey, Index, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -26,6 +26,12 @@ class Front(UUIDMixin, Base):
         DateTime(timezone=True),
         nullable=True,
     )
+    # Optional free-text per-fronting-period annotation, e.g. "during a job
+    # interview" or "panic attack at the wedding". Encrypted at rest because
+    # it's exactly the kind of contextual narrative that the field-level
+    # encryption model is meant to protect, matching the precedent set by
+    # bios and journal entries.
+    custom_status: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships
     system: Mapped["System"] = relationship(back_populates="fronts")

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import Column, Enum, ForeignKey, String, Table, Text
+from sqlalchemy import Boolean, Column, Enum, ForeignKey, String, Table, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -83,6 +83,16 @@ class Member(UUIDMixin, TimestampMixin, Base):
     # editable manually. Not unique within a system; we don't validate against
     # PluralKit's namespace ourselves.
     pluralkit_id: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    # Short visual identifier (single emoji or a few characters). Surfaced
+    # alongside or instead of the avatar fallback in compact lists. Optional.
+    emoji: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    # Marks a Member as a "custom front" — a non-counting fronting entity
+    # (e.g. "Asleep", "Away", "Lost time"). Custom fronts behave like members
+    # for fronting/groups/notifications but are excluded from member headcount
+    # statistics and listed separately in the members UI.
+    is_custom_front: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
     privacy: Mapped[PrivacyLevel] = mapped_column(
         Enum(PrivacyLevel, values_callable=lambda e: [m.value for m in e]),
         default=PrivacyLevel.PRIVATE,

--- a/sheaf/schemas/front.py
+++ b/sheaf/schemas/front.py
@@ -8,11 +8,16 @@ class FrontCreate(BaseModel):
     member_ids: list[uuid.UUID]
     started_at: datetime | None = None
     replace_fronts: bool | None = None  # None = use system's replace_fronts_default
+    custom_status: str | None = None
 
 
 class FrontUpdate(BaseModel):
     ended_at: datetime | None = None
     member_ids: list[uuid.UUID] | None = None
+    # `custom_status` uses an explicit "unset" sentinel: omit the field to
+    # keep the existing value, send `null` to clear it, or send a string
+    # to replace it. Pydantic's `exclude_unset=True` round-trips this.
+    custom_status: str | None = None
 
 
 class FrontRead(BaseModel):
@@ -21,6 +26,7 @@ class FrontRead(BaseModel):
     started_at: datetime
     ended_at: datetime | None
     member_ids: list[uuid.UUID]
+    custom_status: str | None = None
     # Per-member effective "fronting since" timestamp, keyed by member id
     # (string form). When the system has `coalesce_contiguous_fronts` on
     # AND the member appears in a chain of back-to-back front entries

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -21,6 +21,8 @@ class MemberCreate(BaseModel):
     color: str | None = Field(default=None, max_length=7)
     birthday: str | None = Field(default=None, max_length=10)
     pluralkit_id: str | None = Field(default=None, max_length=8)
+    emoji: str | None = Field(default=None, max_length=8)
+    is_custom_front: bool = False
     privacy: PrivacyLevel = PrivacyLevel.PRIVATE
 
     @field_validator("avatar_url", mode="before")
@@ -43,6 +45,8 @@ class MemberUpdate(BaseModel):
     color: str | None = Field(default=None, max_length=7)
     birthday: str | None = Field(default=None, max_length=10)
     pluralkit_id: str | None = Field(default=None, max_length=8)
+    emoji: str | None = Field(default=None, max_length=8)
+    is_custom_front: bool | None = None
     privacy: PrivacyLevel | None = None
 
     @field_validator("avatar_url", mode="before")
@@ -76,6 +80,8 @@ class MemberRead(BaseModel):
     color: str | None
     birthday: str | None
     pluralkit_id: str | None
+    emoji: str | None
+    is_custom_front: bool
     privacy: PrivacyLevel
     created_at: datetime
     updated_at: datetime

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -50,6 +50,8 @@ def decrypt_member_for_read(member: Member) -> MemberRead:
         "color": member.color,
         "birthday": member.birthday,
         "pluralkit_id": member.pluralkit_id,
+        "emoji": member.emoji,
+        "is_custom_front": member.is_custom_front,
         "privacy": member.privacy,
         "created_at": member.created_at,
         "updated_at": member.updated_at,

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -142,6 +142,8 @@ async def run_import(
             color=_trunc(m_data.get("color"), 7),
             birthday=_trunc(m_data.get("birthday"), 10),
             pluralkit_id=_trunc(m_data.get("pluralkit_id"), 8),
+            emoji=_trunc(m_data.get("emoji"), 8),
+            is_custom_front=bool(m_data.get("is_custom_front", False)),
             privacy=_privacy(m_data.get("privacy")),
         )
         db.add(member)
@@ -279,11 +281,17 @@ async def run_import(
             if not front_member_ids:
                 continue
 
+            plaintext_status = f_data.get("custom_status")
             front = Front(
                 id=uuid.uuid4(),
                 system_id=system.id,
                 started_at=started_at,
                 ended_at=ended_at,
+                custom_status=(
+                    encrypt(plaintext_status)
+                    if isinstance(plaintext_status, str) and plaintext_status
+                    else None
+                ),
             )
             db.add(front)
             await db.flush()

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -148,13 +148,17 @@ async def run_import(
         sp_id_to_member[sp_id] = member
         result.members_imported += 1
 
-    # --- Custom fronts → imported as members (marked via description prefix) ---
+    # --- Custom fronts → imported as Members with is_custom_front=True ---
+    # SP's "frontStatuses" are non-counting fronting entities like "Asleep"
+    # or "Away". Sheaf models them as Members carrying the is_custom_front
+    # flag, which the UI uses to list them separately from headcounted
+    # members and exclude them from member-count statistics.
     sp_id_to_custom_front: dict[str, Member] = {}
     if options.custom_fronts:
         for sp_cf in _get_collection(data, "frontStatuses"):
             sp_id = sp_cf.get("_id", "")
             plaintext_cf_name = (sp_cf.get("name") or "unnamed")[:100]
-            plaintext_cf_description = _prefix_custom_front_desc(sp_cf.get("desc"))
+            plaintext_cf_description = sp_cf.get("desc")
             member = Member(
                 id=uuid.uuid4(),
                 system_id=system.id,
@@ -168,6 +172,7 @@ async def run_import(
                 color=_normalize_color(sp_cf.get("color")),
                 avatar_url=_truncate(sp_cf.get("avatarUrl"), 500),
                 privacy=_map_privacy(sp_cf.get("private", True)),
+                is_custom_front=True,
             )
             db.add(member)
             sp_id_to_custom_front[sp_id] = member
@@ -341,11 +346,3 @@ def _truncate(value: str | None, max_len: int) -> str | None:
     if not value:
         return None
     return value[:max_len]
-
-
-def _prefix_custom_front_desc(desc: str | None) -> str:
-    """Mark imported custom fronts in the description."""
-    prefix = "[Imported SP custom front]"
-    if desc:
-        return f"{prefix}\n{desc}"
-    return prefix

--- a/tests/test_sp_gap_bundle.py
+++ b/tests/test_sp_gap_bundle.py
@@ -1,0 +1,274 @@
+"""Integration tests for the SP-gap bundle:
+
+- Member.is_custom_front flag (custom fronts as non-counting fronting entities)
+- Member.emoji (compact visual identifier)
+- Front.custom_status (per-fronting-period free-text annotation)
+
+Plus regression coverage for the SP-importer's switch from the description-
+prefix hack to the new is_custom_front flag.
+"""
+
+import json
+import pathlib
+
+import httpx
+
+
+def test_member_emoji_roundtrips(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/members",
+        json={"name": "Foxy", "emoji": "🦊", "color": "#ff6600"},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["emoji"] == "🦊"
+
+    # Update path
+    resp = auth_client.patch(
+        f"/v1/members/{data['id']}",
+        json={"emoji": "🌙"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["emoji"] == "🌙"
+
+
+def test_member_emoji_clear_via_empty_string(auth_client: httpx.Client):
+    """Members can drop their emoji by patching it to null."""
+    created = auth_client.post(
+        "/v1/members", json={"name": "Wolf", "emoji": "🐺"}
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/members/{created['id']}", json={"emoji": None}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["emoji"] is None
+
+
+def test_member_is_custom_front_default_false(auth_client: httpx.Client):
+    resp = auth_client.post("/v1/members", json={"name": "Real Member"})
+    assert resp.status_code == 201
+    assert resp.json()["is_custom_front"] is False
+
+
+def test_member_can_be_marked_custom_front(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/members",
+        json={"name": "Asleep", "is_custom_front": True},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["is_custom_front"] is True
+
+    # And toggled off
+    resp = auth_client.patch(
+        f"/v1/members/{resp.json()['id']}",
+        json={"is_custom_front": False},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["is_custom_front"] is False
+
+
+def test_custom_fronts_listed_alongside_members(auth_client: httpx.Client):
+    """The /v1/members endpoint returns both kinds; the UI partitions on the
+    is_custom_front flag rather than the API doing it."""
+    auth_client.post("/v1/members", json={"name": "Real"})
+    auth_client.post("/v1/members", json={"name": "Away", "is_custom_front": True})
+
+    members = auth_client.get("/v1/members").json()
+    by_name = {m["name"]: m for m in members}
+    assert by_name["Real"]["is_custom_front"] is False
+    assert by_name["Away"]["is_custom_front"] is True
+
+
+def test_front_custom_status_encrypts_at_rest_and_decrypts_for_read(
+    auth_client: httpx.Client,
+):
+    """The Front model encrypts custom_status at rest, mirroring the
+    encryption pattern used for member descriptions and journal bodies."""
+    member = auth_client.post("/v1/members", json={"name": "Alex"}).json()
+
+    resp = auth_client.post(
+        "/v1/fronts",
+        json={
+            "member_ids": [member["id"]],
+            "custom_status": "during a tense meeting",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    front = resp.json()
+    assert front["custom_status"] == "during a tense meeting"
+
+    # And on the read endpoints
+    listed = auth_client.get("/v1/fronts").json()
+    assert listed[0]["custom_status"] == "during a tense meeting"
+
+    current = auth_client.get("/v1/fronts/current").json()
+    assert current[0]["custom_status"] == "during a tense meeting"
+
+
+def test_front_custom_status_patch_clear_vs_omit(auth_client: httpx.Client):
+    """custom_status uses Pydantic's model_fields_set so a missing field
+    means 'keep' while explicit null means 'clear'."""
+    member = auth_client.post("/v1/members", json={"name": "Bea"}).json()
+    front = auth_client.post(
+        "/v1/fronts",
+        json={"member_ids": [member["id"]], "custom_status": "first try"},
+    ).json()
+
+    # Omit custom_status: keeps the existing value
+    resp = auth_client.patch(f"/v1/fronts/{front['id']}", json={})
+    assert resp.status_code == 200
+    assert resp.json()["custom_status"] == "first try"
+
+    # Explicit null: clears it
+    resp = auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"custom_status": None}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["custom_status"] is None
+
+    # New value: replaces
+    resp = auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"custom_status": "updated"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["custom_status"] == "updated"
+
+
+def test_front_custom_status_optional(auth_client: httpx.Client):
+    """No custom_status supplied at create time leaves the field null."""
+    member = auth_client.post("/v1/members", json={"name": "Cleo"}).json()
+    resp = auth_client.post("/v1/fronts", json={"member_ids": [member["id"]]})
+    assert resp.status_code == 201
+    assert resp.json()["custom_status"] is None
+
+
+# --- SP-import path: frontStatuses -> is_custom_front=True ------------------
+
+
+def _sp_export_with_custom_fronts() -> bytes:
+    return json.dumps(
+        {
+            "users": [{"username": "Test"}],
+            "members": [
+                {"_id": "m1", "name": "Real", "private": False},
+            ],
+            "frontStatuses": [
+                {"_id": "cf1", "name": "Asleep", "color": "#888888"},
+                {"_id": "cf2", "name": "Away", "color": "#aaaaaa"},
+            ],
+        }
+    ).encode()
+
+
+def test_sp_import_marks_frontstatuses_as_custom_fronts(
+    auth_client: httpx.Client,
+):
+    payload = _sp_export_with_custom_fronts()
+    resp = auth_client.post(
+        "/v1/import/simplyplural",
+        files={"file": ("sp.json", payload, "application/json")},
+    )
+    assert resp.status_code == 200, resp.text
+    result = resp.json()
+    assert result["members_imported"] == 1
+    assert result["custom_fronts_imported"] == 2
+
+    members = auth_client.get("/v1/members").json()
+    by_name = {m["name"]: m for m in members}
+    assert by_name["Real"]["is_custom_front"] is False
+    assert by_name["Asleep"]["is_custom_front"] is True
+    assert by_name["Away"]["is_custom_front"] is True
+
+
+def test_sp_import_no_longer_prefixes_custom_front_descriptions(
+    auth_client: httpx.Client,
+):
+    """The old behaviour prepended '[Imported SP custom front]' to the
+    description because there was no flag. With the flag, the description
+    should be left alone (or stay null when SP didn't provide one)."""
+    payload = json.dumps(
+        {
+            "users": [{"username": "Test"}],
+            "members": [],
+            "frontStatuses": [
+                {"_id": "cf1", "name": "Asleep", "desc": "snooze", "private": False},
+                {"_id": "cf2", "name": "Empty", "private": False},  # no desc
+            ],
+        }
+    ).encode()
+    resp = auth_client.post(
+        "/v1/import/simplyplural",
+        files={"file": ("sp.json", payload, "application/json")},
+    )
+    assert resp.status_code == 200
+
+    members = auth_client.get("/v1/members").json()
+    by_name = {m["name"]: m for m in members}
+    assert by_name["Asleep"]["description"] == "snooze"
+    assert by_name["Empty"]["description"] is None
+
+
+# --- Roundtrip via Sheaf export/import --------------------------------------
+
+
+def test_sheaf_export_includes_new_fields(auth_client: httpx.Client):
+    auth_client.post(
+        "/v1/members",
+        json={
+            "name": "Foxy",
+            "emoji": "🦊",
+            "is_custom_front": False,
+        },
+    )
+    auth_client.post(
+        "/v1/members",
+        json={"name": "Asleep", "is_custom_front": True},
+    )
+    member_real = next(
+        m for m in auth_client.get("/v1/members").json() if m["name"] == "Foxy"
+    )
+    auth_client.post(
+        "/v1/fronts",
+        json={
+            "member_ids": [member_real["id"]],
+            "custom_status": "writing tests",
+        },
+    )
+
+    export = auth_client.get("/v1/export").json()
+    by_name = {m["name"]: m for m in export["members"]}
+    assert by_name["Foxy"]["emoji"] == "🦊"
+    assert by_name["Foxy"]["is_custom_front"] is False
+    assert by_name["Asleep"]["is_custom_front"] is True
+
+    assert export["fronts"][0]["custom_status"] == "writing tests"
+
+
+def test_pluralkit_id_doesnt_collide_with_emoji(auth_client: httpx.Client):
+    """Both fields are short strings; make sure the schemas don't conflate
+    them and round-trip cleanly together."""
+    resp = auth_client.post(
+        "/v1/members",
+        json={"name": "Mira", "pluralkit_id": "wyyetr", "emoji": "🦊"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["pluralkit_id"] == "wyyetr"
+    assert data["emoji"] == "🦊"
+
+
+# --- Round-trip via the Sheaf importer, not just the export ----------------
+
+
+def test_pk_import_does_not_set_custom_front(auth_client: httpx.Client):
+    """PK doesn't have a custom-front concept; imported members should all
+    land with is_custom_front=False."""
+    fixture = (
+        pathlib.Path(__file__).parent / "fixtures" / "pk_export_sample.json"
+    )
+    auth_client.post(
+        "/v1/import/pluralkit",
+        files={"file": ("pk.json", fixture.read_bytes(), "application/json")},
+    )
+    members = auth_client.get("/v1/members").json()
+    assert all(m["is_custom_front"] is False for m in members)

--- a/web/src/components/start-front-dialog.tsx
+++ b/web/src/components/start-front-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MemberSelect } from "@/components/member-select";
 
@@ -39,18 +40,27 @@ export function StartFrontDialog({
     wasOpen: boolean;
     members: string[];
     replaceFronts: boolean | null;
+    customStatus: string;
     error: string | null;
-  }>({ wasOpen: false, members: [], replaceFronts: null, error: null });
+  }>({
+    wasOpen: false,
+    members: [],
+    replaceFronts: null,
+    customStatus: "",
+    error: null,
+  });
 
-  let { members: selectedMembers, replaceFronts, error } = draft;
+  let { members: selectedMembers, replaceFronts, customStatus, error } = draft;
   if (open && !draft.wasOpen) {
     selectedMembers = [];
     replaceFronts = null;
+    customStatus = "";
     error = null;
     setDraft({
       wasOpen: true,
       members: [],
       replaceFronts: null,
+      customStatus: "",
       error: null,
     });
   } else if (!open && draft.wasOpen) {
@@ -61,6 +71,8 @@ export function StartFrontDialog({
     setDraft((d) => ({ ...d, members: m, error: null }));
   const setReplaceFronts = (r: boolean | null) =>
     setDraft((d) => ({ ...d, replaceFronts: r, error: null }));
+  const setCustomStatus = (s: string) =>
+    setDraft((d) => ({ ...d, customStatus: s, error: null }));
 
   const effectiveReplace =
     replaceFronts ?? (system?.replace_fronts_default ?? true);
@@ -69,7 +81,11 @@ export function StartFrontDialog({
     if (selectedMembers.length === 0) return;
     setDraft((d) => ({ ...d, error: null }));
     createFront.mutate(
-      { member_ids: selectedMembers, replace_fronts: effectiveReplace },
+      {
+        member_ids: selectedMembers,
+        replace_fronts: effectiveReplace,
+        custom_status: customStatus.trim() || null,
+      },
       {
         onSuccess: () => {
           onOpenChange(false);
@@ -102,6 +118,18 @@ export function StartFrontDialog({
           className="py-2"
           showGroupFilter
         />
+        <div className="space-y-2 pt-1">
+          <Label htmlFor="custom-status" className="text-sm font-normal">
+            Custom status (optional)
+          </Label>
+          <Input
+            id="custom-status"
+            value={customStatus}
+            onChange={(e) => setCustomStatus(e.target.value)}
+            placeholder="e.g. during a job interview"
+            maxLength={500}
+          />
+        </div>
         <div className="flex items-center gap-2 pt-1">
           <Checkbox
             id="replace-fronts"

--- a/web/src/routes/dashboard.tsx
+++ b/web/src/routes/dashboard.tsx
@@ -48,25 +48,33 @@ export function DashboardPage() {
                 {fronts.map((front) => (
                   <div
                     key={front.id}
-                    className="flex items-center justify-between rounded-md border p-3"
+                    className="flex items-start justify-between rounded-md border p-3 gap-2"
                   >
-                    <div className="flex flex-wrap items-center gap-2">
-                      {front.member_ids.map((mid) => {
-                        const m = memberMap.get(mid);
-                        const since =
-                          front.member_since?.[mid] ?? front.started_at;
-                        const capped =
-                          front.member_since_capped?.includes(mid) ?? false;
-                        return (
-                          <Badge key={mid} variant="secondary" className="gap-1.5">
-                            <ColorDot color={m?.color ?? null} />
-                            {m?.display_name ?? m?.name ?? "Unknown"}
-                            <span className="text-muted-foreground">
-                              · {capped ? "> " : ""}{timeAgo(since)}
-                            </span>
-                          </Badge>
-                        );
-                      })}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        {front.member_ids.map((mid) => {
+                          const m = memberMap.get(mid);
+                          const since =
+                            front.member_since?.[mid] ?? front.started_at;
+                          const capped =
+                            front.member_since_capped?.includes(mid) ?? false;
+                          return (
+                            <Badge key={mid} variant="secondary" className="gap-1.5">
+                              <ColorDot color={m?.color ?? null} />
+                              {m?.emoji && <span>{m.emoji}</span>}
+                              {m?.display_name ?? m?.name ?? "Unknown"}
+                              <span className="text-muted-foreground">
+                                · {capped ? "> " : ""}{timeAgo(since)}
+                              </span>
+                            </Badge>
+                          );
+                        })}
+                      </div>
+                      {front.custom_status && (
+                        <p className="mt-2 text-sm italic text-muted-foreground">
+                          &ldquo;{front.custom_status}&rdquo;
+                        </p>
+                      )}
                     </div>
                     <Button
                       size="sm"
@@ -93,7 +101,9 @@ export function DashboardPage() {
           <CardContent>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <p className="text-2xl font-semibold">{members?.length ?? 0}</p>
+                <p className="text-2xl font-semibold">
+                  {members?.filter((m) => !m.is_custom_front).length ?? 0}
+                </p>
                 <p className="text-sm text-muted-foreground">Members</p>
               </div>
               <div>

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -47,6 +47,7 @@ export function FrontsPage() {
       return (
         <Badge key={mid} variant="secondary" className="gap-1.5">
           <ColorDot color={m?.color ?? null} />
+          {m?.emoji && <span>{m.emoji}</span>}
           {m?.display_name ?? m?.name ?? "Unknown"}
           {since && (
             <span className="text-muted-foreground">
@@ -77,13 +78,20 @@ export function FrontsPage() {
               {current.map((front) => (
                 <div
                   key={front.id}
-                  className="flex items-center justify-between rounded-md border p-3"
+                  className="flex items-start justify-between rounded-md border p-3 gap-2"
                 >
-                  <div className="flex flex-wrap items-center gap-2">
-                    {renderMembers(
-                      front.member_ids,
-                      front.member_since,
-                      front.member_since_capped,
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {renderMembers(
+                        front.member_ids,
+                        front.member_since,
+                        front.member_since_capped,
+                      )}
+                    </div>
+                    {front.custom_status && (
+                      <p className="mt-2 text-sm italic text-muted-foreground">
+                        &ldquo;{front.custom_status}&rdquo;
+                      </p>
                     )}
                   </div>
                   <Button
@@ -118,10 +126,17 @@ export function FrontsPage() {
           {history.map((front) => (
             <div
               key={front.id}
-              className="flex items-center justify-between rounded-md border p-3"
+              className="flex items-start justify-between rounded-md border p-3 gap-2"
             >
-              <div className="flex flex-wrap items-center gap-2">
-                {renderMembers(front.member_ids)}
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  {renderMembers(front.member_ids)}
+                </div>
+                {front.custom_status && (
+                  <p className="mt-2 text-sm italic text-muted-foreground">
+                    &ldquo;{front.custom_status}&rdquo;
+                  </p>
+                )}
               </div>
               <div className="flex items-center gap-3 text-sm text-muted-foreground shrink-0">
                 <span>

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -68,6 +68,10 @@ function MemberForm({
   const [description, setDescription] = useState(initial?.description ?? "");
   const [birthday, setBirthday] = useState(initial?.birthday ?? "");
   const [pluralkitId, setPluralkitId] = useState(initial?.pluralkit_id ?? "");
+  const [emoji, setEmoji] = useState(initial?.emoji ?? "");
+  const [isCustomFront, setIsCustomFront] = useState(
+    initial?.is_custom_front ?? false,
+  );
   const [privacy, setPrivacy] = useState<PrivacyLevel>(initial?.privacy ?? "private");
 
   function handleSubmit(e: FormEvent) {
@@ -81,6 +85,8 @@ function MemberForm({
       description: description || null,
       birthday: birthday || null,
       pluralkit_id: pluralkitId.trim() || null,
+      emoji: emoji.trim() || null,
+      is_custom_front: isCustomFront,
       privacy,
     });
   }
@@ -97,13 +103,25 @@ function MemberForm({
         <Label>Name</Label>
         <Input value={name} onChange={(e) => setName(e.target.value)} required />
       </div>
-      <div className="space-y-2">
-        <Label>Display name</Label>
-        <Input
-          value={displayName}
-          onChange={(e) => setDisplayName(e.target.value)}
-          placeholder="Optional — shown instead of name if set"
-        />
+      <div className="grid grid-cols-[1fr_auto] gap-3">
+        <div className="space-y-2">
+          <Label>Display name</Label>
+          <Input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Optional, shown instead of name if set"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Emoji</Label>
+          <Input
+            value={emoji}
+            onChange={(e) => setEmoji(e.target.value)}
+            placeholder="🦊"
+            maxLength={8}
+            className="w-20 text-center"
+          />
+        </div>
       </div>
       <div className="space-y-2">
         <Label>Pronouns</Label>
@@ -173,6 +191,23 @@ function MemberForm({
           </SelectContent>
         </Select>
       </div>
+      <label className="flex items-start gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={isCustomFront}
+          onChange={(e) => setIsCustomFront(e.target.checked)}
+          className="h-4 w-4 mt-0.5 rounded border-input"
+        />
+        <div>
+          <span className="text-sm font-medium">Custom front (not a member)</span>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Marks this entry as a fronting state like &quot;Asleep&quot; or &quot;Away&quot; rather
+            than a system member. Custom fronts can still front and be in
+            groups, but don&apos;t count toward member statistics and are
+            listed separately from members.
+          </p>
+        </div>
+      </label>
       <DialogFooter>
         <Button type="submit" disabled={loading || !name}>
           {loading ? "Saving..." : submitLabel}
@@ -511,11 +546,14 @@ function MemberView({
                 className="text-xl"
                 style={member.color ? { backgroundColor: member.color, color: "#fff" } : undefined}
               >
-                {member.name.charAt(0).toUpperCase()}
+                {member.emoji?.trim() || member.name.charAt(0).toUpperCase()}
               </AvatarFallback>
             </Avatar>
             <div>
-              <p className="text-lg font-semibold">{member.display_name || member.name}</p>
+              <p className="text-lg font-semibold">
+                {member.emoji && <span className="mr-1.5">{member.emoji}</span>}
+                {member.display_name || member.name}
+              </p>
               {member.display_name && (
                 <p className="text-sm text-muted-foreground">{member.name}</p>
               )}
@@ -612,35 +650,28 @@ export function MembersPage() {
           ))}
         </div>
       ) : members && members.length > 0 ? (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {members.map((m) => (
-            <Card
-              key={m.id}
-              className="cursor-pointer transition-colors hover:bg-accent/50"
-              onClick={() => setViewing(m)}
-            >
-              <CardContent className="flex items-center gap-3 p-4">
-                <Avatar>
-                  {m.avatar_url && <AvatarImage src={m.avatar_url} />}
-                  <AvatarFallback
-                    style={m.color ? { backgroundColor: m.color, color: "#fff" } : undefined}
-                  >
-                    {m.name.charAt(0).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="min-w-0 flex-1">
-                  <p className="font-medium truncate">{m.display_name || m.name}</p>
-                  {m.display_name && (
-                    <p className="text-xs text-muted-foreground truncate">{m.name}</p>
-                  )}
-                  {m.pronouns && (
-                    <p className="text-sm text-muted-foreground">{m.pronouns}</p>
-                  )}
+        (() => {
+          const realMembers = members.filter((m) => !m.is_custom_front);
+          const customFronts = members.filter((m) => m.is_custom_front);
+          return (
+            <div className="space-y-8">
+              <MemberGrid members={realMembers} onView={setViewing} />
+              {customFronts.length > 0 && (
+                <div className="space-y-3">
+                  <div className="flex items-baseline justify-between">
+                    <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                      Custom fronts
+                    </h2>
+                    <p className="text-xs text-muted-foreground">
+                      Non-counting fronting states (e.g. Asleep, Away).
+                    </p>
+                  </div>
+                  <MemberGrid members={customFronts} onView={setViewing} />
                 </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+              )}
+            </div>
+          );
+        })()
       ) : (
         <p className="text-muted-foreground">
           No members yet. Create your first member to get started.
@@ -728,5 +759,49 @@ export function MembersPage() {
         />
       )}
     </>
+  );
+}
+
+function MemberGrid({
+  members,
+  onView,
+}: {
+  members: Member[];
+  onView: (m: Member) => void;
+}) {
+  if (members.length === 0) return null;
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {members.map((m) => (
+        <Card
+          key={m.id}
+          className="cursor-pointer transition-colors hover:bg-accent/50"
+          onClick={() => onView(m)}
+        >
+          <CardContent className="flex items-center gap-3 p-4">
+            <Avatar>
+              {m.avatar_url && <AvatarImage src={m.avatar_url} />}
+              <AvatarFallback
+                style={m.color ? { backgroundColor: m.color, color: "#fff" } : undefined}
+              >
+                {m.emoji?.trim() || m.name.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <p className="font-medium truncate">
+                {m.emoji && <span className="mr-1.5">{m.emoji}</span>}
+                {m.display_name || m.name}
+              </p>
+              {m.display_name && (
+                <p className="text-xs text-muted-foreground truncate">{m.name}</p>
+              )}
+              {m.pronouns && (
+                <p className="text-sm text-muted-foreground">{m.pronouns}</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
   );
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -80,6 +80,8 @@ export interface Member {
   color: string | null;
   birthday: string | null;
   pluralkit_id: string | null;
+  emoji: string | null;
+  is_custom_front: boolean;
   privacy: PrivacyLevel;
   created_at: string;
   updated_at: string;
@@ -94,6 +96,8 @@ export interface MemberCreate {
   color?: string | null;
   birthday?: string | null;
   pluralkit_id?: string | null;
+  emoji?: string | null;
+  is_custom_front?: boolean;
   privacy?: PrivacyLevel;
 }
 
@@ -106,6 +110,8 @@ export interface MemberUpdate {
   color?: string | null;
   birthday?: string | null;
   pluralkit_id?: string | null;
+  emoji?: string | null;
+  is_custom_front?: boolean;
   privacy?: PrivacyLevel;
 }
 
@@ -115,6 +121,7 @@ export interface Front {
   started_at: string;
   ended_at: string | null;
   member_ids: string[];
+  custom_status: string | null;
   // Per-member effective "fronting since" timestamp, keyed by member id.
   // For open fronts on /v1/fronts/current with the system's
   // coalesce_contiguous_fronts toggle on, this walks back through
@@ -133,11 +140,14 @@ export interface FrontCreate {
   member_ids: string[];
   started_at?: string | null;
   replace_fronts?: boolean;
+  custom_status?: string | null;
 }
 
 export interface FrontUpdate {
   ended_at?: string | null;
   member_ids?: string[];
+  // Omit to keep, send null to clear, send a string to replace.
+  custom_status?: string | null;
 }
 
 export interface Group {


### PR DESCRIPTION
## Summary

Three small SimplyPlural-parity additions to the member and front data models, all under one migration. Closes the matrix items called out in the recent SP gap analysis.

- **Custom fronts** — new `is_custom_front` boolean on `members`. Marks a Member as a non-counting fronting entity ("Asleep", "Away", "Lost time"). Behaves like a member for fronting/groups/notifications but is excluded from member-headcount stats and listed separately on the Members page. SP importer now sets the flag for `frontStatuses` instead of prefixing the description with `[Imported SP custom front]`.
- **Member emoji** — optional 8-char string surfaced alongside the avatar fallback in compact lists, prefixed onto member badges in the dashboard, fronts page, and member view dialog.
- **Front custom status** — optional Text column on `fronts`, encrypted at rest. Matches the precedent set by member descriptions and journal bodies. Lets users annotate a fronting period with context like "during a job interview" without amending the bio. PATCH semantics: omit to keep, send `null` to clear, send a string to replace (implemented via Pydantic's `model_fields_set`).

Round-trip handling threads through Sheaf export, Sheaf import, and PK import (which doesn't have a custom-front concept and leaves the flag false). Notification payloads do not yet carry custom_status; that's a deliberate follow-up since it affects the resolution layer.

## Test plan

- [x] Members page: create a member with emoji, verify it shows in badges and member list
- [x] Toggle "Custom front" on a member, verify it moves to the separate section and the dashboard headcount drops by one
- [x] Start a front with a custom_status, verify it shows on the dashboard and fronts page
- [x] Run an SP import containing `frontStatuses`, verify they land with `is_custom_front=true` and no description prefix
- [ ] Round-trip Sheaf export -> import: confirm emoji, is_custom_front, and custom_status all survive