### PR TITLE
Paginate fronts history + fix step-up 401 silent-fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Step-up auth denials return 403 instead of 401
+
+Bug surfaced when deleting a notification channel under a system with `delete_confirmation=password` (or `totp` / `both`): a wrong password returned `401 Incorrect password`, which the frontend's `apiFetch` interpreted as "access token may be stale" and silently kicked off the refresh-and-retry path. Refresh succeeded but the retried DELETE still came back 401 (same wrong password) — and the second 401 was swallowed by a `resp.status !== 401` guard meant to avoid double-toasting during normal refresh dances. End result: user clicks Delete, nothing visibly happens.
+
+Fix is two-sided:
+
+- **Backend**: every "user is authenticated, step-up credential is wrong" path now raises **403** instead of **401**. 401 means "authenticate"; 403 means "you are authenticated but can't do this action". The wrong-credential case is the latter. Sites changed: `services/system_safety.verify_destructive_auth` (used by member / channel / front / journal / group / tag / poll / message / front-entry / safety-setting deletes), `api/v1/admin.do_step_up`, `api/v1/systems.update_delete_confirmation`, `api/v1/account.account_data`, `api/v1/export.create_export_job`, `api/v1/auth.request_account_deletion`. The "credential not provided" branches stay 400 (or 422 for admin, matching the existing per-site style).
+- **Frontend**: `apiFetch` and `apiFetchWithHeaders` now distinguish "pre-retry 401" (suppressed; the silent refresh handles it) from "post-retry 401" (surfaced via toast like any other error). A defensive measure on top of the backend fix — covers any future bug where a 401 survives the refresh dance.
+
+Test asserts updated in `test_system_safety`, `test_admin_step_up`, `test_account_deletion`, `test_account_export_completeness` to expect 403 on the wrong-credentials paths.
+
+### Pagination for the fronts history (cursor + numbered, with toggle)
+
+`GET /v1/fronts` was paginated by `limit` + `offset` but had no way to tell a caller "there's more" - so the frontend silently rendered only the first 50 entries and anyone with a longer history was truncated without warning. Now there's an explicit signal, plus a real numbered-pages UI for the people who don't want infinite scroll.
+
+Non-breaking backend additions:
+
+- New `cursor` query param (alternative to `offset`); when set, `offset` is ignored.
+- New `include_total` query param (opt-in) - adds `X-Sheaf-Total-Count` header. Off by default since it costs one extra `COUNT(*)`; the numbered-pages UI opts in, the cursor / "load more" path doesn't.
+- New response headers:
+  - `X-Sheaf-Has-More: true|false` on every response.
+  - `X-Sheaf-Next-Cursor: <opaque>` when more results exist; absent otherwise.
+  - `X-Sheaf-Total-Count: <int>` when `include_total=true`.
+- Cursor is base64url JSON of `{started_at, id}`, opaque to callers. Server uses Postgres row comparison `(started_at, id) < (cursor.started_at, cursor.id)` with a matching `ORDER BY started_at DESC, id DESC` for stable pagination across ties.
+- Cursor-mode has-more detection uses a `limit + 1` probe rather than a separate count, so the response time stays flat regardless of total history length.
+- Existing `offset`-only callers (notably the mobile app in app-store review) are unaffected; the new headers just provide extra info they can ignore.
+
+Frontend `/fronts` history now supports two views, toggleable via a small icon group in the History header and persisted to the URL search params:
+
+- **Infinite (default)**: `useInfiniteQuery` with cursor pagination + Load older entries button. No URL state.
+- **Numbered pages**: opt-in via the toggle (or `?view=paged` directly). Renders First / Prev / 1 2 3 ... N / Next / Last navigation with "Page N of M" and "X entries" indicators. Page + page-size live in URL search params (`?view=paged&page=3&pageSize=50`) so refresh / bookmark / share preserve position. Per-page selector offers 25 / 50 / 100.
+
+Per-user persistence: view mode + page size persist to `client-settings/web` under a `fronts` key, so toggling once sticks across sessions. URL still wins when present (bookmark / share stays deterministic); settings just supply the default on bare `/fronts` visits. Page number itself is transient and not persisted.
+
 ### In-browser "Verify this page" button + attestation links
 
 Two enhancements on the `/about` page's verifiability surface:

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -40,4 +40,4 @@ USER sheaf
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "alembic upgrade head && uvicorn sheaf.main:app --host 0.0.0.0 --port ${SHEAF_PORT:-8000}"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn sheaf.main:app --host 0.0.0.0 --port ${SHEAF_PORT:-8000} --proxy-headers --forwarded-allow-ips=\"${FORWARDED_ALLOW_IPS:-127.0.0.1}\""]

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -91,8 +91,10 @@ async def get_account_data(
     # System Safety's delete_confirmation tier — that gates deletes; this
     # gates the highest-value read.
     if not verify_password(body.password, user.password_hash):
+        # 403: step-up auth denial. See system_safety.verify_destructive_auth
+        # for full reasoning.
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Password incorrect",
         )
     if user.totp_enabled:
@@ -104,7 +106,7 @@ async def get_account_data(
         secret = decrypt(user.totp_secret)
         if not verify_code(secret, body.totp_code):
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
+                status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid TOTP code",
             )
 

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -76,8 +76,11 @@ async def verify_admin_step_up(
             )
         from sheaf.auth.passwords import verify_password
         if not verify_password(body.password, user.password_hash):
+            # 403: caller is already authenticated; this step-up gate
+            # denies the action. 401 would falsely trigger the frontend's
+            # silent-refresh-and-retry path.
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect password"
+                status_code=status.HTTP_403_FORBIDDEN, detail="Incorrect password"
             )
 
     elif level == "totp":
