### PR TITLE
Gate apns_dev opt-in; accept Bearer auth on /notifications/redeem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Mobile push redemption accepts Bearer auth
+
+`POST /v1/notifications/redeem` only consulted the `sheaf_session` cookie when resolving the redeeming account, so mobile clients (which authenticate with `Authorization: Bearer <jwt>` and carry no cookies) failed the mobile-channel "login required" gate and got 401 even with a valid token. The Android app's retry-on-401 logic compounded the issue into a refresh loop.
+
+Fixed by switching the endpoint to `get_current_user_optional`, which accepts either a session cookie or a Bearer access token. Web push redemption is unchanged (auth was always optional there); mobile push redemption now works from both the web fallback (cookie) and the native deep-link flow (Bearer).
+
+### apns_dev sandbox tokens gated behind explicit opt-in
+
+The mobile push backend accepts two APNs environments (`apns_dev` for Xcode-built sandbox installs, `apns_prod` for TestFlight / App Store). Both authenticate with the same `.p8` key, but their tokens are not interchangeable: a sandbox token registered against a prod backend would bounce at the APNs host at delivery time, leaving an orphaned `push_device_tokens` row on a real production account.
+
+Added `APNS_DEV_ENABLED` (default `false`). When off, both `POST /v1/watch-tokens/{id}/channels` with `destination_type=apns_dev` and `POST /v1/devices/push` with `platform=apns_dev` refuse the request (501 and 400 respectively) so prod deployments never see dev rows. Dev / staging / self-hosted-with-TestFlight setups flip the flag on.
+
 ### PATCH endpoints reject explicit null on NOT-NULL columns
 
 Bug fix uncovered while testing on the test instance: `PATCH /v1/systems/me` with `date_format: null` (or any other NOT-NULL column nulled out) crashed with a 500 `NotNullViolationError`. The `| None = None` shape that every Update schema uses to enable "presence-in-body" PATCH semantics also allowed clients to send explicit `null`, which the handler then setattr'd onto the model and pushed to the DB.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
 
 Open-source plural system tracking. A self-hostable replacement for SimplyPlural, built with data security and sustainability in mind.
 
