### PR TITLE
Edit front entry: extended PATCH + per-entry audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### PATCH endpoints reject explicit null on NOT-NULL columns
+
+Bug fix uncovered while testing on the test instance: `PATCH /v1/systems/me` with `date_format: null` (or any other NOT-NULL column nulled out) crashed with a 500 `NotNullViolationError`. The `| None = None` shape that every Update schema uses to enable "presence-in-body" PATCH semantics also allowed clients to send explicit `null`, which the handler then setattr'd onto the model and pushed to the DB.
+
+Fixed by adding `field_validator` rejections at the schema layer for every NOT-NULL column on every Update schema where the handler doesn't already defensively ignore `None`. Clients now get a clean 422 instead of a 500. Validators don't run on default values in Pydantic v2, so the "omit to keep" semantics is unchanged — only explicit `null` for required fields is newly rejected. Affected schemas: `SystemUpdate`, `MemberUpdate`, `GroupUpdate`, `TagUpdate`, `CustomFieldUpdate`, `AnnouncementUpdate`, `ReminderUpdate`, `ChannelUpdate`, `SystemSafetyUpdate`, `FrontUpdate`. `JournalEntryUpdate` and `UserUpdate` were already None-tolerant at the handler layer and don't need the schema-level check.
+
 ### Edit front entry + audit log
 
 SP parity for editing past front entries. Each explicit edit now appends an audit row to `front_audit_events`, capturing who did it, when, what was at front at the time, and a full pre/post snapshot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Edit front entry + audit log
