### PR TITLE
Add reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Reminders
+
+A new reminders surface alongside notification channels. Two trigger types share one data model and ride existing notification channels for delivery.
+
+- **Automated timers**: fire after a front-change event. Choose a specific member (or "any"), a side of the transition (start / stop / either), and a delay in minutes/hours. The reminder dispatches `delay_seconds` after the matching front change. Useful for member-bound self-care cues, medication routines, partner/therapist coordination pings.
+- **Repeated reminders**: cron-style schedule. UI exposes a structured daily / weekly / monthly + time-of-day picker; an "Advanced" toggle takes a raw 5-field cron expression for power users. Each reminder has its own IANA timezone.
+- **Member-scoped repeated reminders**: by default, reminders fire system-wide on schedule. Optionally scope a reminder to specific members so it only fires when one of them is currently fronting. When the schedule fires while no scoped member is fronting and `digest_when_absent=true` (default), the missed firings queue (capped at 5) and drain as a single digest notification when one of the scoped members next starts fronting.
+- API: `POST/GET/PATCH/DELETE /v1/reminders`, gated by the existing `notifications:read` and `notifications:write` scopes (a caller permitted to manage notification destinations also manages reminders that ride them). New `GET /v1/channels` flat-list endpoint for picking a channel without traversing watch tokens.
+- Backend: shared `notification_outbox` rows with `event_type="reminder"`. The dispatcher branches on event_type and skips member-resolution / filter / debounce / quiet-hours for reminders — they were scheduled at a specific time on purpose. Per-channel concurrency limits still apply.
+- Frontend: new `/reminders` route in the sidebar between Notifications and Settings, with a list view and a single create/edit dialog covering both kinds.
+- Title and body are encrypted at rest, matching the existing convention for member descriptions and journal entries.
+
 ### Front-time analytics
 
 - New `GET /v1/analytics/fronting` endpoint, gated by the existing `fronts:read` scope. Returns per-member time-on-front summaries over a configurable window (defaults to last 30 days, capped at 5 years).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 - **Custom fronts** — Mark non-counting fronting entities like "Asleep" or "Away" so they show up in the fronter list without inflating member counts
 - **Front tracking** — Log switches with cofronters and an optional encrypted free-text status per fronting period
 - **Analytics** — Per-member front time, percent of window, session count, longest session, and hour-of-day distribution over a configurable window (7d / 30d / 90d / 1 year). Co-fronting double-counts so individual member stats are accurate.
+- **Reminders** — Schedule daily/weekly/monthly pings or fire reminders X minutes after a member fronts. Member-scoped reminders queue while nobody on the list is fronting and drain as a digest when one next switches in. Delivery rides your existing notification channels.
 - **Groups** — Organize members into groups with nesting (subsystems)
 - **Tags** — Flexible member tagging
 - **Custom fields** — Define your own fields (text, number, date, boolean, select) with per-field privacy

