### PR TITLE
Add scratchpad notes per member and system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Notes
+
+A small scratchpad surface, deliberately separate from journals. One free-form note per member and one per system, encrypted at rest, capped at 5000 plaintext characters.
+
+- **By design lightweight.** No revision history, no System Safety integration, no destructive-auth on edits. Edits overwrite the previous content; clearing the textarea wipes the column. Aimed at "trigger list / fav drink / current med doses" type quick reference, where journals' versioning + protection is unwanted overhead.
+- **Single note per scope.** Multiple notes per member would just reinvent custom fields, which already exist for that.
+- **Markdown rendered with no embedded images.** Same renderer as bios.
+- **API**: `note` field added to `MemberCreate` / `MemberUpdate` / `MemberRead` and to `SystemUpdate` / `SystemRead`. No new endpoints; piggybacks on the existing PATCH surfaces with the existing `members:write` and `system:write` scopes.
+- **Frontend**: notes textarea added under the bio editor on member create/edit, and as a section on Settings → System. Read view shows the note as a dashed-border card under the bio.
+- **Export**: notes are decrypted to plaintext in the Article 20 export alongside other free-text content.
+
 ### Polls
 
 A small voting surface for system-internal decision-making. Headmates cast votes "as" a fronting member, and every action lands in an audit log.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 - **Analytics** — Per-member front time, percent of window, session count, longest session, and hour-of-day distribution over a configurable window (7d / 30d / 90d / 1 year). Co-fronting double-counts so individual member stats are accurate.
 - **Reminders** — Schedule daily/weekly/monthly pings or fire reminders X minutes after a member fronts. Member-scoped reminders queue while nobody on the list is fronting and drain as a digest when one next switches in. Delivery rides your existing notification channels.
 - **Polls** — Run a vote across the system. Each vote is attributed to a specific member who must be in the current front, with a full audit log of cast / change / withdraw events plus a fronting snapshot. Single or multi-choice, results live or hidden until close, hard deadline at creation with auto-purge after retention.
+- **Notes** — Lightweight scratchpad per member and per system. Markdown, encrypted at rest, intentionally without revision history or System Safety protection - for "trigger list / fav drink / current med doses" quick reference where journals' versioning is overkill.
 - **Groups** — Organize members into groups with nesting (subsystems)
 - **Tags** — Flexible member tagging
 - **Custom fields** — Define your own fields (text, number, date, boolean, select) with per-field privacy