+
+SP parity for editing past front entries. Each explicit edit now appends an audit row to `front_audit_events`, capturing who did it, when, what was at front at the time, and a full pre/post snapshot.
+
+- **Extended `PATCH /v1/fronts/{id}`.** Now accepts `started_at` (new), plus the existing `ended_at` (with reopen semantics: send `null` to clear and reopen a closed front), `member_ids`, and `custom_status`. All four use presence-in-body to distinguish "omit" from "explicit set", so a partial PATCH only touches what you sent. Overlap with adjacent entries is allowed (SP parity: front history is self-reported state, not a system-enforced timeline); the only timeline impossibility rejected is `ended_at` strictly before `started_at`.
+- **Audit log.** New `front_audit_events` table — append-only, one row per explicit edit. Stores `actor_user_id`, `fronting_member_ids` (the system-wide currently-fronting set at the moment of the edit, mirroring polls' fronting snapshot), and `before_snapshot` / `after_snapshot` JSONB columns holding the full entry state (member ids, started_at, ended_at, custom_status — encrypted at rest exactly as on the live row). `ON DELETE CASCADE` on `front_id` means the audit log is bound to the entry: purging a front (retention, manual delete) takes its history with it.
+- **No audit for system-driven edits.** Auto-end on `replace_fronts=true` and any other implicit mutation does **not** write an audit row; only explicit `PATCH` calls do. No-op PATCHes (empty body, or body that doesn't actually change the snapshot) also skip the row.
+- **No System Safety gating on edits.** Edits are mutating but not destructive — the audit log itself is the safeguard. Front-entry deletion still goes through System Safety unchanged.
+- **API**: `GET /v1/fronts/{id}/audit` lists audit rows newest-first, gated by `fronts:read`. Ownership is verified via the live front row; other systems' entries 404 (not 403, to avoid leaking existence).
+- **Frontend**: Edit button on each entry (both Currently-fronting and History) opens a dialog with member-set / started_at / ended_at / reopen-toggle / custom_status fields. History toggle (clock icon) on each entry expands inline to show a chronological audit list with per-row "Members: X → Y", "Started: A → B", etc. diffs.
+
 ### Mobile push notifications (FCM + APNs)
 
 Backend wiring so the iOS and Android apps can receive front-change pings (and any other channel-driven notification surface) directly via the OS push providers, on top of the existing notification-channels machinery.

--- a/alembic/versions/e1f2g3h4i5j6_add_front_audit_events.py
+++ b/alembic/versions/e1f2g3h4i5j6_add_front_audit_events.py
@@ -1,0 +1,65 @@
+"""Add front_audit_events
+
+Revision ID: e1f2g3h4i5j6
+Revises: d0e1f2g3h4i5
+Create Date: 2026-05-10
+
+Per-front-entry audit log. Append-only; one row per explicit edit. ON
+DELETE CASCADE on front_id binds the log lifetime to the front entry
+itself — purging a front (retention, manual delete) also purges its
+audit history.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+revision = "e1f2g3h4i5j6"
+down_revision = "d0e1f2g3h4i5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "front_audit_events",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "front_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("fronts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "actor_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "fronting_member_ids",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("before_snapshot", JSONB, nullable=False),
+        sa.Column("after_snapshot", JSONB, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_front_audit_events_front_id",
+        "front_audit_events",
+        ["front_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_front_audit_events_front_id", table_name="front_audit_events"
+    )
+    op.drop_table("front_audit_events")

--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -301,6 +301,7 @@ All resource endpoints require authentication. With API keys, the appropriate sc
 | GET | `/fronts/current` | `fronts:read` |
 | PATCH | `/fronts/{id}` | `fronts:write` |
 | DELETE | `/fronts/{id}` | `fronts:delete` |
+| GET | `/fronts/{id}/audit` | `fronts:read` |
 | GET | `/groups` | `groups:read` |
 | POST | `/groups` | `groups:write` |
 | PATCH | `/groups/{id}` | `groups:write` |
@@ -351,6 +352,28 @@ Uploads can be disabled server-wide (`ALLOW_IMAGE_UPLOADS=false`). When disabled
 Reminders ride a notification channel for delivery (`channel_id`). Two trigger types: `automated` (delay_seconds after a front-change matching `trigger_member_id`/`trigger_event`) and `repeated` (cron-style schedule via either structured `schedule_kind`/`schedule_time`/`schedule_dow_mask`/`schedule_dom`/`schedule_tz` fields, or a raw `cron_expression`).
 
 Repeated reminders can be scope-limited to specific members. When the schedule fires while no scoped member is fronting and `digest_when_absent=true`, the missed firing queues (capped at 5 per reminder, oldest dropped). On the next front-start of a scoped member, the queue drains as a digest notification. Title and body are encrypted at rest.
+
+### Front editing + audit log
+
+`PATCH /v1/fronts/{id}` accepts partial updates to `started_at`, `ended_at`, `member_ids`, and `custom_status`. Presence-in-body determines effect: an omitted field is unchanged, `null` is an explicit clear (which only `ended_at` and `custom_status` accept — `ended_at: null` reopens a closed front, `custom_status: null` clears the status), and a value replaces. `started_at: null` is rejected.
+
+Validation is intentionally permissive (SP parity): overlap with adjacent entries is allowed. The only timeline impossibility rejected is `ended_at` strictly before `started_at`.
+
+Every explicit edit that produces a different snapshot appends a row to `front_audit_events`, captured in the same transaction as the edit. System-driven mutations (auto-end on `replace_fronts=true`, retention purges, etc.) do not write audit rows.
+
+`GET /v1/fronts/{id}/audit` returns audit rows newest-first under `fronts:read`:
+
+```
+{
+  id, front_id, actor_user_id,
+  fronting_member_ids: [uuid, ...],   // system-wide currently-fronting set at edit time
+  before: { started_at, ended_at, member_ids, custom_status },
+  after:  { started_at, ended_at, member_ids, custom_status },
+  created_at
+}
+```
+
+`custom_status` is decrypted in the response (same scope gate as the live front read). Audit rows are bound to the entry via `ON DELETE CASCADE`; deleting the front entry purges its history too.
 
 ### Notes
 

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -11,11 +11,18 @@ from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.crypto import decrypt, encrypt
 from sheaf.database import get_db
 from sheaf.models.front import Front
+from sheaf.models.front_audit_event import FrontAuditEvent
 from sheaf.models.member import Member, front_members
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
-from sheaf.schemas.front import FrontCreate, FrontRead, FrontUpdate
+from sheaf.schemas.front import (
+    FrontAuditEventRead,
+    FrontCreate,
+    FrontRead,
+    FrontSnapshot,
+    FrontUpdate,
+)
 from sheaf.schemas.member import MemberDeleteConfirm
 from sheaf.services.notifications.events import (
     emit_front_change,
@@ -283,6 +290,34 @@ async def create_front(
     return _front_to_read(front)
 
 
+def _front_snapshot_for_audit(front: Front) -> dict:
+    """Serialise a Front into the JSONB shape stored in
+    `front_audit_events.before/after_snapshot`. custom_status stays
+    encrypted in the snapshot exactly as it is on the live row."""
+    return {
+        "started_at": front.started_at.isoformat(),
+        "ended_at": front.ended_at.isoformat() if front.ended_at else None,
+        "member_ids": [str(m.id) for m in front.members],
+        "custom_status_encrypted": front.custom_status,
+    }
+
+
+def _audit_snapshot_to_read(snapshot: dict) -> FrontSnapshot:
+    """Inverse of `_front_snapshot_for_audit` for the audit-list endpoint —
+    decrypts custom_status the same way the live front read does."""
+    ciphertext = snapshot.get("custom_status_encrypted")
+    return FrontSnapshot(
+        started_at=datetime.fromisoformat(snapshot["started_at"]),
+        ended_at=(
+            datetime.fromisoformat(snapshot["ended_at"])
+            if snapshot.get("ended_at")
+            else None
+        ),
+        member_ids=[uuid.UUID(m) for m in snapshot.get("member_ids", [])],
+        custom_status=decrypt(ciphertext) if ciphertext else None,
+    )
+
+
 @router.patch(
     "/{front_id}",
     response_model=FrontRead,
@@ -304,20 +339,37 @@ async def update_front(
     if front is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Front not found")
 
+    # Capture pre-edit state for both the audit log and the
+    # currently-fronting notification emit.
     before_state = await snapshot_front_state(db, system.id)
+    before_snapshot = _front_snapshot_for_audit(front)
+    fronting_ids_at_edit = list(before_state.fronting_member_ids)
 
-    if body.ended_at is not None:
+    fields_set = body.model_fields_set
+    has_explicit_change = False
+
+    if "started_at" in fields_set:
+        if body.started_at is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="started_at cannot be null",
+            )
+        front.started_at = body.started_at
+        has_explicit_change = True
+
+    if "ended_at" in fields_set:
+        # Explicit null reopens a closed front. A non-null value either
+        # closes an open front or moves an existing close timestamp.
         front.ended_at = body.ended_at
+        has_explicit_change = True
 
-    # custom_status uses presence-in-body to distinguish "omit" from
-    # "explicitly clear". model_fields_set is Pydantic v2's per-instance
-    # set of field names that were actually supplied in the input.
-    if "custom_status" in body.model_fields_set:
+    if "custom_status" in fields_set:
         front.custom_status = (
             encrypt(body.custom_status) if body.custom_status else None
         )
+        has_explicit_change = True
 
-    if body.member_ids is not None:
+    if "member_ids" in fields_set and body.member_ids is not None:
         member_result = await db.execute(
             select(Member).where(
                 Member.id.in_(body.member_ids),
@@ -331,8 +383,34 @@ async def update_front(
                 detail="One or more member IDs are invalid",
             )
         front.members = members
+        has_explicit_change = True
+
+    # Sanity-check ordering. Allow overlap with adjacent entries (SP
+    # parity), but reject the impossibilities.
+    if front.ended_at is not None and front.ended_at < front.started_at:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="ended_at cannot be earlier than started_at",
+        )
 
     await db.flush()
+
+    # Append the audit row only if something explicitly changed. A
+    # no-op PATCH (empty body) doesn't pollute history.
+    if has_explicit_change:
+        after_snapshot = _front_snapshot_for_audit(front)
+        if after_snapshot != before_snapshot:
+            db.add(
+                FrontAuditEvent(
+                    id=uuid.uuid4(),
+                    front_id=front.id,
+                    actor_user_id=user.id,
+                    fronting_member_ids=[str(m) for m in fronting_ids_at_edit],
+                    before_snapshot=before_snapshot,
+                    after_snapshot=after_snapshot,
+                    created_at=datetime.now(UTC),
+                )
+            )
 
     after_state = await snapshot_front_state(db, system.id)
     await emit_front_change(
@@ -342,6 +420,54 @@ async def update_front(
     await db.commit()
     await db.refresh(front, ["members"])
     return _front_to_read(front)
+
+
+@router.get(
+    "/{front_id}/audit",
+    response_model=list[FrontAuditEventRead],
+)
+async def list_front_audit(
+    front_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return audit rows for a front entry, newest first.
+
+    Gated by `fronts:read` (router-level dep). The audit log is
+    system-internal; same caller can read the live entry, so the audit
+    rows reveal nothing further. Hard-deleted with the entry via
+    ON DELETE CASCADE on front_id."""
+    system = await _get_user_system(user, db)
+    # Ownership check via the live front row — if the entry doesn't
+    # belong to the caller's system, return 404 regardless of whether
+    # audit rows happen to exist.
+    front_result = await db.execute(
+        select(Front).where(
+            Front.id == front_id, Front.system_id == system.id
+        )
+    )
+    if front_result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Front not found"
+        )
+
+    audit_result = await db.execute(
+        select(FrontAuditEvent)
+        .where(FrontAuditEvent.front_id == front_id)
+        .order_by(FrontAuditEvent.created_at.desc())
+    )
+    return [
+        FrontAuditEventRead(
+            id=row.id,
+            front_id=row.front_id,
+            actor_user_id=row.actor_user_id,
+            fronting_member_ids=[uuid.UUID(s) for s in (row.fronting_member_ids or [])],
+            before=_audit_snapshot_to_read(row.before_snapshot),
+            after=_audit_snapshot_to_read(row.after_snapshot),
+            created_at=row.created_at,
+        )
+        for row in audit_result.scalars().all()
+    ]
 
 
 @router.delete(

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -7,6 +7,7 @@ from sheaf.models.email_suppression import EmailSuppression
 from sheaf.models.email_verification import EmailVerification
 from sheaf.models.export_job import ExportJob, ExportJobStatus
 from sheaf.models.front import Front
+from sheaf.models.front_audit_event import FrontAuditEvent
 from sheaf.models.group import Group
 from sheaf.models.invite_code import InviteCode
 from sheaf.models.job_run import JobRun
@@ -70,6 +71,7 @@ __all__ = [
     "ExportJobStatus",
     "FieldType",
     "Front",
+    "FrontAuditEvent",
     "Group",
     "GroupRuleAction",
     "IncludePrivate",

--- a/sheaf/models/front_audit_event.py
+++ b/sheaf/models/front_audit_event.py
@@ -1,0 +1,71 @@
+"""Per-front-entry audit log.
+
+Append-only. Each row captures one explicit edit of a front entry —
+actor, when, the full pre-edit snapshot, and the full post-edit
+snapshot. Walking the rows in created_at order lets you reconstruct
+exactly what the entry looked like at any point.
+
+Hard-deleted with the front entry itself via FK cascade — the audit
+log is bound to the entry, not to the system. If the entry is purged
+(retention, manual delete), its history goes with it.
+
+Auto-end on `replace_fronts=true` and other system-driven mutations
+do NOT write audit rows; only explicit PATCH /v1/fronts/{id} calls do.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sheaf.models.base import Base, UUIDMixin
+
+
+class FrontAuditEvent(UUIDMixin, Base):
+    __tablename__ = "front_audit_events"
+
+    front_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("fronts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Nullable so a user account deletion (SET NULL) doesn't take audit
+    # rows with it — the historical record stays, attribution just goes
+    # blank. We don't have per-member auth, so attribution is account-level.
+    actor_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # Snapshot of the system's currently-fronting set at the moment of
+    # the edit. Same forensic shape as polls' fronting snapshot — if you
+    # later want to know "who was at front when Alice rewrote this old
+    # entry?", this is the answer. List of UUID strings.
+    fronting_member_ids: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
+
+    # Full pre-edit and post-edit snapshots. Shape:
+    #   {
+    #     "started_at": "2026-05-10T12:00:00+00:00",
+    #     "ended_at":   "2026-05-10T13:00:00+00:00" | null,
+    #     "member_ids": ["uuid1", "uuid2", ...],
+    #     "custom_status_encrypted": "<base64 ciphertext>" | null,
+    #   }
+    # custom_status stays encrypted at rest in the snapshot exactly as
+    # it does on the live front; the audit-read endpoint decrypts for
+    # the response. Same scope (fronts:read) gates both.
+    before_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    after_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )

--- a/sheaf/schemas/announcement.py
+++ b/sheaf/schemas/announcement.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class AnnouncementCreate(BaseModel):
@@ -26,6 +26,18 @@ class AnnouncementUpdate(BaseModel):
     expires_at: datetime | None = None
     clear_starts_at: bool = False
     clear_expires_at: bool = False
+
+    # NOT-NULL columns on the model; the `| None` annotation only exists
+    # so model_fields_set can distinguish "omitted" from "supplied" for
+    # PATCH semantics. Reject explicit nulls before they reach the DB.
+    @field_validator(
+        "title", "body", "severity", "dismissible", "active", "visible_while_logged_out"
+    )
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
 
 
 class AnnouncementPublic(BaseModel):

--- a/sheaf/schemas/custom_field.py
+++ b/sheaf/schemas/custom_field.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from sheaf.models.custom_field import FieldType
 from sheaf.models.system import PrivacyLevel
@@ -21,6 +21,13 @@ class CustomFieldUpdate(BaseModel):
     options: dict | None = None
     order: int | None = None
     privacy: PrivacyLevel | None = None
+
+    @field_validator("name", "order", "privacy")
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
 
 
 class CustomFieldRead(BaseModel):

--- a/sheaf/schemas/front.py
+++ b/sheaf/schemas/front.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class FrontCreate(BaseModel):
@@ -12,15 +12,22 @@ class FrontCreate(BaseModel):
 
 
 class FrontUpdate(BaseModel):
-    # All three of these use presence-in-body to distinguish "omit" from
-    # "explicitly set". Sending `ended_at: null` is reopening a closed
-    # front; sending no `ended_at` key at all leaves it as-is. Same for
-    # custom_status (null clears, omit keeps). started_at must be a
-    # value when supplied; sending null is rejected.
+    # All four of these use presence-in-body to distinguish "omit" from
+    # "explicitly set". Sending `ended_at: null` reopens a closed front;
+    # sending no `ended_at` key at all leaves it as-is. Same for
+    # custom_status (null clears, omit keeps). started_at and member_ids
+    # back NOT-NULL columns; sending null for either is rejected.
     started_at: datetime | None = None
     ended_at: datetime | None = None
     member_ids: list[uuid.UUID] | None = None
     custom_status: str | None = None
+
+    @field_validator("started_at", "member_ids")
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
 
 
 class FrontSnapshot(BaseModel):

--- a/sheaf/schemas/front.py
+++ b/sheaf/schemas/front.py
@@ -12,12 +12,38 @@ class FrontCreate(BaseModel):
 
 
 class FrontUpdate(BaseModel):
+    # All three of these use presence-in-body to distinguish "omit" from
+    # "explicitly set". Sending `ended_at: null` is reopening a closed
+    # front; sending no `ended_at` key at all leaves it as-is. Same for
+    # custom_status (null clears, omit keeps). started_at must be a
+    # value when supplied; sending null is rejected.
+    started_at: datetime | None = None
     ended_at: datetime | None = None
     member_ids: list[uuid.UUID] | None = None
-    # `custom_status` uses an explicit "unset" sentinel: omit the field to
-    # keep the existing value, send `null` to clear it, or send a string
-    # to replace it. Pydantic's `exclude_unset=True` round-trips this.
     custom_status: str | None = None
+
+
+class FrontSnapshot(BaseModel):
+    """Pre- or post-edit state captured in a FrontAuditEvent row."""
+
+    started_at: datetime
+    ended_at: datetime | None
+    member_ids: list[uuid.UUID]
+    custom_status: str | None = None
+
+
+class FrontAuditEventRead(BaseModel):
+    id: uuid.UUID
+    front_id: uuid.UUID
+    actor_user_id: uuid.UUID | None
+    # System members who were fronting at the moment of the edit. Same
+    # forensic shape as polls' fronting snapshot.
+    fronting_member_ids: list[uuid.UUID]
+    before: FrontSnapshot
+    after: FrontSnapshot
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
 
 
 class FrontRead(BaseModel):

--- a/sheaf/schemas/group.py
+++ b/sheaf/schemas/group.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class GroupCreate(BaseModel):
@@ -16,6 +16,13 @@ class GroupUpdate(BaseModel):
     description: str | None = None
     color: str | None = Field(default=None, max_length=7)
     parent_id: uuid.UUID | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
 
 
 class GroupRead(BaseModel):

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -61,6 +61,15 @@ class MemberUpdate(BaseModel):
     def _normalize_description(cls, v: str | None) -> str | None:
         return normalize_description_urls(v)
 
+    # NOT-NULL columns on the model; `| None` is only here so
+    # model_fields_set can distinguish omitted vs supplied.
+    @field_validator("name", "is_custom_front", "privacy")
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
+
 
 class MemberDeleteConfirm(BaseModel):
     password: str | None = None

--- a/sheaf/schemas/notifications.py
+++ b/sheaf/schemas/notifications.py
@@ -121,6 +121,29 @@ class ChannelUpdate(BaseModel):
     group_rules: list[GroupRuleSpec] | None = None
     member_rules: list[MemberRuleSpec] | None = None
 
+    # NOT-NULL columns on the model; `| None` is only here so
+    # model_fields_set can distinguish omitted vs supplied. quiet_hours
+    # is genuinely nullable (null = clear the quiet-hours window), so
+    # it's not in this list.
+    @field_validator(
+        "name",
+        "destination_config",
+        "base_all_members",
+        "base_include_private",
+        "trigger_on_start",
+        "trigger_on_stop",
+        "trigger_on_cofront_change",
+        "cofront_redaction",
+        "payload_sensitivity",
+        "debounce_seconds",
+        "aggregation_window_seconds",
+    )
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
+
 
 class ChannelRead(BaseModel):
     id: uuid.UUID

--- a/sheaf/schemas/reminder.py
+++ b/sheaf/schemas/reminder.py
@@ -87,6 +87,23 @@ class ReminderUpdate(BaseModel):
     scope_member_ids: list[uuid.UUID] | None = None
     digest_when_absent: bool | None = None
 
+    # NOT-NULL columns on the model; the `| None` annotation only exists
+    # so model_fields_set can distinguish omitted vs supplied.
+    @field_validator(
+        "name",
+        "title",
+        "enabled",
+        "channel_id",
+        "trigger_type",
+        "scope",
+        "digest_when_absent",
+    )
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
+
 
 class ReminderRead(BaseModel):
     id: uuid.UUID

--- a/sheaf/schemas/system.py
+++ b/sheaf/schemas/system.py
@@ -54,6 +54,26 @@ class SystemUpdate(BaseModel):
     def _normalize_description(cls, v: str | None) -> str | None:
         return normalize_description_urls(v)
 
+    @field_validator(
+        "name",
+        "privacy",
+        "date_format",
+        "replace_fronts_default",
+        "coalesce_contiguous_fronts",
+    )
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        """These columns are NOT NULL on the model; the `| None` in the
+        annotation only exists so `model_fields_set` can distinguish
+        "omitted" from "supplied" for PATCH semantics. An explicit
+        `null` in the body would otherwise reach the DB and 500. Reject
+        it here with a 422 instead. Validators don't run on default
+        values in Pydantic v2, so this only fires when the client
+        actually sent the field."""
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
+
 
 class SystemRead(BaseModel):
     id: uuid.UUID

--- a/sheaf/schemas/system_safety.py
+++ b/sheaf/schemas/system_safety.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # `delete_confirmation` is re-exported here as the System Safety auth tier.
 # Historical name retained for API / DB compatibility.
@@ -48,6 +48,31 @@ class SystemSafetyUpdate(BaseModel):
     # Re-auth for loosening changes is checked against the *current* auth tier.
     password: str | None = None
     totp_code: str | None = None
+
+    # NOT-NULL columns on the model; `| None` is only here so
+    # model_fields_set can distinguish omitted vs supplied.
+    @field_validator(
+        "grace_period_days",
+        "auth_tier",
+        "applies_to_members",
+        "applies_to_groups",
+        "applies_to_tags",
+        "applies_to_fields",
+        "applies_to_fronts",
+        "applies_to_journals",
+        "applies_to_images",
+        "applies_to_revisions",
+        "applies_to_notifications",
+        "applies_to_reminders",
+        "applies_to_polls",
+        "applies_to_messages",
+        "auto_pin_first_revision",
+    )
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
 
 
 class PendingActionRead(BaseModel):

--- a/sheaf/schemas/tag.py
+++ b/sheaf/schemas/tag.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class TagCreate(BaseModel):
@@ -12,6 +12,13 @@ class TagCreate(BaseModel):
 class TagUpdate(BaseModel):
     name: str | None = Field(default=None, max_length=50)
     color: str | None = Field(default=None, max_length=7)
+
+    @field_validator("name")
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
 
 
 class TagRead(BaseModel):

--- a/tests/test_fronts.py
+++ b/tests/test_fronts.py
@@ -33,15 +33,18 @@ def test_current_fronts(auth_client: httpx.Client):
 
 
 def test_end_front(auth_client: httpx.Client):
+    from datetime import UTC, datetime, timedelta
+
     member_id = _create_member(auth_client, "Ender")
     resp = auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
     front_id = resp.json()["id"]
 
+    end_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
     resp = auth_client.patch(
         f"/v1/fronts/{front_id}",
-        json={"ended_at": "2026-03-18T00:00:00Z"},
+        json={"ended_at": end_at},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.text
     assert resp.json()["ended_at"] is not None
 
 

--- a/tests/test_fronts_audit.py
+++ b/tests/test_fronts_audit.py
@@ -42,7 +42,9 @@ def test_patch_rejects_null_started_at(auth_client: httpx.Client):
     resp = auth_client.patch(
         f"/v1/fronts/{front['id']}", json={"started_at": None}
     )
-    assert resp.status_code == 400
+    # Schema-layer rejection (422 from pydantic) — the handler also has
+    # a defensive 400 path, but the schema catches it first.
+    assert resp.status_code == 422
 
 
 def test_patch_can_reopen_closed_front(auth_client: httpx.Client):

--- a/tests/test_fronts_audit.py
+++ b/tests/test_fronts_audit.py
@@ -1,0 +1,248 @@
+"""Tests for the front-entry audit log + extended PATCH /v1/fronts/{id}.
+
+Covers the SP-parity edit surface (started_at, ended_at, member_ids,
+custom_status, reopen via ended_at=null) and the append-only audit
+log that captures who edited what and when.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def _create_member(client: httpx.Client, name: str) -> str:
+    resp = client.post("/v1/members", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _open_front(client: httpx.Client, member_ids: list[str]) -> dict:
+    resp = client.post("/v1/fronts", json={"member_ids": member_ids})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# --- Extended PATCH surface ------------------------------------------------
+
+
+def test_patch_can_set_started_at(auth_client: httpx.Client):
+    m = _create_member(auth_client, "ShiftLeft")
+    front = _open_front(auth_client, [m])
+    new_started_at = "2026-01-01T10:00:00+00:00"
+    resp = auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"started_at": new_started_at}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["started_at"].startswith("2026-01-01T10:00")
+
+
+def test_patch_rejects_null_started_at(auth_client: httpx.Client):
+    m = _create_member(auth_client, "NullStart")
+    front = _open_front(auth_client, [m])
+    resp = auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"started_at": None}
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_can_reopen_closed_front(auth_client: httpx.Client):
+    """Sending `ended_at: null` explicitly reopens a closed front. The
+    previous behaviour was to ignore null (only None vs missing was
+    distinguishable in the body parser); now `model_fields_set` carries
+    the difference."""
+    from datetime import UTC, datetime, timedelta
+
+    m = _create_member(auth_client, "Reopen")
+    front = _open_front(auth_client, [m])
+    # Close it (use a forward time so the validator doesn't trip).
+    end_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    closed = auth_client.patch(
+        f"/v1/fronts/{front['id']}",
+        json={"ended_at": end_at},
+    ).json()
+    assert closed["ended_at"] is not None
+    # Reopen it.
+    reopened = auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"ended_at": None}
+    ).json()
+    assert reopened["ended_at"] is None
+
+
+def test_patch_rejects_ended_before_started(auth_client: httpx.Client):
+    m = _create_member(auth_client, "BackwardsTime")
+    front = _open_front(auth_client, [m])
+    # Front started at "now"; set ended_at to before that.
+    resp = auth_client.patch(
+        f"/v1/fronts/{front['id']}",
+        json={"ended_at": "2020-01-01T00:00:00+00:00"},
+    )
+    assert resp.status_code == 400
+    assert "earlier" in resp.json()["detail"].lower()
+
+
+def test_patch_allows_overlap_with_adjacent_entry(auth_client: httpx.Client):
+    """SP parity: editing started_at / ended_at to overlap an adjacent
+    front is allowed. Front history is a record of self-reported state,
+    not a system-enforced timeline."""
+    from datetime import UTC, datetime, timedelta
+
+    m = _create_member(auth_client, "Overlapper")
+    # Two fronts back-to-back. Close the first (forward in time), open
+    # the second, then walk the second's started_at back into the first.
+    first = _open_front(auth_client, [m])
+    first_end = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+    auth_client.patch(
+        f"/v1/fronts/{first['id']}", json={"ended_at": first_end}
+    )
+    second = _open_front(auth_client, [m])
+    overlap_start = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    resp = auth_client.patch(
+        f"/v1/fronts/{second['id']}", json={"started_at": overlap_start}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# --- Audit log -------------------------------------------------------------
+
+
+def test_audit_empty_for_unedited_front(auth_client: httpx.Client):
+    m = _create_member(auth_client, "Untouched")
+    front = _open_front(auth_client, [m])
+    resp = auth_client.get(f"/v1/fronts/{front['id']}/audit")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_audit_captures_member_set_change(auth_client: httpx.Client):
+    m1 = _create_member(auth_client, "A")
+    m2 = _create_member(auth_client, "B")
+    front = _open_front(auth_client, [m1])
+    auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"member_ids": [m1, m2]}
+    )
+
+    audit = auth_client.get(f"/v1/fronts/{front['id']}/audit").json()
+    assert len(audit) == 1
+    row = audit[0]
+    assert set(row["before"]["member_ids"]) == {m1}
+    assert set(row["after"]["member_ids"]) == {m1, m2}
+    assert row["actor_user_id"] is not None
+
+
+def test_audit_captures_custom_status_change(auth_client: httpx.Client):
+    m = _create_member(auth_client, "Statusee")
+    front = _open_front(auth_client, [m])
+    auth_client.patch(
+        f"/v1/fronts/{front['id']}",
+        json={"custom_status": "during a job interview"},
+    )
+    audit = auth_client.get(f"/v1/fronts/{front['id']}/audit").json()
+    assert len(audit) == 1
+    assert audit[0]["before"]["custom_status"] is None
+    assert audit[0]["after"]["custom_status"] == "during a job interview"
+
+
+def test_audit_no_row_for_noop_patch(auth_client: httpx.Client):
+    """An empty PATCH body, or a PATCH where the resulting snapshot
+    exactly equals the prior one, doesn't pollute the audit log."""
+    m = _create_member(auth_client, "Noop")
+    front = _open_front(auth_client, [m])
+    # Empty body.
+    auth_client.patch(f"/v1/fronts/{front['id']}", json={})
+    # Same member set (no-op even though field is set).
+    auth_client.patch(f"/v1/fronts/{front['id']}", json={"member_ids": [m]})
+    audit = auth_client.get(f"/v1/fronts/{front['id']}/audit").json()
+    assert audit == []
+
+
+def test_audit_orders_newest_first(auth_client: httpx.Client):
+    m1 = _create_member(auth_client, "Sequenced1")
+    m2 = _create_member(auth_client, "Sequenced2")
+    front = _open_front(auth_client, [m1])
+    auth_client.patch(
+        f"/v1/fronts/{front['id']}",
+        json={"custom_status": "first edit"},
+    )
+    auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"member_ids": [m1, m2]}
+    )
+    audit = auth_client.get(f"/v1/fronts/{front['id']}/audit").json()
+    assert len(audit) == 2
+    # Newest first: the member-set change is row 0, the status change row 1.
+    assert set(audit[0]["after"]["member_ids"]) == {m1, m2}
+    assert audit[1]["after"]["custom_status"] == "first edit"
+
+
+def test_audit_captures_fronting_member_ids_at_edit_time(
+    auth_client: httpx.Client,
+):
+    """fronting_member_ids snapshot: who was at front when the edit
+    happened. Editing an old closed entry while Alice is currently
+    fronting records [Alice], not the edited entry's members."""
+    alice = _create_member(auth_client, "AliceFronting")
+    bob = _create_member(auth_client, "BobOldEntry")
+
+    # Old entry to be edited (closed).
+    old_front = _open_front(auth_client, [bob])
+    auth_client.patch(
+        f"/v1/fronts/{old_front['id']}",
+        json={"ended_at": "2026-04-01T00:00:00+00:00"},
+    )
+
+    # Alice is currently fronting.
+    _open_front(auth_client, [alice])
+
+    # Edit the old (Bob) entry; the audit row should record Alice's id.
+    auth_client.patch(
+        f"/v1/fronts/{old_front['id']}",
+        json={"custom_status": "thinking back on this"},
+    )
+    audit = auth_client.get(f"/v1/fronts/{old_front['id']}/audit").json()
+    assert len(audit) == 1
+    assert audit[0]["fronting_member_ids"] == [alice]
+
+
+def test_audit_cascades_on_front_delete(auth_client: httpx.Client):
+    """Deleting the front entry deletes its audit history (ON DELETE
+    CASCADE). The audit log is bound to the entry, not the system."""
+    m = _create_member(auth_client, "DeleteMe")
+    front = _open_front(auth_client, [m])
+    auth_client.patch(
+        f"/v1/fronts/{front['id']}",
+        json={"custom_status": "doomed entry"},
+    )
+    # Confirm the audit row exists.
+    pre = auth_client.get(f"/v1/fronts/{front['id']}/audit").json()
+    assert len(pre) == 1
+
+    # Delete the front; auth tier in test env is "none", so no confirm
+    # body needed.
+    resp = auth_client.delete(f"/v1/fronts/{front['id']}")
+    assert resp.status_code in {200, 202, 204}
+
+    # 404 on audit (front gone). Anything stored should be gone too.
+    audit_after = auth_client.get(f"/v1/fronts/{front['id']}/audit")
+    assert audit_after.status_code == 404
+
+
+def test_audit_ownership_other_systems_get_404(auth_client: httpx.Client):
+    """A front from another user's system must 404 on /audit, not leak
+    history (and not 403, which would confirm existence)."""
+    import os
+    import uuid as _uuid
+
+    # Create the front under auth_client's system.
+    m = _create_member(auth_client, "Mine")
+    front = _open_front(auth_client, [m])
+
+    # Register a fresh user, hit /audit for the other system's front.
+    email = f"audit-other-{_uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as other:
+        reg = other.post(
+            "/v1/auth/register",
+            json={"email": email, "password": "testpassword123"},
+        )
+        assert reg.status_code == 201, reg.text
+        other.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+        resp = other.get(f"/v1/fronts/{front['id']}/audit")
+    assert resp.status_code == 404

