### PR TITLE
Fix Sheaf import rejecting current v2 export files

### DIFF
--- a/sheaf/api/v1/sheaf_import.py
+++ b/sheaf/api/v1/sheaf_import.py
@@ -33,10 +33,23 @@ async def _parse_upload(file: UploadFile) -> dict:
             detail="Invalid JSON file.",
         ) from exc
 
-    if not isinstance(parsed, dict) or parsed.get("version") != "1":
+    # Accept both legacy v1 exports and current v2 exports. v2 added new
+    # top-level keys (reminders, watch_tokens, polls, journals, revisions,
+    # uploaded_files) over time; the importer only consumes the original
+    # set (system / members / fronts / groups / tags / custom_fields) and
+    # silently ignores extras, so accepting v2 is forward-compatible
+    # without requiring per-field handlers for the not-yet-importable
+    # surfaces. New format versions should be added here as they ship.
+    if (
+        not isinstance(parsed, dict)
+        or parsed.get("version") not in {"1", "2"}
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Not a valid Sheaf export file (missing version field).",
+            detail=(
+                "Not a valid Sheaf export file (missing or unsupported "
+                "version field — expected 1 or 2)."
+            ),
         )
     return parsed
 

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -1,7 +1,15 @@
 """Sheaf data import service.
 
-Imports data from Sheaf's own export format (version "1"). Generates new UUIDs
-for all entities and maps old IDs to new ones for cross-references.
+Imports data from Sheaf's own export format. Versions "1" and "2" are
+accepted; "2" added top-level keys over time (reminders, watch_tokens,
+polls, journals, revisions, uploaded_files) which this importer
+deliberately does not consume — those carry runtime state or live
+deliverability info that doesn't round-trip into a fresh instance
+without re-registration. The fields here are silently ignored when
+present.
+
+Generates new UUIDs for all imported entities and maps old IDs to new
+ones for cross-references inside the file.
 """
 
 import logging