@@ -94,7 +97,7 @@ async def verify_admin_step_up(
         totp_secret = decrypt(user.totp_secret)
         if not totp.verify_code(totp_secret, body.totp_code):
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code"
+                status_code=status.HTTP_403_FORBIDDEN, detail="Invalid TOTP code"
             )
 
     await set_admin_step_up(user.id)

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -1590,8 +1590,10 @@ async def request_account_deletion(
 
     # Verify password
     if not verify_password(body.password, user.password_hash):
+        # 403: step-up auth denial. See system_safety.verify_destructive_auth
+        # for full reasoning.
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Incorrect password",
         )
 
@@ -1618,7 +1620,7 @@ async def request_account_deletion(
                     valid_recovery = True
             if not valid_recovery:
                 raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    status_code=status.HTTP_403_FORBIDDEN,
                     detail="Invalid TOTP code",
                 )
 

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -616,8 +616,10 @@ async def create_export_job(
         )
 
     if not verify_password(body.password, user.password_hash):
+        # 403: step-up auth denial. See system_safety.verify_destructive_auth
+        # for full reasoning.
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Password incorrect",
         )
     if user.totp_enabled:
@@ -629,7 +631,7 @@ async def create_export_job(
         secret = decrypt(user.totp_secret)
         if not verify_code(secret, body.totp_code):
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
+                status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid TOTP code",
             )
 

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import func, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -28,6 +28,7 @@ from sheaf.services.notifications.events import (
     emit_front_change,
     snapshot_front_state,
 )
