### PR TITLE
Add Tupperbox import support

### DIFF
--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -27,6 +27,7 @@ from sheaf.api.v1 import (
     system_safety,
     systems,
     tags,
+    tb_import,
     version,
     watch_tokens,
     webhooks,
@@ -110,6 +111,10 @@ v1_router.include_router(
 )
 v1_router.include_router(
     sheaf_import.router,
+    dependencies=[Depends(require_scope("import:write"))],
+)
+v1_router.include_router(
+    tb_import.router,
     dependencies=[Depends(require_scope("import:write"))],
 )
 v1_router.include_router(webhooks.router)

--- a/sheaf/api/v1/tb_import.py
+++ b/sheaf/api/v1/tb_import.py
@@ -1,0 +1,108 @@
+"""Tupperbox data import endpoints.
+
+File-upload only: Tupperbox has no public API for third-party clients,
+so a `tb!export` JSON dump is the only path. The shape is simple
+enough that one preview + one import endpoint is all we need.
+"""
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
+from sheaf.models.system import System
+from sheaf.models.user import User
+from sheaf.schemas.tb_import import (
+    TBImportOptions,
+    TBImportResult,
+    TBPreviewSummary,
+)
+from sheaf.services.tb_import import preview as build_preview
+from sheaf.services.tb_import import run_import
+
+logger = logging.getLogger("sheaf.import.tb")
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+MAX_IMPORT_SIZE = 100 * 1024 * 1024  # 100MB — TB exports are tiny but be safe
+
+
+async def _parse_upload(file: UploadFile) -> dict[str, Any]:
+    """Read and parse a Tupperbox export JSON file from a multipart upload."""
+    data = await file.read()
+    if len(data) > MAX_IMPORT_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Import file too large. Max 100MB.",
+        )
+    try:
+        parsed = json.loads(data)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid JSON file.",
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Export file does not contain a Tupperbox export object.",
+        )
+    return parsed
+
+
+async def _get_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if not system:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Create a system first.",
+        )
+    return system
+
+
+def _options_from_query(
+    member_ids: str | None,
+    groups: bool,
+) -> TBImportOptions:
+    parsed_member_ids: list[str] | None = None
+    if member_ids is not None:
+        parsed_member_ids = [m.strip() for m in member_ids.split(",") if m.strip()]
+    return TBImportOptions(
+        member_ids=parsed_member_ids,
+        groups=groups,
+    )
+
+
+@router.post("/tupperbox/preview", response_model=TBPreviewSummary)
+async def preview_file_import(
+    file: UploadFile,
+    _user: User = Depends(get_current_user),
+):
+    """Parse a Tupperbox export file and return a summary."""
+    data = await _parse_upload(file)
+    return build_preview(data)
+
+
+@router.post("/tupperbox", response_model=TBImportResult)
+async def do_file_import(
+    file: UploadFile,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    member_ids: str | None = None,
+    groups: bool = True,
+):
+    """Import data from a Tupperbox export file.
+
+    Use the preview endpoint first to see what's in the file and to
+    gather IDs for the optional member_ids parameter (comma-separated).
+    """
+    data = await _parse_upload(file)
+    system = await _get_system(user, db)
+    options = _options_from_query(member_ids, groups)
+    return await run_import(data, options, system, db)