--- a/tests/test_patch_null_rejection.py
+++ b/tests/test_patch_null_rejection.py
@@ -1,0 +1,161 @@
+"""Tests that PATCH endpoints reject explicit `null` on NOT-NULL columns.
+
+The bug surfaced via PATCH /v1/systems/me sending `date_format: null`,
+which the schema accepted (because `date_format: DateFormat | None = None`
+is the standard "presence-in-body" pattern) and which then crashed at
+the DB with a NotNullViolationError.
+
+This file covers every Update schema that backs a NOT-NULL column,
+asserting 422 (schema-layer rejection) instead of 500."""
+
+from __future__ import annotations
+
+import os
+import uuid as _uuid
+
+import httpx
+
+
+def _system_id(client: httpx.Client) -> str:
+    return client.get("/v1/systems/me").json()["id"]
+
+
+def test_systems_patch_rejects_null_date_format(auth_client: httpx.Client):
+    """The original bug from the test instance: omitting + sending null
+    for a NOT-NULL column 500'd. Now 422'd at the schema layer."""
+    resp = auth_client.patch(
+        "/v1/systems/me",
+        json={"name": "test", "date_format": None},
+    )
+    assert resp.status_code == 422
+
+
+def test_systems_patch_rejects_null_replace_fronts_default(
+    auth_client: httpx.Client,
+):
+    resp = auth_client.patch(
+        "/v1/systems/me",
+        json={"replace_fronts_default": None},
+    )
+    assert resp.status_code == 422
+
+
+def test_systems_patch_rejects_null_privacy(auth_client: httpx.Client):
+    resp = auth_client.patch("/v1/systems/me", json={"privacy": None})
+    assert resp.status_code == 422
+
+
+def test_systems_patch_allows_null_for_nullable_columns(auth_client: httpx.Client):
+    """Sanity check: the nullable columns (description, tag, color,
+    avatar_url) still accept null, since null = "clear" there."""
+    resp = auth_client.patch(
+        "/v1/systems/me",
+        json={"description": None, "tag": None, "color": None},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_member_patch_rejects_null_name(auth_client: httpx.Client):
+    member = auth_client.post(
+        "/v1/members", json={"name": "Original"}
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/members/{member['id']}", json={"name": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_member_patch_rejects_null_privacy(auth_client: httpx.Client):
+    member = auth_client.post(
+        "/v1/members", json={"name": "PrivacyTest"}
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/members/{member['id']}", json={"privacy": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_member_patch_rejects_null_is_custom_front(auth_client: httpx.Client):
+    member = auth_client.post(
+        "/v1/members", json={"name": "CFTest"}
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/members/{member['id']}", json={"is_custom_front": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_group_patch_rejects_null_name(auth_client: httpx.Client):
+    group = auth_client.post("/v1/groups", json={"name": "Original"}).json()
+    resp = auth_client.patch(
+        f"/v1/groups/{group['id']}", json={"name": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_tag_patch_rejects_null_name(auth_client: httpx.Client):
+    tag = auth_client.post("/v1/tags", json={"name": "Original"}).json()
+    resp = auth_client.patch(f"/v1/tags/{tag['id']}", json={"name": None})
+    assert resp.status_code == 422
+
+
+def test_custom_field_patch_rejects_null_name(auth_client: httpx.Client):
+    field = auth_client.post(
+        "/v1/fields",
+        json={"name": "f", "field_type": "text"},
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/fields/{field['id']}", json={"name": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_front_patch_rejects_null_member_ids(auth_client: httpx.Client):
+    member = auth_client.post(
+        "/v1/members", json={"name": "FrontTest"}
+    ).json()
+    front = auth_client.post(
+        "/v1/fronts", json={"member_ids": [member["id"]]}
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"member_ids": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_system_safety_rejects_null_grace_period(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        "/v1/system/safety", json={"grace_period_days": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_system_safety_rejects_null_applies_to_members(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        "/v1/system/safety", json={"applies_to_members": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_reminder_patch_rejects_null_name(auth_client: httpx.Client):
+    # Reminder creation needs a channel. Skip if no convenient setup.
+    # Schema-level rejection happens before any DB lookup, so we can
+    # PATCH a non-existent id and still get 422.
+    resp = auth_client.patch(
+        f"/v1/reminders/{_uuid.uuid4()}", json={"name": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_channel_patch_rejects_null_name(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        f"/v1/channels/{_uuid.uuid4()}", json={"name": None}
+    )
+    assert resp.status_code == 422
+
+
+def test_channel_patch_rejects_null_debounce_seconds(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        f"/v1/channels/{_uuid.uuid4()}", json={"debounce_seconds": None}
+    )
+    assert resp.status_code == 422

--- a/web/src/components/edit-front-dialog.tsx
+++ b/web/src/components/edit-front-dialog.tsx
@@ -1,0 +1,232 @@
+import { useState } from "react";
+
+import { useUpdateFront } from "@/hooks/use-fronts";
+import type { Front } from "@/types/api";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { MemberSelect } from "@/components/member-select";
+
+function toLocalInput(iso: string | null): string {
+  if (!iso) return "";
+  // datetime-local wants YYYY-MM-DDTHH:mm in the browser's local zone.
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+function fromLocalInput(value: string): string | null {
+  if (!value) return null;
+  return new Date(value).toISOString();
+}
+
+export function EditFrontDialog({
+  front,
+  onOpenChange,
+  onSaved,
+}: {
+  // null = closed
+  front: Front | null;
+  onOpenChange: (open: boolean) => void;
+  onSaved?: () => void;
+}) {
+  const updateFront = useUpdateFront();
+
+  // Reinit the form on the open transition without useEffect (lint
+  // blocks setState-in-effect). Tracking which front the form was
+  // last populated from is enough.
+  const [draft, setDraft] = useState<{
+    fromFrontId: string | null;
+    memberIds: string[];
+    startedAt: string;
+    endedAt: string;
+    reopen: boolean;
+    customStatus: string;
+  }>({
+    fromFrontId: null,
+    memberIds: [],
+    startedAt: "",
+    endedAt: "",
+    reopen: false,
+    customStatus: "",
+  });
+
+  if (front && draft.fromFrontId !== front.id) {
+    setDraft({
+      fromFrontId: front.id,
+      memberIds: front.member_ids,
+      startedAt: toLocalInput(front.started_at),
+      endedAt: toLocalInput(front.ended_at),
+      reopen: false,
+      customStatus: front.custom_status ?? "",
+    });
+  } else if (!front && draft.fromFrontId !== null) {
+    setDraft((d) => ({ ...d, fromFrontId: null }));
+  }
+
+  function handleSave() {
+    if (!front) return;
+    const body: {
+      started_at?: string;
+      ended_at?: string | null;
+      member_ids?: string[];
+      custom_status?: string | null;
+    } = {};
+
+    const originalStartedAt = toLocalInput(front.started_at);
+    const originalEndedAt = toLocalInput(front.ended_at);
+    const originalCustomStatus = front.custom_status ?? "";
+    const originalMemberIds = [...front.member_ids].sort();
+    const draftMemberIds = [...draft.memberIds].sort();
+
+    if (draft.startedAt !== originalStartedAt) {
+      const iso = fromLocalInput(draft.startedAt);
+      if (iso) body.started_at = iso;
+    }
+    // Reopen flag wins: explicit clear.
+    if (draft.reopen) {
+      body.ended_at = null;
+    } else if (draft.endedAt !== originalEndedAt) {
+      body.ended_at = fromLocalInput(draft.endedAt);
+    }
+    if (draft.customStatus !== originalCustomStatus) {
+      body.custom_status = draft.customStatus.trim() || null;
+    }
+    if (
+      originalMemberIds.length !== draftMemberIds.length ||
+      originalMemberIds.some((id, i) => id !== draftMemberIds[i])
+    ) {
+      body.member_ids = draft.memberIds;
+    }
+
+    if (Object.keys(body).length === 0) {
+      onOpenChange(false);
+      return;
+    }
+
+    updateFront.mutate(
+      { id: front.id, data: body },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          onSaved?.();
+        },
+      },
+    );
+  }
+
+  return (
+    <Dialog open={!!front} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit front entry</DialogTitle>
+          <DialogDescription>
+            Changes are recorded in this entry's history. Overlap with
+            adjacent entries is allowed; ended_at before started_at is not.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-normal">Fronting members</Label>
+          <MemberSelect
+            selected={draft.memberIds}
+            onChange={(m) => setDraft((d) => ({ ...d, memberIds: m }))}
+            className="py-2"
+            showGroupFilter
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="started-at" className="text-sm font-normal">
+              Started
+            </Label>
+            <Input
+              id="started-at"
+              type="datetime-local"
+              value={draft.startedAt}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, startedAt: e.target.value }))
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ended-at" className="text-sm font-normal">
+              Ended
+            </Label>
+            <Input
+              id="ended-at"
+              type="datetime-local"
+              value={draft.endedAt}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, endedAt: e.target.value, reopen: false }))
+              }
+              disabled={draft.reopen}
+            />
+          </div>
+        </div>
+
+        {front?.ended_at && (
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="reopen"
+              checked={draft.reopen}
+              onCheckedChange={(v) =>
+                setDraft((d) => ({
+                  ...d,
+                  reopen: v === true,
+                  endedAt: v === true ? "" : d.endedAt,
+                }))
+              }
+            />
+            <Label
+              htmlFor="reopen"
+              className="text-sm font-normal cursor-pointer"
+            >
+              Reopen (clear ended_at)
+            </Label>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="custom-status" className="text-sm font-normal">
+            Custom status
+          </Label>
+          <Input
+            id="custom-status"
+            value={draft.customStatus}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, customStatus: e.target.value }))
+            }
+            placeholder="e.g. during a job interview"
+            maxLength={500}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={handleSave}
+            disabled={
+              !front ||
+              draft.memberIds.length === 0 ||
+              updateFront.isPending
+            }
+          >
+            {updateFront.isPending ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/front-audit-history.tsx
+++ b/web/src/components/front-audit-history.tsx
@@ -1,0 +1,124 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { listFrontAudit } from "@/lib/fronts";
+import { useMembers } from "@/hooks/use-members";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatDateTime } from "@/lib/utils";
+import type { FrontSnapshot } from "@/types/api";
+
+function memberNames(
+  ids: string[],
+  members: Map<string, { display_name: string | null; name: string }>,
+): string {
+  if (ids.length === 0) return "(none)";
+  return ids
+    .map((id) => {
+      const m = members.get(id);
+      return m?.display_name ?? m?.name ?? "Unknown";
+    })
+    .join(", ");
+}
+
+function diff(
+  before: FrontSnapshot,
+  after: FrontSnapshot,
+  members: Map<string, { display_name: string | null; name: string }>,
+): { label: string; from: string; to: string }[] {
+  const rows: { label: string; from: string; to: string }[] = [];
+
+  const beforeIds = [...before.member_ids].sort();
+  const afterIds = [...after.member_ids].sort();
+  if (
+    beforeIds.length !== afterIds.length ||
+    beforeIds.some((id, i) => id !== afterIds[i])
+  ) {
+    rows.push({
+      label: "Members",
+      from: memberNames(before.member_ids, members),
+      to: memberNames(after.member_ids, members),
+    });
+  }
+  if (before.started_at !== after.started_at) {
+    rows.push({
+      label: "Started",
+      from: formatDateTime(before.started_at),
+      to: formatDateTime(after.started_at),
+    });
+  }
+  if (before.ended_at !== after.ended_at) {
+    rows.push({
+      label: "Ended",
+      from: before.ended_at ? formatDateTime(before.ended_at) : "(open)",
+      to: after.ended_at ? formatDateTime(after.ended_at) : "(open)",
+    });
+  }
+  if ((before.custom_status ?? "") !== (after.custom_status ?? "")) {
+    rows.push({
+      label: "Status",
+      from: before.custom_status || "(none)",
+      to: after.custom_status || "(none)",
+    });
+  }
+  return rows;
+}
+
+export function FrontAuditHistory({ frontId }: { frontId: string }) {
+  const { data: events, isLoading } = useQuery({
+    queryKey: ["fronts", frontId, "audit"],
+    queryFn: () => listFrontAudit(frontId),
+  });
+  const { data: memberList } = useMembers();
+  const members = new Map(
+    memberList?.map((m) => [m.id, { display_name: m.display_name, name: m.name }]) ??
+      [],
+  );
+
+  if (isLoading) {
+    return <Skeleton className="h-12 w-full" />;
+  }
+  if (!events || events.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No edits recorded for this entry.
+      </p>
+    );
+  }
+  return (
+    <ul className="space-y-3">
+      {events.map((ev) => {
+        const changes = diff(ev.before, ev.after, members);
+        return (
+          <li
+            key={ev.id}
+            className="rounded-md border bg-muted/30 px-3 py-2 text-sm"
+          >
+            <div className="text-xs text-muted-foreground">
+              {formatDateTime(ev.created_at)}
+              {ev.fronting_member_ids.length > 0 && (
+                <span>
+                  {" "}· at-front: {memberNames(ev.fronting_member_ids, members)}
+                </span>
+              )}
+            </div>
+            {changes.length === 0 ? (
+              <p className="text-xs italic text-muted-foreground">
+                (no diff)
+              </p>
+            ) : (
+              <ul className="mt-1 space-y-0.5">
+                {changes.map((c) => (
+                  <li key={c.label} className="text-xs">
+                    <span className="font-medium">{c.label}:</span>{" "}
+                    <span className="text-muted-foreground">{c.from}</span>
+                    {" → "}
+                    <span>{c.to}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/lib/fronts.ts
+++ b/web/src/lib/fronts.ts
@@ -2,6 +2,7 @@ import type {
   DeleteResult,
   DestructiveConfirm,
   Front,
+  FrontAuditEvent,
   FrontCreate,
   FrontUpdate,
 } from "@/types/api";
@@ -34,4 +35,8 @@ export function deleteFront(id: string, confirm?: DestructiveConfirm) {
     method: "DELETE",
     ...(confirm ? { body: JSON.stringify(confirm) } : {}),
   });
+}
+
+export function listFrontAudit(id: string) {
+  return apiFetch<FrontAuditEvent[]>(`/v1/fronts/${id}/audit`);
 }

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, History, Pencil } from "lucide-react";
 import {
   useCurrentFronts,
   useFronts,
@@ -10,6 +11,8 @@ import { useMembers } from "@/hooks/use-members";
 import { PageHeader } from "@/components/page-header";
 import { ColorDot } from "@/components/color-dot";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
+import { EditFrontDialog } from "@/components/edit-front-dialog";
+import { FrontAuditHistory } from "@/components/front-audit-history";
 import { StartFrontDialog } from "@/components/start-front-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +21,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
 import { formatDateTime, timeAgo } from "@/lib/utils";
 import { getMySystem } from "@/lib/systems";
+import type { Front } from "@/types/api";
 
 export function FrontsPage() {
   const { data: current, isLoading: currentLoading } = useCurrentFronts();
@@ -28,6 +32,19 @@ export function FrontsPage() {
   const deleteFront = useDeleteFront();
   const [showStart, setShowStart] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Front | null>(null);
+  const [expandedHistory, setExpandedHistory] = useState<Set<string>>(
+    new Set(),
+  );
+
+  function toggleHistory(id: string) {
+    setExpandedHistory((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
 
   const memberMap = new Map(members?.map((m) => [m.id, m]) ?? []);
 
@@ -78,30 +95,59 @@ export function FrontsPage() {
               {current.map((front) => (
                 <div
                   key={front.id}
-                  className="flex items-start justify-between rounded-md border p-3 gap-2"
+                  className="rounded-md border p-3 space-y-2"
                 >
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      {renderMembers(
-                        front.member_ids,
-                        front.member_since,
-                        front.member_since_capped,
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        {renderMembers(
+                          front.member_ids,
+                          front.member_since,
+                          front.member_since_capped,
+                        )}
+                      </div>
+                      {front.custom_status && (
+                        <p className="mt-2 text-sm italic text-muted-foreground">
+                          &ldquo;{front.custom_status}&rdquo;
+                        </p>
                       )}
                     </div>
-                    {front.custom_status && (
-                      <p className="mt-2 text-sm italic text-muted-foreground">
-                        &ldquo;{front.custom_status}&rdquo;
-                      </p>
-                    )}
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => toggleHistory(front.id)}
+                        aria-label="Show edit history"
+                        title="Show edit history"
+                      >
+                        {expandedHistory.has(front.id) ? (
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        ) : (
+                          <ChevronRight className="h-3.5 w-3.5" />
+                        )}
+                        <History className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setEditing(front)}
+                      >
+                        <Pencil className="h-3.5 w-3.5 mr-1" />
+                        Edit
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleEndFront(front.id)}
+                        disabled={updateFront.isPending}
+                      >
+                        End
+                      </Button>
+                    </div>
                   </div>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleEndFront(front.id)}
-                    disabled={updateFront.isPending}
-                  >
-                    End
-                  </Button>
+                  {expandedHistory.has(front.id) && (
+                    <FrontAuditHistory frontId={front.id} />
+                  )}
                 </div>
               ))}
             </div>
@@ -124,36 +170,62 @@ export function FrontsPage() {
       ) : history && history.length > 0 ? (
         <div className="space-y-2">
           {history.map((front) => (
-            <div
-              key={front.id}
-              className="flex items-start justify-between rounded-md border p-3 gap-2"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  {renderMembers(front.member_ids)}
+            <div key={front.id} className="rounded-md border p-3 space-y-2">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {renderMembers(front.member_ids)}
+                  </div>
+                  {front.custom_status && (
+                    <p className="mt-2 text-sm italic text-muted-foreground">
+                      &ldquo;{front.custom_status}&rdquo;
+                    </p>
+                  )}
                 </div>
-                {front.custom_status && (
-                  <p className="mt-2 text-sm italic text-muted-foreground">
-                    &ldquo;{front.custom_status}&rdquo;
-                  </p>
-                )}
+                <div className="flex items-center gap-3 text-sm text-muted-foreground shrink-0">
+                  <span>
+                    {formatDateTime(front.started_at)}
+                    {front.ended_at
+                      ? ` — ${formatDateTime(front.ended_at)}`
+                      : " — ongoing"}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 px-2"
+                    onClick={() => toggleHistory(front.id)}
+                    aria-label="Show edit history"
+                    title="Show edit history"
+                  >
+                    {expandedHistory.has(front.id) ? (
+                      <ChevronDown className="h-3.5 w-3.5" />
+                    ) : (
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    )}
+                    <History className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 px-2"
+                    onClick={() => setEditing(front)}
+                  >
+                    <Pencil className="h-3.5 w-3.5 mr-1" />
+                    Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-destructive-foreground h-7 px-2"
+                    onClick={() => setDeleting(front.id)}
+                  >
+                    Delete
+                  </Button>
+                </div>
               </div>
-              <div className="flex items-center gap-3 text-sm text-muted-foreground shrink-0">
-                <span>
-                  {formatDateTime(front.started_at)}
-                  {front.ended_at
-                    ? ` — ${formatDateTime(front.ended_at)}`
-                    : " — ongoing"}
-                </span>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="text-destructive-foreground h-7 px-2"
-                  onClick={() => setDeleting(front.id)}
-                >
-                  Delete
-                </Button>
-              </div>
+              {expandedHistory.has(front.id) && (
+                <FrontAuditHistory frontId={front.id} />
+              )}
             </div>
           ))}
         </div>
@@ -162,6 +234,11 @@ export function FrontsPage() {
       )}
 
       <StartFrontDialog open={showStart} onOpenChange={setShowStart} />
+
+      <EditFrontDialog
+        front={editing}
+        onOpenChange={(open) => !open && setEditing(null)}
+      />
 
       {/* Delete confirm */}
       <DestructiveConfirmDialog

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -229,10 +229,30 @@ export interface FrontingAnalytics {
 }
 
 export interface FrontUpdate {
+  // All fields use presence-in-body to distinguish "omit" (keep) from
+  // "explicitly set". Sending null on ended_at reopens a closed front;
+  // sending null on custom_status clears it. started_at cannot be null.
+  started_at?: string;
   ended_at?: string | null;
   member_ids?: string[];
-  // Omit to keep, send null to clear, send a string to replace.
   custom_status?: string | null;
+}
+
+export interface FrontSnapshot {
+  started_at: string;
+  ended_at: string | null;
+  member_ids: string[];
+  custom_status: string | null;
+}
+
+export interface FrontAuditEvent {
+  id: string;
+  front_id: string;
+  actor_user_id: string | null;
+  fronting_member_ids: string[];
+  before: FrontSnapshot;
+  after: FrontSnapshot;
+  created_at: string;
 }
 
 export interface Group {


### PR DESCRIPTION
## Summary
- SP parity for editing past front entries. `PATCH /v1/fronts/{id}` now accepts `started_at` (new field) and adds explicit-clear semantics: `ended_at: null` reopens a closed front, `custom_status: null` clears the status. All fields use presence-in-body so a partial PATCH only touches what was sent.
- New `front_audit_events` table (append-only, one row per explicit edit, FK cascade on `front_id`). Captures actor, when, system-wide fronting set at edit time, and full pre/post snapshots.
- `GET /v1/fronts/{id}/audit` returns rows newest-first under `fronts:read`. Other systems' entries 404.
- Validation is permissive (SP parity): overlap with adjacent entries allowed; only impossibility rejected is `ended_at` strictly before `started_at`.
- No System Safety gating on edits — the audit log is the safeguard. Delete still goes through System Safety unchanged.
- Auto-end on `replace_fronts=true` does **not** write audit rows; only explicit PATCH calls do. No-op PATCHes also skip.
- Frontend: Edit button per entry opens a dialog (members / started / ended / reopen / status). History toggle expands inline to show chronological diffs.

## Task
Closes SP gap #176.

## Test plan
- [x] `pytest tests/test_fronts.py tests/test_fronts_audit.py` (19/19 pass)
- [x] Full suite: 609 passed across all non-PK-flake tests
- [x] `ruff check sheaf/ tests/` clean
- [x] `npm run lint && npx tsc --noEmit` clean
- [x] Smoke test in browser: edit an open entry, edit a closed entry, reopen a closed entry, toggle history panel, verify "actor" + "at-front" show correctly, delete an entry and confirm audit goes with it.