--- a/alembic/versions/b8c9d0e1f2g3_add_notes_to_members_and_systems.py
+++ b/alembic/versions/b8c9d0e1f2g3_add_notes_to_members_and_systems.py
@@ -1,0 +1,30 @@
+"""Add members.note and systems.note columns
+
+Revision ID: b8c9d0e1f2g3
+Revises: a7b8c9d0e1f2
+Create Date: 2026-05-07
+
+Lightweight scratchpad note per scope. One per member, one per system.
+Encrypted at rest like description. Deliberately no revisions, no
+System Safety integration, no sub-records — overwrite is the only
+edit path. Soft-capped at ~5kb plaintext at the schema layer.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "b8c9d0e1f2g3"
+down_revision = "a7b8c9d0e1f2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("members", sa.Column("note", sa.Text(), nullable=True))
+    op.add_column("systems", sa.Column("note", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("systems", "note")
+    op.drop_column("members", "note")

--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -352,6 +352,12 @@ Reminders ride a notification channel for delivery (`channel_id`). Two trigger t
 
 Repeated reminders can be scope-limited to specific members. When the schedule fires while no scoped member is fronting and `digest_when_absent=true`, the missed firing queues (capped at 5 per reminder, oldest dropped). On the next front-start of a scoped member, the queue drains as a digest notification. Title and body are encrypted at rest.
 
+### Notes
+
+A scratchpad text field on each member and on the system itself. Distinct from journals: no revisions, no System Safety integration, no destructive-auth on edit. The scratchpad use case ("trigger list / fav drink / current med doses") wanted journals' machinery to be off, not on. Use journals for anything you want versioned or protected.
+
+No new endpoints — `note: string | null` is part of `MemberCreate` / `MemberUpdate` / `MemberRead` (under `members:write`) and `SystemUpdate` / `SystemRead` (under `system:write`). Hard cap of 5000 plaintext characters. Empty string in a PATCH clears the column. Markdown is rendered with image embeds disabled. Encrypted at rest; decrypted plaintext appears in the Article 20 export.
+
 ### Polls
 
 | Method | Path | Description |

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -221,6 +221,7 @@ async def export_all(
                 "emoji": m.emoji,
                 "is_custom_front": m.is_custom_front,
                 "privacy": m.privacy.value,
+                "note": decrypt(m.note) if m.note else None,
                 "created_at": m.created_at.isoformat(),
             }
             for (m, name, description) in members_with_plaintext
@@ -307,6 +308,7 @@ def _system_dict(system: System) -> dict:
         "id": str(system.id),
         "name": system.name,
         "description": system.description,
+        "note": decrypt(system.note) if system.note else None,
         "tag": system.tag,
         "avatar_url": system.avatar_url,
         "color": system.color,

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -128,12 +128,18 @@ async def create_member(
     data = body.model_dump()
     plaintext_name: str = data.pop("name")
     plaintext_description: str | None = data.pop("description", None)
+    plaintext_note: str | None = data.pop("note", None)
     member = Member(
         system_id=system.id,
         name=encrypt(plaintext_name),
         name_hash=blind_index(plaintext_name),
         description=(
             encrypt(plaintext_description) if plaintext_description is not None else None
+        ),
+        note=(
+            encrypt(plaintext_note)
+            if plaintext_note is not None and plaintext_note != ""
+            else None
         ),
         **data,
     )
@@ -188,6 +194,13 @@ async def update_member(
             member.name_hash = blind_index(value)
         elif key == "description":
             member.description = encrypt(value) if value is not None else None
+        elif key == "note":
+            # Empty string clears the column. Notes are deliberately
+            # overwrite-only; no revision capture here.
+            if value is None or value == "":
+                member.note = None
+            else:
+                member.note = encrypt(value)
         else:
             setattr(member, key, value)
     await db.commit()

--- a/sheaf/api/v1/systems.py
+++ b/sheaf/api/v1/systems.py
@@ -5,13 +5,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.auth.dependencies import get_current_user, get_current_user_optional, require_scope
 from sheaf.auth.passwords import verify_password
 from sheaf.auth.totp import verify_code
-from sheaf.crypto import decrypt
+from sheaf.crypto import decrypt, encrypt
 from sheaf.database import get_db
 from sheaf.models.system import DeleteConfirmation, PrivacyLevel, System
 from sheaf.models.user import User
 from sheaf.schemas.system import DeleteConfirmationUpdate, SystemRead, SystemUpdate
 
 router = APIRouter(prefix="/systems", tags=["systems"])
+
+
+def _system_to_read(system: System) -> SystemRead:
+    """Build a SystemRead with `note` decrypted to plaintext.
+
+    System.note is the only encrypted-at-rest field on System (description
+    is plaintext for historical reasons), so we just patch it through here
+    rather than building a parallel `decrypt_system_for_read` helper."""
+    plaintext_note = decrypt(system.note) if system.note else None
+    return SystemRead.model_validate(
+        {**system.__dict__, "note": plaintext_note}
+    )
 
 
 async def _get_user_system(user: User, db: AsyncSession) -> System:
@@ -27,7 +39,8 @@ async def get_own_system(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    return await _get_user_system(user, db)
+    system = await _get_user_system(user, db)
+    return _system_to_read(system)
 
 
 @router.patch(
@@ -43,10 +56,18 @@ async def update_own_system(
     system = await _get_user_system(user, db)
     update_data = body.model_dump(exclude_unset=True)
     for key, value in update_data.items():
-        setattr(system, key, value)
+        if key == "note":
+            # Encrypt at rest. Empty string clears the column (notes are
+            # overwrite-only, no revisions).
+            if value is None or value == "":
+                system.note = None
+            else:
+                system.note = encrypt(value)
+        else:
+            setattr(system, key, value)
     await db.commit()
     await db.refresh(system)
-    return system
+    return _system_to_read(system)
 
 
 @router.put(
@@ -90,7 +111,7 @@ async def update_delete_confirmation(
     system.delete_confirmation = body.level
     await db.commit()
     await db.refresh(system)
-    return system
+    return _system_to_read(system)
 
 
 @router.get("/{system_id}", response_model=SystemRead)
@@ -108,4 +129,4 @@ async def get_system(
     if system.privacy != PrivacyLevel.PUBLIC and (user is None or system.user_id != user.id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="System not found")
 
-    return system
+    return _system_to_read(system)

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -99,6 +99,13 @@ class Member(UUIDMixin, TimestampMixin, Base):
         nullable=False,
     )
 
+    # Free-text scratchpad note. Encrypted at rest like description.
+    # Deliberately lightweight: no revisions, no System Safety protection,
+    # no sub-records — overwriting clears the previous content with no
+    # history. For "trigger list / fav drink / current med doses" type
+    # quick reference. Soft-capped at ~5kb plaintext at the schema layer.
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Relationships
     system: Mapped["System"] = relationship(back_populates="members")
     fronts: Mapped[list["Front"]] = relationship(

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -41,6 +41,9 @@ class System(UUIDMixin, TimestampMixin, Base):
 
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Free-text scratchpad note. Same shape as Member.note: encrypted at
+    # rest, lightweight, no revisions or System Safety integration.
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
     tag: Mapped[str | None] = mapped_column(String(8), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     color: Mapped[str | None] = mapped_column(String(7), nullable=True)

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -24,6 +24,7 @@ class MemberCreate(BaseModel):
     emoji: str | None = Field(default=None, max_length=8)
     is_custom_front: bool = False
     privacy: PrivacyLevel = PrivacyLevel.PRIVATE
+    note: str | None = Field(default=None, max_length=5000)
 
     @field_validator("avatar_url", mode="before")
     @classmethod
@@ -48,6 +49,7 @@ class MemberUpdate(BaseModel):
     emoji: str | None = Field(default=None, max_length=8)
     is_custom_front: bool | None = None
     privacy: PrivacyLevel | None = None
+    note: str | None = Field(default=None, max_length=5000)
 
     @field_validator("avatar_url", mode="before")
     @classmethod
@@ -83,6 +85,7 @@ class MemberRead(BaseModel):
     emoji: str | None
     is_custom_front: bool
     privacy: PrivacyLevel
+    note: str | None
     created_at: datetime
     updated_at: datetime
 

--- a/sheaf/schemas/system.py
+++ b/sheaf/schemas/system.py
@@ -15,6 +15,7 @@ from sheaf.models.system import DateFormat, DeleteConfirmation, PrivacyLevel
 class SystemCreate(BaseModel):
     name: str = Field(max_length=100)
     description: str | None = None
+    note: str | None = Field(default=None, max_length=5000)
     tag: str | None = Field(default=None, max_length=8)
     avatar_url: str | None = Field(default=None, max_length=500)
     color: str | None = Field(default=None, max_length=7)
@@ -34,6 +35,7 @@ class SystemCreate(BaseModel):
 class SystemUpdate(BaseModel):
     name: str | None = Field(default=None, max_length=100)
     description: str | None = None
+    note: str | None = Field(default=None, max_length=5000)
     tag: str | None = Field(default=None, max_length=8)
     avatar_url: str | None = Field(default=None, max_length=500)
     color: str | None = Field(default=None, max_length=7)
@@ -57,6 +59,7 @@ class SystemRead(BaseModel):
     id: uuid.UUID
     name: str
     description: str | None
+    note: str | None
     tag: str | None
     avatar_url: str | None
     color: str | None

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -27,6 +27,12 @@ def member_description_plaintext(member: Member) -> str | None:
     return decrypt(member.description)
 
 
+def member_note_plaintext(member: Member) -> str | None:
+    if member.note is None:
+        return None
+    return decrypt(member.note)
+
+
 def set_member_name(member: Member, plaintext: str) -> None:
     """Encrypt + hash a new plaintext name onto a Member instance."""
     member.name = encrypt(plaintext)
@@ -35,6 +41,16 @@ def set_member_name(member: Member, plaintext: str) -> None:
 
 def set_member_description(member: Member, plaintext: str | None) -> None:
     member.description = encrypt(plaintext) if plaintext is not None else None
+
+
+def set_member_note(member: Member, plaintext: str | None) -> None:
+    """Set / clear the scratchpad note. Empty string normalises to None
+    so deleting the contents in the UI clears the column rather than
+    persisting an encrypted empty string."""
+    if plaintext is None or plaintext == "":
+        member.note = None
+    else:
+        member.note = encrypt(plaintext)
 
 
 def decrypt_member_for_read(member: Member) -> MemberRead:
@@ -53,6 +69,7 @@ def decrypt_member_for_read(member: Member) -> MemberRead:
         "emoji": member.emoji,
         "is_custom_front": member.is_custom_front,
         "privacy": member.privacy,
+        "note": member_note_plaintext(member),
         "created_at": member.created_at,
         "updated_at": member.updated_at,
     })

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,119 @@
+"""Integration tests for the lightweight scratchpad notes on members
+and the owning system."""
+
+from __future__ import annotations
+
+import httpx
+
+
+# --- Member notes --------------------------------------------------------
+
+
+def test_create_member_with_note(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/members",
+        json={"name": "Alice", "note": "trigger: loud noises"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["note"] == "trigger: loud noises"
+
+
+def test_create_member_without_note_returns_null(auth_client: httpx.Client):
+    resp = auth_client.post("/v1/members", json={"name": "Bob"})
+    assert resp.status_code == 201
+    assert resp.json()["note"] is None
+
+
+def test_update_member_note(auth_client: httpx.Client):
+    member = auth_client.post("/v1/members", json={"name": "C"}).json()
+    resp = auth_client.patch(
+        f"/v1/members/{member['id']}",
+        json={"note": "fav drink: oat flat white"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["note"] == "fav drink: oat flat white"
+
+
+def test_update_member_note_overwrite(auth_client: httpx.Client):
+    """Notes are overwrite-only: updating replaces, no history captured."""
+    member = auth_client.post(
+        "/v1/members", json={"name": "D", "note": "first"},
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/members/{member['id']}",
+        json={"note": "second"},
+    )
+    assert resp.json()["note"] == "second"
+
+    # No revision should have been captured for the note (revisions are
+    # for bios only).
+    revs = auth_client.get(f"/v1/members/{member['id']}/revisions").json()
+    assert revs == []
+
+
+def test_clear_member_note_with_empty_string(auth_client: httpx.Client):
+    member = auth_client.post(
+        "/v1/members", json={"name": "E", "note": "stale"},
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/members/{member['id']}",
+        json={"note": ""},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["note"] is None
+
+
+def test_member_note_length_cap(auth_client: httpx.Client):
+    member = auth_client.post("/v1/members", json={"name": "F"}).json()
+    too_long = "x" * 5001
+    resp = auth_client.patch(
+        f"/v1/members/{member['id']}",
+        json={"note": too_long},
+    )
+    assert resp.status_code == 422
+
+
+# --- System notes --------------------------------------------------------
+
+
+def test_update_system_note(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        "/v1/systems/me",
+        json={"note": "household contacts list..."},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["note"] == "household contacts list..."
+
+
+def test_get_system_returns_decrypted_note(auth_client: httpx.Client):
+    auth_client.patch("/v1/systems/me", json={"note": "system scratchpad"})
+    resp = auth_client.get("/v1/systems/me")
+    assert resp.status_code == 200
+    assert resp.json()["note"] == "system scratchpad"
+
+
+def test_clear_system_note_with_empty_string(auth_client: httpx.Client):
+    auth_client.patch("/v1/systems/me", json={"note": "stuff"})
+    resp = auth_client.patch("/v1/systems/me", json={"note": ""})
+    assert resp.status_code == 200
+    assert resp.json()["note"] is None
+
+
+def test_system_note_length_cap(auth_client: httpx.Client):
+    too_long = "x" * 5001
+    resp = auth_client.patch("/v1/systems/me", json={"note": too_long})
+    assert resp.status_code == 422
+
+
+# --- Export --------------------------------------------------------------
+
+
+def test_notes_appear_in_export_decrypted(auth_client: httpx.Client):
+    auth_client.patch("/v1/systems/me", json={"note": "system note"})
+    auth_client.post(
+        "/v1/members",
+        json={"name": "Alice", "note": "alice's scratchpad"},
+    )
+    export = auth_client.get("/v1/export").json()
+    assert export["system"]["note"] == "system note"
+    assert any(m["note"] == "alice's scratchpad" for m in export["members"])

--- a/web/src/components/settings/system-profile-card.tsx
+++ b/web/src/components/settings/system-profile-card.tsx
@@ -48,13 +48,14 @@ function SystemSettingsForm({
   onSubmit,
   loading,
 }: {
-  initial: { name: string; description: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format?: DateFormat };
-  onSubmit: (data: { name: string; description: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format: DateFormat }) => void;
+  initial: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format?: DateFormat };
+  onSubmit: (data: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format: DateFormat }) => void;
   loading: boolean;
 }) {
   const [name, setName] = useState(initial.name);
   const [avatarUrl, setAvatarUrl] = useState(initial.avatar_url);
   const [description, setDescription] = useState(initial.description ?? "");
+  const [note, setNote] = useState(initial.note ?? "");
   const [tag, setTag] = useState(initial.tag ?? "");
   const [color, setColor] = useState(initial.color ?? "");
   const [privacy, setPrivacy] = useState<PrivacyLevel>(initial.privacy);
@@ -66,6 +67,7 @@ function SystemSettingsForm({
       name,
       avatar_url: avatarUrl,
       description: description || null,
+      note: note || null,
       tag: tag || null,
       color: color || null,
       privacy,
@@ -97,6 +99,22 @@ function SystemSettingsForm({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Optional"
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="system-note">Notes</Label>
+            <textarea
+              id="system-note"
+              className="w-full rounded-md border bg-background p-2 text-sm font-mono"
+              rows={4}
+              maxLength={5000}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Quick reference scratchpad..."
+            />
+            <p className="text-xs text-muted-foreground">
+              Markdown supported. Edits overwrite immediately. No revision
+              history, not protected by System Safety.
+            </p>
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -66,6 +66,7 @@ function MemberForm({
   const [pronouns, setPronouns] = useState(initial?.pronouns ?? "");
   const [color, setColor] = useState(initial?.color ?? "#6366f1");
   const [description, setDescription] = useState(initial?.description ?? "");
+  const [note, setNote] = useState(initial?.note ?? "");
   const [birthday, setBirthday] = useState(initial?.birthday ?? "");
   const [pluralkitId, setPluralkitId] = useState(initial?.pluralkit_id ?? "");
   const [emoji, setEmoji] = useState(initial?.emoji ?? "");
@@ -83,6 +84,7 @@ function MemberForm({
       pronouns: pronouns || null,
       color: color || null,
       description: description || null,
+      note: note || null,
       birthday: birthday || null,
       pluralkit_id: pluralkitId.trim() || null,
       emoji: emoji.trim() || null,
@@ -163,6 +165,22 @@ function MemberForm({
         <Suspense fallback={<div className="h-[120px] rounded-md border border-input" />}>
           <BioEditor value={description} onChange={setDescription} />
         </Suspense>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="member-note">Notes</Label>
+        <textarea
+          id="member-note"
+          className="w-full rounded-md border bg-background p-2 text-sm font-mono"
+          rows={4}
+          maxLength={5000}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Quick reference scratchpad — trigger list, fav drink, current med doses..."
+        />
+        <p className="text-xs text-muted-foreground">
+          Markdown supported. Edits overwrite immediately. No revision
+          history, not protected by System Safety.
+        </p>
       </div>
       <div className="space-y-2">
         <Label>PluralKit ID</Label>
@@ -576,6 +594,18 @@ function MemberView({
             <div className="rounded-md border bg-muted/30 px-3 py-2">
               <Suspense fallback={<p className="text-sm text-muted-foreground">Loading...</p>}>
                 <MarkdownPreview content={member.description} />
+              </Suspense>
+            </div>
+          )}
+
+          {/* Notes — scratchpad surface, deliberately separate from bio */}
+          {member.note && (
+            <div className="rounded-md border border-dashed bg-muted/20 px-3 py-2">
+              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Notes
+              </p>
+              <Suspense fallback={<p className="text-sm text-muted-foreground">Loading...</p>}>
+                <MarkdownPreview content={member.note} />
               </Suspense>
             </div>
           )}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -45,6 +45,9 @@ export interface System {
   id: string;
   name: string;
   description: string | null;
+  /** Lightweight scratchpad note; deliberately overwrite-only and not
+   *  protected by System Safety. ~5kb plaintext cap. */
+  note: string | null;
   tag: string | null;
   avatar_url: string | null;
   color: string | null;
@@ -60,6 +63,7 @@ export interface System {
 export interface SystemUpdate {
   name?: string;
   description?: string | null;
+  note?: string | null;
   tag?: string | null;
   avatar_url?: string | null;
   color?: string | null;
@@ -83,6 +87,9 @@ export interface Member {
   emoji: string | null;
   is_custom_front: boolean;
   privacy: PrivacyLevel;
+  /** Lightweight scratchpad note; deliberately overwrite-only and not
+   *  protected by System Safety. ~5kb plaintext cap. */
+  note: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -99,6 +106,7 @@ export interface MemberCreate {
   emoji?: string | null;
   is_custom_front?: boolean;
   privacy?: PrivacyLevel;
+  note?: string | null;
 }
 
 export interface MemberUpdate {
@@ -113,6 +121,7 @@ export interface MemberUpdate {
   emoji?: string | null;
   is_custom_front?: boolean;
   privacy?: PrivacyLevel;
+  note?: string | null;
 }
 
 export interface Front {


### PR DESCRIPTION
Single free-form note per scope, stored as encrypted Text on members.note and systems.note. Capped at 5000 plaintext characters. Edits overwrite the previous content; an empty string in a PATCH clears the column.

Deliberately lightweight as a counterpart to journals: no revision history, no System Safety integration, no destructive-auth on edits. Use journals for anything that wants versioning or delete protection. The scratchpad use case (trigger lists, fav drinks, current med doses) wanted that machinery off, not on.

The note field is part of the existing MemberCreate / MemberUpdate / MemberRead and SystemUpdate / SystemRead surfaces — no new endpoints, no new scopes. Markdown rendered with image embeds off, same renderer as bios. Decrypted to plaintext for the Article 20 export.