-> **Status:** selfhostable and usable — hosted service is still being set up. Feedback welcome via [issues](https://github.com/sheaf-project/sheaf/issues) or our [Discord](https://discord.gg/WFaKQPzFx8).
+> **Status:** selfhostable; hosted app in [open beta](https://test.sheaf.sh). Feedback welcome via [issues](https://github.com/sheaf-project/sheaf/issues) or our [Discord](https://discord.gg/WFaKQPzFx8).
+
+[Android/WearOS](https://github.com/sheaf-project/android) and [iOS/WatchOS](https://github.com/sheaf-project/ios) clients are pending approval; ask on Discord for private test access.
+
+Sheaf supports the [OpenPlural](https://github.com/skylartaylor/openplural) data standard proposal as a founding project, and will be migrating to the format for exports once finalised.
 
 ## Why
 
@@ -25,6 +29,7 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 
 ## Features
 
+- **Web, mobile, and wearable apps** - Sheaf also supports first-class API support for custom clients and integrations, and development of custom or alternative clients for the Sheaf API is encouraged.
 - **Members** — Profiles with name, pronouns, description, colour, birthday, avatar, emoji, privacy levels, optional PluralKit ID
 - **Custom fronts** — Mark non-counting fronting entities like "Asleep" or "Away" so they show up in the fronter list without inflating member counts
 - **Front tracking** — Log switches with cofronters and an optional encrypted free-text status per fronting period

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -32,6 +32,10 @@ services:
       APNS_KEY_ID: "TESTKEY001"
       APNS_BUNDLE_ID: "com.sheaftest.app"
       APNS_P8_KEY: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"
+      # apns_dev is opt-in (off by default to keep prod from accepting
+      # sandbox tokens). The test stack mimics a dev/staging deploy by
+      # flipping it on so apns_dev paths get exercised.
+      APNS_DEV_ENABLED: "true"
     volumes: []
     depends_on:
       db:

--- a/sheaf/api/v1/devices.py
+++ b/sheaf/api/v1/devices.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -52,6 +52,20 @@ async def register_push_device(
     3. Otherwise: insert a new row, evicting the oldest-`last_seen_at`
        row first if the per-account soft cap is hit.
     """
+    # apns_dev is opt-in. Prod deployments leave APNS_DEV_ENABLED off
+    # so sandbox tokens can't be registered against the prod backend
+    # (where APNs would bounce them at delivery time anyway). Reject
+    # at registration so we don't accrue orphaned dev rows on a prod
+    # account; symmetric with the channel-creation gate.
+    if (
+        body.platform == PushPlatform.APNS_DEV
+        and not settings.apns_dev_enabled
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="apns_dev is not enabled on this server",
+        )
+
     now = datetime.now(UTC)
 
     # Path 1: exact match.

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -229,6 +229,18 @@ def _validate_destination(body_type: str) -> None:
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail="APNs is not configured on this server",
         )
+    # apns_dev is opt-in even when APNs creds are configured. Prod
+    # deployments keep `apns_dev_enabled` off so sandbox tokens can't
+    # be registered against the production backend (where they'd
+    # bounce at the APNs host anyway).
+    if (
+        body_type == DestinationType.APNS_DEV.value
+        and not settings.apns_dev_enabled
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="apns_dev is not enabled on this server",
+        )
 
 
 def _validate_direct_config(body_type: str, config: dict) -> None:

--- a/sheaf/api/v1/notifications_public.py
+++ b/sheaf/api/v1/notifications_public.py
@@ -6,8 +6,11 @@
 - POST /v1/notifications/manage/{token}/unsubscribe : disable the channel.
 
 These endpoints accept anonymous traffic. If the redeemer is currently
-signed in (session cookie present), `redeemed_by_account_id` is also set
-so future cross-system management UIs can list this subscription.
+signed in (web session cookie OR Bearer access token), `redeemed_by_account_id`
+is also set so future cross-system management UIs can list this subscription.
+Mobile push channels require an authenticated redeemer (the native app sends
+a Bearer token after sheaf:// deep-link handoff); web push treats auth as
+optional.
 """
 
 from __future__ import annotations
@@ -18,6 +21,7 @@ from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sheaf.auth.dependencies import get_current_user_optional
 from sheaf.auth.sessions import get_session_user_id
 from sheaf.config import settings
 from sheaf.database import get_db
@@ -27,6 +31,7 @@ from sheaf.models.notification_channel import (
     NotificationChannel,
 )
 from sheaf.models.system import System
+from sheaf.models.user import User
 from sheaf.models.watch_token import WatchToken
 from sheaf.schemas.notifications import (
     ManageChannelView,
@@ -112,8 +117,8 @@ async def preview_activation(
 @router.post("/redeem", response_model=RedeemResponse)
 async def redeem_activation(
     body: RedeemRequest,
-    session_id: str | None = Cookie(default=None, alias="sheaf_session"),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(get_current_user_optional),
 ) -> RedeemResponse:
     # Find a candidate channel by hashing the code and looking it up. The
     # hash is keyed (jwt_secret_key) so an attacker without the server key
@@ -163,10 +168,10 @@ async def redeem_activation(
             )
         channel.destination_config = body.push_subscription.model_dump()  # noqa: SIM102
 
-    # Resolve the redeemer's account from the session cookie.
-    redeemer_account_id = None
-    if session_id is not None:
-        redeemer_account_id = await get_session_user_id(session_id)
+    # Resolve the redeemer's account from either a web session cookie
+    # (browser flow) or a Bearer access token (mobile / API client flow);
+    # `get_current_user_optional` accepts both. None = anonymous redemption.
+    redeemer_account_id = current_user.id if current_user is not None else None
 
     if is_mobile:
         # Mobile push is account-anchored: a session is required, and the

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -342,6 +342,12 @@ class Settings(BaseSettings):
     apns_team_id: str = ""
     apns_key_id: str = ""
     apns_bundle_id: str = ""
+    # Opt-in flag for accepting apns_dev tokens / channels. Production
+    # deployments should leave this off so dev-environment device tokens
+    # can't be registered against the prod backend (which would orphan
+    # them anyway, since the prod APNs host bounces sandbox tokens).
+    # Flip on for dev / staging / self-hosted-with-TestFlight setups.
+    apns_dev_enabled: bool = False
     # Optional override used as the apns-topic header for apns_dev
     # devices when set. Falls back to apns_bundle_id when unset. Only
     # relevant if dev and prod builds ever ship under different bundle

--- a/tests/test_apns_dev_gate.py
+++ b/tests/test_apns_dev_gate.py
@@ -1,0 +1,86 @@
+"""Unit tests for the APNS_DEV_ENABLED feature flag.
+
+The flag gates two surfaces:
+- POST /v1/watch-tokens/{id}/channels with destination_type=apns_dev
+- POST /v1/devices/push with platform=apns_dev
+
+Integration tests in the test stack run with APNS_DEV_ENABLED=true so the
+"on" paths are already exercised end-to-end. These unit tests cover the
+"off" path, where the gate should reject sandbox-token registration so
+production deployments don't accrue orphaned dev rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from sheaf.api.v1.notification_channels import _validate_destination
+from sheaf.config import settings
+
+
+@pytest.fixture
+def apns_creds_configured(monkeypatch):
+    """Pretend APNs credentials are present so the gate reaches the
+    apns_dev_enabled check rather than tripping the earlier creds gate."""
+    monkeypatch.setattr(settings, "apns_team_id", "TESTTEAM01")
+    monkeypatch.setattr(settings, "apns_key_id", "TESTKEY001")
+    monkeypatch.setattr(settings, "apns_bundle_id", "com.sheaftest.app")
+    monkeypatch.setattr(
+        settings,
+        "apns_p8_key",
+        "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    )
+
+
+def test_channel_apns_dev_rejected_when_flag_off(apns_creds_configured, monkeypatch):
+    monkeypatch.setattr(settings, "apns_dev_enabled", False)
+    with pytest.raises(HTTPException) as exc:
+        _validate_destination("apns_dev")
+    assert exc.value.status_code == 501
+    assert "apns_dev" in exc.value.detail
+
+
+def test_channel_apns_dev_allowed_when_flag_on(apns_creds_configured, monkeypatch):
+    monkeypatch.setattr(settings, "apns_dev_enabled", True)
+    # Should not raise.
+    _validate_destination("apns_dev")
+
+
+def test_channel_apns_prod_not_affected_by_flag(apns_creds_configured, monkeypatch):
+    """The gate is apns_dev-only; apns_prod passes regardless of the flag."""
+    monkeypatch.setattr(settings, "apns_dev_enabled", False)
+    _validate_destination("apns_prod")
+
+
+def test_channel_apns_dev_creds_check_runs_before_flag(monkeypatch):
+    """If APNs creds are not configured at all, the earlier creds gate
+    fires first. Flag state shouldn't matter."""
+    monkeypatch.setattr(settings, "apns_team_id", "")
+    monkeypatch.setattr(settings, "apns_key_id", "")
+    monkeypatch.setattr(settings, "apns_bundle_id", "")
+    monkeypatch.setattr(settings, "apns_p8_key", "")
+    monkeypatch.setattr(settings, "apns_dev_enabled", True)
+    with pytest.raises(HTTPException) as exc:
+        _validate_destination("apns_dev")
+    assert exc.value.status_code == 501
+    assert "APNs is not configured" in exc.value.detail
+
+
+def test_device_endpoint_gate_matches_channel_gate():
+    """The device-registration endpoint shares the same gate pattern as
+    the channel-creation endpoint. This is a structural assertion: both
+    sites read `settings.apns_dev_enabled` and both raise on apns_dev when
+    the flag is off, keeping the surfaces symmetric so prod deployments
+    don't get a sneaky half-open door."""
+    import inspect
+
+    from sheaf.api.v1 import devices
+
+    source = inspect.getsource(devices.register_push_device)
+    assert "apns_dev_enabled" in source, (
+        "device-registration endpoint must consult apns_dev_enabled"
+    )
+    assert "PushPlatform.APNS_DEV" in source, (
+        "device-registration endpoint must compare against the APNS_DEV enum value"
+    )

--- a/tests/test_notifications_mobile.py
+++ b/tests/test_notifications_mobile.py
@@ -110,6 +110,34 @@ def test_redeem_mobile_rejects_push_subscription(auth_client: httpx.Client):
     assert "mobile push" in resp.json()["detail"].lower()
 
 
+def test_redeem_mobile_succeeds_with_bearer_token(auth_client: httpx.Client):
+    """Mobile clients authenticate with Bearer access tokens, not cookies.
+    Redemption must accept Bearer auth for the mobile sheaf:// deep-link
+    handoff to work — the native app has no session cookie to send."""
+    channel_id, code = _create_channel(auth_client, destination_type="apns_prod")
+    email = f"mobile-redeem-bearer-{_uuid.uuid4().hex[:8]}@sheaf.dev"
+    # Register on one client to get a token, then move to a *fresh* client
+    # so no session cookie is carried. Only the Authorization header
+    # authenticates the request, matching the mobile-app shape.
+    with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as register_c:
+        reg = register_c.post(
+            "/v1/auth/register",
+            json={"email": email, "password": "testpassword123"},
+        )
+        assert reg.status_code == 201, reg.text
+        access_token = reg.json()["access_token"]
+    with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as bearer_c:
+        bearer_c.headers["Authorization"] = f"Bearer {access_token}"
+        resp = bearer_c.post(
+            "/v1/notifications/redeem",
+            json={"activation_code": code},
+        )
+    assert resp.status_code == 200, resp.text
+    fresh = auth_client.get(f"/v1/channels/{channel_id}").json()
+    assert fresh["destination_state"] == "active"
+    assert fresh["redeemed_by_account_id"] is not None
+
+
 def test_redeem_mobile_succeeds_with_session(auth_client: httpx.Client):
     """Logged-in redemption with no push_subscription succeeds, binds
     redeemed_by_account_id, and returns an empty management_url (mobile


### PR DESCRIPTION
## Summary

Two related fixes that came out of testing the mobile push redemption flow on the test instance.

### 1. `APNS_DEV_ENABLED` flag (default off)

Apple's dev and prod APNs hosts both authenticate with the same `.p8` key, but their tokens aren't interchangeable: a sandbox-environment token registered against a prod backend would silently bounce at delivery time, leaving an orphaned `push_device_tokens` row tied to a real account.

Added `APNS_DEV_ENABLED` (default `false`). When off:
- `POST /v1/devices/push` with `platform=apns_dev` returns 400
- `POST /v1/watch-tokens/{id}/channels` with `destination_type=apns_dev` returns 501

Dev / staging / self-hosted-with-TestFlight setups flip the flag on. Test stack does so via `docker-compose.test.yml` so the existing `apns_dev` integration coverage still runs.

### 2. Bearer auth on `POST /v1/notifications/redeem`

The endpoint only consulted the `sheaf_session` cookie when resolving the redeeming account, so mobile clients (which authenticate with `Authorization: Bearer <jwt>` and carry no cookies) failed the mobile-channel auth gate with 401 even on otherwise-valid tokens. Combined with retry-on-401 logic in the Android client, this turned into a refresh loop that bottomed out at \`Too many follow-up requests: 21\`.

Swapped the endpoint to \`get_current_user_optional\`, which accepts either auth shape. Web push redemption is unchanged (auth was always optional there); mobile push redemption now works from both the web fallback (cookie) and the native \`sheaf://\` deep-link handoff (Bearer).

## Test plan

- [x] Unit tests cover the apns_dev gate-off paths (\`tests/test_apns_dev_gate.py\`)
- [x] New integration test exercises Bearer-only redemption with a fresh cookie-less client (\`test_redeem_mobile_succeeds_with_bearer_token\`)
- [x] Existing apns_dev / mobile push / notification suites pass with the test stack flag on (35 + 33 green)
- [x] \`ruff check sheaf/\` clean
- [ ] Manual verification on the test instance: mobile redeem flow now succeeds end-to-end via the native deep link
- [ ] Confirm the gate is off by default on a fresh deploy (no \`APNS_DEV_ENABLED\` in env), then flip on and re-test