--- a/sheaf/schemas/tb_import.py
+++ b/sheaf/schemas/tb_import.py
@@ -1,0 +1,40 @@
+"""Pydantic models for Tupperbox data import.
+
+Tupperbox is a Discord proxy bot. Its export covers a flat list of
+"tuppers" (member-equivalents) and the groups they belong to. There's
+no system-level metadata, no fronting history, no custom fields, and
+no privacy model — just identity + grouping data. The schemas here
+mirror that smaller surface.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class TBImportOptions(BaseModel):
+    """What to import from a Tupperbox export."""
+
+    member_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Tupperbox tupper IDs (as strings) to import. None = all. Used "
+            "to let the user deselect specific tuppers on the preview screen."
+        ),
+    )
+    groups: bool = True
+
+
+class TBPreviewMember(BaseModel):
+    id: str  # Tupperbox numeric id, stringified for transport
+    name: str
+
+
+class TBPreviewSummary(BaseModel):
+    member_count: int = 0
+    members: list[TBPreviewMember] = []
+    group_count: int = 0
+
+
+class TBImportResult(BaseModel):
+    members_imported: int = 0
+    groups_imported: int = 0
+    warnings: list[str] = []

--- a/sheaf/services/tb_import.py
+++ b/sheaf/services/tb_import.py
@@ -1,0 +1,246 @@
+"""Tupperbox data import.
+
+Tupperbox exports are JSON files produced by the bot's `tb!export`
+command. Top-level shape:
+
+  - `tuppers` — array of tupper objects (member-equivalents)
+  - `groups` — array of group objects
+
+There's no system metadata, no fronting log, no custom fields, no
+privacy model, and no per-member colour. The whole import collapses
+down to creating Members + Groups and wiring the group memberships.
+
+A handful of Tupperbox concepts have no equivalent in Sheaf and are
+dropped silently to match the PluralKit importer's behaviour:
+
+  - `brackets` / `show_brackets` — Tupperbox proxy tags; Sheaf is not a
+    Discord proxy.
+  - `tag` (per-tupper) — system-tag suffix appended when proxying.
+  - `banner` — Sheaf has no member banner.
+  - `last_used`, `posts`, `avatar` (CDN filename without URL),
+    `created_at` — not modelled.
+
+Member IDs in the export are integers; we stringify them for transport
+through preview/options so the wire format matches the other importers'
+string-id convention.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.crypto import blind_index, encrypt
+from sheaf.models.group import Group
+from sheaf.models.member import Member, group_members
+from sheaf.models.system import PrivacyLevel, System
+from sheaf.schemas.tb_import import (
+    TBImportOptions,
+    TBImportResult,
+    TBPreviewMember,
+    TBPreviewSummary,
+)
+
+logger = logging.getLogger("sheaf.import.tb")
+
+
+def _list(data: dict, key: str) -> list[dict]:
+    """Get a list-typed collection from TB data, defaulting to empty."""
+    value = data.get(key)
+    return value if isinstance(value, list) else []
+
+
+def _tupper_id(tupper: dict) -> str | None:
+    """Stringify a tupper's numeric id for use as a stable key."""
+    tid = tupper.get("id")
+    if tid is None:
+        return None
+    return str(tid)
+
+
+def preview(data: dict) -> TBPreviewSummary:
+    """Summarise a Tupperbox export for the user before they confirm."""
+    tuppers = _list(data, "tuppers")
+    groups = _list(data, "groups")
+
+    return TBPreviewSummary(
+        member_count=len(tuppers),
+        members=[
+            TBPreviewMember(
+                id=_tupper_id(t) or "",
+                name=_clean_str(t.get("name")) or "unnamed",
+            )
+            for t in tuppers
+            if _tupper_id(t) is not None
+        ],
+        group_count=len(groups),
+    )
+
+
+async def run_import(
+    data: dict,
+    options: TBImportOptions,
+    system: System,
+    db: AsyncSession,
+) -> TBImportResult:
+    """Import a parsed Tupperbox export into the user's system."""
+    result = TBImportResult()
+    warnings: list[str] = []
+
+    tuppers = _list(data, "tuppers")
+    if options.member_ids is not None:
+        wanted = set(options.member_ids)
+        tuppers = [t for t in tuppers if _tupper_id(t) in wanted]
+
+    id_to_member: dict[str, Member] = {}
+    for tupper in tuppers:
+        member = _build_member(tupper, system.id)
+        if member is None:
+            continue
+        db.add(member)
+        tid = _tupper_id(tupper)
+        if tid is not None:
+            id_to_member[tid] = member
+        result.members_imported += 1
+
+    await db.flush()
+
+    if options.groups:
+        result.groups_imported = await _import_groups(
+            _list(data, "groups"), tuppers, system.id, id_to_member, db
+        )
+
+    result.warnings = warnings
+    return result
+
+
+# --- Members -----------------------------------------------------------------
+
+
+def _build_member(tupper: dict, system_id: uuid.UUID) -> Member | None:
+    """Construct a Sheaf Member from a Tupperbox tupper object.
+
+    Returns None if the row lacks a usable name. Tupperbox has no privacy
+    flags, so every imported member defaults to PRIVATE — users can flip
+    individual members to public after import if they want.
+    """
+    plaintext_name = _clean_str(tupper.get("name"))
+    if not plaintext_name:
+        return None
+    plaintext_name = plaintext_name[:100]
+    plaintext_description = _clean_str(tupper.get("description"))
+
+    return Member(
+        id=uuid.uuid4(),
+        system_id=system_id,
+        name=encrypt(plaintext_name),
+        name_hash=blind_index(plaintext_name),
+        display_name=_truncate(_clean_str(tupper.get("nick")), 100),
+        description=encrypt(plaintext_description) if plaintext_description else None,
+        pronouns=None,  # Tupperbox doesn't model pronouns.
+        avatar_url=_truncate(_clean_str(tupper.get("avatar_url")), 500),
+        color=None,  # Tupperbox doesn't model member colour.
+        birthday=_normalize_birthday(tupper.get("birthday")),
+        privacy=PrivacyLevel.PRIVATE,
+    )
+
+
+# --- Groups ------------------------------------------------------------------
+
+
+async def _import_groups(
+    tb_groups: list[dict],
+    selected_tuppers: list[dict],
+    system_id: uuid.UUID,
+    id_to_member: dict[str, Member],
+    db: AsyncSession,
+) -> int:
+    """Create Sheaf Groups and wire member associations.
+
+    Tupperbox doesn't list members on its group objects; the relationship
+    is the other way round (each tupper has a `group_id`). We invert that
+    mapping here, restricted to tuppers the user actually selected.
+    """
+    imported = 0
+    sheaf_group_by_tbid: dict[str, Group] = {}
+
+    for tb_g in tb_groups:
+        name = _clean_str(tb_g.get("name"))
+        if not name:
+            continue
+        gid = tb_g.get("id")
+        if gid is None:
+            continue
+        group = Group(
+            id=uuid.uuid4(),
+            system_id=system_id,
+            name=name[:100],
+            description=_clean_str(tb_g.get("description")),
+        )
+        db.add(group)
+        sheaf_group_by_tbid[str(gid)] = group
+        imported += 1
+
+    if not sheaf_group_by_tbid:
+        return 0
+
+    await db.flush()
+
+    # Build the group → [members] map from each tupper's group_id field.
+    for tupper in selected_tuppers:
+        gid = tupper.get("group_id")
+        if gid is None:
+            continue
+        group = sheaf_group_by_tbid.get(str(gid))
+        if group is None:
+            continue
+        tid = _tupper_id(tupper)
+        if tid is None:
+            continue
+        member = id_to_member.get(tid)
+        if member is None:
+            continue
+        await db.execute(
+            group_members.insert().values(group_id=group.id, member_id=member.id)
+        )
+
+    return imported
+
+
+# --- Helpers -----------------------------------------------------------------
+
+
+def _clean_str(value: Any) -> str | None:
+    """Coerce to string, strip whitespace, return None for empty."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    return value or None
+
+
+def _truncate(value: str | None, max_len: int) -> str | None:
+    if value is None:
+        return None
+    return value[:max_len]
+
+
+def _normalize_birthday(value: Any) -> str | None:
+    """Tupperbox stores birthdays as full ISO timestamps with a year.
+
+    Sheaf stores them as YYYY-MM-DD (or MM-DD when year-less). We just
+    take the date prefix; if the prefix doesn't look like a date we drop
+    the value rather than store garbage.
+    """
+    s = _clean_str(value)
+    if not s:
+        return None
+    # Accept either a date-only prefix or a full ISO timestamp.
+    date_part = s[:10]
+    if len(date_part) != 10 or date_part[4] != "-" or date_part[7] != "-":
+        return None
+    return date_part

--- a/tests/fixtures/tupperbox_export_sample.json
+++ b/tests/fixtures/tupperbox_export_sample.json
@@ -1,0 +1,71 @@
+{
+  "groups": [
+    {
+      "id": 100001,
+      "name": "Core",
+      "avatar": null,
+      "description": "Primary group.",
+      "tag": null
+    },
+    {
+      "id": 100002,
+      "name": "Visitors",
+      "avatar": "https://cdn.tupperbox.app/example/group.webp",
+      "description": null,
+      "tag": null
+    }
+  ],
+  "tuppers": [
+    {
+      "id": 200001,
+      "name": "Alpha",
+      "brackets": ["a:", ""],
+      "avatar_url": "https://cdn.tupperbox.app/example/alpha.webp",
+      "avatar": "alpha",
+      "banner": null,
+      "posts": 12,
+      "show_brackets": false,
+      "birthday": "1990-04-15T00:00:00.000Z",
+      "description": "First test tupper.",
+      "tag": null,
+      "nick": "Alpha the First",
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "group_id": 100001,
+      "last_used": "2024-06-01T12:00:00.000Z"
+    },
+    {
+      "id": 200002,
+      "name": "Beta",
+      "brackets": ["[", "]"],
+      "avatar_url": null,
+      "avatar": null,
+      "banner": null,
+      "posts": 0,
+      "show_brackets": true,
+      "birthday": null,
+      "description": null,
+      "tag": null,
+      "nick": null,
+      "created_at": "2024-01-02T00:00:00.000Z",
+      "group_id": 100001,
+      "last_used": null
+    },
+    {
+      "id": 200003,
+      "name": "Gamma",
+      "brackets": ["g:", ""],
+      "avatar_url": null,
+      "avatar": null,
+      "banner": "https://cdn.tupperbox.app/example/gamma-banner.webp",
+      "posts": 3,
+      "show_brackets": false,
+      "birthday": null,
+      "description": "Group-less tupper.",
+      "tag": "| Example",
+      "nick": null,
+      "created_at": "2024-01-03T00:00:00.000Z",
+      "group_id": null,
+      "last_used": null
+    }
+  ]
+}

--- a/tests/test_tb_import.py
+++ b/tests/test_tb_import.py
@@ -1,0 +1,181 @@
+"""Integration tests for the Tupperbox data importer.
+
+These cover the file-upload path end-to-end via the public HTTP API.
+The fixture in tests/fixtures/tupperbox_export_sample.json is a small
+synthetic Tupperbox export covering:
+  - a fully-populated tupper (display name, description, birthday, avatar)
+  - a minimal tupper (no nick, no description, no avatar, no birthday)
+  - a group-less tupper that also exercises dropped fields (banner, tag)
+  - two groups (one with an avatar that gets dropped, one without)
+"""
+
+import json
+import pathlib
+
+import httpx
+import pytest
+
+FIXTURE_PATH = pathlib.Path(__file__).parent / "fixtures" / "tupperbox_export_sample.json"
+
+
+@pytest.fixture
+def tb_export_bytes() -> bytes:
+    return FIXTURE_PATH.read_bytes()
+
+
+@pytest.fixture
+def tb_export() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _upload(client: httpx.Client, path: str, payload: bytes, **params):
+    return client.post(
+        path,
+        files={"file": ("tb_export.json", payload, "application/json")},
+        params=params,
+    )
+
+
+# --- Preview path ------------------------------------------------------------
+
+
+def test_preview_summarises_export(auth_client: httpx.Client, tb_export_bytes: bytes):
+    resp = _upload(auth_client, "/v1/import/tupperbox/preview", tb_export_bytes)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["member_count"] == 3
+    assert data["group_count"] == 2
+    ids = {m["id"] for m in data["members"]}
+    assert ids == {"200001", "200002", "200003"}
+    names = {m["name"] for m in data["members"]}
+    assert names == {"Alpha", "Beta", "Gamma"}
+
+
+def test_preview_rejects_invalid_json(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/import/tupperbox/preview",
+        files={"file": ("not_json.json", b"this is not json", "application/json")},
+    )
+    assert resp.status_code == 400
+
+
+def test_preview_rejects_non_object(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/import/tupperbox/preview",
+        files={"file": ("array.json", b"[1, 2, 3]", "application/json")},
+    )
+    assert resp.status_code == 400
+
+
+# --- Default import ----------------------------------------------------------
+
+
+def test_import_default_creates_members_and_groups(
+    auth_client: httpx.Client, tb_export_bytes: bytes
+):
+    resp = _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
+    assert resp.status_code == 200, resp.text
+    result = resp.json()
+    assert result["members_imported"] == 3
+    assert result["groups_imported"] == 2
+    assert result["warnings"] == []
+
+    members = auth_client.get("/v1/members").json()
+    by_name = {m["name"]: m for m in members}
+    assert set(by_name) == {"Alpha", "Beta", "Gamma"}
+
+
+def test_import_maps_per_field_data(
+    auth_client: httpx.Client, tb_export_bytes: bytes
+):
+    _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
+    members = auth_client.get("/v1/members").json()
+    alpha = next(m for m in members if m["name"] == "Alpha")
+    assert alpha["display_name"] == "Alpha the First"
+    assert alpha["avatar_url"] == "https://cdn.tupperbox.app/example/alpha.webp"
+    assert alpha["birthday"] == "1990-04-15"
+    # Tupperbox has no privacy model — everything defaults to private.
+    assert alpha["privacy"] == "private"
+    # Tupperbox has no member colour or pronouns.
+    assert alpha["color"] is None
+    assert alpha["pronouns"] is None
+
+
+def test_import_handles_minimal_member(
+    auth_client: httpx.Client, tb_export_bytes: bytes
+):
+    """Beta has no nick, no description, no avatar, no birthday."""
+    _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
+    members = auth_client.get("/v1/members").json()
+    beta = next(m for m in members if m["name"] == "Beta")
+    assert beta["display_name"] is None
+    assert beta["description"] is None
+    assert beta["avatar_url"] is None
+    assert beta["birthday"] is None
+
+
+def test_import_groups_link_correct_members(
+    auth_client: httpx.Client, tb_export_bytes: bytes
+):
+    """Alpha + Beta are in 'Core'; Gamma is group-less."""
+    _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
+    groups = auth_client.get("/v1/groups").json()
+    by_name = {g["name"]: g for g in groups}
+    assert set(by_name) == {"Core", "Visitors"}
+
+    core_members = auth_client.get(f"/v1/groups/{by_name['Core']['id']}/members").json()
+    assert sorted(m["name"] for m in core_members) == ["Alpha", "Beta"]
+
+    visitors_members = auth_client.get(
+        f"/v1/groups/{by_name['Visitors']['id']}/members"
+    ).json()
+    assert visitors_members == []
+
+
+def test_import_skips_groups_when_disabled(
+    auth_client: httpx.Client, tb_export_bytes: bytes
+):
+    resp = _upload(
+        auth_client,
+        "/v1/import/tupperbox",
+        tb_export_bytes,
+        groups="false",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["groups_imported"] == 0
+    assert auth_client.get("/v1/groups").json() == []
+
+
+# --- Selective import (member_ids filter) ------------------------------------
+
+
+def test_member_ids_filter_drops_unselected(
+    auth_client: httpx.Client, tb_export_bytes: bytes
+):
+    resp = _upload(
+        auth_client,
+        "/v1/import/tupperbox",
+        tb_export_bytes,
+        member_ids="200001,200003",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["members_imported"] == 2
+
+    names = sorted(m["name"] for m in auth_client.get("/v1/members").json())
+    assert names == ["Alpha", "Gamma"]
+
+
+def test_filter_drops_group_memberships_for_unselected(
+    auth_client: httpx.Client, tb_export_bytes: bytes
+):
+    """When Beta is deselected, the Core group keeps Alpha but not Beta."""
+    _upload(
+        auth_client,
+        "/v1/import/tupperbox",
+        tb_export_bytes,
+        member_ids="200001",
+    )
+    groups = auth_client.get("/v1/groups").json()
+    core = next(g for g in groups if g["name"] == "Core")
+    members = auth_client.get(f"/v1/groups/{core['id']}/members").json()
+    assert sorted(m["name"] for m in members) == ["Alpha"]

--- a/tests/test_tb_import_unit.py
+++ b/tests/test_tb_import_unit.py
@@ -1,0 +1,80 @@
+"""Unit tests for Tupperbox import helpers.
+
+These exercise the pure-Python normalisation helpers without a running
+server or database. End-to-end coverage lives in test_tb_import.py.
+"""
+
+from sheaf.services.tb_import import (
+    _clean_str,
+    _normalize_birthday,
+    _tupper_id,
+    preview,
+)
+
+
+def test_normalize_birthday_takes_date_prefix_from_iso_timestamp():
+    assert _normalize_birthday("2025-10-01T00:00:00.000Z") == "2025-10-01"
+    assert _normalize_birthday("1990-04-15T00:00:00.000Z") == "1990-04-15"
+
+
+def test_normalize_birthday_passes_through_plain_date():
+    assert _normalize_birthday("1990-04-15") == "1990-04-15"
+
+
+def test_normalize_birthday_drops_garbage():
+    assert _normalize_birthday("totally not a date string") is None
+    assert _normalize_birthday("2025/10/01") is None  # Wrong separator
+    assert _normalize_birthday("") is None
+    assert _normalize_birthday(None) is None
+
+
+def test_clean_str_strips_and_nones_empties():
+    assert _clean_str("  hello  ") == "hello"
+    assert _clean_str("") is None
+    assert _clean_str("   ") is None
+    assert _clean_str(None) is None
+
+
+def test_tupper_id_stringifies_numeric_ids():
+    assert _tupper_id({"id": 12345}) == "12345"
+    assert _tupper_id({"id": "abc"}) == "abc"
+    assert _tupper_id({}) is None
+    assert _tupper_id({"id": None}) is None
+
+
+def test_preview_summarises_minimal_export():
+    data = {
+        "tuppers": [
+            {"id": 1, "name": "Alpha"},
+            {"id": 2, "name": "Beta"},
+        ],
+        "groups": [{"id": 10, "name": "Core"}],
+    }
+    summary = preview(data)
+    assert summary.member_count == 2
+    assert summary.group_count == 1
+    ids = {m.id for m in summary.members}
+    assert ids == {"1", "2"}
+
+
+def test_preview_handles_missing_collections():
+    summary = preview({})
+    assert summary.member_count == 0
+    assert summary.group_count == 0
+    assert summary.members == []
+
+
+def test_preview_skips_tuppers_without_id():
+    """Defensive: a tupper without an id is unusable downstream so we drop it from preview."""
+    data = {
+        "tuppers": [
+            {"id": 1, "name": "Alpha"},
+            {"name": "Orphan"},
+        ],
+    }
+    summary = preview(data)
+    # member_count still reflects raw row count (matches PK behaviour).
+    assert summary.member_count == 2
+    # But the surfaced members list only contains rows with usable IDs.
+    assert len(summary.members) == 1
+    assert summary.members[0].id == "1"

--- a/web/src/components/settings/data-import-card.tsx
+++ b/web/src/components/settings/data-import-card.tsx
@@ -11,7 +11,8 @@ export function DataImportCard() {
       <CardContent>
         <p className="text-sm text-muted-foreground mb-3">
           Supported sources: SimplyPlural (export file), PluralKit (export file
-          or live API via your <code>pk;token</code>), Sheaf (export file).
+          or live API via your <code>pk;token</code>), Tupperbox (export file),
+          Sheaf (export file).
         </p>
         <Link to="/import">
           <Button variant="outline">Import data</Button>

--- a/web/src/lib/tb-import.ts
+++ b/web/src/lib/tb-import.ts
@@ -1,0 +1,53 @@
+import { apiFetch } from "./api-client";
+
+export interface TBPreviewMember {
+  id: string;
+  name: string;
+}
+
+export interface TBPreviewSummary {
+  member_count: number;
+  members: TBPreviewMember[];
+  group_count: number;
+}
+
+export interface TBImportResult {
+  members_imported: number;
+  groups_imported: number;
+  warnings: string[];
+}
+
+export interface TBImportOptions {
+  member_ids: string[] | null;
+  groups: boolean;
+}
+
+export async function previewImport(file: File): Promise<TBPreviewSummary> {
+  const form = new FormData();
+  form.append("file", file);
+  return apiFetch<TBPreviewSummary>("/v1/import/tupperbox/preview", {
+    method: "POST",
+    headers: {},
+    body: form,
+  });
+}
+
+export async function runImport(
+  file: File,
+  options: TBImportOptions,
+): Promise<TBImportResult> {
+  const params = new URLSearchParams();
+  params.set("groups", String(options.groups));
+  if (options.member_ids !== null) {
+    params.set("member_ids", options.member_ids.join(","));
+  }
+
+  const form = new FormData();
+  form.append("file", file);
+
+  return apiFetch<TBImportResult>(`/v1/import/tupperbox?${params.toString()}`, {
+    method: "POST",
+    headers: {},
+    body: form,
+  });
+}

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -25,9 +25,15 @@ import {
   previewImportFromApi as previewPKApi,
   runImportFromApi as runPKApi,
 } from "@/lib/pk-import";
+import {
+  type TBPreviewSummary,
+  type TBImportResult,
+  previewImport as previewTB,
+  runImport as runTB,
+} from "@/lib/tb-import";
 import { Input } from "@/components/ui/input";
 
-type Source = "choose" | "sheaf" | "sp" | "pk";
+type Source = "choose" | "sheaf" | "sp" | "pk" | "tb";
 type Step = "upload" | "preview" | "importing" | "done";
 type PKMethod = "choose" | "file" | "api";
 
@@ -46,6 +52,9 @@ export function ImportPage() {
       )}
       {source === "pk" && (
         <PKImportFlow onBack={() => setSource("choose")} />
+      )}
+      {source === "tb" && (
+        <TBImportFlow onBack={() => setSource("choose")} />
       )}
     </>
   );
@@ -92,6 +101,22 @@ function SourcePicker({ onSelect }: { onSelect: (s: Source) => void }) {
           <p className="text-sm text-muted-foreground">
             Pull from your PluralKit account using a token (the same one you
             use for <code>pk;token</code>), or upload a PK data export file.
+          </p>
+        </CardContent>
+      </Card>
+      <Card
+        className="cursor-pointer hover:border-primary transition-colors"
+        onClick={() => onSelect("tb")}
+      >
+        <CardHeader>
+          <CardTitle className="text-base">Import from Tupperbox</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Upload a Tupperbox export file (run <code>tb!export</code> on
+            Discord). Tupperbox doesn't track fronting, so only your tuppers
+            and groups come across. Proxy brackets and per-tupper tags are
+            dropped since Sheaf doesn't proxy Discord messages.
           </p>
         </CardContent>
       </Card>
@@ -777,6 +802,161 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
               )}
               {result.fronts_imported > 0 && (
                 <div>Fronts: <strong>{result.fronts_imported}</strong></div>
+              )}
+            </div>
+            <Warnings warnings={result.warnings} />
+            <Button onClick={() => navigate("/members")} className="w-full">
+              View members
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tupperbox import flow
+// ---------------------------------------------------------------------------
+
+function TBImportFlow({ onBack }: { onBack: () => void }) {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>("upload");
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<TBPreviewSummary | null>(null);
+  const [result, setResult] = useState<TBImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [allMembers, setAllMembers] = useState(true);
+  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set());
+  const [groups, setGroups] = useState(true);
+
+  async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+    setError(null);
+    try {
+      const p = await previewTB(f);
+      setPreview(p);
+      setStep("preview");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to parse file");
+    }
+  }
+
+  async function handleImport() {
+    if (!file) return;
+    setStep("importing");
+    setError(null);
+    try {
+      const r = await runTB(file, {
+        member_ids: allMembers ? null : Array.from(selectedMembers),
+        groups,
+      });
+      setResult(r);
+      setStep("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Import failed");
+      setStep("preview");
+    }
+  }
+
+  function toggleMember(id: string) {
+    setSelectedMembers((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <>
+      {error && <ErrorBanner message={error} />}
+
+      {step === "upload" && (
+        <Card className="max-w-lg">
+          <CardHeader>
+            <CardTitle className="text-base">Upload Tupperbox export file</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Run <code>tb!export</code> on Discord, then upload the JSON
+              attachment Tupperbox DMs you.
+            </p>
+            <input
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileSelect}
+              className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+            />
+            <Button variant="outline" size="sm" onClick={onBack}>
+              Back
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "preview" && preview && (
+        <div className="grid gap-4 max-w-2xl">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Export summary</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-3 text-sm">
+              <div>Members: <strong>{preview.member_count}</strong></div>
+              <div>Groups: <strong>{preview.group_count}</strong></div>
+              <div className="col-span-2 text-xs text-muted-foreground">
+                Tupperbox doesn't track fronting, system metadata, or
+                pronouns/colour per tupper. Proxy brackets, banners, and
+                per-tupper tags are dropped on import.
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Import options</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Checkbox
+                label="Groups"
+                checked={groups}
+                onChange={setGroups}
+              />
+
+              <MemberSelector
+                members={preview.members}
+                totalCount={preview.member_count}
+                allMembers={allMembers}
+                setAllMembers={setAllMembers}
+                selectedMembers={selectedMembers}
+                toggleMember={toggleMember}
+              />
+
+              <Button onClick={handleImport} className="w-full">
+                Import
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {step === "importing" && <ImportingCard />}
+
+      {step === "done" && result && (
+        <Card className="max-w-lg">
+          <CardHeader>
+            <CardTitle className="text-base">Import complete</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {result.members_imported > 0 && (
+                <div>Members: <strong>{result.members_imported}</strong></div>
+              )}
+              {result.groups_imported > 0 && (
+                <div>Groups: <strong>{result.groups_imported}</strong></div>
               )}
             </div>
             <Warnings warnings={result.warnings} />


### PR DESCRIPTION
## Summary

Adds a Tupperbox importer alongside the existing Sheaf / PluralKit / SimplyPlural ones. Tupperbox is a Discord proxy bot whose export is a flat JSON dump of tuppers (member-equivalents) and groups, with no system-level metadata, no fronting history, no custom fields, and no privacy model. The import collapses to creating Members + Groups and wiring group memberships from each tupper's `group_id` field.

### Dropped on import (no Sheaf equivalent)

Matches PluralKit's behaviour around `proxy_tags`: drop silently rather than warn per-import.

- `brackets` / `show_brackets` (Discord proxy tags)
- `tag` (per-tupper system-tag suffix)
- `banner` (Sheaf members have no banner field)
- `last_used` / `posts` (not modelled)
- Group `avatar` (Sheaf groups have no avatar / icon)

### Mapping notes

- Birthdays are ISO timestamps in the export; we take the `YYYY-MM-DD` prefix. Tupperbox always stores a year, so unlike PK there is no `0004-` sentinel to collapse.
- Imported members default to `PrivacyLevel.PRIVATE` (Tupperbox has no privacy model). Users can flip individual members to public after import.
- Tupperbox has no `color` or `pronouns` per tupper, so those are left null on import.

### Files

- `sheaf/{schemas,services,api/v1}/tb_import.py` + router registration under `import:write`
- `web/src/lib/tb-import.ts` + `TBImportFlow` in `web/src/routes/import.tsx`
- Synthetic test fixture at `tests/fixtures/tupperbox_export_sample.json`
- 9 integration tests (`tests/test_tb_import.py`) + 9 unit tests (`tests/test_tb_import_unit.py`)

## Test plan

- [x] Full `./run_tests.sh` green across all 8 configurations
- [x] Module imports compile clean (`uv run python -c "import sheaf.api.v1.tb_import; ..."`)
- [ ] Smoke test in browser: select Tupperbox source on /import, upload a real export, confirm preview counts match, run import, verify members + group memberships land
- [ ] Confirm the dropped-fields note is visible on the preview screen