### PR TITLE
Grey out history buttons on entries without history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Grey out history buttons on entries without history
+
+Small UX polish across every surface that has an edit/audit/revision history button. Before, the button was always enabled, so you'd click it and find an empty list. Now the button is disabled and dimmed when nothing's there, so you can see at a glance which entries have actually been edited.
+
+- **Fronts** (`/fronts` - both Currently-fronting and History): the per-entry History toggle is disabled until the entry has at least one audit row. Backed by a new `has_audit_history` boolean on the `FrontRead` API shape, populated via a single batched `EXISTS` query per list (no per-row round-trip).
+- **Members** (bio history modal): the History button in the member detail dialog is disabled until the bio has been edited at least once. Backed by `has_bio_revisions` on `MemberRead`, same batched-`EXISTS` pattern. Nested contexts (tag / group member lists) default to `false` since the modal is opened from the members route; if you need the accurate value, fetch from `GET /v1/members` or `/v1/members/{id}`.
+- **Messages**: the History button is disabled when `updated_at` equals `created_at` (no edit has happened yet). No backend change needed - the existing "(edited)" indicator already relies on this signal.
+- **Journal entries**: the Revisions button is disabled when `revision_count === 0`. No backend change needed - the existing single-entry endpoint already returns the count.
+
 ### Mobile push redemption accepts Bearer auth
 
 `POST /v1/notifications/redeem` only consulted the `sheaf_session` cookie when resolving the redeeming account, so mobile clients (which authenticate with `Authorization: Bearer <jwt>` and carry no cookies) failed the mobile-channel "login required" gate and got 401 even with a valid token. The Android app's retry-on-401 logic compounded the issue into a refresh loop.

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -50,6 +50,7 @@ def _front_to_read(
     *,
     member_since: dict[str, datetime] | None = None,
     member_since_capped: list[str] | None = None,
+    has_audit_history: bool = False,
 ) -> FrontRead:
     """Project a Front row to its API shape.
 
@@ -62,6 +63,11 @@ def _front_to_read(
     walk-back depth limit; the returned timestamp is a lower bound,
     not the true chain start. Frontends should render those with a
     "> X ago" prefix to be honest about precision.
+
+    `has_audit_history` reflects whether at least one FrontAuditEvent
+    exists for this entry. Computed once per list call via a batch
+    EXISTS query (see `_load_audit_existence`); single-front endpoints
+    do their own one-row check.
     """
     if member_since is None:
         member_since = {str(m.id): front.started_at for m in front.members}
@@ -74,7 +80,32 @@ def _front_to_read(
         custom_status=decrypt(front.custom_status) if front.custom_status else None,
         member_since=member_since,
         member_since_capped=member_since_capped or [],
+        has_audit_history=has_audit_history,
     )