--- a/alembic/versions/x4y5z6a7b8c9_add_reminders.py
+++ b/alembic/versions/x4y5z6a7b8c9_add_reminders.py
@@ -1,0 +1,153 @@
+"""Add reminder, reminder_scope_member, reminder_pending tables
+
+Revision ID: x4y5z6a7b8c9
+Revises: w3x4y5z6a7b8
+Create Date: 2026-05-06
+
+Two kinds of reminders share the same row:
+
+- automated: triggered by a front-change event (member starts/stops/any),
+  fires `delay_hours` after the event lands. No queue.
+- repeated: cron-style schedule (daily/weekly/monthly + time-of-day, with
+  an "advanced" raw cron string for power users). Optionally member-scoped
+  with a digest-on-next-front-of-scope-member fallback.
+
+Both ride on top of an existing notification_channel for delivery.
+Reminder pending rows queue up missed firings for member-scoped repeated
+reminders; capped at 5 per reminder, oldest dropped on overflow.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "x4y5z6a7b8c9"
+down_revision = "w3x4y5z6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reminders",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "system_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("systems.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "channel_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("notification_channels.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String(120), nullable=False),
+        # title + body are encrypted at rest (matching member descriptions
+        # and journal entries) — they're free-text user content.
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        # 'automated' (front-event-triggered) or 'repeated' (cron-scheduled)
+        sa.Column("trigger_type", sa.String(16), nullable=False),
+        # --- automated trigger fields ---
+        # null trigger_member_id with trigger_event=any = "any front change"
+        sa.Column(
+            "trigger_member_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("members.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("trigger_event", sa.String(16), nullable=True),
+        sa.Column("delay_seconds", sa.Integer(), nullable=True),
+        # --- repeated schedule fields (structured) ---
+        sa.Column("schedule_kind", sa.String(16), nullable=True),
+        sa.Column("schedule_time", sa.String(5), nullable=True),  # HH:MM
+        # bitmask, Mon=1, Tue=2, ..., Sun=64
+        sa.Column("schedule_dow_mask", sa.Integer(), nullable=True),
+        sa.Column("schedule_dom", sa.Integer(), nullable=True),
+        sa.Column("schedule_tz", sa.String(64), nullable=True),
+        # --- repeated schedule fields (advanced cron) ---
+        # When set, takes precedence over the structured fields above.
+        sa.Column("cron_expression", sa.String(120), nullable=True),
+        # --- scoping (repeated only) ---
+        sa.Column(
+            "scope",
+            sa.String(8),
+            nullable=False,
+            server_default="system",
+        ),
+        sa.Column(
+            "digest_when_absent",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        # --- runtime state ---
+        # Tracks the last fire so the scheduler can detect missed firings
+        # across server downtime without firing every missed slot.
+        sa.Column("last_fired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_table(
+        "reminder_scope_members",
+        sa.Column(
+            "reminder_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("reminders.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "member_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("members.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+
+    op.create_table(
+        "reminder_pending",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "reminder_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("reminders.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "scheduled_for", sa.DateTime(timezone=True), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reminder_pending")
+    op.drop_table("reminder_scope_members")
+    op.drop_table("reminders")

--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -336,6 +336,22 @@ Upload returns `{ "url": "...", "key": "...", "size": 12345 }`. Store the `key`;
 
 Uploads can be disabled server-wide (`ALLOW_IMAGE_UPLOADS=false`). When disabled, `POST /files/upload` returns 403 for regular users; admins and users with `can_upload_images=true` are unaffected. `GET /auth/me` returns `uploads_allowed: bool` — the effective permission for the current user. Hide upload UI when it is false and fall back to external-URL input where available.
 
+### Reminders
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/reminders` | List all reminders for the caller's system |
+| POST | `/reminders` | Create a reminder. Gated by `notifications:write`. |
+| GET | `/reminders/{id}` | Read |
+| PATCH | `/reminders/{id}` | Update. Gated by `notifications:write`. |
+| DELETE | `/reminders/{id}` | Delete. Gated by `notifications:write`. |
+| GET | `/reminders/{id}/next-fire` | Compute next scheduled fire time (null for automated reminders) |
+| GET | `/channels` | Flat list of notification channels for the system, used when picking a destination for a reminder. |
+
+Reminders ride a notification channel for delivery (`channel_id`). Two trigger types: `automated` (delay_seconds after a front-change matching `trigger_member_id`/`trigger_event`) and `repeated` (cron-style schedule via either structured `schedule_kind`/`schedule_time`/`schedule_dow_mask`/`schedule_dom`/`schedule_tz` fields, or a raw `cron_expression`).
+
+Repeated reminders can be scope-limited to specific members. When the schedule fires while no scoped member is fronting and `digest_when_absent=true`, the missed firing queues (capped at 5 per reminder, oldest dropped). On the next front-start of a scoped member, the queue drains as a digest notification. Title and body are encrypted at rest.
+
 ### Analytics
 
 | Method | Path | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "altcha>=0.2.0",
     "httpx>=0.28.0",
     "pywebpush>=2.0.0",
+    "croniter>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -174,6 +174,19 @@ async def export_all(
     )
     uploaded_files = list(files_result.scalars().all())
 
+    # Reminders — config the user explicitly set up. Title and body are
+    # encrypted at rest; we decrypt for the export so the user has the
+    # plaintext. Pending queue rows are runtime state and not exported.
+    from sheaf.models.reminder import Reminder
+
+    reminders_result = await db.execute(
+        select(Reminder)
+        .options(selectinload(Reminder.scope_members))
+        .where(Reminder.system_id == system.id)
+        .order_by(Reminder.created_at.asc())
+    )
+    reminders = list(reminders_result.scalars().all())
+
     return {
         "version": "2",
         "system": _system_dict(system),
@@ -249,6 +262,7 @@ async def export_all(
         "revisions": [_revision_dict(r) for r in revisions],
         "watch_tokens": [_watch_token_dict(t) for t in watch_tokens],
         "uploaded_files": [_uploaded_file_dict(f) for f in uploaded_files],
+        "reminders": [_reminder_dict(r) for r in reminders],
     }
 
 
@@ -265,6 +279,7 @@ def _empty_export() -> dict:
         "revisions": [],
         "watch_tokens": [],
         "uploaded_files": [],
+        "reminders": [],
     }
 
 
@@ -409,6 +424,44 @@ def _uploaded_file_dict(f: UploadedFile) -> dict:
         "size_bytes": f.size_bytes,
         "content_type": f.content_type,
         "created_at": f.created_at.isoformat(),
+    }
+
+
+def _reminder_dict(reminder) -> dict:
+    """Reminder config the user explicitly built up. Title and body are
+    decrypted to plaintext for the export. Pending-queue rows are
+    transient runtime state and not included.
+
+    Re-importable in the sense that the trigger config and channel
+    reference carry over to another instance; runtime state (last_fired_at,
+    pending queue) is omitted and the channel_id is just the original UUID
+    so a re-import on a fresh instance won't resolve unless the channels
+    were imported there too."""
+    title = decrypt(reminder.title) if reminder.title else ""
+    body = decrypt(reminder.body) if reminder.body else None
+    return {
+        "id": str(reminder.id),
+        "channel_id": str(reminder.channel_id),
+        "name": reminder.name,
+        "title": title,
+        "body": body,
+        "enabled": reminder.enabled,
+        "trigger_type": reminder.trigger_type,
+        "trigger_member_id": (
+            str(reminder.trigger_member_id) if reminder.trigger_member_id else None
+        ),
+        "trigger_event": reminder.trigger_event,
+        "delay_seconds": reminder.delay_seconds,
+        "schedule_kind": reminder.schedule_kind,
+        "schedule_time": reminder.schedule_time,
+        "schedule_dow_mask": reminder.schedule_dow_mask,
+        "schedule_dom": reminder.schedule_dom,
+        "schedule_tz": reminder.schedule_tz,
+        "cron_expression": reminder.cron_expression,
+        "scope": reminder.scope,
+        "scope_member_ids": [str(m.id) for m in reminder.scope_members],
+        "digest_when_absent": reminder.digest_when_absent,
+        "created_at": reminder.created_at.isoformat(),
     }
 
 

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -360,6 +360,41 @@ async def list_channels(
     return [_channel_to_read(c) for c in result.scalars().all()]
 
 
+@router.get("/channels", response_model=list[ChannelRead])
+async def list_all_channels(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ChannelRead]:
+    """Flat list of every notification channel in the user's system.
+
+    The per-token list endpoint above is the right shape for the
+    notifications UI (which is grouped by watch token); this flat view
+    is the right shape for the reminders UI, which doesn't care about
+    tokens — it just needs to pick a destination. Same auth model:
+    you only see channels under your own non-revoked watch tokens.
+    """
+    from sheaf.models.system import System
+    from sheaf.models.watch_token import WatchToken
+
+    system_result = await db.execute(
+        select(System).where(System.user_id == user.id)
+    )
+    system = system_result.scalar_one_or_none()
+    if system is None:
+        return []
+    result = await db.execute(
+        select(NotificationChannel)
+        .join(WatchToken, NotificationChannel.watch_token_id == WatchToken.id)
+        .where(WatchToken.system_id == system.id)
+        .options(
+            selectinload(NotificationChannel.group_rules),
+            selectinload(NotificationChannel.member_rules),
+        )
+        .order_by(NotificationChannel.created_at.desc())
+    )
+    return [_channel_to_read(c) for c in result.scalars().all()]
+
+
 @router.get("/channels/{channel_id}", response_model=ChannelRead)
 async def get_channel(
     channel_id: uuid.UUID,

--- a/sheaf/api/v1/reminders.py
+++ b/sheaf/api/v1/reminders.py
@@ -1,0 +1,482 @@
+"""Reminders API.
+
+CRUD endpoints for the two reminder kinds (automated front-event
+triggered, and repeated cron/structured-schedule). Both kinds are
+gated by the `notifications:write` scope on the assumption that a
+caller permitted to manage notification destinations is also
+permitted to manage reminders that ride those destinations.
+"""
+
+import uuid
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from croniter import croniter
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from sheaf.auth.dependencies import get_current_user, require_scope
+from sheaf.database import get_db
+from sheaf.models.member import Member
+from sheaf.models.notification_channel import NotificationChannel
+from sheaf.models.pending_action import PendingActionType
+from sheaf.models.reminder import Reminder
+from sheaf.models.system import System
+from sheaf.models.user import User
+from sheaf.models.watch_token import WatchToken
+from sheaf.schemas.member import MemberDeleteConfirm
+from sheaf.schemas.reminder import (
+    ReminderCreate,
+    ReminderRead,
+    ReminderUpdate,
+)
+from sheaf.services.reminders import (
+    compute_next_fire,
+    decrypt_for_read,
+    encrypt_title_body,
+)
+from sheaf.services.system_safety import (
+    is_safeguarded,
+    queue_pending_action,
+    verify_destructive_auth,
+)
+
+router = APIRouter(prefix="/reminders", tags=["reminders"])
+
+
+# --- Helpers ---------------------------------------------------------------
+
+
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
+
+
+async def _get_owned_reminder(
+    reminder_id: uuid.UUID, system: System, db: AsyncSession
+) -> Reminder:
+    result = await db.execute(
+        select(Reminder)
+        .options(
+            selectinload(Reminder.scope_members),
+            selectinload(Reminder.pending),
+        )
+        .where(
+            Reminder.id == reminder_id,
+            Reminder.system_id == system.id,
+        )
+    )
+    reminder = result.scalar_one_or_none()
+    if reminder is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Reminder not found"
+        )
+    return reminder
+
+
+async def _validate_channel(
+    channel_id: uuid.UUID, system: System, db: AsyncSession
+) -> NotificationChannel:
+    """Confirm the supplied channel belongs to the user's system.
+
+    Reminders point to a channel via `channel_id`; the channel itself
+    belongs to a watch token, which belongs to a system. We refuse
+    reminders that would send through a different system's channel.
+    """
+    result = await db.execute(
+        select(NotificationChannel)
+        .join(WatchToken, NotificationChannel.watch_token_id == WatchToken.id)
+        .where(
+            NotificationChannel.id == channel_id,
+            WatchToken.system_id == system.id,
+        )
+    )
+    channel = result.scalar_one_or_none()
+    if channel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notification channel not found.",
+        )
+    return channel
+
+
+async def _validate_scope_members(
+    member_ids: list[uuid.UUID], system: System, db: AsyncSession
+) -> list[Member]:
+    """Confirm all member ids exist within this system."""
+    if not member_ids:
+        return []
+    result = await db.execute(
+        select(Member).where(
+            Member.id.in_(member_ids),
+            Member.system_id == system.id,
+        )
+    )
+    members = list(result.scalars().all())
+    if len(members) != len(member_ids):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more scope_member_ids are invalid.",
+        )
+    return members
+
+
+def _validate_trigger_config(
+    trigger_type: str,
+    *,
+    trigger_event: str | None,
+    delay_seconds: int | None,
+    schedule_kind: str | None,
+    schedule_time: str | None,
+    schedule_dow_mask: int | None,
+    schedule_dom: int | None,
+    schedule_tz: str | None,
+    cron_expression: str | None,
+) -> None:
+    """Cross-field validation for the trigger config.
+
+    Pydantic catches per-field shapes; this layer enforces the bigger
+    "what fields are required given the trigger type" rules.
+    """
+    if trigger_type == "automated":
+        if delay_seconds is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="automated reminders require delay_seconds.",
+            )
+        if trigger_event not in ("start", "stop", "any"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="trigger_event must be start | stop | any.",
+            )
+        return
+
+    if trigger_type != "repeated":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="trigger_type must be automated or repeated.",
+        )
+
+    # Repeated: either cron_expression OR a structured schedule.
+    if cron_expression:
+        try:
+            croniter(cron_expression)
+        except (ValueError, KeyError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid cron expression: {exc}",
+            ) from exc
+    else:
+        if schedule_kind not in ("daily", "weekly", "monthly"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "repeated reminders require either cron_expression or a "
+                    "structured schedule_kind (daily | weekly | monthly)."
+                ),
+            )
+        if schedule_time is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="schedule_time (HH:MM) is required for structured schedules.",
+            )
+        if schedule_kind == "weekly" and not schedule_dow_mask:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="weekly schedules require schedule_dow_mask (1-127).",
+            )
+        if schedule_kind == "monthly" and not schedule_dom:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="monthly schedules require schedule_dom (1-31).",
+            )
+
+    if schedule_tz is not None:
+        try:
+            ZoneInfo(schedule_tz)
+        except ZoneInfoNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown timezone: {schedule_tz}",
+            ) from exc
+
+
+def _to_read(reminder: Reminder) -> ReminderRead:
+    decrypted = decrypt_for_read(reminder)
+    return ReminderRead(
+        id=reminder.id,
+        system_id=reminder.system_id,
+        channel_id=reminder.channel_id,
+        name=reminder.name,
+        title=decrypted["title"],
+        body=decrypted["body"],
+        enabled=reminder.enabled,
+        trigger_type=reminder.trigger_type,
+        trigger_member_id=reminder.trigger_member_id,
+        trigger_event=reminder.trigger_event,
+        delay_seconds=reminder.delay_seconds,
+        schedule_kind=reminder.schedule_kind,
+        schedule_time=reminder.schedule_time,
+        schedule_dow_mask=reminder.schedule_dow_mask,
+        schedule_dom=reminder.schedule_dom,
+        schedule_tz=reminder.schedule_tz,
+        cron_expression=reminder.cron_expression,
+        scope=reminder.scope,
+        scope_member_ids=decrypted["scope_member_ids"],
+        digest_when_absent=reminder.digest_when_absent,
+        last_fired_at=reminder.last_fired_at,
+        pending_count=decrypted["pending_count"],
+        next_fire_at=decrypted["next_fire_at"],
+        created_at=reminder.created_at,
+        updated_at=reminder.updated_at,
+    )
+
+
+# --- CRUD -----------------------------------------------------------------
+
+
+@router.get("", response_model=list[ReminderRead])
+async def list_reminders(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    result = await db.execute(
+        select(Reminder)
+        .options(
+            selectinload(Reminder.scope_members),
+            selectinload(Reminder.pending),
+        )
+        .where(Reminder.system_id == system.id)
+        .order_by(Reminder.created_at.desc())
+    )
+    return [_to_read(r) for r in result.scalars().all()]
+
+
+@router.post(
+    "",
+    response_model=ReminderRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_scope("notifications:write"))],
+)
+async def create_reminder(
+    body: ReminderCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    await _validate_channel(body.channel_id, system, db)
+    _validate_trigger_config(
+        body.trigger_type,
+        trigger_event=body.trigger_event,
+        delay_seconds=body.delay_seconds,
+        schedule_kind=body.schedule_kind,
+        schedule_time=body.schedule_time,
+        schedule_dow_mask=body.schedule_dow_mask,
+        schedule_dom=body.schedule_dom,
+        schedule_tz=body.schedule_tz,
+        cron_expression=body.cron_expression,
+    )
+    scope_members = await _validate_scope_members(
+        body.scope_member_ids, system, db
+    )
+
+    title_ct, body_ct = encrypt_title_body(body.title, body.body)
+    reminder = Reminder(
+        id=uuid.uuid4(),
+        system_id=system.id,
+        channel_id=body.channel_id,
+        name=body.name,
+        title=title_ct,
+        body=body_ct,
+        enabled=body.enabled,
+        trigger_type=body.trigger_type,
+        trigger_member_id=body.trigger_member_id,
+        trigger_event=body.trigger_event,
+        delay_seconds=body.delay_seconds,
+        schedule_kind=body.schedule_kind,
+        schedule_time=body.schedule_time,
+        schedule_dow_mask=body.schedule_dow_mask,
+        schedule_dom=body.schedule_dom,
+        schedule_tz=body.schedule_tz,
+        cron_expression=body.cron_expression,
+        scope=body.scope,
+        digest_when_absent=body.digest_when_absent,
+        scope_members=scope_members,
+    )
+    db.add(reminder)
+    await db.commit()
+    # Re-fetch with relations for the response shape.
+    refreshed = await _get_owned_reminder(reminder.id, system, db)
+    return _to_read(refreshed)
+
+
+@router.get("/{reminder_id}", response_model=ReminderRead)
+async def get_reminder(
+    reminder_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    reminder = await _get_owned_reminder(reminder_id, system, db)
+    return _to_read(reminder)
+
+
+@router.patch(
+    "/{reminder_id}",
+    response_model=ReminderRead,
+    dependencies=[Depends(require_scope("notifications:write"))],
+)
+async def update_reminder(
+    reminder_id: uuid.UUID,
+    body: ReminderUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    reminder = await _get_owned_reminder(reminder_id, system, db)
+
+    update_data = body.model_dump(exclude_unset=True)
+
+    if "channel_id" in update_data:
+        await _validate_channel(update_data["channel_id"], system, db)
+
+    # Re-run cross-field validation against the post-update view of the
+    # reminder so a partial PATCH that flips trigger_type doesn't produce
+    # a half-valid config.
+    next_view = {**_reminder_dict(reminder), **update_data}
+    _validate_trigger_config(
+        next_view["trigger_type"],
+        trigger_event=next_view.get("trigger_event"),
+        delay_seconds=next_view.get("delay_seconds"),
+        schedule_kind=next_view.get("schedule_kind"),
+        schedule_time=next_view.get("schedule_time"),
+        schedule_dow_mask=next_view.get("schedule_dow_mask"),
+        schedule_dom=next_view.get("schedule_dom"),
+        schedule_tz=next_view.get("schedule_tz"),
+        cron_expression=next_view.get("cron_expression"),
+    )
+
+    if "scope_member_ids" in update_data:
+        members = await _validate_scope_members(
+            update_data["scope_member_ids"], system, db
+        )
+        reminder.scope_members = members
+        del update_data["scope_member_ids"]
+
+    # Encrypt title/body when they change. Other fields just `setattr`.
+    if "title" in update_data or "body" in update_data:
+        new_title = update_data.get("title", _decrypted(reminder.title) or "")
+        new_body = update_data.get(
+            "body", _decrypted(reminder.body)
+        )
+        title_ct, body_ct = encrypt_title_body(new_title, new_body)
+        reminder.title = title_ct
+        reminder.body = body_ct
+        update_data.pop("title", None)
+        update_data.pop("body", None)
+
+    for key, value in update_data.items():
+        setattr(reminder, key, value)
+
+    await db.commit()
+    refreshed = await _get_owned_reminder(reminder.id, system, db)
+    return _to_read(refreshed)
+
+
+@router.delete(
+    "/{reminder_id}",
+    dependencies=[Depends(require_scope("notifications:delete"))],
+)
+async def delete_reminder(
+    reminder_id: uuid.UUID,
+    body: MemberDeleteConfirm | None = None,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Delete a reminder.
+
+    Reuses the System Safety machinery for delete protection: when the
+    notifications safety category is enabled with a non-zero grace
+    period, the delete is queued as a pending action and executed by
+    the background finalizer. Step-up auth (password / TOTP) gates the
+    request via `verify_destructive_auth`, matching the behaviour of
+    notification channel deletion.
+    """
+    system = await _get_user_system(user, db)
+    reminder = await _get_owned_reminder(reminder_id, system, db)
+    verify_destructive_auth(
+        user,
+        system,
+        body.password if body else None,
+        body.totp_code if body else None,
+    )
+
+    if is_safeguarded(system, PendingActionType.REMINDER_DELETE):
+        pending = await queue_pending_action(
+            db=db,
+            system=system,
+            user=user,
+            action_type=PendingActionType.REMINDER_DELETE,
+            target_id=reminder.id,
+            target_label=reminder.name,
+        )
+        await db.commit()
+        await db.refresh(pending)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "pending_action_id": str(pending.id),
+                "finalize_after": pending.finalize_after.isoformat(),
+            },
+        )
+
+    await db.delete(reminder)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/{reminder_id}/next-fire", response_model=dict)
+async def get_next_fire(
+    reminder_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the next scheduled fire time, useful for UI previews
+    of cron expressions and structured schedules."""
+    system = await _get_user_system(user, db)
+    reminder = await _get_owned_reminder(reminder_id, system, db)
+    next_fire = compute_next_fire(reminder)
+    return {"next_fire_at": next_fire.isoformat() if next_fire else None}
+
+
+# --- Internal helpers -----------------------------------------------------
+
+
+def _decrypted(ciphertext: str | None) -> str | None:
+    from sheaf.crypto import decrypt
+
+    return decrypt(ciphertext) if ciphertext else None
+
+
+def _reminder_dict(reminder: Reminder) -> dict:
+    """Snapshot the validation-relevant fields of an existing reminder
+    for cross-field PATCH validation."""
+    return {
+        "trigger_type": reminder.trigger_type,
+        "trigger_event": reminder.trigger_event,
+        "delay_seconds": reminder.delay_seconds,
+        "schedule_kind": reminder.schedule_kind,
+        "schedule_time": reminder.schedule_time,
+        "schedule_dow_mask": reminder.schedule_dow_mask,
+        "schedule_dom": reminder.schedule_dom,
+        "schedule_tz": reminder.schedule_tz,
+        "cron_expression": reminder.cron_expression,
+    }

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -17,6 +17,7 @@ from sheaf.api.v1 import (
     notification_channels,
     notifications_public,
     pk_import,
+    reminders,
     retention,
     sheaf_import,
     sp_import,
@@ -120,6 +121,10 @@ v1_router.include_router(
     dependencies=[Depends(require_scope("notifications:read"))],
 )
 v1_router.include_router(notifications_public.router)
+v1_router.include_router(
+    reminders.router,
+    dependencies=[Depends(require_scope("notifications:read"))],
+)
 
 # File serve catch-all MUST be last — {path:path} would shadow other routes
 v1_router.include_router(files.serve_router)

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -30,6 +30,7 @@ from sheaf.models.notification_channel_member_rule import (
 )
 from sheaf.models.notification_outbox import NotificationOutboxRow
 from sheaf.models.pending_action import PendingAction, PendingActionStatus, PendingActionType
+from sheaf.models.reminder import Reminder, ReminderPending, reminder_scope_members
 from sheaf.models.retention_trim_notice import RetentionTrimNotice, RetentionTrimStatus
 from sheaf.models.safety_change_request import SafetyChangeRequest, SafetyChangeStatus
 from sheaf.models.system import DeleteConfirmation, PrivacyLevel, System
@@ -75,6 +76,8 @@ __all__ = [
     "PendingActionStatus",
     "PendingActionType",
     "PrivacyLevel",
+    "Reminder",
+    "ReminderPending",
     "RetentionTrimNotice",
     "RetentionTrimStatus",
     "SafetyChangeRequest",
@@ -90,4 +93,5 @@ __all__ = [
     "front_members",
     "group_members",
     "member_tags",
+    "reminder_scope_members",
 ]

--- a/sheaf/models/pending_action.py
+++ b/sheaf/models/pending_action.py
@@ -20,6 +20,7 @@ class PendingActionType(StrEnum):
     REVISION_UNPIN = "revision_unpin"
     WATCH_TOKEN_REVOKE = "watch_token_revoke"
     CHANNEL_DELETE = "channel_delete"
+    REMINDER_DELETE = "reminder_delete"
 
 
 class PendingActionStatus(StrEnum):

--- a/sheaf/models/reminder.py
+++ b/sheaf/models/reminder.py
@@ -1,0 +1,159 @@
+"""Reminder data model.
+
+Two trigger types share one row, discriminated by `trigger_type`:
+
+- automated: front-event-driven. Set `trigger_member_id` (or null for
+  "any front change") and `delay_seconds`. The notifications event hook
+  enqueues a delayed send when a matching event lands.
+- repeated: schedule-driven. Use the structured `schedule_*` fields for
+  daily/weekly/monthly cadence, or `cron_expression` for the "Advanced"
+  power-user mode (takes precedence when set).
+
+Repeated reminders can be scope-limited to specific members. When the
+schedule fires and no scoped member is currently fronting, the reminder
+either drops silently (`digest_when_absent=False`) or queues a row in
+`reminder_pending` (default). On the next front-start of any scoped
+member, the queue is drained as a single digest notification per channel.
+The pending queue caps at 5 entries per reminder; oldest is dropped on
+overflow.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from sheaf.models.base import Base, TimestampMixin, UUIDMixin
+
+# M2M: reminders <-> members (scoping for repeated reminders)
+reminder_scope_members = Table(
+    "reminder_scope_members",
+    Base.metadata,
+    Column(
+        "reminder_id",
+        UUID(as_uuid=True),
+        ForeignKey("reminders.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "member_id",
+        UUID(as_uuid=True),
+        ForeignKey("members.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
+
+
+class Reminder(UUIDMixin, TimestampMixin, Base):
+    __tablename__ = "reminders"
+
+    system_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("systems.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    channel_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("notification_channels.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    # title + body are encrypted at rest (matching the encryption discipline
+    # used for member descriptions and journal entries — both are free-text
+    # user content).
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False, server_default="true"
+    )
+
+    # "automated" or "repeated"
+    trigger_type: Mapped[str] = mapped_column(String(16), nullable=False)
+
+    # --- automated (front-event-triggered) ---
+    # null trigger_member_id with trigger_event="any" = "any front change"
+    trigger_member_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("members.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    # "start" | "stop" | "any"
+    trigger_event: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    delay_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # --- repeated (structured schedule) ---
+    # "daily" | "weekly" | "monthly"
+    schedule_kind: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    # HH:MM in schedule_tz
+    schedule_time: Mapped[str | None] = mapped_column(String(5), nullable=True)
+    # bitmask, Mon=1, Tue=2, ..., Sun=64
+    schedule_dow_mask: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    schedule_dom: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    schedule_tz: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # --- repeated (advanced cron) ---
+    # When set, takes precedence over the structured fields above.
+    cron_expression: Mapped[str | None] = mapped_column(String(120), nullable=True)
+
+    # --- scoping (repeated only) ---
+    # "system" | "member"
+    scope: Mapped[str] = mapped_column(
+        String(8), nullable=False, default="system", server_default="system"
+    )
+    digest_when_absent: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False, server_default="true"
+    )
+
+    # Runtime state
+    last_fired_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Relationships
+    scope_members: Mapped[list["Member"]] = relationship(
+        secondary=reminder_scope_members,
+    )
+    pending: Mapped[list["ReminderPending"]] = relationship(
+        back_populates="reminder",
+        cascade="all, delete-orphan",
+    )
+
+
+class ReminderPending(UUIDMixin, Base):
+    """A reminder that *should* have fired at `scheduled_for` but didn't
+    because no scope-member was fronting. Drained as part of a digest
+    notification when any scope-member next starts fronting."""
+
+    __tablename__ = "reminder_pending"
+
+    reminder_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("reminders.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    scheduled_for: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default="now()",
+    )
+
+    reminder: Mapped[Reminder] = relationship(back_populates="pending")

--- a/sheaf/schemas/reminder.py
+++ b/sheaf/schemas/reminder.py
@@ -1,0 +1,124 @@
+"""Pydantic models for the reminder feature."""
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+# A few sentinel/format constants the API layer reuses.
+TRIGGER_TYPE = Literal["automated", "repeated"]
+TRIGGER_EVENT = Literal["start", "stop", "any"]
+SCHEDULE_KIND = Literal["daily", "weekly", "monthly"]
+SCOPE = Literal["system", "member"]
+
+
+class ReminderBase(BaseModel):
+    """Fields shared by create and update payloads."""
+
+    name: str = Field(min_length=1, max_length=120)
+    title: str = Field(min_length=1, max_length=500)
+    body: str | None = Field(default=None, max_length=2000)
+    enabled: bool = True
+    channel_id: uuid.UUID
+
+    trigger_type: TRIGGER_TYPE
+
+    # automated trigger
+    trigger_member_id: uuid.UUID | None = None
+    trigger_event: TRIGGER_EVENT | None = None
+    delay_seconds: int | None = Field(default=None, ge=0, le=7 * 24 * 3600)
+
+    # repeated structured schedule
+    schedule_kind: SCHEDULE_KIND | None = None
+    schedule_time: str | None = Field(default=None, pattern=r"^[0-2]\d:[0-5]\d$")
+    schedule_dow_mask: int | None = Field(default=None, ge=0, le=127)
+    schedule_dom: int | None = Field(default=None, ge=1, le=31)
+    schedule_tz: str | None = Field(default=None, max_length=64)
+
+    # repeated advanced cron (takes precedence over structured fields)
+    cron_expression: str | None = Field(default=None, max_length=120)
+
+    # scoping (repeated only)
+    scope: SCOPE = "system"
+    scope_member_ids: list[uuid.UUID] = Field(default_factory=list)
+    digest_when_absent: bool = True
+
+    @field_validator("schedule_time")
+    @classmethod
+    def _check_time_range(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        hh, mm = v.split(":")
+        if int(hh) > 23 or int(mm) > 59:
+            raise ValueError("schedule_time must be 00:00-23:59")
+        return v
+
+
+class ReminderCreate(ReminderBase):
+    pass
+
+
+class ReminderUpdate(BaseModel):
+    """Partial update — only the fields that are explicitly supplied
+    are written. Member rules are replaced wholesale when supplied;
+    omit `scope_member_ids` to leave them alone."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    title: str | None = Field(default=None, min_length=1, max_length=500)
+    body: str | None = Field(default=None, max_length=2000)
+    enabled: bool | None = None
+    channel_id: uuid.UUID | None = None
+
+    trigger_type: TRIGGER_TYPE | None = None
+    trigger_member_id: uuid.UUID | None = None
+    trigger_event: TRIGGER_EVENT | None = None
+    delay_seconds: int | None = Field(default=None, ge=0, le=7 * 24 * 3600)
+
+    schedule_kind: SCHEDULE_KIND | None = None
+    schedule_time: str | None = Field(default=None, pattern=r"^[0-2]\d:[0-5]\d$")
+    schedule_dow_mask: int | None = Field(default=None, ge=0, le=127)
+    schedule_dom: int | None = Field(default=None, ge=1, le=31)
+    schedule_tz: str | None = Field(default=None, max_length=64)
+
+    cron_expression: str | None = Field(default=None, max_length=120)
+
+    scope: SCOPE | None = None
+    scope_member_ids: list[uuid.UUID] | None = None
+    digest_when_absent: bool | None = None
+
+
+class ReminderRead(BaseModel):
+    id: uuid.UUID
+    system_id: uuid.UUID
+    channel_id: uuid.UUID
+
+    name: str
+    title: str
+    body: str | None
+    enabled: bool
+    trigger_type: str
+
+    trigger_member_id: uuid.UUID | None
+    trigger_event: str | None
+    delay_seconds: int | None
+
+    schedule_kind: str | None
+    schedule_time: str | None
+    schedule_dow_mask: int | None
+    schedule_dom: int | None
+    schedule_tz: str | None
+    cron_expression: str | None
+
+    scope: str
+    scope_member_ids: list[uuid.UUID]
+    digest_when_absent: bool
+
+    last_fired_at: datetime | None
+    pending_count: int
+    next_fire_at: datetime | None
+
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -621,6 +621,15 @@ async def _cleanup_export_jobs(db: AsyncSession) -> dict:
     return {"items_processed": handled}
 
 
+async def _tick_repeated_reminders(db: AsyncSession) -> dict:
+    """Fire repeated reminders whose schedule has elapsed since last tick."""
+    from sheaf.services.reminders import tick_repeated_reminders
+
+    enqueued = await tick_repeated_reminders(db)
+    await db.commit()
+    return {"items_processed": enqueued}
+
+
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -723,6 +732,13 @@ def _register_all_jobs() -> None:
         description="Delete expired export artefacts and mark rows EXPIRED",
         func=_cleanup_export_jobs,
         interval_seconds=lambda: settings.export_cleanup_interval_seconds,
+    )
+
+    register_job(
+        name="tick_repeated_reminders",
+        description="Fire any due repeated reminders into the notification outbox",
+        func=_tick_repeated_reminders,
+        interval_seconds=lambda: 60,
     )
 
     # Dev-only jobs — sheaf_dev is NOT installed in production Docker images

--- a/sheaf/services/notifications/dispatcher.py
+++ b/sheaf/services/notifications/dispatcher.py
@@ -36,6 +36,7 @@ from sheaf.models.notification_channel import (
 from sheaf.models.notification_outbox import NotificationOutboxRow
 from sheaf.services.members import member_name_plaintext
 from sheaf.services.notifications.handlers import deliver
+from sheaf.services.notifications.payload import RenderedMessage
 from sheaf.services.notifications.resolution import resolve_member_visibility
 
 logger = logging.getLogger("sheaf.notifications.dispatcher")
@@ -134,9 +135,19 @@ async def _process_row(
             await _drop(db, row, f"channel state {channel.destination_state}")
             return
 
+        # Reminders take a separate code path: no member resolution, no
+        # filter application, no debounce/quiet-hours suppression. They
+        # were scheduled at a specific time on purpose; if the user
+        # didn't want them firing during quiet hours they wouldn't have
+        # set them. Per-channel rate limits still apply via the semaphore.
+        now = datetime.now(UTC)
+        if row.event_type == "reminder":
+            message = _render_reminder(row.event_payload)
+            await _deliver_or_retry(db, row, channel, message, sems)
+            return
+
         # Debounce: skip if the channel got a successful delivery within the
         # debounce window. Re-queue past the window.
-        now = datetime.now(UTC)
         if (
             channel.last_delivered_at is not None
             and channel.debounce_seconds > 0
@@ -191,44 +202,85 @@ async def _process_row(
             await _drop(db, row, "no visible content for this channel")
             return
 
-        sem = sems.get(channel.destination_type)
-        if sem is None:
-            await _drop(db, row, f"no handler for {channel.destination_type}")
-            return
+        await _deliver_or_retry(db, row, channel, message, sems)
 
-        # Resolve channel owner for handlers that need per-user accounting
-        # (currently just Pushover's per-user monthly cap on the shared app).
-        owner_user_id, owner_tier = await _resolve_channel_owner(db, channel)
 
-        async with sem:
-            outcome = await deliver(
-                channel,
-                message,
-                event_id=str(row.event_id),
-                owner_user_id=owner_user_id,
-                owner_tier=owner_tier,
-            )
+def _render_reminder(payload: dict) -> RenderedMessage:
+    """Build a delivery message for a reminder outbox row.
 
-        if outcome.ok:
-            row.delivered_at = datetime.now(UTC)
-            channel.last_delivered_at = row.delivered_at
-            await db.commit()
-            return
+    Two payload kinds:
+      - reminder_single: one fire of one reminder; title is the user's
+        reminder title, body is the user's body verbatim.
+      - reminder_digest: multiple missed firings of one reminder, drained
+        because a scope-member just started fronting. Body summarises with
+        a count + last-missed timestamp; recipients click through if they
+        want the full detail.
+    """
+    kind = payload.get("kind")
+    title = payload.get("title") or "Reminder"
+    body = payload.get("body") or ""
+    if kind == "reminder_digest":
+        count = payload.get("missed_count") or 0
+        last = payload.get("last_missed_at") or ""
+        suffix = f" (×{count})" if count > 1 else ""
+        # Keep the body terse — channels with a strict size budget (web push
+        # at ~4KB) don't have room for full per-occurrence detail anyway.
+        digest_lines = [f"{title}{suffix}"]
+        if last:
+            digest_lines.append(f"last scheduled at {last}")
+        if body:
+            digest_lines.append(body)
+        return RenderedMessage(
+            title="Missed reminders" if count > 1 else title,
+            body="\n".join(digest_lines),
+        )
+    return RenderedMessage(title=title, body=body)
 
-        if outcome.permanent:
-            channel.destination_state = DestinationState.DISABLED.value
-            await _drop(db, row, f"permanent: {outcome.error}")
-            return
 
-        # Transient: backoff + requeue.
-        row.failed_attempts += 1
-        row.last_error = outcome.error
-        backoff = _BACKOFF_BASE_SECONDS * (2 ** min(row.failed_attempts - 1, 6))
-        row.next_retry_after = datetime.now(UTC) + timedelta(seconds=backoff)
-        row.deliver_after = row.next_retry_after
-        row.claimed_at = None
-        row.claimed_by = None
+async def _deliver_or_retry(
+    db: AsyncSession,
+    row: NotificationOutboxRow,
+    channel: NotificationChannel,
+    message: RenderedMessage,
+    sems: dict[str, asyncio.Semaphore],
+) -> None:
+    """Common delivery tail used by both front-change and reminder rows."""
+    sem = sems.get(channel.destination_type)
+    if sem is None:
+        await _drop(db, row, f"no handler for {channel.destination_type}")
+        return
+
+    owner_user_id, owner_tier = await _resolve_channel_owner(db, channel)
+
+    async with sem:
+        outcome = await deliver(
+            channel,
+            message,
+            event_id=str(row.event_id),
+            owner_user_id=owner_user_id,
+            owner_tier=owner_tier,
+        )
+
+    if outcome.ok:
+        row.delivered_at = datetime.now(UTC)
+        channel.last_delivered_at = row.delivered_at
         await db.commit()
+        return
+
+    if outcome.permanent:
+        channel.destination_state = DestinationState.DISABLED.value
+        await _drop(db, row, f"permanent: {outcome.error}")
+        return
+
+    # Transient: backoff + requeue.
+    row.failed_attempts += 1
+    row.last_error = outcome.error
+    backoff = _BACKOFF_BASE_SECONDS * (2 ** min(row.failed_attempts - 1, 6))
+    row.next_retry_after = datetime.now(UTC) + timedelta(seconds=backoff)
+    row.deliver_after = row.next_retry_after
+    row.claimed_at = None
+    row.claimed_by = None
+    await db.commit()
 
 
 async def _load_row(

--- a/sheaf/services/notifications/events.py
+++ b/sheaf/services/notifications/events.py
@@ -91,11 +91,36 @@ async def emit_front_change(
 
     Returns the number of outbox rows enqueued. Caller commits the session.
     """
-    started = bool(after.fronting_member_ids - before.fronting_member_ids)
-    stopped = bool(before.fronting_member_ids - after.fronting_member_ids)
+    started_ids = after.fronting_member_ids - before.fronting_member_ids
+    stopped_ids = before.fronting_member_ids - after.fronting_member_ids
+    started = bool(started_ids)
+    stopped = bool(stopped_ids)
     cofront_changed = _has_cofront_change(before, after)
     if not (started or stopped or cofront_changed):
         return 0
+
+    # Reminders ride alongside front-change notifications: automated
+    # timers fire `delay_seconds` after the matching event, and member-
+    # scoped repeated-reminder digests drain when a scope-member starts
+    # fronting after a stretch with none of them on. Importing here to
+    # avoid a circular import at module load.
+    from sheaf.services.reminders import (
+        drain_digests_for_started_members,
+        emit_for_front_event,
+    )
+
+    await emit_for_front_event(
+        db,
+        system_id=system_id,
+        started_member_ids=set(started_ids),
+        stopped_member_ids=set(stopped_ids),
+    )
+    await drain_digests_for_started_members(
+        db,
+        system_id=system_id,
+        started_member_ids=set(started_ids),
+        previously_fronting=set(before.fronting_member_ids),
+    )
 
     event_id = event_id or uuid.uuid4()
     now = now or datetime.now(UTC)

--- a/sheaf/services/reminders.py
+++ b/sheaf/services/reminders.py
@@ -1,0 +1,548 @@
+"""Reminder scheduling and dispatch.
+
+Two trigger types share one Reminder row:
+
+- automated: enqueued reactively from `emit_front_change` when a matching
+  event lands. The notification outbox carries the delay via
+  `deliver_after`. No scheduler tick involved.
+- repeated: a 60-second job tick walks enabled rows and fires those whose
+  next-fire time is in the past. Member-scoped reminders that fire while
+  no scoped member is fronting drop into a pending queue for digesting on
+  the next scope-member front-start.
+
+Reminder payloads ride the existing `notification_outbox` with
+`event_type="reminder"`. The dispatcher branches on event_type and skips
+the front-change-specific resolution / filter / cofront-redaction path
+for these — reminders are direct sends to the channel with the literal
+title and body the user configured.
+
+# Future enhancements (not in v1)
+
+- Mobile push notifications (APNs / FCM) as a destination type. Today
+  reminders ride the existing notification channels: web push, webhook,
+  ntfy, Pushover. For most users on mobile, the natural place for a
+  reminder is the OS push system on their own phone — that needs an
+  APNs/FCM destination type alongside the existing four, plus a
+  capability flow for the mobile apps to register their device tokens.
+  Likely the highest-impact follow-up; reminders are the feature most
+  users would expect to fire to their phone first.
+- Member-scoping condition on automated timers ("ping me 30 min after
+  Alice fronts, but only if Bob isn't fronting").
+- Per-channel-type custom digest template (right now the digest format
+  is hardcoded to "title (×count) — last <timestamp>").
+- Reminder pause/snooze without disabling (e.g. "skip the next two
+  fires" without a full edit dance).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from croniter import croniter
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from sheaf.crypto import decrypt, encrypt
+from sheaf.models.front import Front
+from sheaf.models.notification_channel import (
+    DestinationState,
+    NotificationChannel,
+)
+from sheaf.models.notification_outbox import NotificationOutboxRow
+from sheaf.models.reminder import Reminder, ReminderPending
+
+logger = logging.getLogger("sheaf.reminders")
+
+# Cap on the pending queue per reminder. Anything beyond this drops the
+# oldest entry. Keeps the digest notification readable when a scope
+# member has been gone for a long stretch.
+_MAX_PENDING_PER_REMINDER = 5
+
+# Bitmask: Mon=1, Tue=2, Wed=4, Thu=8, Fri=16, Sat=32, Sun=64.
+# Matches Python's datetime.weekday() ordering (Mon=0..Sun=6).
+_DOW_BITS = [1 << i for i in range(7)]
+
+
+# --- Helpers ---------------------------------------------------------------
+
+
+def _decrypt_or_none(value: str | None) -> str | None:
+    return decrypt(value) if value else None
+
+
+def _zone(name: str | None) -> ZoneInfo:
+    """Resolve a tz name to ZoneInfo, falling back to UTC if invalid.
+
+    Validation also happens at the API layer; this is the safety net for
+    rows that pre-date a deprecation, or for misconfigurations that
+    shouldn't crash the scheduler tick on every iteration.
+    """
+    if not name:
+        return ZoneInfo("UTC")
+    try:
+        return ZoneInfo(name)
+    except ZoneInfoNotFoundError:
+        logger.warning("reminder has unknown timezone %s, using UTC", name)
+        return ZoneInfo("UTC")
+
+
+def compute_next_fire(
+    reminder: Reminder, *, after: datetime | None = None
+) -> datetime | None:
+    """Compute the next fire time strictly after `after` (default: now).
+
+    Returns None for automated reminders (they're event-driven, not
+    schedule-driven) or for repeated reminders without a valid schedule
+    config.
+    """
+    if reminder.trigger_type != "repeated":
+        return None
+    after = after or datetime.now(UTC)
+    tz = _zone(reminder.schedule_tz)
+
+    # Advanced cron mode wins when present.
+    if reminder.cron_expression:
+        try:
+            it = croniter(reminder.cron_expression, after.astimezone(tz))
+            local_next = it.get_next(datetime)
+            if local_next.tzinfo is None:
+                local_next = local_next.replace(tzinfo=tz)
+            return local_next.astimezone(UTC)
+        except (ValueError, KeyError):
+            logger.warning(
+                "reminder %s has invalid cron expression %r, skipping",
+                reminder.id,
+                reminder.cron_expression,
+            )
+            return None
+
+    if not reminder.schedule_kind or not reminder.schedule_time:
+        return None
+
+    hh, mm = reminder.schedule_time.split(":")
+    hour, minute = int(hh), int(mm)
+
+    cursor_local = after.astimezone(tz)
+    # Probe a generous number of candidate days. 366 covers any monthly
+    # schedule on the day of a non-existent month-day (Feb 30 etc.).
+    for offset in range(366):
+        candidate = (cursor_local + timedelta(days=offset)).replace(
+            hour=hour, minute=minute, second=0, microsecond=0
+        )
+        if candidate <= cursor_local:
+            continue
+        if reminder.schedule_kind == "daily":
+            return candidate.astimezone(UTC)
+        if reminder.schedule_kind == "weekly":
+            mask = reminder.schedule_dow_mask or 0
+            if mask == 0:
+                return None
+            if mask & _DOW_BITS[candidate.weekday()]:
+                return candidate.astimezone(UTC)
+        elif reminder.schedule_kind == "monthly":
+            dom = reminder.schedule_dom or 1
+            if candidate.day == dom:
+                return candidate.astimezone(UTC)
+    return None
+
+
+# --- Enqueue helpers -------------------------------------------------------
+
+
+def _new_outbox_row(
+    *,
+    channel_id: uuid.UUID,
+    deliver_after: datetime,
+    event_payload: dict,
+) -> NotificationOutboxRow:
+    """Construct a not-yet-flushed outbox row for a reminder fire.
+
+    Keeping the outbox shape consistent with front-change events lets the
+    same dispatcher claim and process both. The dispatcher branches on
+    event_type to render a reminder body vs a front-change body.
+    """
+    now = datetime.now(UTC)
+    return NotificationOutboxRow(
+        id=uuid.uuid4(),
+        event_id=uuid.uuid4(),
+        channel_id=channel_id,
+        event_type="reminder",
+        event_payload=event_payload,
+        enqueued_at=now,
+        deliver_after=deliver_after,
+    )
+
+
+def _reminder_payload(
+    reminder: Reminder, *, scheduled_for: datetime | None = None
+) -> dict:
+    """Render the outbox event_payload for a single reminder fire."""
+    return {
+        "kind": "reminder_single",
+        "reminder_id": str(reminder.id),
+        "title": _decrypt_or_none(reminder.title) or "",
+        "body": _decrypt_or_none(reminder.body),
+        "scheduled_for": (
+            scheduled_for.astimezone(UTC).isoformat()
+            if scheduled_for is not None
+            else None
+        ),
+    }
+
+
+def _digest_payload(
+    reminder: Reminder, *, pending_rows: Iterable[ReminderPending]
+) -> dict:
+    """Render a digest event_payload covering missed firings of one reminder.
+
+    Pooling across *reminders* (e.g. "Daily meds + Stretch break missed
+    while Bob was away") happens at dispatch time inside the channel
+    handler — at this point we still produce one outbox row per reminder
+    so each can be tracked independently.
+    """
+    rows = sorted(pending_rows, key=lambda r: r.scheduled_for)
+    return {
+        "kind": "reminder_digest",
+        "reminder_id": str(reminder.id),
+        "title": _decrypt_or_none(reminder.title) or "",
+        "body": _decrypt_or_none(reminder.body),
+        "missed_count": len(rows),
+        "first_missed_at": rows[0].scheduled_for.astimezone(UTC).isoformat()
+        if rows
+        else None,
+        "last_missed_at": rows[-1].scheduled_for.astimezone(UTC).isoformat()
+        if rows
+        else None,
+    }
+
+
+# --- Repeated-reminder scheduler tick -------------------------------------
+
+
+async def tick_repeated_reminders(db: AsyncSession) -> int:
+    """Fire any due repeated reminders.
+
+    Returns the number of outbox rows enqueued (excluding pending-queue
+    inserts). Called from the job runner on a 60-second cadence.
+    """
+    now = datetime.now(UTC)
+    result = await db.execute(
+        select(Reminder)
+        .options(
+            selectinload(Reminder.scope_members),
+            selectinload(Reminder.pending),
+        )
+        .where(
+            Reminder.trigger_type == "repeated",
+            Reminder.enabled.is_(True),
+        )
+    )
+    reminders = list(result.scalars().all())
+    enqueued = 0
+
+    # Batch-load currently-fronting member ids per system so we can answer
+    # "is any scope-member of this reminder fronting?" without one query
+    # per reminder. Most deployments have one system per user, so this is
+    # usually a single small set.
+    system_ids = {r.system_id for r in reminders}
+    fronting_by_system = await _currently_fronting_by_system(db, system_ids)
+
+    for reminder in reminders:
+        if not _channel_is_active(await _load_channel(db, reminder.channel_id)):
+            continue
+
+        # Anchor scheduling against last_fired_at (or created_at if never
+        # fired) so a server-down period doesn't stack up multiple fires.
+        anchor = reminder.last_fired_at or reminder.created_at
+        next_fire = compute_next_fire(reminder, after=anchor)
+        if next_fire is None or next_fire > now:
+            continue
+
+        fronting = fronting_by_system.get(reminder.system_id, set())
+        scoped_active = _scope_satisfied(reminder, fronting)
+        if reminder.scope == "system" or scoped_active:
+            db.add(
+                _new_outbox_row(
+                    channel_id=reminder.channel_id,
+                    deliver_after=next_fire,
+                    event_payload=_reminder_payload(reminder, scheduled_for=next_fire),
+                )
+            )
+            enqueued += 1
+        elif reminder.digest_when_absent:
+            await _enqueue_pending(db, reminder, scheduled_for=next_fire)
+
+        reminder.last_fired_at = next_fire
+
+    return enqueued
+
+
+async def _enqueue_pending(
+    db: AsyncSession, reminder: Reminder, *, scheduled_for: datetime
+) -> None:
+    """Push a missed-firing onto the per-reminder pending queue.
+
+    The cap is enforced by deleting the oldest extra rows. We do this in
+    one transaction with the insert so the visible queue length never
+    exceeds the cap.
+    """
+    db.add(
+        ReminderPending(
+            id=uuid.uuid4(),
+            reminder_id=reminder.id,
+            scheduled_for=scheduled_for,
+        )
+    )
+    await db.flush()
+
+    # Trim to cap. There's a tiny race here if multiple ticks ran in
+    # parallel, but the scheduler is single-process; in practice this is
+    # always exact.
+    pending_q = await db.execute(
+        select(ReminderPending)
+        .where(ReminderPending.reminder_id == reminder.id)
+        .order_by(ReminderPending.scheduled_for.desc())
+    )
+    rows = list(pending_q.scalars().all())
+    if len(rows) > _MAX_PENDING_PER_REMINDER:
+        for old in rows[_MAX_PENDING_PER_REMINDER:]:
+            await db.delete(old)
+
+
+# --- Automated-trigger hook ------------------------------------------------
+
+
+async def emit_for_front_event(
+    db: AsyncSession,
+    *,
+    system_id: uuid.UUID,
+    started_member_ids: set[uuid.UUID],
+    stopped_member_ids: set[uuid.UUID],
+) -> int:
+    """Wire automated reminders into front-change events.
+
+    For every enabled `automated` reminder in this system whose trigger
+    matches one of the started/stopped member ids (or "any"), enqueue an
+    outbox row with `deliver_after = now + delay_seconds`. Returns the
+    number of rows enqueued.
+    """
+    if not (started_member_ids or stopped_member_ids):
+        return 0
+
+    result = await db.execute(
+        select(Reminder).where(
+            Reminder.system_id == system_id,
+            Reminder.trigger_type == "automated",
+            Reminder.enabled.is_(True),
+        )
+    )
+    reminders = list(result.scalars().all())
+    if not reminders:
+        return 0
+
+    now = datetime.now(UTC)
+    enqueued = 0
+    for reminder in reminders:
+        channel = await _load_channel(db, reminder.channel_id)
+        if not _channel_is_active(channel):
+            continue
+
+        if not _trigger_matches(
+            reminder,
+            started_member_ids=started_member_ids,
+            stopped_member_ids=stopped_member_ids,
+        ):
+            continue
+
+        delay = max(0, reminder.delay_seconds or 0)
+        deliver_after = now + timedelta(seconds=delay)
+        db.add(
+            _new_outbox_row(
+                channel_id=reminder.channel_id,
+                deliver_after=deliver_after,
+                event_payload=_reminder_payload(reminder),
+            )
+        )
+        reminder.last_fired_at = now
+        enqueued += 1
+    return enqueued
+
+
+# --- Drain hook (member-scoped digest) -------------------------------------
+
+
+async def drain_digests_for_started_members(
+    db: AsyncSession,
+    *,
+    system_id: uuid.UUID,
+    started_member_ids: set[uuid.UUID],
+    previously_fronting: set[uuid.UUID],
+) -> int:
+    """When a scope-member starts fronting, drain their reminder pending queue.
+
+    Only fires when the started member is the FIRST scope-member of a
+    reminder to come on (i.e., before this event, no scope-member of this
+    reminder was fronting). Otherwise an existing scope-member is already
+    receiving notifications and the digest is redundant.
+
+    Returns the number of digest outbox rows enqueued.
+    """
+    if not started_member_ids:
+        return 0
+
+    # Pull every reminder in this system that has at least one pending row,
+    # plus its scope members and channel.
+    result = await db.execute(
+        select(Reminder)
+        .options(
+            selectinload(Reminder.scope_members),
+            selectinload(Reminder.pending),
+        )
+        .where(
+            Reminder.system_id == system_id,
+            Reminder.scope == "member",
+        )
+    )
+    reminders = [r for r in result.scalars().all() if r.pending]
+    if not reminders:
+        return 0
+
+    enqueued = 0
+    now = datetime.now(UTC)
+    for reminder in reminders:
+        scope_ids = {m.id for m in reminder.scope_members}
+        if not scope_ids:
+            continue
+
+        # Was a scope-member already fronting before this event? If so,
+        # the digest already had its chance and shouldn't fire again.
+        if scope_ids & previously_fronting:
+            continue
+        # Is at least one scope-member among the just-started?
+        if not (scope_ids & started_member_ids):
+            continue
+
+        channel = await _load_channel(db, reminder.channel_id)
+        if not _channel_is_active(channel):
+            continue
+
+        db.add(
+            _new_outbox_row(
+                channel_id=reminder.channel_id,
+                deliver_after=now,
+                event_payload=_digest_payload(reminder, pending_rows=reminder.pending),
+            )
+        )
+        enqueued += 1
+
+        # Empty the queue for this reminder.
+        await db.execute(
+            delete(ReminderPending).where(
+                ReminderPending.reminder_id == reminder.id
+            )
+        )
+
+    return enqueued
+
+
+# --- Internal helpers ------------------------------------------------------
+
+
+def _trigger_matches(
+    reminder: Reminder,
+    *,
+    started_member_ids: set[uuid.UUID],
+    stopped_member_ids: set[uuid.UUID],
+) -> bool:
+    """Decide whether an automated reminder fires for this front-change.
+
+    The trigger event filter ("start", "stop", "any") narrows which side
+    of the transition we look at; trigger_member_id then narrows further
+    to a specific member, or null = "any member moved on the matching
+    side". Result is the OR of (start-matches) and (stop-matches).
+    """
+    event = reminder.trigger_event
+    target = reminder.trigger_member_id
+
+    def _hits(side: set[uuid.UUID]) -> bool:
+        if not side:
+            return False
+        return target is None or target in side
+
+    if event in (None, "any", "start") and _hits(started_member_ids):
+        return True
+    return event in ("any", "stop") and _hits(stopped_member_ids)
+
+
+def _scope_satisfied(reminder: Reminder, fronting_ids: set[uuid.UUID]) -> bool:
+    """Is the scope condition met right now?
+
+    For system-scoped reminders, always True. For member-scoped, True if
+    at least one scope member is currently fronting.
+    """
+    if reminder.scope != "member":
+        return True
+    scope_ids = {m.id for m in reminder.scope_members}
+    return bool(scope_ids & fronting_ids)
+
+
+async def _currently_fronting_by_system(
+    db: AsyncSession, system_ids: Iterable[uuid.UUID]
+) -> dict[uuid.UUID, set[uuid.UUID]]:
+    """Map {system_id: {member_ids currently fronting}} for the given systems."""
+    system_ids = list(system_ids)
+    if not system_ids:
+        return {}
+    result = await db.execute(
+        select(Front)
+        .options(selectinload(Front.members))
+        .where(
+            Front.system_id.in_(system_ids),
+            Front.ended_at.is_(None),
+        )
+    )
+    out: dict[uuid.UUID, set[uuid.UUID]] = {sid: set() for sid in system_ids}
+    for front in result.scalars().all():
+        out[front.system_id].update(m.id for m in front.members)
+    return out
+
+
+async def _load_channel(
+    db: AsyncSession, channel_id: uuid.UUID
+) -> NotificationChannel | None:
+    return (
+        await db.execute(
+            select(NotificationChannel).where(NotificationChannel.id == channel_id)
+        )
+    ).scalar_one_or_none()
+
+
+def _channel_is_active(channel: NotificationChannel | None) -> bool:
+    return (
+        channel is not None
+        and channel.destination_state == DestinationState.ACTIVE
+    )
+
+
+# --- Encryption helpers (used by API layer) -------------------------------
+
+
+def encrypt_title_body(title: str, body: str | None) -> tuple[str, str | None]:
+    """Encrypt a reminder's title and body for storage."""
+    return encrypt(title), (encrypt(body) if body else None)
+
+
+def decrypt_for_read(reminder: Reminder) -> dict:
+    """Build the decrypted, scope-resolved view used by the read API."""
+    return {
+        "title": _decrypt_or_none(reminder.title) or "",
+        "body": _decrypt_or_none(reminder.body),
+        "scope_member_ids": [m.id for m in reminder.scope_members],
+        "pending_count": len(reminder.pending),
+        "next_fire_at": compute_next_fire(reminder),
+    }

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -33,6 +33,7 @@ from sheaf.models.pending_action import (
     PendingActionStatus,
     PendingActionType,
 )
+from sheaf.models.reminder import Reminder
 from sheaf.models.safety_change_request import (
     SafetyChangeRequest,
     SafetyChangeStatus,
@@ -68,6 +69,7 @@ _CATEGORY_BY_ACTION: dict[str, str] = {
     PendingActionType.REVISION_UNPIN: "revisions",
     PendingActionType.WATCH_TOKEN_REVOKE: "notifications",
     PendingActionType.CHANNEL_DELETE: "notifications",
+    PendingActionType.REMINDER_DELETE: "notifications",
 }
 
 _MODEL_BY_ACTION: dict[str, type] = {
@@ -81,6 +83,7 @@ _MODEL_BY_ACTION: dict[str, type] = {
     PendingActionType.REVISION_UNPIN: ContentRevision,
     PendingActionType.WATCH_TOKEN_REVOKE: WatchToken,
     PendingActionType.CHANNEL_DELETE: NotificationChannel,
+    PendingActionType.REMINDER_DELETE: Reminder,
 }
 
 

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -1,0 +1,425 @@
+"""Integration tests for the reminders API."""
+
+import httpx
+
+
+def _system_id(client: httpx.Client) -> str:
+    resp = client.get("/v1/systems/me")
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+def _create_channel(client: httpx.Client) -> str:
+    """Spin up a webhook channel for the auth_client's system; return its id.
+
+    Webhook channels go active on creation (no activation step), which is
+    the cheapest way to give the reminders endpoints a valid channel to
+    reference in tests.
+    """
+    sid = _system_id(client)
+    tok = client.post(
+        f"/v1/systems/{sid}/watch-tokens", json={"label": "test"}
+    ).json()
+    resp = client.post(
+        f"/v1/watch-tokens/{tok['id']}/channels",
+        json={
+            "name": "Test webhook",
+            "destination_type": "webhook",
+            "destination_config": {"url": "https://example.com/webhook"},
+            "webhook_secret": "supersecret",
+            "base_all_members": True,
+            "trigger_on_start": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["channel"]["id"]
+
+
+# --- Create + read --------------------------------------------------------
+
+
+def test_create_repeated_daily_reminder(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Daily meds",
+            "title": "Take meds",
+            "body": "10mg of X, 5mg of Y",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "Daily meds"
+    assert body["title"] == "Take meds"
+    assert body["body"] == "10mg of X, 5mg of Y"
+    assert body["trigger_type"] == "repeated"
+    assert body["schedule_kind"] == "daily"
+    assert body["scope"] == "system"
+    assert body["next_fire_at"] is not None
+
+
+def test_create_automated_reminder(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Stretch ping",
+            "title": "Get up and stretch",
+            "trigger_type": "automated",
+            "trigger_event": "start",
+            "delay_seconds": 1800,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["trigger_type"] == "automated"
+    assert body["delay_seconds"] == 1800
+    assert body["next_fire_at"] is None  # automated has no schedule
+
+
+def test_create_with_advanced_cron_takes_precedence(
+    auth_client: httpx.Client,
+):
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Mondays",
+            "title": "Weekly review",
+            "trigger_type": "repeated",
+            "cron_expression": "0 9 * * 1",
+            "schedule_tz": "UTC",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["cron_expression"] == "0 9 * * 1"
+    assert resp.json()["next_fire_at"] is not None
+
+
+def test_list_returns_reminders(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "First",
+            "title": "Hello",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+        },
+    )
+    auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Second",
+            "title": "World",
+            "trigger_type": "automated",
+            "trigger_event": "any",
+            "delay_seconds": 60,
+        },
+    )
+    resp = auth_client.get("/v1/reminders")
+    assert resp.status_code == 200
+    names = sorted(r["name"] for r in resp.json())
+    assert names == ["First", "Second"]
+
+
+# --- Validation -----------------------------------------------------------
+
+
+def test_reject_repeated_without_schedule_or_cron(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Bad",
+            "title": "x",
+            "trigger_type": "repeated",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_reject_automated_without_delay(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Bad",
+            "title": "x",
+            "trigger_type": "automated",
+            "trigger_event": "start",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_reject_invalid_cron(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Bad",
+            "title": "x",
+            "trigger_type": "repeated",
+            "cron_expression": "not a cron",
+            "schedule_tz": "UTC",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_reject_invalid_timezone(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Bad",
+            "title": "x",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "Mars/Olympus",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_reject_other_users_channel(auth_client: httpx.Client):
+    """Channels are owned by a system; you can't aim a reminder at a
+    channel that doesn't belong to you."""
+    import uuid
+
+    bogus_channel_id = str(uuid.uuid4())
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": bogus_channel_id,
+            "name": "x",
+            "title": "x",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+        },
+    )
+    assert resp.status_code == 404
+
+
+# --- Update --------------------------------------------------------------
+
+
+def test_update_changes_fields(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    created = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Old",
+            "title": "Old title",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+        },
+    ).json()
+
+    resp = auth_client.patch(
+        f"/v1/reminders/{created['id']}",
+        json={
+            "name": "New",
+            "title": "New title",
+            "schedule_time": "21:00",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "New"
+    assert body["title"] == "New title"
+    assert body["schedule_time"] == "21:00"
+
+
+def test_disable_reminder(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    created = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "x",
+            "title": "x",
+            "trigger_type": "automated",
+            "trigger_event": "any",
+            "delay_seconds": 60,
+        },
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/reminders/{created['id']}", json={"enabled": False}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+
+
+# --- Delete --------------------------------------------------------------
+
+
+def test_delete_reminder(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    created = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "x",
+            "title": "x",
+            "trigger_type": "automated",
+            "trigger_event": "any",
+            "delay_seconds": 60,
+        },
+    ).json()
+    resp = auth_client.delete(f"/v1/reminders/{created['id']}")
+    assert resp.status_code == 204
+
+    resp = auth_client.get(f"/v1/reminders/{created['id']}")
+    assert resp.status_code == 404
+
+
+# --- Member-scoped reminders ---------------------------------------------
+
+
+def test_member_scope_round_trip(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    alice = auth_client.post("/v1/members", json={"name": "Alice"}).json()
+    bob = auth_client.post("/v1/members", json={"name": "Bob"}).json()
+
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Alice or Bob daily",
+            "title": "Daily",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+            "scope": "member",
+            "scope_member_ids": [alice["id"], bob["id"]],
+            "digest_when_absent": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["scope"] == "member"
+    assert set(body["scope_member_ids"]) == {alice["id"], bob["id"]}
+    assert body["digest_when_absent"] is True
+
+
+def test_scope_member_ids_must_belong_to_system(auth_client: httpx.Client):
+    import uuid
+
+    channel_id = _create_channel(auth_client)
+    resp = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "x",
+            "title": "x",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+            "scope": "member",
+            "scope_member_ids": [str(uuid.uuid4())],
+        },
+    )
+    assert resp.status_code == 400
+
+
+# --- next-fire endpoint --------------------------------------------------
+
+
+def test_next_fire_endpoint(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    created = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Daily",
+            "title": "x",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+        },
+    ).json()
+    resp = auth_client.get(f"/v1/reminders/{created['id']}/next-fire")
+    assert resp.status_code == 200
+    assert resp.json()["next_fire_at"] is not None
+
+
+# --- Export inclusion ----------------------------------------------------
+
+
+def test_reminders_appear_in_data_export(auth_client: httpx.Client):
+    """Reminders are config (not transient state), so the GDPR
+    Article 20 export should carry them. Title/body decrypt to plaintext
+    for the export."""
+    channel_id = _create_channel(auth_client)
+    auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "Daily check",
+            "title": "Check your meds",
+            "body": "Plaintext body content",
+            "trigger_type": "repeated",
+            "schedule_kind": "daily",
+            "schedule_time": "09:00",
+            "schedule_tz": "UTC",
+        },
+    )
+    export = auth_client.get("/v1/export").json()
+    assert "reminders" in export
+    assert len(export["reminders"]) == 1
+    row = export["reminders"][0]
+    assert row["name"] == "Daily check"
+    assert row["title"] == "Check your meds"
+    assert row["body"] == "Plaintext body content"
+    assert row["schedule_kind"] == "daily"
+    # Pending queue rows are runtime state, not exported.
+    assert "pending" not in row
+    assert "last_fired_at" not in row
+
+
+# --- next-fire endpoint redux -------------------------------------------
+
+
+def test_next_fire_for_automated_returns_null(auth_client: httpx.Client):
+    channel_id = _create_channel(auth_client)
+    created = auth_client.post(
+        "/v1/reminders",
+        json={
+            "channel_id": channel_id,
+            "name": "x",
+            "title": "x",
+            "trigger_type": "automated",
+            "trigger_event": "any",
+            "delay_seconds": 60,
+        },
+    ).json()
+    resp = auth_client.get(f"/v1/reminders/{created['id']}/next-fire")
+    assert resp.status_code == 200
+    assert resp.json()["next_fire_at"] is None

--- a/tests/test_reminders_unit.py
+++ b/tests/test_reminders_unit.py
@@ -1,0 +1,284 @@
+"""Unit tests for reminder scheduling primitives.
+
+Covers `compute_next_fire` for daily/weekly/monthly/cron schedules and
+`_trigger_matches` for automated front-event matching. These are pure
+functions over `Reminder` instances, so we construct them in-memory
+without touching the DB.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from sheaf.models.reminder import Reminder
+from sheaf.services.reminders import _trigger_matches, compute_next_fire
+
+
+def _r(**kwargs) -> Reminder:
+    """Build a freshly-defaulted Reminder for use in pure-function tests.
+
+    Only fields explicitly supplied are set, plus a created_at default
+    (the scheduler uses created_at as the anchor for first-ever fires)."""
+    defaults: dict = {
+        "id": None,
+        "system_id": None,
+        "channel_id": None,
+        "name": "test",
+        "title": "title",
+        "trigger_type": "repeated",
+        "scope": "system",
+        "digest_when_absent": True,
+        "enabled": True,
+    }
+    defaults.update(kwargs)
+    r = Reminder(**defaults)
+    return r
+
+
+# --- compute_next_fire: structured schedules ------------------------------
+
+
+def test_daily_schedule_picks_next_occurrence():
+    after = datetime(2026, 5, 6, 8, 0, tzinfo=UTC)
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="daily",
+            schedule_time="09:00",
+            schedule_tz="UTC",
+        ),
+        after=after,
+    )
+    assert next_fire == datetime(2026, 5, 6, 9, 0, tzinfo=UTC)
+
+
+def test_daily_schedule_rolls_to_tomorrow_when_today_passed():
+    after = datetime(2026, 5, 6, 10, 0, tzinfo=UTC)
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="daily",
+            schedule_time="09:00",
+            schedule_tz="UTC",
+        ),
+        after=after,
+    )
+    assert next_fire == datetime(2026, 5, 7, 9, 0, tzinfo=UTC)
+
+
+def test_weekly_schedule_picks_next_matching_day():
+    """Tue (1, mask bit 2) only schedule starting Mon should land Tuesday."""
+    after = datetime(2026, 5, 4, 8, 0, tzinfo=UTC)  # Mon
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="weekly",
+            schedule_time="09:00",
+            schedule_dow_mask=0b0000010,  # Tue only
+            schedule_tz="UTC",
+        ),
+        after=after,
+    )
+    assert next_fire == datetime(2026, 5, 5, 9, 0, tzinfo=UTC)
+
+
+def test_weekly_schedule_with_empty_mask_is_inert():
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="weekly",
+            schedule_time="09:00",
+            schedule_dow_mask=0,
+            schedule_tz="UTC",
+        ),
+        after=datetime(2026, 5, 6, tzinfo=UTC),
+    )
+    assert next_fire is None
+
+
+def test_monthly_schedule_picks_dom():
+    after = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="monthly",
+            schedule_time="09:00",
+            schedule_dom=15,
+            schedule_tz="UTC",
+        ),
+        after=after,
+    )
+    assert next_fire == datetime(2026, 5, 15, 9, 0, tzinfo=UTC)
+
+
+def test_monthly_schedule_skips_when_dom_already_passed():
+    after = datetime(2026, 5, 20, 12, 0, tzinfo=UTC)
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="monthly",
+            schedule_time="09:00",
+            schedule_dom=15,
+            schedule_tz="UTC",
+        ),
+        after=after,
+    )
+    assert next_fire == datetime(2026, 6, 15, 9, 0, tzinfo=UTC)
+
+
+def test_schedule_respects_timezone():
+    """09:00 NYC = 13:00 UTC (winter EST) / 14:00 UTC (summer EDT)."""
+    # Mid-winter so EST is in effect
+    after = datetime(2026, 1, 5, 0, 0, tzinfo=UTC)
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="daily",
+            schedule_time="09:00",
+            schedule_tz="America/New_York",
+        ),
+        after=after,
+    )
+    assert next_fire == datetime(2026, 1, 5, 14, 0, tzinfo=UTC)
+
+
+# --- compute_next_fire: cron mode ----------------------------------------
+
+
+def test_cron_takes_precedence_over_structured():
+    after = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    next_fire = compute_next_fire(
+        _r(
+            cron_expression="0 9 * * 1",  # Mondays at 09:00
+            schedule_kind="daily",  # ignored
+            schedule_time="09:00",
+            schedule_tz="UTC",
+        ),
+        after=after,
+    )
+    # 2026-05-06 is Wed; next Monday is 2026-05-11
+    assert next_fire == datetime(2026, 5, 11, 9, 0, tzinfo=UTC)
+
+
+def test_invalid_cron_yields_none():
+    next_fire = compute_next_fire(
+        _r(cron_expression="not a cron string", schedule_tz="UTC"),
+        after=datetime(2026, 5, 6, tzinfo=UTC),
+    )
+    assert next_fire is None
+
+
+# --- compute_next_fire: edge cases ---------------------------------------
+
+
+def test_automated_reminder_yields_none():
+    """Automated reminders are event-driven; they don't have a scheduled
+    next-fire."""
+    next_fire = compute_next_fire(
+        _r(
+            trigger_type="automated",
+            trigger_event="any",
+            delay_seconds=600,
+        )
+    )
+    assert next_fire is None
+
+
+def test_repeated_with_no_schedule_config_yields_none():
+    next_fire = compute_next_fire(_r())  # neither cron nor structured
+    assert next_fire is None
+
+
+def test_unknown_timezone_falls_back_to_utc():
+    """Validation rejects bad tz at the API layer; the scheduler tick
+    must not crash on data that somehow slipped through."""
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="daily",
+            schedule_time="09:00",
+            schedule_tz="Mars/Olympus",
+        ),
+        after=datetime(2026, 5, 6, 8, 0, tzinfo=UTC),
+    )
+    assert next_fire == datetime(2026, 5, 6, 9, 0, tzinfo=UTC)
+
+
+# --- _trigger_matches ----------------------------------------------------
+
+
+import uuid  # noqa: E402
+
+ALICE = uuid.uuid4()
+BOB = uuid.uuid4()
+
+
+def test_trigger_matches_specific_member_start():
+    r = _r(trigger_type="automated", trigger_event="start", trigger_member_id=ALICE)
+    assert _trigger_matches(
+        r, started_member_ids={ALICE}, stopped_member_ids=set()
+    )
+    assert not _trigger_matches(
+        r, started_member_ids={BOB}, stopped_member_ids=set()
+    )
+
+
+def test_trigger_matches_any_member_when_member_id_null():
+    r = _r(trigger_type="automated", trigger_event="start", trigger_member_id=None)
+    assert _trigger_matches(
+        r, started_member_ids={BOB}, stopped_member_ids=set()
+    )
+    assert not _trigger_matches(
+        r, started_member_ids=set(), stopped_member_ids={BOB}
+    )
+
+
+def test_trigger_matches_any_event_covers_both_sides():
+    r = _r(trigger_type="automated", trigger_event="any", trigger_member_id=ALICE)
+    assert _trigger_matches(
+        r, started_member_ids={ALICE}, stopped_member_ids=set()
+    )
+    assert _trigger_matches(
+        r, started_member_ids=set(), stopped_member_ids={ALICE}
+    )
+    assert not _trigger_matches(
+        r, started_member_ids={BOB}, stopped_member_ids={BOB}
+    )
+
+
+def test_trigger_matches_stop_event_only():
+    r = _r(trigger_type="automated", trigger_event="stop", trigger_member_id=ALICE)
+    assert _trigger_matches(
+        r, started_member_ids=set(), stopped_member_ids={ALICE}
+    )
+    assert not _trigger_matches(
+        r, started_member_ids={ALICE}, stopped_member_ids=set()
+    )
+
+
+def test_trigger_does_not_match_empty_event_sets():
+    r = _r(trigger_type="automated", trigger_event="any", trigger_member_id=None)
+    assert not _trigger_matches(
+        r, started_member_ids=set(), stopped_member_ids=set()
+    )
+
+
+# --- Daylight Saving sanity checks ---------------------------------------
+
+
+def test_daily_schedule_around_dst_spring_forward():
+    """In NYC on 2026-03-08 the wall clock jumps 02:00 -> 03:00. A daily
+    09:00 schedule is well clear of the gap and should fire normally
+    that day."""
+    after = datetime(2026, 3, 7, 0, 0, tzinfo=UTC)
+    next_fire = compute_next_fire(
+        _r(
+            schedule_kind="daily",
+            schedule_time="09:00",
+            schedule_tz="America/New_York",
+        ),
+        after=after,
+    )
+    assert next_fire is not None
+    # 2026-03-07 is in EST (UTC-5), so 09:00 local = 14:00 UTC
+    assert next_fire == datetime(2026, 3, 7, 14, 0, tzinfo=UTC)
+    # Probe the next day too: 2026-03-08 is in EDT (UTC-4) post-shift
+    next_after = compute_next_fire(
+        _r(
+            schedule_kind="daily",
+            schedule_time="09:00",
+            schedule_tz="America/New_York",
+        ),
+        after=next_fire + timedelta(seconds=1),
+    )
+    assert next_after == datetime(2026, 3, 8, 13, 0, tzinfo=UTC)

--- a/uv.lock
+++ b/uv.lock
@@ -466,6 +466,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1506,6 +1518,7 @@ dependencies = [
     { name = "altcha" },
     { name = "argon2-cffi" },
     { name = "asyncpg" },
+    { name = "croniter" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -1551,6 +1564,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 'ses'", specifier = ">=1.35.0" },
+    { name = "croniter", specifier = ">=2.0.0" },
     { name = "email-validator", specifier = ">=2.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },

--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Shield,
   BookOpen,
   Bell,
+  BellRing,
   BarChart3,
   PanelLeftClose,
   PanelLeftOpen,
@@ -31,6 +32,7 @@ const navItems = [
   { to: "/analytics", label: "Analytics", icon: BarChart3 },
   { to: "/groups", label: "Groups", icon: FolderOpen },
   { to: "/notifications", label: "Notifications", icon: Bell },
+  { to: "/reminders", label: "Reminders", icon: BellRing },
   { to: "/settings", label: "Settings", icon: Settings },
 ];
 

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -59,6 +59,10 @@ export function listChannels(tokenId: string) {
   );
 }
 
+export function listAllChannels() {
+  return apiFetch<NotificationChannel[]>("/v1/channels");
+}
+
 export function createChannel(tokenId: string, data: ChannelCreate) {
   return apiFetch<ChannelCreateResponse>(
     `/v1/watch-tokens/${tokenId}/channels`,

--- a/web/src/lib/reminders.ts
+++ b/web/src/lib/reminders.ts
@@ -1,0 +1,51 @@
+import { apiFetch } from "./api-client";
+import type {
+  DeleteResult,
+  DestructiveConfirm,
+  Reminder,
+  ReminderCreate,
+  ReminderUpdate,
+} from "@/types/api";
+
+export async function listReminders(): Promise<Reminder[]> {
+  return apiFetch<Reminder[]>("/v1/reminders");
+}
+
+export async function createReminder(body: ReminderCreate): Promise<Reminder> {
+  return apiFetch<Reminder>("/v1/reminders", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function updateReminder(
+  id: string,
+  body: ReminderUpdate,
+): Promise<Reminder> {
+  return apiFetch<Reminder>(`/v1/reminders/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteReminder(
+  id: string,
+  confirm?: DestructiveConfirm,
+): Promise<DeleteResult> {
+  return apiFetch<DeleteResult>(`/v1/reminders/${id}`, {
+    method: "DELETE",
+    ...(confirm ? { body: JSON.stringify(confirm) } : {}),
+  });
+}
+
+export async function getNextFire(
+  id: string,
+): Promise<{ next_fire_at: string | null }> {
+  return apiFetch<{ next_fire_at: string | null }>(
+    `/v1/reminders/${id}/next-fire`,
+  );
+}
+
+// Day-of-week bit values matching Python's weekday() ordering (Mon=0..Sun=6).
+export const DOW_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+export const DOW_BITS = [1, 2, 4, 8, 16, 32, 64] as const;

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -23,6 +23,7 @@ import { NotificationsPage } from "./notifications";
 import { NotificationChannelPage } from "./notifications.$channelId";
 import { NotificationsRedeemPage } from "./notifications.redeem";
 import { NotificationsManagePage } from "./notifications.manage.$mgmtToken";
+import { RemindersPage } from "./reminders";
 import { AdminLayout } from "./admin/_layout";
 import { VerifyEmailPage } from "./verify-email";
 import { ForgotPasswordPage } from "./forgot-password";
@@ -71,6 +72,7 @@ export const router = createBrowserRouter([
       { path: "groups", element: <GroupsPage /> },
       { path: "notifications", element: <NotificationsPage /> },
       { path: "notifications/:channelId", element: <NotificationChannelPage /> },
+      { path: "reminders", element: <RemindersPage /> },
       {
         path: "settings",
         element: <SettingsLayout />,

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -117,7 +117,7 @@ function MemberForm({
           <Input
             value={emoji}
             onChange={(e) => setEmoji(e.target.value)}
-            placeholder="🦊"
+            placeholder=""
             maxLength={8}
             className="w-20 text-center"
           />

--- a/web/src/routes/reminders.tsx
+++ b/web/src/routes/reminders.tsx
@@ -1,0 +1,870 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Bell, Pause, Pencil, Play, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { useMembers } from "@/hooks/use-members";
+import { getMySystem } from "@/lib/systems";
+import { listAllChannels } from "@/lib/notifications";
+import {
+  DOW_BITS,
+  DOW_LABELS,
+  createReminder,
+  deleteReminder,
+  listReminders,
+  updateReminder,
+} from "@/lib/reminders";
+import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { isDeleteQueued } from "@/types/api";
+import type {
+  DestructiveConfirm,
+  Member,
+  Reminder,
+  ReminderCreate,
+  ReminderScheduleKind,
+  ReminderTriggerEvent,
+  ReminderTriggerType,
+} from "@/types/api";
+
+function browserTz(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+export function RemindersPage() {
+  const qc = useQueryClient();
+  const { data: reminders, isLoading } = useQuery({
+    queryKey: ["reminders"],
+    queryFn: listReminders,
+  });
+  const { data: channels } = useQuery({
+    queryKey: ["channels", "all"],
+    queryFn: listAllChannels,
+  });
+  const { data: members } = useMembers();
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+  });
+
+  const [editing, setEditing] = useState<Reminder | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState<Reminder | null>(null);
+
+  const memberById = useMemo(
+    () => new Map<string, Member>((members ?? []).map((m) => [m.id, m])),
+    [members],
+  );
+  const channelById = useMemo(
+    () => new Map((channels ?? []).map((c) => [c.id, c])),
+    [channels],
+  );
+
+  const deleteMut = useMutation({
+    mutationFn: ({
+      id,
+      confirm,
+    }: {
+      id: string;
+      confirm?: DestructiveConfirm;
+    }) => deleteReminder(id, confirm),
+    onSuccess: (resp) => {
+      qc.invalidateQueries({ queryKey: ["reminders"] });
+      setDeleting(null);
+      if (isDeleteQueued(resp)) {
+        toast.success(
+          `Deletion queued. Will finalize after ${new Date(
+            resp.finalize_after,
+          ).toLocaleString()} unless cancelled.`,
+        );
+      } else {
+        toast.success("Reminder deleted");
+      }
+    },
+  });
+
+  const enabledMut = useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      updateReminder(id, { enabled }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["reminders"] }),
+  });
+
+  return (
+    <>
+      <PageHeader title="Reminders">
+        <Button
+          onClick={() => setCreating(true)}
+          disabled={!channels || channels.length === 0}
+        >
+          New reminder
+        </Button>
+      </PageHeader>
+
+      <p className="mb-6 max-w-2xl text-sm text-muted-foreground">
+        Reminders ride your existing notification channels — pick a channel
+        when creating one. Automated reminders fire after a member fronts;
+        repeated reminders run on a schedule, optionally only when a
+        specific member is around.
+      </p>
+
+      {channels && channels.length === 0 && (
+        <Card className="mb-6 max-w-xl">
+          <CardContent className="py-6 text-sm text-muted-foreground">
+            You haven&apos;t set up any notification channels yet. Create one
+            on the <a href="/notifications" className="underline">Notifications</a>{" "}
+            page first, then come back here to add reminders that ride it.
+          </CardContent>
+        </Card>
+      )}
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-20" />
+          ))}
+        </div>
+      ) : !reminders || reminders.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No reminders yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {reminders.map((r) => (
+            <ReminderRow
+              key={r.id}
+              reminder={r}
+              memberById={memberById}
+              channelName={channelById.get(r.channel_id)?.name ?? "Unknown channel"}
+              onEdit={() => setEditing(r)}
+              onDelete={() => setDeleting(r)}
+              onToggle={(v) => enabledMut.mutate({ id: r.id, enabled: v })}
+            />
+          ))}
+        </div>
+      )}
+
+      {(creating || editing) && (
+        // The key forces a fresh mount when switching between rows, so
+        // useState initialisers re-run with the new `initial`. Cleaner
+        // than a useEffect+setState reset pattern.
+        <ReminderDialog
+          key={editing?.id ?? "new"}
+          open
+          initial={editing}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+          channels={channels ?? []}
+          members={members ?? []}
+        />
+      )}
+
+      <DestructiveConfirmDialog
+        open={!!deleting}
+        onOpenChange={(open) => !open && setDeleting(null)}
+        title="Delete reminder"
+        description={
+          deleting
+            ? `Delete reminder "${deleting.name}"? This stops it firing immediately.`
+            : ""
+        }
+        tier={system?.delete_confirmation ?? "none"}
+        loading={deleteMut.isPending}
+        onConfirm={(confirm) =>
+          deleting && deleteMut.mutate({ id: deleting.id, confirm })
+        }
+      />
+    </>
+  );
+}
+
+function ReminderRow({
+  reminder,
+  memberById,
+  channelName,
+  onEdit,
+  onDelete,
+  onToggle,
+}: {
+  reminder: Reminder;
+  memberById: Map<string, Member>;
+  channelName: string;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggle: (v: boolean) => void;
+}) {
+  const summary = useMemo(
+    () => triggerSummary(reminder, memberById),
+    [reminder, memberById],
+  );
+  const nextFire = reminder.next_fire_at
+    ? new Date(reminder.next_fire_at).toLocaleString()
+    : null;
+  return (
+    <div className="rounded-md border p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Bell className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="font-medium">{reminder.name}</span>
+            {!reminder.enabled && (
+              <Badge variant="outline" className="text-xs">
+                Disabled
+              </Badge>
+            )}
+            {reminder.pending_count > 0 && (
+              <Badge variant="secondary" className="text-xs">
+                {reminder.pending_count} queued
+              </Badge>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">{summary}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            via {channelName}
+            {nextFire && ` · next ${nextFire}`}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onToggle(!reminder.enabled)}
+            title={reminder.enabled ? "Pause" : "Resume"}
+          >
+            {reminder.enabled ? (
+              <>
+                <Pause className="mr-1 h-4 w-4" /> Pause
+              </>
+            ) : (
+              <>
+                <Play className="mr-1 h-4 w-4" /> Resume
+              </>
+            )}
+          </Button>
+          <Button variant="ghost" size="icon" onClick={onEdit} title="Edit">
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onDelete}
+            title="Delete"
+            className="text-destructive-foreground"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function triggerSummary(
+  reminder: Reminder,
+  memberById: Map<string, Member>,
+): string {
+  if (reminder.trigger_type === "automated") {
+    const member =
+      reminder.trigger_member_id !== null
+        ? memberById.get(reminder.trigger_member_id)?.name ?? "Unknown"
+        : "anyone";
+    const event =
+      reminder.trigger_event === "stop"
+        ? "stops fronting"
+        : reminder.trigger_event === "any"
+          ? "fronts or stops"
+          : "fronts";
+    const delay = formatDuration(reminder.delay_seconds ?? 0);
+    return `Fires ${delay} after ${member} ${event}`;
+  }
+  if (reminder.cron_expression) {
+    return `Cron: ${reminder.cron_expression} (${reminder.schedule_tz ?? "UTC"})`;
+  }
+  const time = reminder.schedule_time ?? "??:??";
+  if (reminder.schedule_kind === "daily") {
+    return `Daily at ${time} (${reminder.schedule_tz ?? "UTC"})`;
+  }
+  if (reminder.schedule_kind === "weekly") {
+    const days = DOW_LABELS.filter(
+      (_, i) => (reminder.schedule_dow_mask ?? 0) & DOW_BITS[i],
+    ).join(", ");
+    return `Weekly ${days || "(no days set)"} at ${time}`;
+  }
+  if (reminder.schedule_kind === "monthly") {
+    return `Day ${reminder.schedule_dom} of every month at ${time}`;
+  }
+  return "No schedule";
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)} min`;
+  if (seconds < 86400) {
+    const hours = seconds / 3600;
+    return hours === Math.round(hours)
+      ? `${hours} h`
+      : `${hours.toFixed(1)} h`;
+  }
+  return `${Math.round(seconds / 86400)} d`;
+}
+
+// ---------------------------------------------------------------------------
+// Create / edit dialog
+// ---------------------------------------------------------------------------
+
+function ReminderDialog({
+  open,
+  initial,
+  channels,
+  members,
+  onClose,
+}: {
+  open: boolean;
+  initial: Reminder | null;
+  channels: { id: string; name: string }[];
+  members: Member[];
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [name, setName] = useState(initial?.name ?? "");
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [body, setBody] = useState(initial?.body ?? "");
+  const [channelId, setChannelId] = useState(
+    initial?.channel_id ?? channels[0]?.id ?? "",
+  );
+  const [triggerType, setTriggerType] = useState<ReminderTriggerType>(
+    initial?.trigger_type ?? "repeated",
+  );
+
+  // Automated state
+  const [triggerMemberId, setTriggerMemberId] = useState<string>(
+    initial?.trigger_member_id ?? "",
+  );
+  const [triggerEvent, setTriggerEvent] = useState<ReminderTriggerEvent>(
+    initial?.trigger_event ?? "start",
+  );
+  const [delaySeconds, setDelaySeconds] = useState<number>(
+    initial?.delay_seconds ?? 1800,
+  );
+
+  // Repeated state
+  const [advanced, setAdvanced] = useState<boolean>(!!initial?.cron_expression);
+  const [scheduleKind, setScheduleKind] = useState<ReminderScheduleKind>(
+    initial?.schedule_kind ?? "daily",
+  );
+  const [scheduleTime, setScheduleTime] = useState(
+    initial?.schedule_time ?? "09:00",
+  );
+  const [dowMask, setDowMask] = useState<number>(
+    initial?.schedule_dow_mask ?? 0,
+  );
+  const [scheduleDom, setScheduleDom] = useState<number>(
+    initial?.schedule_dom ?? 1,
+  );
+  const [tz, setTz] = useState(initial?.schedule_tz ?? browserTz());
+  const [cronExpression, setCronExpression] = useState(
+    initial?.cron_expression ?? "",
+  );
+
+  // Scoping
+  const [scope, setScope] = useState<"system" | "member">(
+    initial?.scope ?? "system",
+  );
+  const [scopeMemberIds, setScopeMemberIds] = useState<string[]>(
+    initial?.scope_member_ids ?? [],
+  );
+  const [digestWhenAbsent, setDigestWhenAbsent] = useState<boolean>(
+    initial?.digest_when_absent ?? true,
+  );
+
+  const saveMut = useMutation({
+    mutationFn: async () => {
+      const payload: ReminderCreate = {
+        channel_id: channelId,
+        name,
+        title,
+        body: body || null,
+        trigger_type: triggerType,
+        trigger_member_id:
+          triggerType === "automated" ? triggerMemberId || null : null,
+        trigger_event: triggerType === "automated" ? triggerEvent : null,
+        delay_seconds: triggerType === "automated" ? delaySeconds : null,
+        schedule_kind:
+          triggerType === "repeated" && !advanced ? scheduleKind : null,
+        schedule_time:
+          triggerType === "repeated" && !advanced ? scheduleTime : null,
+        schedule_dow_mask:
+          triggerType === "repeated" && !advanced && scheduleKind === "weekly"
+            ? dowMask
+            : null,
+        schedule_dom:
+          triggerType === "repeated" && !advanced && scheduleKind === "monthly"
+            ? scheduleDom
+            : null,
+        schedule_tz: triggerType === "repeated" ? tz : null,
+        cron_expression:
+          triggerType === "repeated" && advanced ? cronExpression : null,
+        scope: triggerType === "repeated" ? scope : "system",
+        scope_member_ids:
+          triggerType === "repeated" && scope === "member" ? scopeMemberIds : [],
+        digest_when_absent: digestWhenAbsent,
+      };
+      if (initial) {
+        return updateReminder(initial.id, payload);
+      }
+      return createReminder(payload);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["reminders"] });
+      toast.success(initial ? "Reminder updated" : "Reminder created");
+      onClose();
+    },
+  });
+
+  const realMembers = members.filter((m) => !m.is_custom_front);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{initial ? "Edit reminder" : "New reminder"}</DialogTitle>
+          <DialogDescription>
+            Reminders deliver through a notification channel you've already set up.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="r-name">Name</Label>
+            <Input
+              id="r-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Daily meds"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="r-channel">Send via</Label>
+            <Select value={channelId} onValueChange={setChannelId}>
+              <SelectTrigger id="r-channel">
+                <SelectValue placeholder="Select a channel" />
+              </SelectTrigger>
+              <SelectContent>
+                {channels.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="r-title">Title</Label>
+              <Input
+                id="r-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Example title"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Trigger type</Label>
+              <Select
+                value={triggerType}
+                onValueChange={(v) => setTriggerType(v as ReminderTriggerType)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="repeated">Schedule</SelectItem>
+                  <SelectItem value="automated">After a switch</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="r-body">Body (optional)</Label>
+            <textarea
+              id="r-body"
+              className="w-full rounded-md border bg-background p-2 text-sm"
+              rows={2}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Example reminder text"
+            />
+          </div>
+
+          {triggerType === "automated" ? (
+            <AutomatedSection
+              members={realMembers}
+              triggerMemberId={triggerMemberId}
+              setTriggerMemberId={setTriggerMemberId}
+              triggerEvent={triggerEvent}
+              setTriggerEvent={setTriggerEvent}
+              delaySeconds={delaySeconds}
+              setDelaySeconds={setDelaySeconds}
+            />
+          ) : (
+            <RepeatedSection
+              advanced={advanced}
+              setAdvanced={setAdvanced}
+              scheduleKind={scheduleKind}
+              setScheduleKind={setScheduleKind}
+              scheduleTime={scheduleTime}
+              setScheduleTime={setScheduleTime}
+              dowMask={dowMask}
+              setDowMask={setDowMask}
+              scheduleDom={scheduleDom}
+              setScheduleDom={setScheduleDom}
+              tz={tz}
+              setTz={setTz}
+              cronExpression={cronExpression}
+              setCronExpression={setCronExpression}
+              members={realMembers}
+              scope={scope}
+              setScope={setScope}
+              scopeMemberIds={scopeMemberIds}
+              setScopeMemberIds={setScopeMemberIds}
+              digestWhenAbsent={digestWhenAbsent}
+              setDigestWhenAbsent={setDigestWhenAbsent}
+            />
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => saveMut.mutate()}
+            disabled={
+              !name || !title || !channelId || saveMut.isPending
+            }
+          >
+            {saveMut.isPending ? "Saving…" : initial ? "Save" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AutomatedSection(props: {
+  members: Member[];
+  triggerMemberId: string;
+  setTriggerMemberId: (v: string) => void;
+  triggerEvent: ReminderTriggerEvent;
+  setTriggerEvent: (v: ReminderTriggerEvent) => void;
+  delaySeconds: number;
+  setDelaySeconds: (v: number) => void;
+}) {
+  const minutes = Math.round(props.delaySeconds / 60);
+  return (
+    <div className="space-y-3 rounded-md border p-3 bg-muted/20">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label>When</Label>
+          <Select
+            value={props.triggerMemberId || "_any"}
+            onValueChange={(v) =>
+              props.setTriggerMemberId(v === "_any" ? "" : v)
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_any">any member</SelectItem>
+              {props.members.map((m) => (
+                <SelectItem key={m.id} value={m.id}>
+                  {m.display_name || m.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label>Event</Label>
+          <Select
+            value={props.triggerEvent}
+            onValueChange={(v) =>
+              props.setTriggerEvent(v as ReminderTriggerEvent)
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="start">starts fronting</SelectItem>
+              <SelectItem value="stop">stops fronting</SelectItem>
+              <SelectItem value="any">fronts or stops</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="r-delay">Fire after (minutes)</Label>
+        <Input
+          id="r-delay"
+          type="number"
+          min={0}
+          max={10080}
+          value={minutes}
+          onChange={(e) =>
+            props.setDelaySeconds(Math.max(0, Number(e.target.value)) * 60)
+          }
+        />
+        <p className="text-xs text-muted-foreground">
+          The reminder will fire {minutes} minute{minutes === 1 ? "" : "s"} after
+          the matching front change.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function RepeatedSection(props: {
+  advanced: boolean;
+  setAdvanced: (v: boolean) => void;
+  scheduleKind: ReminderScheduleKind;
+  setScheduleKind: (v: ReminderScheduleKind) => void;
+  scheduleTime: string;
+  setScheduleTime: (v: string) => void;
+  dowMask: number;
+  setDowMask: (v: number) => void;
+  scheduleDom: number;
+  setScheduleDom: (v: number) => void;
+  tz: string;
+  setTz: (v: string) => void;
+  cronExpression: string;
+  setCronExpression: (v: string) => void;
+  members: Member[];
+  scope: "system" | "member";
+  setScope: (v: "system" | "member") => void;
+  scopeMemberIds: string[];
+  setScopeMemberIds: (v: string[]) => void;
+  digestWhenAbsent: boolean;
+  setDigestWhenAbsent: (v: boolean) => void;
+}) {
+  const tzOptions = useMemo(() => {
+    try {
+      return (Intl as unknown as { supportedValuesOf?: (k: string) => string[] })
+        .supportedValuesOf?.("timeZone") ?? [props.tz];
+    } catch {
+      return [props.tz];
+    }
+  }, [props.tz]);
+
+  return (
+    <div className="space-y-3 rounded-md border p-3 bg-muted/20">
+      <div className="flex items-center justify-between">
+        <Label>Schedule</Label>
+        <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+          <input
+            type="checkbox"
+            checked={props.advanced}
+            onChange={(e) => props.setAdvanced(e.target.checked)}
+          />
+          Advanced (cron)
+        </label>
+      </div>
+
+      {props.advanced ? (
+        <div className="space-y-1.5">
+          <Input
+            value={props.cronExpression}
+            onChange={(e) => props.setCronExpression(e.target.value)}
+            placeholder="0 9 * * 1"
+            spellCheck={false}
+          />
+          <p className="text-xs text-muted-foreground">
+            Standard 5-field cron syntax (minute, hour, day-of-month, month,
+            day-of-week). Example: <code>0 9 * * 1</code> = Mondays at 09:00.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Frequency</Label>
+              <Select
+                value={props.scheduleKind}
+                onValueChange={(v) =>
+                  props.setScheduleKind(v as ReminderScheduleKind)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="daily">Daily</SelectItem>
+                  <SelectItem value="weekly">Weekly</SelectItem>
+                  <SelectItem value="monthly">Monthly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Time of day</Label>
+              <Input
+                type="time"
+                value={props.scheduleTime}
+                onChange={(e) => props.setScheduleTime(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {props.scheduleKind === "weekly" && (
+            <div className="space-y-1.5">
+              <Label>Days</Label>
+              <div className="flex flex-wrap gap-1.5">
+                {DOW_LABELS.map((label, i) => {
+                  const bit = DOW_BITS[i];
+                  const on = (props.dowMask & bit) !== 0;
+                  return (
+                    <button
+                      key={label}
+                      type="button"
+                      onClick={() =>
+                        props.setDowMask(
+                          on ? props.dowMask & ~bit : props.dowMask | bit,
+                        )
+                      }
+                      className={`rounded-md border px-2 py-1 text-xs ${
+                        on
+                          ? "bg-primary text-primary-foreground border-primary"
+                          : "bg-background"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {props.scheduleKind === "monthly" && (
+            <div className="space-y-1.5">
+              <Label>Day of month</Label>
+              <Input
+                type="number"
+                min={1}
+                max={31}
+                value={props.scheduleDom}
+                onChange={(e) =>
+                  props.setScheduleDom(
+                    Math.min(31, Math.max(1, Number(e.target.value))),
+                  )
+                }
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <Label>Timezone</Label>
+        <Select value={props.tz} onValueChange={props.setTz}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="max-h-72">
+            {tzOptions.map((opt) => (
+              <SelectItem key={opt} value={opt}>
+                {opt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="border-t pt-3 space-y-2">
+        <Label>Only fire when…</Label>
+        <Select
+          value={props.scope}
+          onValueChange={(v) => props.setScope(v as "system" | "member")}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="system">always (system-wide)</SelectItem>
+            <SelectItem value="member">a specific member is fronting</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {props.scope === "member" && (
+          <>
+            <div className="flex flex-wrap gap-1.5">
+              {props.members.map((m) => {
+                const on = props.scopeMemberIds.includes(m.id);
+                return (
+                  <button
+                    key={m.id}
+                    type="button"
+                    onClick={() =>
+                      props.setScopeMemberIds(
+                        on
+                          ? props.scopeMemberIds.filter((id) => id !== m.id)
+                          : [...props.scopeMemberIds, m.id],
+                      )
+                    }
+                    className={`rounded-md border px-2 py-1 text-xs ${
+                      on
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : "bg-background"
+                    }`}
+                  >
+                    {m.display_name || m.name}
+                  </button>
+                );
+              })}
+            </div>
+            <label className="flex items-start gap-2 text-xs cursor-pointer pt-1">
+              <input
+                type="checkbox"
+                checked={props.digestWhenAbsent}
+                onChange={(e) => props.setDigestWhenAbsent(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                If nobody on the list is fronting at the trigger time, queue the
+                reminder and send it as a digest when one of them next starts
+                fronting (capped at 5 missed firings).
+              </span>
+            </label>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -143,6 +143,64 @@ export interface FrontCreate {
   custom_status?: string | null;
 }
 
+// --- Reminders -----------------------------------------------------------
+
+export type ReminderTriggerType = "automated" | "repeated";
+export type ReminderTriggerEvent = "start" | "stop" | "any";
+export type ReminderScheduleKind = "daily" | "weekly" | "monthly";
+export type ReminderScope = "system" | "member";
+
+export interface Reminder {
+  id: string;
+  system_id: string;
+  channel_id: string;
+  name: string;
+  title: string;
+  body: string | null;
+  enabled: boolean;
+  trigger_type: ReminderTriggerType;
+  trigger_member_id: string | null;
+  trigger_event: ReminderTriggerEvent | null;
+  delay_seconds: number | null;
+  schedule_kind: ReminderScheduleKind | null;
+  schedule_time: string | null;
+  schedule_dow_mask: number | null;
+  schedule_dom: number | null;
+  schedule_tz: string | null;
+  cron_expression: string | null;
+  scope: ReminderScope;
+  scope_member_ids: string[];
+  digest_when_absent: boolean;
+  last_fired_at: string | null;
+  pending_count: number;
+  next_fire_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ReminderCreate {
+  channel_id: string;
+  name: string;
+  title: string;
+  body?: string | null;
+  enabled?: boolean;
+  trigger_type: ReminderTriggerType;
+  trigger_member_id?: string | null;
+  trigger_event?: ReminderTriggerEvent | null;
+  delay_seconds?: number | null;
+  schedule_kind?: ReminderScheduleKind | null;
+  schedule_time?: string | null;
+  schedule_dow_mask?: number | null;
+  schedule_dom?: number | null;
+  schedule_tz?: string | null;
+  cron_expression?: string | null;
+  scope?: ReminderScope;
+  scope_member_ids?: string[];
+  digest_when_absent?: boolean;
+}
+
+export type ReminderUpdate = Partial<ReminderCreate>;
+
 export interface MemberFrontingStats {
   member_id: string;
   is_custom_front: boolean;


### PR DESCRIPTION
## Summary
- Adds reminders backed by the existing notification channel pipeline. Two trigger types: automated (fires on a member's front start/stop with optional delay) and repeated (daily/weekly/monthly via structured UI, or arbitrary cron for power users).
- Repeated reminders can be scoped to specific members, with an optional digest-when-absent queue (cap 5) that drains as a single notification when a scope-member next fronts.
- Title and body encrypted at rest. Delete is gated by destructive auth and can be safeguarded via System Safety. Reminders included in the data export with decrypted title/body; pending queue rows are runtime state and excluded.

## Test plan
- [x] Backend: \`./run_tests.sh\` (new \`test_reminders_unit.py\` + \`test_reminders_api.py\` cover compute_next_fire DST handling, cron, structured schedules, CRUD, validation, member-scope, export, next-fire endpoint)
- [x] Frontend: \`npm run lint\` + \`tsc --noEmit\` clean
- [x] Manual: create a daily repeated reminder, member-scoped, observe digest behaviour while no scope-member is fronting and on next front
- [x] Manual: create an automated reminder bound to a member's start event with a delay
- [x] Manual: pause/resume button, delete with destructive confirm + System Safety queue path
- [x] Manual: \`/v1/export\` includes reminders with plaintext title/body