@@ -112,6 +120,11 @@ async def run_import(
                 system.color = sys_data["color"][:7] if sys_data["color"] else None
             if sys_data.get("privacy"):
                 system.privacy = _privacy(sys_data["privacy"])
+            # Notes are encrypted at rest. Empty-string clears (matches the
+            # PATCH /systems/me semantics).
+            if "note" in sys_data:
+                note_val = sys_data["note"]
+                system.note = encrypt(note_val) if note_val else None
 
     # --- Members ---
     export_members = data.get("members", [])
@@ -126,6 +139,7 @@ async def run_import(
         old_id = m_data.get("id", "")
         plaintext_name = (m_data.get("name") or "unnamed")[:100]
         plaintext_description = m_data.get("description")
+        plaintext_note = m_data.get("note")
         member = Member(
             id=uuid.uuid4(),
             system_id=system.id,
@@ -135,6 +149,11 @@ async def run_import(
             description=(
                 encrypt(plaintext_description)
                 if plaintext_description is not None
+                else None
+            ),
+            note=(
+                encrypt(plaintext_note)
+                if plaintext_note
                 else None
             ),
             pronouns=_trunc(m_data.get("pronouns"), 100),

--- a/tests/test_sheaf_import.py
+++ b/tests/test_sheaf_import.py
@@ -1,0 +1,214 @@
+"""Integration tests for the Sheaf-to-Sheaf import endpoint.
+
+Covers the version-check gate (v1 + v2 accepted, anything else rejected),
+forward-compat with v2-only top-level keys (reminders / polls / etc. are
+silently ignored), and a basic round-trip on the importable subset.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import httpx
+
+
+def _upload(client: httpx.Client, path: str, payload: dict) -> httpx.Response:
+    body = json.dumps(payload).encode("utf-8")
+    return client.post(
+        path,
+        files={"file": ("export.json", io.BytesIO(body), "application/json")},
+    )
+
+
+def test_preview_rejects_missing_version(auth_client: httpx.Client):
+    resp = _upload(
+        auth_client,
+        "/v1/import/sheaf/preview",
+        {"system": {"name": "Whatever"}, "members": []},
+    )
+    assert resp.status_code == 400
+    assert "version" in resp.json()["detail"].lower()
+
+
+def test_preview_rejects_unknown_version(auth_client: httpx.Client):
+    resp = _upload(
+        auth_client,
+        "/v1/import/sheaf/preview",
+        {"version": "99", "system": {"name": "x"}, "members": []},
+    )
+    assert resp.status_code == 400
+
+
+def test_preview_accepts_v1(auth_client: httpx.Client):
+    resp = _upload(
+        auth_client,
+        "/v1/import/sheaf/preview",
+        {
+            "version": "1",
+            "system": {"name": "Old"},
+            "members": [{"id": "m1", "name": "Alice"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["system_name"] == "Old"
+    assert body["member_count"] == 1
+
+
+def test_preview_accepts_v2_with_extra_keys(auth_client: httpx.Client):
+    """A current-format export carries reminders / polls / watch_tokens /
+    journals / revisions / uploaded_files. Those aren't re-importable
+    yet but their presence must not gate the preview."""
+    resp = _upload(
+        auth_client,
+        "/v1/import/sheaf/preview",
+        {
+            "version": "2",
+            "system": {"name": "Current"},
+            "members": [{"id": "m1", "name": "Alice"}],
+            "fronts": [],
+            "groups": [],
+            "tags": [],
+            "custom_fields": [],
+            "reminders": [{"id": "r1", "name": "drift-by"}],
+            "watch_tokens": [{"id": "w1"}],
+            "polls": [{"id": "p1"}],
+            "journals": [{"id": "j1"}],
+            "revisions": [],
+            "uploaded_files": [],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["member_count"] == 1
+
+
+def test_roundtrip_export_then_import(auth_client: httpx.Client):
+    """Build a non-trivial system, hit /v1/export, then feed the bytes
+    straight back into /v1/import/sheaf. The format that the export
+    emits today must be accepted by the importer that ships with it.
+    Future v→v+1 bumps that break this test catch a forgotten import-
+    side update."""
+    # Build the source system: members in a group, with a tag, a custom
+    # field, and an open front. Mix of fields the importer handles.
+    alice = auth_client.post(
+        "/v1/members",
+        json={"name": "Alice", "pronouns": "she/her", "color": "#ff0066"},
+    ).json()
+    bob = auth_client.post(
+        "/v1/members",
+        json={"name": "Bob", "is_custom_front": False},
+    ).json()
+
+    auth_client.patch(
+        "/v1/systems/me",
+        json={
+            "name": "Source System",
+            "description": "before-export",
+            "note": "household scratchpad",
+        },
+    )
+    auth_client.patch(
+        f"/v1/members/{alice['id']}",
+        json={"note": "alice's quick reference"},
+    )
+
+    group = auth_client.post(
+        "/v1/groups", json={"name": "Inner circle"},
+    ).json()
+    auth_client.put(
+        f"/v1/groups/{group['id']}/members",
+        json={"member_ids": [alice["id"], bob["id"]]},
+    )
+
+    tag = auth_client.post("/v1/tags", json={"name": "Trusted"}).json()
+    auth_client.put(
+        f"/v1/tags/{tag['id']}/members",
+        json={"member_ids": [alice["id"]]},
+    )
+
+    field = auth_client.post(
+        "/v1/fields",
+        json={"name": "Birthstone", "field_type": "text"},
+    ).json()
+    auth_client.put(
+        f"/v1/members/{alice['id']}/fields",
+        json=[{"field_id": field["id"], "value": "amethyst"}],
+    )
+
+    auth_client.post("/v1/fronts", json={"member_ids": [alice["id"]]})
+
+    # Export.
+    export_resp = auth_client.get("/v1/export")
+    assert export_resp.status_code == 200, export_resp.text
+    payload = export_resp.json()
+    assert payload["version"] == "2"
+
+    # Importer wipe-or-merge semantics: import into the same system. The
+    # importer creates fresh entities (new UUIDs), so we expect counts
+    # to double rather than fail.
+    members_before = len(auth_client.get("/v1/members").json())
+
+    resp = _upload(auth_client, "/v1/import/sheaf", payload)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["members_imported"] == 2
+    assert body["fronts_imported"] >= 1
+    assert body["groups_imported"] == 1
+    assert body["tags_imported"] == 1
+    assert body["custom_fields_imported"] == 1
+
+    # New members landed alongside the originals.
+    after = auth_client.get("/v1/members").json()
+    assert len(after) == members_before + 2
+    names = sorted(m["name"] for m in after)
+    assert names.count("Alice") == 2
+    assert names.count("Bob") == 2
+
+    # Notes round-trip through encryption: every imported Alice has the
+    # original note text, and the system note re-decrypts to the original.
+    alice_notes = [m["note"] for m in after if m["name"] == "Alice"]
+    assert alice_notes == ["alice's quick reference"] * 2
+    system_after = auth_client.get("/v1/systems/me").json()
+    assert system_after["note"] == "household scratchpad"
+
+
+def test_run_import_v2_imports_known_fields(auth_client: httpx.Client):
+    resp = _upload(
+        auth_client,
+        "/v1/import/sheaf",
+        {
+            "version": "2",
+            "system": {"name": "Imported System"},
+            "members": [
+                {"id": "m1", "name": "Alice"},
+                {"id": "m2", "name": "Bob"},
+            ],
+            "fronts": [
+                {
+                    "id": "f1",
+                    "started_at": "2026-05-01T12:00:00+00:00",
+                    "ended_at": None,
+                    "member_ids": ["m1"],
+                }
+            ],
+            "groups": [
+                {"id": "g1", "name": "Inner circle", "member_ids": ["m1", "m2"]}
+            ],
+            "tags": [],
+            "custom_fields": [],
+            # v2-only fields the importer ignores by design — must not crash.
+            "reminders": [{"id": "r1", "name": "ignored"}],
+            "polls": [{"id": "p1"}],
+            "watch_tokens": [],
+            "journals": [],
+            "revisions": [],
+            "uploaded_files": [],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["members_imported"] == 2
+    assert body["fronts_imported"] == 1
+    assert body["groups_imported"] == 1


### PR DESCRIPTION
## Summary
- Importer's version gate was hardcoded to `"1"` while the export started emitting `"2"` with the account-export-completeness work, so every import of a current export 400'd with "missing version field". Loosen the gate to accept `"1"` or `"2"`.
- v2's new top-level keys (reminders / polls / watch_tokens / journals / revisions / uploaded_files) carry runtime state that doesn't round-trip onto a fresh instance, so the importer continues to ignore them silently — no per-field handlers needed for forward-compat.
- Wires note import (member + system, encrypted at rest) so notes survive a roundtrip now that they're part of the export.

## Test plan
- [x] `tests/test_sheaf_import.py` covers the version gate (rejects missing/unknown, accepts 1 + 2), v2 with all extra keys present, basic v2 import of the importable subset, and a full export→import roundtrip including notes
- [x] 24/24 across import + notes + members + export pass against a fresh test stack
- [x] Manually validated against a real exported file: 44 members, 6 fronts, 4 groups, 1 tag, 0 warnings