+
+
+async def _load_audit_existence(
+    db: AsyncSession, front_ids: list[uuid.UUID]
+) -> set[uuid.UUID]:
+    """Return the subset of given front_ids that have at least one
+    FrontAuditEvent row. One round-trip regardless of the list size."""
+    if not front_ids:
+        return set()
+    result = await db.execute(
+        select(FrontAuditEvent.front_id)
+        .where(FrontAuditEvent.front_id.in_(front_ids))
+        .distinct()
+    )
+    return {row[0] for row in result.all()}
+
+
+async def _front_has_audit(db: AsyncSession, front_id: uuid.UUID) -> bool:
+    result = await db.execute(
+        select(FrontAuditEvent.id)
+        .where(FrontAuditEvent.front_id == front_id)
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
 
 
 # Walk-back depth cap: pathological cycles aside, real chains are
@@ -173,7 +204,11 @@ async def list_fronts(
         .limit(limit)
         .offset(offset)
     )
-    return [_front_to_read(f) for f in result.scalars().all()]
+    fronts = list(result.scalars().all())
+    with_audit = await _load_audit_existence(db, [f.id for f in fronts])
+    return [
+        _front_to_read(f, has_audit_history=f.id in with_audit) for f in fronts
+    ]
 
 
 @router.get("/current", response_model=list[FrontRead])
@@ -190,11 +225,13 @@ async def get_current_fronts(
     )
     fronts = list(result.scalars().all())
     member_since_map = await _build_coalesced_member_since(db, system, fronts)
+    with_audit = await _load_audit_existence(db, [f.id for f in fronts])
     return [
         _front_to_read(
             f,
             member_since=member_since_map[f.id][0],
             member_since_capped=member_since_map[f.id][1],
+            has_audit_history=f.id in with_audit,
         )
         for f in fronts
     ]
@@ -419,7 +456,9 @@ async def update_front(
 
     await db.commit()
     await db.refresh(front, ["members"])
-    return _front_to_read(front)
+    return _front_to_read(
+        front, has_audit_history=await _front_has_audit(db, front.id)
+    )
 
 
 @router.get(

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -69,6 +69,40 @@ async def _get_own_member(
     return member
 
 
+async def _load_bio_revision_existence(
+    db: AsyncSession, member_ids: list[uuid.UUID]
+) -> set[uuid.UUID]:
+    """Return the subset of member_ids that have at least one bio
+    ContentRevision. One round-trip regardless of list size."""
+    if not member_ids:
+        return set()
+    result = await db.execute(
+        select(ContentRevision.target_id)
+        .where(
+            ContentRevision.target_type
+            == ContentRevisionTarget.MEMBER_BIO.value,
+            ContentRevision.target_id.in_(member_ids),
+        )
+        .distinct()
+    )
+    return {row[0] for row in result.all()}
+
+
+async def _member_has_bio_revisions(
+    db: AsyncSession, member_id: uuid.UUID
+) -> bool:
+    result = await db.execute(
+        select(ContentRevision.id)
+        .where(
+            ContentRevision.target_type
+            == ContentRevisionTarget.MEMBER_BIO.value,
+            ContentRevision.target_id == member_id,
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
 @router.get("", response_model=list[MemberRead])
 async def list_members(
     user: User = Depends(get_current_user),
@@ -80,8 +114,16 @@ async def list_members(
     result = await db.execute(
         select(Member).where(Member.system_id == system.id)
     )
-    members = result.scalars().all()
-    decoded = [decrypt_member_for_read(m) for m in members]
+    members = list(result.scalars().all())
+    with_revisions = await _load_bio_revision_existence(
+        db, [m.id for m in members]
+    )
+    decoded = [
+        decrypt_member_for_read(
+            m, has_bio_revisions=m.id in with_revisions
+        )
+        for m in members
+    ]
     decoded.sort(key=lambda m: (m.display_name or m.name).casefold())
     return decoded
 
@@ -157,7 +199,10 @@ async def get_member(
 ):
     system = await _get_user_system(user, db)
     member = await _get_own_member(member_id, system, db)
-    return decrypt_member_for_read(member)
+    return decrypt_member_for_read(
+        member,
+        has_bio_revisions=await _member_has_bio_revisions(db, member.id),
+    )
 
 
 @router.patch(
@@ -205,7 +250,10 @@ async def update_member(
             setattr(member, key, value)
     await db.commit()
     await db.refresh(member)
-    return decrypt_member_for_read(member)
+    return decrypt_member_for_read(
+        member,
+        has_bio_revisions=await _member_has_bio_revisions(db, member.id),
+    )
 
 
 @router.delete(
@@ -374,7 +422,10 @@ async def restore_bio_revision(
     )
     await db.commit()
     await db.refresh(member)
-    return decrypt_member_for_read(member)
+    return decrypt_member_for_read(
+        member,
+        has_bio_revisions=await _member_has_bio_revisions(db, member.id),
+    )
 
 
 @router.post(

--- a/sheaf/schemas/front.py
+++ b/sheaf/schemas/front.py
@@ -73,5 +73,9 @@ class FrontRead(BaseModel):
     # UIs should render these with a "> X ago" prefix. Empty in the
     # overwhelming majority of cases — chains are typically 1-3 entries.
     member_since_capped: list[str] = []
+    # True iff at least one FrontAuditEvent row exists for this front.
+    # Lets the UI grey out the history button on entries that have never
+    # been edited, without making the recipient pay for a per-row fetch.
+    has_audit_history: bool = False
 
     model_config = {"from_attributes": True}

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -97,6 +97,12 @@ class MemberRead(BaseModel):
     note: str | None
     created_at: datetime
     updated_at: datetime
+    # True iff at least one ContentRevision exists for this member's bio.
+    # Lets the UI grey out the bio history button on members whose bio
+    # has never been edited. Defaults to False for non-list contexts
+    # (e.g. nested in tag / group responses) where computing this would
+    # be a needless round-trip.
+    has_bio_revisions: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -53,8 +53,17 @@ def set_member_note(member: Member, plaintext: str | None) -> None:
         member.note = encrypt(plaintext)
 
 
-def decrypt_member_for_read(member: Member) -> MemberRead:
-    """Build a MemberRead with name + description decrypted to plaintext."""
+def decrypt_member_for_read(
+    member: Member, *, has_bio_revisions: bool = False
+) -> MemberRead:
+    """Build a MemberRead with name + description decrypted to plaintext.
+
+    `has_bio_revisions` is opt-in: callers that need an accurate value
+    (the /v1/members endpoints, since the bio history button reads it)
+    look it up and pass through. Nested contexts (tag / group member
+    lists) default to False; the bio history modal is opened from the
+    members route, not from those, so a stale value there is harmless.
+    """
     return MemberRead.model_validate({
         "id": member.id,
         "system_id": member.system_id,
@@ -72,6 +81,7 @@ def decrypt_member_for_read(member: Member) -> MemberRead:
         "note": member_note_plaintext(member),
         "created_at": member.created_at,
         "updated_at": member.updated_at,
+        "has_bio_revisions": has_bio_revisions,
     })
 
 

--- a/tests/test_fronts_audit.py
+++ b/tests/test_fronts_audit.py
@@ -227,6 +227,58 @@ def test_audit_cascades_on_front_delete(auth_client: httpx.Client):
     assert audit_after.status_code == 404
 
 
+# --- has_audit_history flag -----------------------------------------------
+
+
+def test_has_audit_history_false_on_create(auth_client: httpx.Client):
+    """Freshly-created fronts have no audit rows yet, so the flag is
+    False. The list endpoint should reflect that too."""
+    m = _create_member(auth_client, "FreshFront")
+    front = _open_front(auth_client, [m])
+    assert front["has_audit_history"] is False
+
+    listed = auth_client.get("/v1/fronts").json()
+    matching = next(f for f in listed if f["id"] == front["id"])
+    assert matching["has_audit_history"] is False
+
+
+def test_has_audit_history_true_after_explicit_patch(auth_client: httpx.Client):
+    """An explicit PATCH that changes a field writes an audit row, and
+    the flag flips to True on the patched response and on subsequent
+    list / current reads."""
+    m = _create_member(auth_client, "EditMe")
+    front = _open_front(auth_client, [m])
+
+    patched = auth_client.patch(
+        f"/v1/fronts/{front['id']}",
+        json={"custom_status": "thinking"},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["has_audit_history"] is True
+
+    listed = auth_client.get("/v1/fronts").json()
+    matching = next(f for f in listed if f["id"] == front["id"])
+    assert matching["has_audit_history"] is True
+
+    current = auth_client.get("/v1/fronts/current").json()
+    in_current = next(
+        (f for f in current if f["id"] == front["id"]), None
+    )
+    if in_current is not None:
+        assert in_current["has_audit_history"] is True
+
+
+def test_has_audit_history_unchanged_on_noop_patch(auth_client: httpx.Client):
+    """A no-op PATCH (empty body) doesn't write an audit row, so the
+    flag stays False."""
+    m = _create_member(auth_client, "NoopPatch")
+    front = _open_front(auth_client, [m])
+
+    patched = auth_client.patch(f"/v1/fronts/{front['id']}", json={})
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["has_audit_history"] is False
+
+
 def test_audit_ownership_other_systems_get_404(auth_client: httpx.Client):
     """A front from another user's system must 404 on /audit, not leak
     history (and not 403, which would confirm existence)."""

--- a/tests/test_journals.py
+++ b/tests/test_journals.py
@@ -281,6 +281,47 @@ def test_bio_edit_captures_revision(auth_client: httpx.Client):
     assert revs[0]["target_type"] == "member_bio"
 
 
+def test_member_has_bio_revisions_flag(auth_client: httpx.Client):
+    """`has_bio_revisions` lights up once the bio has been edited at least
+    once. Lets the members UI grey out the History button on members
+    whose bio has never changed."""
+    fresh = auth_client.post(
+        "/v1/members", json={"name": "Fresh", "description": "first bio"}
+    ).json()
+    # Right after create, no revisions exist yet.
+    assert fresh["has_bio_revisions"] is False
+    got = auth_client.get(f"/v1/members/{fresh['id']}").json()
+    assert got["has_bio_revisions"] is False
+    listed = auth_client.get("/v1/members").json()
+    matching = next(m for m in listed if m["id"] == fresh["id"])
+    assert matching["has_bio_revisions"] is False
+
+    # Edit the bio — a revision is captured.
+    edited = auth_client.patch(
+        f"/v1/members/{fresh['id']}", json={"description": "second bio"}
+    ).json()
+    assert edited["has_bio_revisions"] is True
+    got_after = auth_client.get(f"/v1/members/{fresh['id']}").json()
+    assert got_after["has_bio_revisions"] is True
+    listed_after = auth_client.get("/v1/members").json()
+    matching_after = next(m for m in listed_after if m["id"] == fresh["id"])
+    assert matching_after["has_bio_revisions"] is True
+
+
+def test_member_has_bio_revisions_unaffected_by_non_description_edit(
+    auth_client: httpx.Client,
+):
+    """Editing a non-description field doesn't write a revision, so the
+    flag stays False."""
+    member = auth_client.post(
+        "/v1/members", json={"name": "PronounEdit", "description": "stable"}
+    ).json()
+    edited = auth_client.patch(
+        f"/v1/members/{member['id']}", json={"pronouns": "they/them"}
+    ).json()
+    assert edited["has_bio_revisions"] is False
+
+
 def test_bio_revisions_isolated_per_member(auth_client: httpx.Client):
     a = auth_client.post(
         "/v1/members", json={"name": "A", "description": "a-v1"}

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -117,8 +117,13 @@ export function FrontsPage() {
                         size="sm"
                         variant="ghost"
                         onClick={() => toggleHistory(front.id)}
+                        disabled={!front.has_audit_history}
                         aria-label="Show edit history"
-                        title="Show edit history"
+                        title={
+                          front.has_audit_history
+                            ? "Show edit history"
+                            : "No edit history"
+                        }
                       >
                         {expandedHistory.has(front.id) ? (
                           <ChevronDown className="h-3.5 w-3.5" />
@@ -194,8 +199,13 @@ export function FrontsPage() {
                     variant="ghost"
                     className="h-7 px-2"
                     onClick={() => toggleHistory(front.id)}
+                    disabled={!front.has_audit_history}
                     aria-label="Show edit history"
-                    title="Show edit history"
+                    title={
+                      front.has_audit_history
+                        ? "Show edit history"
+                        : "No edit history"
+                    }
                   >
                     {expandedHistory.has(front.id) ? (
                       <ChevronDown className="h-3.5 w-3.5" />

--- a/web/src/routes/journals.$id.tsx
+++ b/web/src/routes/journals.$id.tsx
@@ -120,6 +120,10 @@ export function JournalDetailPage() {
               size="sm"
               variant="outline"
               onClick={() => setShowRevisions((s) => !s)}
+              disabled={entry.revision_count === 0}
+              title={
+                entry.revision_count > 0 ? "Show revisions" : "No revisions yet"
+              }
             >
               <History className="h-4 w-4 mr-1" />
               Revisions {entry.revision_count > 0 && `(${entry.revision_count})`}

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -721,6 +721,10 @@ function MemberView({
                 size="sm"
                 onClick={() => setShowRevisions((v) => !v)}
                 aria-pressed={showRevisions}
+                disabled={!member.has_bio_revisions}
+                title={
+                  member.has_bio_revisions ? "Bio history" : "No bio history"
+                }
               >
                 <History className="h-3.5 w-3.5 mr-1" />
                 History

--- a/web/src/routes/messages.tsx
+++ b/web/src/routes/messages.tsx
@@ -586,7 +586,17 @@ function MessageRow({
           <Pencil className="size-3" />
           Edit
         </Button>
-        <Button size="sm" variant="ghost" onClick={onHistory}>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onHistory}
+          disabled={!msg.updated_at || msg.updated_at === msg.created_at}
+          title={
+            msg.updated_at && msg.updated_at !== msg.created_at
+              ? "Message history"
+              : "No edit history"
+          }
+        >
           <History className="size-3" />
           History
         </Button>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -92,6 +92,12 @@ export interface Member {
   note: string | null;
   created_at: string;
   updated_at: string;
+  /** True iff at least one ContentRevision exists for this member's
+   *  bio. Populated by the /v1/members list + get endpoints; nested
+   *  contexts (tag / group member lists) may return false even when
+   *  history exists — open the bio history modal from the members
+   *  route for an accurate signal. */
+  has_bio_revisions: boolean;
 }
 
 export interface MemberCreate {
@@ -143,6 +149,9 @@ export interface Front {
   // `member_since` entry is a lower bound, not the true chain start —
   // render with a "> X ago" prefix.
   member_since_capped: string[];
+  // True iff at least one audit row exists for this front. Lets the UI
+  // grey out the history button on entries that have never been edited.
+  has_audit_history: boolean;
 }
 
 export interface FrontCreate {


### PR DESCRIPTION
## Summary

Adds a binary "has history" signal on the relevant API responses so the frontend can disable + dim the History / Revisions button when there's nothing to show, instead of always letting the user click into an empty list.

- `FrontRead` grows `has_audit_history`, populated by a single batched `EXISTS` query across the fronts list / current endpoints, and a single check on `PATCH` return.
- `MemberRead` grows `has_bio_revisions`, same pattern. Nested contexts (tag / group member lists) default to `false` since the bio history modal is opened from the members route; if you ever need an accurate value there, fetch from `/v1/members` or `/v1/members/{id}` directly.
- Messages reuse the existing `updated_at != created_at` signal client-side.
- Journal entries reuse the existing `revision_count` already returned on the detail GET.

UX choice: dim-when-empty rather than highlight-when-present. Most entries will accrue history over time, so dimming the absence is the quieter visual signal and matches how disabled buttons read elsewhere in the UI.

## Test plan

- [x] `ruff check sheaf/` clean
- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `pytest tests/test_fronts.py tests/test_fronts_audit.py tests/test_fronts_coalesce.py tests/test_members.py tests/test_member_limits.py tests/test_journals.py tests/test_groups_tags.py tests/test_messages.py tests/test_notes.py` - 110 pass
- [x] 5 new integration tests cover create / explicit PATCH / no-op PATCH / non-description member edit transitions
- [x] Manual UI check on test instance: history button greyed on a fresh front / member / journal / message, lights up after one edit