### PR TITLE
Fix flaky import tests: commit before responding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fix flaky import tests: commit before responding
+
+`run_import` in both the PluralKit (`sheaf/services/pk_import.py`) and Tupperbox (`sheaf/services/tb_import.py`) importers wrote rows via `db.flush()` but never called `db.commit()` inside the handler. They relied on the auto-commit at the end of `get_db`, which for FastAPI `yield` dependencies runs *after* the response has been delivered to the client. A test (or any client) firing a follow-up request immediately after a 200 OK could race that cleanup-commit and see an empty members list, manifesting on CI as a `KeyError: 'Alice'` in `test_import_resolves_visibility_to_privacy_enum`. The race window is microseconds on a fast local machine and milliseconds on slow CI runners; rerunning usually won the race. Fixed by committing explicitly at the end of both importers' `run_import`, matching the convention every other write endpoint in the codebase already follows.
+
+Also hardened the `_upload` test helper in `tests/test_pk_import.py` and `tests/test_tb_import.py` to assert `2xx` on the response so any future server-side failure surfaces as a clear assertion failure instead of a downstream `KeyError`.
+
 ### Grey out history buttons on entries without history
 
 Small UX polish across every surface that has an edit/audit/revision history button. Before, the button was always enabled, so you'd click it and find an empty list. Now the button is disabled and dimmed when nothing's there, so you can see at a glance which entries have actually been edited.

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -146,6 +146,15 @@ async def run_import(
         warnings.extend(switch_warnings)
 
     result.warnings = warnings
+    # Commit explicitly here, before the handler returns. `get_db` does
+    # auto-commit on successful exit, but for `yield` dependencies that
+    # cleanup runs *after* the response has been sent to the client.
+    # Without an explicit commit inside the handler, a follow-up request
+    # (e.g. the test's GET /v1/members right after import) can race the
+    # cleanup-commit and see an empty members list. The window is
+    # microseconds locally and milliseconds on slow CI runners, so the
+    # symptom is a flaky test, not a deterministic one.
+    await db.commit()
     return result
 
 

--- a/sheaf/services/tb_import.py
+++ b/sheaf/services/tb_import.py
@@ -114,6 +114,11 @@ async def run_import(
         )
 
     result.warnings = warnings
+    # See pk_import.run_import for the full rationale: `get_db`'s
+    # auto-commit runs after the response is sent, which races a
+    # follow-up request on slow CI. Commit explicitly here so writes
+    # are visible by the time the client receives the response.
+    await db.commit()
     return result
 
 

--- a/tests/test_pk_import.py
+++ b/tests/test_pk_import.py
@@ -34,11 +34,16 @@ def pk_export() -> dict:
 
 
 def _upload(client: httpx.Client, path: str, payload: bytes, **params):
-    return client.post(
+    """Multipart-upload a PK export. Asserts the response is 2xx so any
+    server-side failure surfaces here instead of as a downstream
+    KeyError when a later assertion looks for a missing member."""
+    resp = client.post(
         path,
         files={"file": ("pk_export.json", payload, "application/json")},
         params=params,
     )
+    assert 200 <= resp.status_code < 300, resp.text
+    return resp
 
 
 # --- Preview path ------------------------------------------------------------

--- a/tests/test_tb_import.py
+++ b/tests/test_tb_import.py
@@ -29,11 +29,16 @@ def tb_export() -> dict:
 
 
 def _upload(client: httpx.Client, path: str, payload: bytes, **params):
-    return client.post(
+    """Multipart-upload a TB export. Asserts the response is 2xx so any
+    server-side failure surfaces here instead of as a downstream
+    KeyError when a later assertion looks for a missing member."""
+    resp = client.post(
         path,
         files={"file": ("tb_export.json", payload, "application/json")},
         params=params,
     )
+    assert 200 <= resp.status_code < 300, resp.text
+    return resp
 
 
 # --- Preview path ------------------------------------------------------------


### PR DESCRIPTION
## Summary

The PluralKit and Tupperbox importers (`sheaf/services/pk_import.py`, `sheaf/services/tb_import.py`) wrote rows via `db.flush()` but never called `db.commit()` inside the handler. They relied on the auto-commit at the end of `get_db`, which for FastAPI `yield`-style dependencies runs *after* the response is delivered to the client. A client firing a follow-up request immediately after a 200 OK could race that cleanup-commit and see an empty members list - manifesting on CI as a `KeyError: 'Alice'` in `test_import_resolves_visibility_to_privacy_enum`. Race window is microseconds locally (always wins) and milliseconds on slow CI runners (occasionally loses).

Fixed by committing explicitly at the end of `run_import` in both services, matching the convention every other write endpoint in the codebase already follows (146 occurrences of `await db.commit()` in `sheaf/services/` + `sheaf/api/v1/`).

Also hardened the `_upload` test helpers in `tests/test_pk_import.py` and `tests/test_tb_import.py` to assert `2xx` on the response, so any future server-side regression surfaces as a clear assertion failure instead of a mysterious downstream `KeyError`.

## Test plan

- [x] `ruff check sheaf/` clean
- [x] `pytest tests/test_pk_import.py tests/test_pk_import_unit.py tests/test_tb_import.py tests/test_tb_import_unit.py` - 45 pass
- [x] Re-ran the previously-failing test 5x in a row locally; clean
- [x] CI on this PR runs the full suite under all 8 server configs - if the fix lands, the flake disappears across the board