+from sheaf.services.pagination import decode_cursor, encode_cursor
 from sheaf.services.system_safety import (
     is_safeguarded,
     queue_pending_action,
@@ -190,21 +191,97 @@ async def _build_coalesced_member_since(
 
 @router.get("", response_model=list[FrontRead])
 async def list_fronts(
+    response: Response,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
+    cursor: str | None = Query(
+        default=None,
+        description=(
+            "Opaque pagination cursor. Pass the value of "
+            "`X-Sheaf-Next-Cursor` from the previous response to fetch "
+            "the next page. When set, `offset` is ignored. Callers "
+            "should treat the value as a black box."
+        ),
+    ),
+    include_total: bool = Query(
+        default=False,
+        description=(
+            "Opt-in: include `X-Sheaf-Total-Count` header with the total "
+            "number of entries in the system. Costs one extra COUNT query; "
+            "set true only when the UI actually renders page numbers."
+        ),
+    ),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    """List front entries newest-first.
+
+    Pagination: cursor-based (preferred) or offset-based (legacy). When
+    more entries exist beyond the current page, the response carries:
+
+    - `X-Sheaf-Has-More: true|false`
+    - `X-Sheaf-Next-Cursor: <opaque>` (only when `Has-More` is true)
+
+    Detection uses a `limit + 1` probe rather than a separate `COUNT(*)`,
+    so the response time stays flat regardless of total history length.
+    """
     system = await _get_user_system(user, db)
-    result = await db.execute(
+
+    query = (
         select(Front)
         .options(selectinload(Front.members))
         .where(Front.system_id == system.id)
-        .order_by(Front.started_at.desc())
-        .limit(limit)
-        .offset(offset)
+        # Stable order under tied started_at: id is the deterministic
+        # tiebreaker the cursor's row comparison also uses, so pagination
+        # neither skips nor duplicates rows.
+        .order_by(Front.started_at.desc(), Front.id.desc())
     )
-    fronts = list(result.scalars().all())
+
+    if cursor is not None:
+        try:
+            cursor_started, cursor_id = decode_cursor(cursor)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid cursor",
+            ) from exc
+        # Postgres row comparison: rows whose (started_at, id) is
+        # lexicographically less than the cursor's pair. With the matching
+        # ORDER BY, this is exactly "the next page of older entries".
+        query = query.where(
+            tuple_(Front.started_at, Front.id)
+            < tuple_(cursor_started, cursor_id)
+        )
+    elif offset:
+        # Legacy callers pinned to offset-based paging keep working.
+        query = query.offset(offset)
+
+    # Probe for one extra row so we can answer "is there more?" without a
+    # COUNT query. Trim before returning.
+    result = await db.execute(query.limit(limit + 1))
+    rows = list(result.scalars().all())
+    has_more = len(rows) > limit
+    fronts = rows[:limit]
+
+    response.headers["X-Sheaf-Has-More"] = "true" if has_more else "false"
+    if has_more and fronts:
+        last = fronts[-1]
+        response.headers["X-Sheaf-Next-Cursor"] = encode_cursor(
+            last.started_at, last.id
+        )
+
+    if include_total:
+        # Opt-in: only when the UI is rendering numbered pages and actually
+        # needs the count. COUNT(*) on a system_id-indexed filter is fast,
+        # but it's still an extra round-trip we don't want every caller
+        # paying for.
+        total_result = await db.execute(
+            select(func.count())
+            .select_from(Front)
+            .where(Front.system_id == system.id)
+        )
+        response.headers["X-Sheaf-Total-Count"] = str(total_result.scalar_one())
+
     with_audit = await _load_audit_existence(db, [f.id for f in fronts])
     return [
         _front_to_read(f, has_audit_history=f.id in with_audit) for f in fronts

--- a/sheaf/api/v1/systems.py
+++ b/sheaf/api/v1/systems.py
@@ -82,8 +82,10 @@ async def update_delete_confirmation(
 ):
     """Update delete confirmation level. Requires password (+ TOTP if enabled)."""
     if not verify_password(body.password, user.password_hash):
+        # 403: step-up auth denial. See system_safety.verify_destructive_auth
+        # for full reasoning.
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid password",
         )
 
@@ -96,7 +98,7 @@ async def update_delete_confirmation(
         secret = decrypt(user.totp_secret)
         if not verify_code(secret, body.totp_code):
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
+                status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid TOTP code",
             )
 

--- a/sheaf/services/pagination.py
+++ b/sheaf/services/pagination.py
@@ -1,0 +1,65 @@
+"""Cursor pagination helpers.
+
+Generic encode/decode for opaque cursors keyed on (sort_value, id). The
+cursor is base64url-encoded JSON; callers treat it as a black box, the
+server decodes and uses it to construct a WHERE filter. The pattern is:
+
+    SELECT ... FROM tbl
+    WHERE (sort_col, id) < (cursor.sort_value, cursor.id)
+    ORDER BY sort_col DESC, id DESC
+    LIMIT N + 1;
+
+The `+1` is the "is there more?" probe — fetch one extra row, return
+only N, and use the leftover as the has_more signal. Avoids a separate
+COUNT(*) query whose cost scales with history length.
+
+Postgres row comparison `(a, b) < (c, d)` evaluates as
+`a < c OR (a = c AND b < d)`, which is exactly the lexicographic
+semantics we want for stable pagination across rows with tied sort values.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import uuid
+from datetime import datetime
+from typing import TypedDict
+
+
+class CursorPayload(TypedDict):
+    """Decoded cursor: the sort_value + id pair from the last item of the
+    previous page. Server uses it to filter the next query."""
+
+    sort_value: str  # ISO-8601 timestamp string (kept as string for cross-encoding stability)
+    id: str  # UUID string
+
+
+def encode_cursor(sort_value: datetime, item_id: uuid.UUID) -> str:
+    """Encode a (sort_value, id) pair as an opaque base64url JSON cursor."""
+    payload = {"s": sort_value.isoformat(), "i": str(item_id)}
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def decode_cursor(cursor: str) -> tuple[datetime, uuid.UUID]:
+    """Decode a cursor back into (sort_value, id). Raises ValueError on
+    any malformed input — callers should translate to a 400 response."""
+    try:
+        # Re-pad — urlsafe_b64encode without padding loses the trailing =s,
+        # which b64decode is picky about.
+        padding = "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(cursor + padding)
+        payload = json.loads(raw)
+        sort_value = datetime.fromisoformat(payload["s"])
+        item_id = uuid.UUID(payload["i"])
+        return sort_value, item_id
+    except (
+        binascii.Error,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise ValueError("Invalid cursor") from exc

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -140,8 +140,14 @@ def verify_destructive_auth(
                 detail="Password required",
             )
         if not verify_password(password, user.password_hash):
+            # 403 (not 401) — the caller IS authenticated; the step-up
+            # password gate denied this specific destructive action. 401
+            # would trip the frontend's silent-refresh-and-retry path,
+            # which is meaningless here (refreshing the access token
+            # doesn't make the wrong password right) and hides the real
+            # error from the user.
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
+                status_code=status.HTTP_403_FORBIDDEN,
                 detail="Incorrect password",
             )
 
@@ -157,8 +163,9 @@ def verify_destructive_auth(
             )
         secret = decrypt(user.totp_secret)
         if not verify_code(secret, totp_code):
+            # Same reasoning as the wrong-password branch: 403, not 401.
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
+                status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid TOTP code",
             )
 

--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -93,7 +93,9 @@ def test_request_deletion_wrong_password(auth_client: httpx.Client):
         "/v1/auth/delete-account",
         json={"password": "wrongpassword"},
     )
-    assert resp.status_code == 401
+    # 403, not 401: caller is authenticated; the step-up gate denies
+    # the action. 401 would trip the frontend's silent-refresh-retry.
+    assert resp.status_code == 403
 
 
 def test_request_deletion_already_pending(auth_client: httpx.Client):

--- a/tests/test_account_export_completeness.py
+++ b/tests/test_account_export_completeness.py
@@ -78,7 +78,9 @@ def test_export_version_bumped_to_2(auth_client: httpx.Client):
 
 def test_account_data_requires_password(auth_client: httpx.Client):
     r = auth_client.post("/v1/account/data", json={"password": "wrong"})
-    assert r.status_code == 401
+    # 403, not 401: step-up gate denial. See test_system_safety for full
+    # rationale.
+    assert r.status_code == 403
 
 
 def test_account_data_succeeds_with_correct_password(auth_client: httpx.Client):
@@ -140,7 +142,9 @@ def test_export_job_requires_password(auth_client: httpx.Client):
         "/v1/export/jobs",
         json={"include_images": False, "password": "wrong"},
     )
-    assert r.status_code == 401
+    # 403, not 401: step-up gate denial. See test_system_safety for full
+    # rationale.
+    assert r.status_code == 403
 
 
 def test_export_job_create_then_list(auth_client: httpx.Client):

--- a/tests/test_admin_step_up.py
+++ b/tests/test_admin_step_up.py
@@ -59,7 +59,9 @@ def test_password_step_up_required(raw_admin_client: httpx.Client):
 @pytest.mark.admin_auth_password
 def test_password_step_up_wrong_password_rejected(raw_admin_client: httpx.Client):
     resp = raw_admin_client.post("/v1/admin/auth", json={"password": "wrongpassword"})
-    assert resp.status_code == 401
+    # 403, not 401: caller is authenticated; the admin step-up gate is
+    # denying access. 401 would trip the frontend's silent-refresh-retry.
+    assert resp.status_code == 403
 
 
 @pytest.mark.admin_auth_password
@@ -116,9 +118,9 @@ def test_totp_step_up_wrong_code_rejected(raw_admin_client: httpx.Client):
     totp = pyotp.TOTP(secret)
     raw_admin_client.post("/v1/auth/totp/verify", json={"code": totp.now()})
 
-    # Wrong code
+    # Wrong code → 403 (step-up gate denial). See password variant above.
     resp = raw_admin_client.post("/v1/admin/auth", json={"totp_code": "000000"})
-    assert resp.status_code == 401
+    assert resp.status_code == 403
 
 
 @pytest.mark.admin_auth_totp

--- a/tests/test_fronts.py
+++ b/tests/test_fronts.py
@@ -63,3 +63,122 @@ def test_front_history_pagination(auth_client: httpx.Client):
     resp = auth_client.get("/v1/fronts", params={"limit": 2})
     assert resp.status_code == 200
     assert len(resp.json()) == 2
+
+
+# --- Cursor pagination ------------------------------------------------------
+
+
+def test_history_has_more_signals_when_truncated(auth_client: httpx.Client):
+    """A `limit` smaller than the total set yields `X-Sheaf-Has-More: true`
+    and a non-empty `X-Sheaf-Next-Cursor` header. Both surfaces are how
+    callers know they're not seeing the whole list."""
+    member_id = _create_member(auth_client, "HasMore")
+    for _ in range(4):
+        auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
+    resp = auth_client.get("/v1/fronts", params={"limit": 2})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+    assert resp.headers["X-Sheaf-Has-More"] == "true"
+    assert resp.headers.get("X-Sheaf-Next-Cursor")
+
+
+def test_history_has_more_false_when_page_is_short(auth_client: httpx.Client):
+    member_id = _create_member(auth_client, "Short")
+    for _ in range(3):
+        auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
+    resp = auth_client.get("/v1/fronts", params={"limit": 50})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+    assert resp.headers["X-Sheaf-Has-More"] == "false"
+    # No next-cursor when there's nothing further to fetch.
+    assert "X-Sheaf-Next-Cursor" not in resp.headers
+
+
+def test_history_exact_limit_boundary(auth_client: httpx.Client):
+    """`limit == total` is the boundary case where the `+ 1` probe must
+    not falsely advertise `has_more=true`."""
+    member_id = _create_member(auth_client, "Boundary")
+    for _ in range(3):
+        auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
+    resp = auth_client.get("/v1/fronts", params={"limit": 3})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+    assert resp.headers["X-Sheaf-Has-More"] == "false"
+    assert "X-Sheaf-Next-Cursor" not in resp.headers
+
+
+def test_history_cursor_paginates_through_all(auth_client: httpx.Client):
+    """Walking pages via the returned cursor yields every entry exactly
+    once, in the same order as a single big request."""
+    member_id = _create_member(auth_client, "Walker")
+    for _ in range(7):
+        auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
+
+    # Reference: fetch everything in one go.
+    all_resp = auth_client.get("/v1/fronts", params={"limit": 50})
+    all_ids = [f["id"] for f in all_resp.json()]
+    assert len(all_ids) == 7
+
+    # Walk in pages of 3.
+    collected: list[str] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        params: dict[str, str | int] = {"limit": 3}
+        if cursor is not None:
+            params["cursor"] = cursor
+        resp = auth_client.get("/v1/fronts", params=params)
+        assert resp.status_code == 200
+        collected.extend(f["id"] for f in resp.json())
+        pages += 1
+        if resp.headers["X-Sheaf-Has-More"] != "true":
+            break
+        cursor = resp.headers["X-Sheaf-Next-Cursor"]
+        assert pages < 10, "runaway pagination"
+
+    assert collected == all_ids
+
+
+def test_history_cursor_invalid_returns_400(auth_client: httpx.Client):
+    resp = auth_client.get(
+        "/v1/fronts", params={"limit": 5, "cursor": "not-a-real-cursor"}
+    )
+    assert resp.status_code == 400
+    assert "cursor" in resp.json()["detail"].lower()
+
+
+def test_history_total_count_opt_in(auth_client: httpx.Client):
+    """`include_total=true` adds `X-Sheaf-Total-Count` (one extra COUNT
+    query). Off by default so cursor / load-more callers don't pay."""
+    member_id = _create_member(auth_client, "Counter")
+    for _ in range(4):
+        auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
+
+    off = auth_client.get("/v1/fronts", params={"limit": 2})
+    assert "X-Sheaf-Total-Count" not in off.headers
+
+    on = auth_client.get(
+        "/v1/fronts", params={"limit": 2, "include_total": "true"}
+    )
+    assert on.status_code == 200
+    assert on.headers["X-Sheaf-Total-Count"] == "4"
+
+
+def test_history_cursor_takes_precedence_over_offset(auth_client: httpx.Client):
+    """When both are sent, cursor wins. Offset is silently ignored — the
+    response is the cursor's next page, not offset-from-start."""
+    member_id = _create_member(auth_client, "BothParams")
+    for _ in range(5):
+        auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
+
+    first = auth_client.get("/v1/fronts", params={"limit": 2}).json()
+    first_resp = auth_client.get("/v1/fronts", params={"limit": 2})
+    cursor = first_resp.headers["X-Sheaf-Next-Cursor"]
+
+    # cursor says "page 2"; offset=0 would say "page 1". Cursor wins.
+    resp = auth_client.get(
+        "/v1/fronts", params={"limit": 2, "cursor": cursor, "offset": 0}
+    )
+    assert resp.status_code == 200
+    page2 = resp.json()
+    assert {f["id"] for f in page2}.isdisjoint({f["id"] for f in first})

--- a/tests/test_system_safety.py
+++ b/tests/test_system_safety.py
@@ -411,13 +411,16 @@ def test_delete_endpoint_requires_password_when_tier_set(client: httpx.Client):
     assert no_body.status_code == 400
     assert no_body.json()["detail"] == "Password required"
 
-    # Wrong password → 401 Incorrect password
+    # Wrong password → 403 Incorrect password. 403 (not 401) because the
+    # caller IS authenticated; the step-up password gate is denying this
+    # specific destructive action. 401 would trip the frontend's silent
+    # token-refresh-and-retry path, which can't fix a wrong password.
     wrong = client.request(
         "DELETE",
         f"/v1/members/{member['id']}",
         json={"password": "not-the-password"},
     )
-    assert wrong.status_code == 401
+    assert wrong.status_code == 403
     assert wrong.json()["detail"] == "Incorrect password"
 
     # Member still exists.
@@ -449,7 +452,7 @@ def test_delete_endpoint_reauth_then_queues_when_safeguarded(client: httpx.Clien
         f"/v1/members/{member['id']}",
         json={"password": "nope"},
     )
-    assert wrong.status_code == 401
+    assert wrong.status_code == 403
     assert client.get("/v1/system/safety").json()["pending_actions"] == []
 
     # Correct password → 202 pending (safeguard takes over).

--- a/web/src/components/page-nav.tsx
+++ b/web/src/components/page-nav.tsx
@@ -1,0 +1,101 @@
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Numbered-page navigation: First / Prev / [page numbers with ellipsis] / Next / Last.
+ * Shows up to ~7 page buttons around the current page; uses "…" gaps for
+ * long lists so very long histories don't blow out the layout.
+ */
+function pageWindow(current: number, total: number, span = 2): (number | "ellipsis-left" | "ellipsis-right")[] {
+  if (total <= 1) return [];
+  const out: (number | "ellipsis-left" | "ellipsis-right")[] = [];
+  const lo = Math.max(2, current - span);
+  const hi = Math.min(total - 1, current + span);
+  out.push(1);
+  if (lo > 2) out.push("ellipsis-left");
+  for (let p = lo; p <= hi; p++) out.push(p);
+  if (hi < total - 1) out.push("ellipsis-right");
+  if (total > 1) out.push(total);
+  return out;
+}
+
+export interface PageNavProps {
+  page: number;
+  totalPages: number;
+  onChange: (page: number) => void;
+}
+
+export function PageNav({ page, totalPages, onChange }: PageNavProps) {
+  if (totalPages <= 1) return null;
+  const items = pageWindow(page, totalPages);
+  return (
+    <nav
+      className="flex flex-wrap items-center justify-center gap-1"
+      aria-label="Pagination"
+    >
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-8 px-2"
+        disabled={page <= 1}
+        onClick={() => onChange(1)}
+        aria-label="First page"
+      >
+        <ChevronsLeft className="size-3.5" />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-8 px-2"
+        disabled={page <= 1}
+        onClick={() => onChange(page - 1)}
+        aria-label="Previous page"
+      >
+        <ChevronLeft className="size-3.5" />
+      </Button>
+      {items.map((it, idx) =>
+        typeof it === "number" ? (
+          <Button
+            key={it}
+            size="sm"
+            variant={it === page ? "default" : "ghost"}
+            className="h-8 min-w-8 px-2"
+            onClick={() => onChange(it)}
+            aria-current={it === page ? "page" : undefined}
+            aria-label={`Page ${it}`}
+          >
+            {it}
+          </Button>
+        ) : (
+          <span
+            key={`${it}-${idx}`}
+            className="px-1 text-muted-foreground select-none"
+            aria-hidden
+          >
+            …
+          </span>
+        ),
+      )}
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-8 px-2"
+        disabled={page >= totalPages}
+        onClick={() => onChange(page + 1)}
+        aria-label="Next page"
+      >
+        <ChevronRight className="size-3.5" />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-8 px-2"
+        disabled={page >= totalPages}
+        onClick={() => onChange(totalPages)}
+        aria-label="Last page"
+      >
+        <ChevronsRight className="size-3.5" />
+      </Button>
+    </nav>
+  );
+}

--- a/web/src/hooks/use-fronts.ts
+++ b/web/src/hooks/use-fronts.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   isDeleteQueued,
@@ -13,10 +18,36 @@ export const frontKeys = {
   current: ["fronts", "current"] as const,
 };
 
-export function useFronts(limit = 50, offset = 0) {
+/**
+ * Cursor-paginated front history. Surface `fetchNextPage` + `hasNextPage`
+ * to wire a "Load older" button; the `items` getter flattens the page
+ * array so consumers don't have to know about page boundaries.
+ */
+export function useFronts(limit = 50) {
+  const query = useInfiniteQuery({
+    queryKey: [...frontKeys.all, "history", limit],
+    queryFn: ({ pageParam }: { pageParam: string | null }) =>
+      api.listFronts({ limit, cursor: pageParam }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.nextCursor : null,
+  });
+  const items = query.data?.pages.flatMap((p) => p.items) ?? [];
+  return { ...query, items };
+}
+
+/**
+ * Offset-paginated front history with a known total count, for the
+ * numbered-pages view. `placeholderData: keepPreviousData` keeps the
+ * old page visible while the new one loads so the page doesn't flash
+ * empty when paging.
+ */
+export function useFrontsPaged(page: number, limit = 50) {
+  const safePage = Math.max(1, page);
   return useQuery({
-    queryKey: [...frontKeys.all, limit, offset],
-    queryFn: () => api.listFronts(limit, offset),
+    queryKey: [...frontKeys.all, "paged", safePage, limit],
+    queryFn: () => api.listFrontsPaged({ page: safePage, limit }),
+    placeholderData: (prev) => prev,
   });
 }
 

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -102,7 +102,9 @@ export async function apiFetch<T>(
   let resp = await fetch(path, { ...fetchOptions, headers, credentials: "same-origin" });
 
   // Auto-refresh on 401 using HttpOnly cookie (skip for login/register)
+  let attemptedRefresh = false;
   if (resp.status === 401 && !skipRefresh) {
+    attemptedRefresh = true;
     if (!refreshPromise) {
       refreshPromise = refreshAccessToken();
     }
@@ -134,11 +136,18 @@ export async function apiFetch<T>(
     }
 
     // Show toast for non-auth errors (auth errors during login/register are
-    // handled inline by the form, not via toast)
+    // handled inline by the form, not via toast).
     if (resp.status >= 500) {
       toast.error("Server error — please try again");
+    } else if (resp.status === 401 && attemptedRefresh) {
+      // Post-retry 401: refresh succeeded but the action itself still
+      // came back unauthorized. Not an auth-flow concern (the silent
+      // refresh already ran) — surface it like any other error so the
+      // user sees what went wrong instead of clicking into silence.
+      toast.error(detail);
     } else if (resp.status !== 401 && resp.status !== 409) {
-      // Don't toast 401 (handled by refresh) or 409 (conflict, shown inline)
+      // Skip pre-retry 401 (the refresh dance handles it) and 409
+      // (conflict, shown inline by the caller).
       toast.error(detail);
     }
 
@@ -146,4 +155,76 @@ export async function apiFetch<T>(
   }
 
   return resp.json();
+}
+
+/**
+ * Same auth + error handling as `apiFetch`, but returns both the parsed
+ * body and the response headers. Use when the endpoint signals pagination
+ * (or any other metadata) via headers — e.g. `GET /v1/fronts` returns
+ * `X-Sheaf-Has-More` / `X-Sheaf-Next-Cursor` alongside the bare array body.
+ */
+export async function apiFetchWithHeaders<T>(
+  path: string,
+  options: ApiFetchOptions = {},
+): Promise<{ body: T; headers: Headers }> {
+  const { skipRefresh, ...fetchOptions } = options;
+  const isFormData = fetchOptions.body instanceof FormData;
+  const headers: Record<string, string> = {
+    ...(isFormData ? {} : { "Content-Type": "application/json" }),
+    ...(fetchOptions.headers as Record<string, string>),
+  };
+
+  if (accessToken) {
+    headers["Authorization"] = `Bearer ${accessToken}`;
+  }
+
+  let resp = await fetch(path, {
+    ...fetchOptions,
+    headers,
+    credentials: "same-origin",
+  });
+
+  let attemptedRefresh = false;
+  if (resp.status === 401 && !skipRefresh) {
+    attemptedRefresh = true;
+    if (!refreshPromise) {
+      refreshPromise = refreshAccessToken();
+    }
+    const newToken = await refreshPromise;
+    refreshPromise = null;
+
+    if (newToken) {
+      headers["Authorization"] = `Bearer ${newToken}`;
+      resp = await fetch(path, {
+        ...fetchOptions,
+        headers,
+        credentials: "same-origin",
+      });
+    }
+  }
+
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({ detail: resp.statusText }));
+    const detail = body.detail || "Request failed";
+    if (resp.status === 401 && detail === "Session revoked") {
+      accessToken = null;
+      toast.error("Your session has been revoked. Redirecting to login...");
+      setTimeout(() => {
+        window.location.href = "/login";
+      }, 1500);
+      throw new ApiError(resp.status, detail);
+    }
+    if (resp.status >= 500) {
+      toast.error("Server error — please try again");
+    } else if (resp.status === 401 && attemptedRefresh) {
+      // Post-retry 401: refresh succeeded but the action itself still
+      // came back unauthorized. Surface it like any other error.
+      toast.error(detail);
+    } else if (resp.status !== 401 && resp.status !== 409) {
+      toast.error(detail);
+    }
+    throw new ApiError(resp.status, detail);
+  }
+
+  return { body: await resp.json(), headers: resp.headers };
 }

--- a/web/src/lib/fronts.ts
+++ b/web/src/lib/fronts.ts
@@ -6,10 +6,66 @@ import type {
   FrontCreate,
   FrontUpdate,
 } from "@/types/api";
-import { apiFetch } from "./api-client";
+import { apiFetch, apiFetchWithHeaders } from "./api-client";
 
-export function listFronts(limit = 50, offset = 0) {
-  return apiFetch<Front[]>(`/v1/fronts?limit=${limit}&offset=${offset}`);
+export interface FrontsPage {
+  items: Front[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export interface FrontsPagedPage {
+  items: Front[];
+  hasMore: boolean;
+  total: number;
+}
+
+/**
+ * Fetch one page of the front history. Cursor pagination: omit `cursor`
+ * for the first page, then pass the previous response's `nextCursor` to
+ * advance. The server signals end-of-list with `hasMore = false`.
+ */
+export async function listFronts(
+  opts: { limit?: number; cursor?: string | null } = {},
+): Promise<FrontsPage> {
+  const limit = opts.limit ?? 50;
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (opts.cursor) params.set("cursor", opts.cursor);
+  const { body, headers } = await apiFetchWithHeaders<Front[]>(
+    `/v1/fronts?${params.toString()}`,
+  );
+  return {
+    items: body,
+    hasMore: headers.get("X-Sheaf-Has-More") === "true",
+    nextCursor: headers.get("X-Sheaf-Next-Cursor"),
+  };
+}
+
+/**
+ * Fetch one numbered page (offset-based) with a total count for rendering
+ * page-number navigation. Pays one extra `COUNT(*)` query on the server,
+ * so use this for the paginated view; the cursor variant is cheaper for
+ * "load more" / infinite-scroll flows.
+ */
+export async function listFrontsPaged(opts: {
+  page: number;
+  limit?: number;
+}): Promise<FrontsPagedPage> {
+  const limit = opts.limit ?? 50;
+  const offset = Math.max(0, (opts.page - 1) * limit);
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+    include_total: "true",
+  });
+  const { body, headers } = await apiFetchWithHeaders<Front[]>(
+    `/v1/fronts?${params.toString()}`,
+  );
+  return {
+    items: body,
+    hasMore: headers.get("X-Sheaf-Has-More") === "true",
+    total: Number.parseInt(headers.get("X-Sheaf-Total-Count") ?? "0", 10),
+  };
 }
 
 export function getCurrentFronts() {

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, ChevronRight, History, Pencil } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "react-router";
+import { apiFetch } from "@/lib/api-client";
+import { ChevronDown, ChevronRight, History, Infinity as InfinityIcon, ListOrdered, Pencil } from "lucide-react";
 import {
   useCurrentFronts,
   useFronts,
+  useFrontsPaged,
   useUpdateFront,
   useDeleteFront,
 } from "@/hooks/use-fronts";
@@ -13,19 +16,147 @@ import { ColorDot } from "@/components/color-dot";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { EditFrontDialog } from "@/components/edit-front-dialog";
 import { FrontAuditHistory } from "@/components/front-audit-history";
+import { PageNav } from "@/components/page-nav";
 import { StartFrontDialog } from "@/components/start-front-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { formatDateTime, timeAgo } from "@/lib/utils";
 import { getMySystem } from "@/lib/systems";
 import type { Front } from "@/types/api";
 
+const HISTORY_PAGE_SIZES = [25, 50, 100] as const;
+type ViewMode = "infinite" | "paged";
+
+interface FrontsViewPrefs {
+  view?: ViewMode;
+  pageSize?: number;
+}
+
+function isViewMode(v: unknown): v is ViewMode {
+  return v === "infinite" || v === "paged";
+}
+
+function isPageSize(v: unknown): v is (typeof HISTORY_PAGE_SIZES)[number] {
+  return (
+    typeof v === "number" &&
+    (HISTORY_PAGE_SIZES as readonly number[]).includes(v)
+  );
+}
+
 export function FrontsPage() {
+  const qc = useQueryClient();
   const { data: current, isLoading: currentLoading } = useCurrentFronts();
-  const { data: history, isLoading: historyLoading } = useFronts();
+
+  // Saved defaults from client settings — only consulted when the URL
+  // doesn't already pin a view / pageSize. URL wins so bookmarking and
+  // link-sharing stay deterministic; settings just pick the default the
+  // user sees on a fresh visit.
+  const { data: clientSettings } = useQuery({
+    queryKey: ["client-settings", "web"],
+    queryFn: async () => {
+      try {
+        const res = await apiFetch<{ settings: Record<string, unknown> }>(
+          "/v1/settings/client/web",
+        );
+        return res.settings;
+      } catch {
+        return {} as Record<string, unknown>;
+      }
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+  const savedFrontsPrefs =
+    (clientSettings?.fronts as FrontsViewPrefs | undefined) ?? {};
+  const savedView: ViewMode = isViewMode(savedFrontsPrefs.view)
+    ? savedFrontsPrefs.view
+    : "infinite";
+  const savedPageSize = isPageSize(savedFrontsPrefs.pageSize)
+    ? savedFrontsPrefs.pageSize
+    : 50;
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view: ViewMode = searchParams.has("view")
+    ? searchParams.get("view") === "paged"
+      ? "paged"
+      : "infinite"
+    : savedView;
+  const page = Math.max(
+    1,
+    Number.parseInt(searchParams.get("page") || "1", 10) || 1,
+  );
+  const pageSize = (() => {
+    if (!searchParams.has("pageSize")) return savedPageSize;
+    const raw = Number.parseInt(searchParams.get("pageSize") || "50", 10);
+    return isPageSize(raw) ? raw : savedPageSize;
+  })();
+
+  async function persistFrontsPrefs(next: FrontsViewPrefs) {
+    // PUT merges client-side: read the existing blob, splice in our key,
+    // write back. Same shape as the announcement-banners dismissal flow.
+    const current = clientSettings ?? {};
+    try {
+      await apiFetch("/v1/settings/client/web", {
+        method: "PUT",
+        body: JSON.stringify({
+          settings: { ...current, fronts: { ...savedFrontsPrefs, ...next } },
+        }),
+      });
+      qc.invalidateQueries({ queryKey: ["client-settings", "web"] });
+    } catch {
+      // Persistence failure is non-fatal — URL state still works.
+    }
+  }
+
+  function setView(next: ViewMode) {
+    const params = new URLSearchParams(searchParams);
+    if (next === "infinite") {
+      params.delete("view");
+      params.delete("page");
+      params.delete("pageSize");
+    } else {
+      params.set("view", "paged");
+      params.set("page", "1");
+    }
+    setSearchParams(params, { replace: true });
+    void persistFrontsPrefs({ view: next });
+  }
+  function setPage(next: number) {
+    const params = new URLSearchParams(searchParams);
+    params.set("page", String(next));
+    setSearchParams(params, { replace: true });
+    // Page number is transient: not persisted.
+  }
+  function setPageSize(next: number) {
+    const params = new URLSearchParams(searchParams);
+    params.set("pageSize", String(next));
+    params.set("page", "1");
+    setSearchParams(params, { replace: true });
+    if (isPageSize(next)) void persistFrontsPrefs({ pageSize: next });
+  }
+
+  const {
+    items: infiniteHistory,
+    isLoading: infiniteLoading,
+    hasNextPage: infiniteHasMore,
+    fetchNextPage: fetchMoreInfinite,
+    isFetchingNextPage: infiniteLoadingMore,
+  } = useFronts(50);
+  const pagedQuery = useFrontsPaged(page, pageSize);
+  const isPaged = view === "paged";
+  const history = isPaged ? (pagedQuery.data?.items ?? []) : infiniteHistory;
+  const historyLoading = isPaged ? pagedQuery.isLoading : infiniteLoading;
+  const total = pagedQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const { data: members } = useMembers();
   const { data: system } = useQuery({ queryKey: ["system", "me"], queryFn: getMySystem });
   const updateFront = useUpdateFront();
@@ -165,7 +296,55 @@ export function FrontsPage() {
       <Separator className="my-6" />
 
       {/* History */}
-      <h2 className="text-lg font-semibold mb-4">History</h2>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold">History</h2>
+        <div className="flex items-center gap-2 text-sm">
+          {isPaged && total > 0 && (
+            <span className="text-muted-foreground">
+              {total} {total === 1 ? "entry" : "entries"}
+            </span>
+          )}
+          {isPaged && (
+            <Select
+              value={String(pageSize)}
+              onValueChange={(v) => setPageSize(Number.parseInt(v, 10))}
+            >
+              <SelectTrigger size="sm" className="h-8 w-[5.5rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HISTORY_PAGE_SIZES.map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    {n} / page
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <div className="inline-flex rounded-md border bg-muted/40 p-0.5">
+            <Button
+              size="sm"
+              variant={isPaged ? "ghost" : "default"}
+              className="h-7 px-2"
+              onClick={() => setView("infinite")}
+              aria-pressed={!isPaged}
+              title="Infinite scroll"
+            >
+              <InfinityIcon className="size-3.5" />
+            </Button>
+            <Button
+              size="sm"
+              variant={isPaged ? "default" : "ghost"}
+              className="h-7 px-2"
+              onClick={() => setView("paged")}
+              aria-pressed={isPaged}
+              title="Numbered pages"
+            >
+              <ListOrdered className="size-3.5" />
+            </Button>
+          </div>
+        </div>
+      </div>
       {historyLoading ? (
         <div className="space-y-2">
           {[1, 2, 3].map((i) => (
@@ -238,6 +417,30 @@ export function FrontsPage() {
               )}
             </div>
           ))}
+          {!isPaged && infiniteHasMore && (
+            <div className="flex justify-center pt-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => fetchMoreInfinite()}
+                disabled={infiniteLoadingMore}
+              >
+                {infiniteLoadingMore ? "Loading…" : "Load older entries"}
+              </Button>
+            </div>
+          )}
+          {isPaged && (
+            <div className="flex flex-col items-center gap-2 pt-2">
+              <PageNav
+                page={page}
+                totalPages={totalPages}
+                onChange={setPage}
+              />
+              <span className="text-xs text-muted-foreground">
+                Page {page} of {totalPages}
+              </span>
+            </div>
+          )}
         </div>
       ) : (
         <p className="text-muted-foreground">No front history yet.</p>


### PR DESCRIPTION
Two pieces on one branch — pagination work uncovered the step-up bug while testing, fix tagged in here rather than spun off.

## 1. Pagination for the fronts history

`GET /v1/fronts` was paginated by limit + offset but had no "is there more" signal, so the frontend silently rendered only the first 50 entries and anyone with a longer history was truncated without warning.

**Backend (non-breaking):**
- New `cursor` query param (alternative to `offset`); when set, `offset` is ignored.
- New `include_total` opt-in param that emits `X-Sheaf-Total-Count` (one extra `COUNT(*)` — off by default so cursor / load-more callers don't pay).
- New response headers on every list call: `X-Sheaf-Has-More: true|false`, plus `X-Sheaf-Next-Cursor: <opaque>` when has-more is true.
- Cursor is base64url JSON of `{started_at, id}`, opaque to callers. `ORDER BY started_at DESC, id DESC` + Postgres row comparison `(started_at, id) < (cursor.started_at, cursor.id)` gives stable pagination across ties.
- Has-more detection uses a `limit + 1` probe rather than a separate count, so response time stays flat regardless of total history length. Mobile and any other consumer continue to work unchanged.

**Frontend:**
- View toggle in the History header (infinite-scroll icon vs numbered-pages icon), persisted to URL search params (`?view=paged&page=N&pageSize=L`) so refresh / bookmark / share preserves position.
- Infinite (default): `useInfiniteQuery` + Load older entries button.
- Numbered pages: `useQuery` with `placeholderData=keepPreviousData` (page doesn't flash empty during navigation) + a new `PageNav` component rendering First / Prev / windowed page numbers / Next / Last with ellipsis for long lists. Page-size select offers 25 / 50 / 100.
- Per-user persistence: view + pageSize persist to `client-settings/web` under a `fronts` key, so a one-time toggle sticks across sessions. URL still wins when present; settings just provide the default on bare `/fronts` visits. Page number itself is transient.

**Tests:** 6 new integration tests for the cursor + count surface (has-more on truncation, has-more=false on short pages, exact-limit boundary, full walk via cursor returns every entry once, invalid cursor → 400, total-count opt-in, cursor wins over offset). All 13 fronts tests pass.

## 2. Step-up auth denials return 403 instead of 401

Bug surfaced when deleting a notification channel under a system with `delete_confirmation=password`: wrong password returned `401 Incorrect password`, which the frontend's `apiFetch` read as "access token may be stale" and silently fired the refresh-and-retry path. Refresh succeeded but the retried DELETE still came back 401 — and a `resp.status !== 401` guard meant to suppress double-toasting during normal refresh dances swallowed the post-retry 401. End result: click Delete, nothing visibly happens.

Fix is two-sided:

- **Backend**: every "user is authenticated, step-up credential is wrong" path now raises **403** instead of **401**. 401 means "authenticate"; 403 means "authenticated but can't do this action". Sites: `services/system_safety.verify_destructive_auth` (covers member / channel / front / journal / group / tag / poll / message / safety deletes), `api/v1/admin.do_step_up`, `api/v1/systems.update_delete_confirmation`, `api/v1/account.account_data`, `api/v1/export.create_export_job`, `api/v1/auth.request_account_deletion`. The "credential not provided" branches stay 400 / 422 per-site.
- **Frontend**: `apiFetch` + `apiFetchWithHeaders` now distinguish pre-retry 401 (suppressed; refresh handles it) from post-retry 401 (surfaced via toast like any other error). Defensive measure on top of the backend fix.

Test asserts updated in `test_system_safety`, `test_admin_step_up`, `test_account_deletion`, `test_account_export_completeness` to expect 403 on wrong-credentials paths.

## Test plan

- [x] `ruff check sheaf/` clean
- [x] `npx tsc --noEmit` + `npm run lint` clean
- [x] `pytest tests/test_fronts.py` — 13/13
- [x] `pytest tests/test_system_safety.py tests/test_account_deletion.py tests/test_account_export_completeness.py tests/test_admin_step_up.py` — 45 pass, 11 skip (admin-step-up tests need a different `ADMIN_AUTH_LEVEL` config)
- [x] Live curl repro of the channel-delete bug: no body → 400, wrong password → **403** (was 401), correct password → 204
- [x] Manual UI check on test instance: paginated view shows correct totals after backend rebuild; toggle persists across reloads; delete-channel with wrong password now shows a clear toast instead of clicking into silence