### PR TITLE
Unify mobile push into mobile_push, route activation via sheaf.sh, thread channel ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Unified `mobile_push` channels (collapse of fcm / apns_dev / apns_prod)
+
+The platform-specific mobile destination types had to be picked at channel creation, even though the owner didn't know which OS the recipient was on. Replaced with a single `mobile_push` type that binds to a Sheaf account at redemption and fans out across every `push_device_tokens` row for that account at delivery time — one channel rings every device the recipient has signed into, iOS or Android.
+
+Breaking change (pre-GA, mobile app coordinated):
+
+- New `DestinationType.MOBILE_PUSH` value. The legacy `fcm` / `apns_dev` / `apns_prod` values stay in the Python enum + API Literal type so read-back of historical audit / export rows still validates, but channel creation refuses them with a message pointing at `mobile_push`.
+- Migration `f2g3h4i5j6k7` collapses any existing channel rows to `mobile_push`.
+- Per-channel platform gating + `APNS_DEV_ENABLED` channel-level enforcement removed (the flag still gates apns_dev *device-token* registration, which is the orthogonal "don't accrue sandbox tokens on a prod backend" concern).
+- Dispatcher's `_deliver_mobile_push` drops the `platform` parameter and queries all of the account's device tokens, routing each to the FCM or APNs handler based on the device row's own `platform`.
+- Owner-side UI: one "Mobile push (iOS + Android)" option in the channel-create dialog replaces the three platform-specific rows.
+- Mobile app coordination: app reads its API target from `/v1/version` at first-run; deep-link domain (`sheaf.sh/redeem` via Universal Links / App Links) is built into the published app. Self-hosters route through `sheaf.sh/redeem?code=...&instance=https://...` or use the `sheaf://` custom-scheme fallback.
+
+### Device list management in the Receiving tab
+
+A recipient can now see and manage every device registered to their account from the Receiving tab.
+
+- `push_device_tokens` gains `enabled` (bool, default true) and `label` (optional 80-char user-visible device name set by the mobile app at registration).
+- New endpoints: `PATCH /v1/devices/push/{id}` to toggle `enabled` or rename the device; `DELETE /v1/devices/push/{id}` to remove a device from the web UI (the existing token-based DELETE stays for the mobile app's logout flow).
+- Dispatcher's mobile-push fan-out skips rows where `enabled = false`, so a recipient can mute one device (e.g. the work phone over the weekend) without unregistering it entirely.
+- Receiving tab gets a "Your devices" card with one row per registered token: label (rename inline), platform badge, last-seen-at, on/off checkbox, remove button.
+
+### Recipient label fix: "Paused by sender" vs "Unsubscribed"
+
+Owner-paused channels and recipient-unsubscribed channels both flipped `destination_state` to `disabled`, and the recipient UI labelled them both as "Unsubscribed" — confusing in the owner-paused case ("but I didn't unsubscribe").
+
+- New `paused_by_sender` column on `notification_channels`. Owner pause sets it to true; re-enable clears it; recipient unsubscribe leaves it false (its default).
+- Exposed on `ChannelRead`, `ReceivingChannelView`, and `ManageChannelView`. Receiving-tab list and manage-link page render "Paused by sender" (amber) when the flag is set, "Unsubscribed" (muted) otherwise.
+- Manage-page copy distinguishes the two: the paused branch tells the recipient that subscription will resume automatically when the sender does, with a pointer to ask for removal if they want to opt out permanently.
+
 ### Step-up auth denials return 403 instead of 401
 
 Bug surfaced when deleting a notification channel under a system with `delete_confirmation=password` (or `totp` / `both`): a wrong password returned `401 Incorrect password`, which the frontend's `apiFetch` interpreted as "access token may be stale" and silently kicked off the refresh-and-retry path. Refresh succeeded but the retried DELETE still came back 401 (same wrong password) — and the second 401 was swallowed by a `resp.status !== 401` guard meant to avoid double-toasting during normal refresh dances. End result: user clicks Delete, nothing visibly happens.

--- a/alembic/versions/f2g3h4i5j6k7_collapse_mobile_push_types.py
+++ b/alembic/versions/f2g3h4i5j6k7_collapse_mobile_push_types.py
@@ -1,0 +1,53 @@
+"""Collapse fcm/apns_dev/apns_prod into mobile_push
+
+Revision ID: f2g3h4i5j6k7
+Revises: e1f2g3h4i5j6
+Create Date: 2026-05-13
+
+The platform-specific destination types had to be chosen at channel
+creation, even though the OS the recipient was on was unknown to the
+owner. Unifying as `mobile_push` removes that mismatch: the channel
+binds to a Sheaf account at redemption, and the dispatcher fans out
+across every `push_device_tokens` row for that account, routing each
+token to FCM (Android) or APNs (iOS, dev/prod per-token) automatically.
+
+In-place column update — destination_type is a String column (not a
+PG enum), so no type changes needed. Rows that were previously
+fcm / apns_dev / apns_prod become mobile_push. No data loss: the
+account-side fan-out covers every platform automatically. The legacy
+enum values stay in the Python enum for read-back of historical
+audit / export records, but channel creation now refuses them.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f2g3h4i5j6k7"
+down_revision = "e1f2g3h4i5j6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE notification_channels SET destination_type = 'mobile_push' "
+            "WHERE destination_type IN ('fcm', 'apns_dev', 'apns_prod')"
+        )
+    )
+    # push_device_tokens.platform stays per-device (the platform is a
+    # property of the registered device, not the channel) — no change
+    # needed there.
+
+
+def downgrade() -> None:
+    # Best-effort: there's no original-platform information once a row
+    # has been collapsed to mobile_push, so we can't restore the exact
+    # prior value. The closest reasonable behaviour is to leave the
+    # rows as mobile_push and let the application's legacy enum members
+    # surface them on read. A hard downgrade would have to choose one
+    # of the three legacy values arbitrarily, which is worse than just
+    # accepting the lossy semantic.
+    pass

--- a/alembic/versions/g3h4i5j6k7l8_push_device_enabled_label.py
+++ b/alembic/versions/g3h4i5j6k7l8_push_device_enabled_label.py
@@ -1,0 +1,46 @@
+"""Add `enabled` and `label` to push_device_tokens
+
+Revision ID: g3h4i5j6k7l8
+Revises: f2g3h4i5j6k7
+Create Date: 2026-05-13
+
+`enabled` lets a recipient mute one of their devices without
+unregistering it entirely (e.g. work phone over the weekend). The
+dispatcher's mobile-push fan-out skips disabled rows.
+
+`label` is the user-visible device name (e.g. "Sarah's iPhone"). The
+mobile app sends it at registration; the receiving-tab device list
+renders it. Nullable — old rows registered before this migration get
+a platform-based default at render time.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "g3h4i5j6k7l8"
+down_revision = "f2g3h4i5j6k7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "push_device_tokens",
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+    op.add_column(
+        "push_device_tokens",
+        sa.Column("label", sa.String(length=80), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("push_device_tokens", "label")
+    op.drop_column("push_device_tokens", "enabled")

--- a/alembic/versions/h4i5j6k7l8m9_channel_paused_by_sender.py
+++ b/alembic/versions/h4i5j6k7l8m9_channel_paused_by_sender.py
@@ -1,0 +1,45 @@
+"""Add `paused_by_sender` to notification_channels
+
+Revision ID: h4i5j6k7l8m9
+Revises: g3h4i5j6k7l8
+Create Date: 2026-05-13
+
+The `disabled` channel state covered two distinct user actions:
+the owner pausing the channel, and the recipient unsubscribing. From
+the recipient's side both looked identical and the UI labelled them
+both as "Unsubscribed" — confusing in the owner-paused case ("but I
+didn't unsubscribe"). This column splits the two: True means the
+owner paused, False means the recipient unsubscribed (or the column
+was never set). Cleared on re-enable.
+
+Default false matches "recipient unsubscribed" semantics on existing
+disabled rows, which is the conservative interpretation — we can't
+tell which side disabled a pre-migration row, and "Unsubscribed" is
+the existing label so behaviour is unchanged for legacy rows.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "h4i5j6k7l8m9"
+down_revision = "g3h4i5j6k7l8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notification_channels",
+        sa.Column(
+            "paused_by_sender",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notification_channels", "paused_by_sender")

--- a/sheaf/api/v1/devices.py
+++ b/sheaf/api/v1/devices.py
@@ -23,6 +23,7 @@ from sheaf.schemas.push_device import (
     PushDeviceDeleteRequest,
     PushDeviceRead,
     PushDeviceRegisterRequest,
+    PushDeviceUpdateRequest,
 )
 
 router = APIRouter(prefix="/devices", tags=["devices"])
@@ -83,6 +84,8 @@ async def register_push_device(
             existing.install_id = body.install_id
         if body.app_version is not None:
             existing.app_version = body.app_version
+        if body.label is not None:
+            existing.label = body.label
         await db.commit()
         await db.refresh(existing)
         return PushDeviceRead.model_validate(existing)
@@ -102,6 +105,8 @@ async def register_push_device(
             rotating.last_seen_at = now
             if body.app_version is not None:
                 rotating.app_version = body.app_version
+            if body.label is not None:
+                rotating.label = body.label
             await db.commit()
             await db.refresh(rotating)
             return PushDeviceRead.model_validate(rotating)
@@ -131,6 +136,7 @@ async def register_push_device(
         token=body.token,
         install_id=body.install_id,
         app_version=body.app_version,
+        label=body.label,
         last_seen_at=now,
     )
     db.add(new_row)
@@ -162,6 +168,77 @@ async def delete_push_device(
             PushDeviceToken.token == body.token,
         )
     )
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.patch(
+    "/push/{device_id}",
+    response_model=PushDeviceRead,
+    dependencies=[Depends(require_scope("notifications:write"))],
+)
+async def update_push_device(
+    device_id: uuid.UUID,
+    body: PushDeviceUpdateRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PushDeviceRead:
+    """Update a device's `enabled` flag or `label`. Recipient-facing —
+    edited from the Receiving tab's device list. Other fields (token,
+    platform, install_id) come from the mobile app at registration and
+    aren't user-editable.
+
+    Account-scoped: a device row belonging to another user 404s,
+    matching the rest of the per-account ownership pattern."""
+    result = await db.execute(
+        select(PushDeviceToken).where(
+            PushDeviceToken.id == device_id,
+            PushDeviceToken.account_id == user.id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Device not found"
+        )
+    fields = body.model_dump(exclude_unset=True)
+    if "enabled" in fields and fields["enabled"] is not None:
+        row.enabled = bool(fields["enabled"])
+    if "label" in fields:
+        # Empty string clears the label; the front-end falls back to
+        # the platform-based default.
+        label = fields["label"]
+        row.label = label or None
+    await db.commit()
+    await db.refresh(row)
+    return PushDeviceRead.model_validate(row)
+
+
+@router.delete(
+    "/push/{device_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_scope("notifications:write"))],
+)
+async def delete_push_device_by_id(
+    device_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Recipient-side: drop a device by its id (from the Receiving
+    tab's device list). The token-based DELETE above stays for the
+    mobile app's logout flow; this one is for the web UI which has
+    no access to the raw token."""
+    result = await db.execute(
+        select(PushDeviceToken).where(
+            PushDeviceToken.id == device_id,
+            PushDeviceToken.account_id == user.id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        # Idempotent — already-removed devices return 204.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    await db.delete(row)
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -49,6 +49,9 @@ from sheaf.services.notifications.activation import (
 from sheaf.services.notifications.activation import (
     issue_activation_code,
 )
+from sheaf.services.notifications.activation import (
+    mobile_activation_url as build_mobile_activation_url,
+)
 from sheaf.services.notifications.handlers import deliver
 from sheaf.services.notifications.resolution import (
     build_group_name_lookup,
@@ -90,6 +93,26 @@ _LEGACY_MOBILE_TYPES = {
     DestinationType.APNS_DEV.value,
     DestinationType.APNS_PROD.value,
 }
+
+
+def _build_activation_url(
+    destination_type: str, channel_id: uuid.UUID, code: str
+) -> str:
+    """Pick the right activation URL builder for the channel type.
+
+    mobile_push funnels through the shared Universal Link host (see
+    settings.mobile_link_base_url) so the iOS / Android apps can claim
+    the path via associated-domains / asset-links. Other push-style
+    types (web_push) stay on the instance's own frontend.
+    """
+    if destination_type == DestinationType.MOBILE_PUSH.value:
+        return build_mobile_activation_url(
+            mobile_link_base_url=settings.mobile_link_base_url,
+            instance_base_url=settings.sheaf_base_url or "",
+            channel_id=channel_id,
+            code=code,
+        )
+    return build_activation_url(settings.sheaf_base_url or "", channel_id, code)
 
 
 async def _system_for_user(user: User, db: AsyncSession) -> System:
@@ -352,8 +375,8 @@ async def create_channel(
         channel.destination_state = DestinationState.PENDING_REGISTRATION.value
         channel.activation_code_hash = issued.code_hash
         channel.activation_code_expires_at = issued.expires_at
-        activation_url = build_activation_url(
-            settings.sheaf_base_url or "", channel.id, issued.code
+        activation_url = _build_activation_url(
+            body.destination_type, channel.id, issued.code
         )
         activation_expires = issued.expires_at
     else:
@@ -688,8 +711,8 @@ async def duplicate_channel(
         clone.destination_state = DestinationState.PENDING_REGISTRATION.value
         clone.activation_code_hash = issued.code_hash
         clone.activation_code_expires_at = issued.expires_at
-        activation_url = build_activation_url(
-            settings.sheaf_base_url or "", clone.id, issued.code
+        activation_url = _build_activation_url(
+            src.destination_type, clone.id, issued.code
         )
         activation_expires = issued.expires_at
     elif src.destination_type == DestinationType.WEBHOOK.value:
@@ -752,8 +775,8 @@ async def reissue_activation(
     channel.activation_code_expires_at = issued.expires_at
     await db.commit()
     return ReissueActivationResponse(
-        activation_url=build_activation_url(
-            settings.sheaf_base_url or "", channel.id, issued.code
+        activation_url=_build_activation_url(
+            channel.destination_type, channel.id, issued.code
         ),
         activation_expires_at=issued.expires_at,
     )

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -68,14 +68,10 @@ router = APIRouter(prefix="", tags=["notifications"])
 
 _PUSH_TYPES = {
     DestinationType.WEB_PUSH.value,
-    DestinationType.FCM.value,
-    DestinationType.APNS_DEV.value,
-    DestinationType.APNS_PROD.value,
+    DestinationType.MOBILE_PUSH.value,
 }
 _MOBILE_PUSH_TYPES = {
-    DestinationType.FCM.value,
-    DestinationType.APNS_DEV.value,
-    DestinationType.APNS_PROD.value,
+    DestinationType.MOBILE_PUSH.value,
 }
 _DIRECT_TYPES = {
     DestinationType.WEBHOOK.value,
@@ -85,6 +81,14 @@ _DIRECT_TYPES = {
 _RESERVED_TYPES = {
     DestinationType.EMAIL.value,
     DestinationType.DISCORD.value,
+}
+# Legacy mobile types are kept in the enum for read-back of historical
+# rows; channel creation refuses them and a migration collapsed any
+# existing rows to MOBILE_PUSH.
+_LEGACY_MOBILE_TYPES = {
+    DestinationType.FCM.value,
+    DestinationType.APNS_DEV.value,
+    DestinationType.APNS_PROD.value,
 }
 
 
@@ -146,6 +150,7 @@ def _channel_to_read(channel: NotificationChannel) -> ChannelRead:
         name=channel.name,
         destination_type=channel.destination_type,
         destination_state=channel.destination_state,
+        paused_by_sender=channel.paused_by_sender,
         destination_config=_redacted_destination_config(channel),
         event_type=channel.event_type,
         activation_code_expires_at=channel.activation_code_expires_at,
@@ -209,37 +214,34 @@ def _validate_destination(body_type: str) -> None:
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail=f"destination_type {body_type!r} not yet supported",
         )
+    if body_type in _LEGACY_MOBILE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"destination_type {body_type!r} has been replaced by "
+                "'mobile_push' — a single channel that fans out to all "
+                "of the recipient's registered iOS / Android devices."
+            ),
+        )
     if body_type not in _PUSH_TYPES and body_type not in _DIRECT_TYPES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"unknown destination_type {body_type!r}",
         )
-    # Mobile push feature-flags: reject channel creation when credentials
-    # for the relevant provider aren't configured on this deployment.
-    if body_type == DestinationType.FCM.value and not _fcm_configured():
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="FCM is not configured on this server",
-        )
-    if (
-        body_type in {DestinationType.APNS_DEV.value, DestinationType.APNS_PROD.value}
-        and not _apns_configured()
+    # Mobile push: must have at least one provider's credentials so the
+    # server can actually dispatch. Either FCM (Android) or APNs (iOS) on
+    # its own is enough — single-platform deployments still want to
+    # accept mobile_push channels and just no-op for the other platform
+    # at dispatch time.
+    if body_type == DestinationType.MOBILE_PUSH.value and not (
+        _fcm_configured() or _apns_configured()
     ):
         raise HTTPException(
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="APNs is not configured on this server",
-        )
-    # apns_dev is opt-in even when APNs creds are configured. Prod
-    # deployments keep `apns_dev_enabled` off so sandbox tokens can't
-    # be registered against the production backend (where they'd
-    # bounce at the APNs host anyway).
-    if (
-        body_type == DestinationType.APNS_DEV.value
-        and not settings.apns_dev_enabled
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="apns_dev is not enabled on this server",
+            detail=(
+                "mobile_push is not configured on this server — neither "
+                "FCM nor APNs credentials are set."
+            ),
         )
 
 
@@ -616,6 +618,9 @@ async def enable_channel(
             detail="Channel is awaiting activation; can't enable until redeemed",
         )
     channel.destination_state = DestinationState.ACTIVE.value
+    # Re-enable clears the pause-cause flag — whatever happened next time
+    # the channel goes DISABLED gets its own fresh attribution.
+    channel.paused_by_sender = False
     await db.commit()
     return _channel_to_read(await _load_owned_channel(db, user, channel.id))
 
@@ -634,6 +639,7 @@ async def disable_channel(
     re-enable later to resume."""
     channel = await _load_owned_channel(db, user, channel_id)
     channel.destination_state = DestinationState.DISABLED.value
+    channel.paused_by_sender = True
     await db.commit()
     return _channel_to_read(await _load_owned_channel(db, user, channel.id))
 
@@ -1042,6 +1048,7 @@ async def list_receiving(
                 system_label=getattr(system, "display_name", None),
                 destination_type=channel.destination_type,
                 destination_state=channel.destination_state,
+                paused_by_sender=channel.paused_by_sender,
                 redeemed_at=channel.redeemed_at,
                 last_delivered_at=channel.last_delivered_at,
             )

--- a/sheaf/api/v1/notifications_public.py
+++ b/sheaf/api/v1/notifications_public.py
@@ -153,7 +153,11 @@ async def redeem_activation(
             detail="Activation code has expired",
         )
 
+    # Legacy fcm / apns_* rows kept defensively in case any survive the
+    # migration to mobile_push (they shouldn't, but the redemption path
+    # is the wrong place to fail loudly).
     mobile_push_types = {
+        DestinationType.MOBILE_PUSH.value,
         DestinationType.FCM.value,
         DestinationType.APNS_DEV.value,
         DestinationType.APNS_PROD.value,
@@ -297,6 +301,7 @@ async def view_managed(
         system_label=system_label,
         destination_type=channel.destination_type,
         destination_state=channel.destination_state,
+        paused_by_sender=channel.paused_by_sender,
     )
 
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -176,6 +176,14 @@ class Settings(BaseSettings):
     # An explicit http:// URL opts in to non-Secure cookies for plain-HTTP dev.
     sheaf_base_url: str = ""
 
+    # Shared Universal Link / App Link host for mobile_push activation
+    # URLs. Every instance routes mobile_push redemption links through
+    # this host because the mobile app's associated-domains entitlement
+    # is baked in at build time and trusts only one origin. The default
+    # points at the public sheaf.sh website; self-hosters who fork and
+    # republish the apps override this to their own host.
+    mobile_link_base_url: str = "https://sheaf.sh"
+
     # Admin dashboard step-up authentication level.
     # "none"     — any admin can access the dashboard immediately.
     # "password" — admin must re-enter their password (valid for 2 hours).

--- a/sheaf/models/notification_channel.py
+++ b/sheaf/models/notification_channel.py
@@ -13,22 +13,32 @@ class DestinationType(enum.StrEnum):
     """Supported destinations and reserved placeholders for ones whose
     handler hasn't shipped yet (channel creation rejects those with 501).
 
-    The APNs values are split by build environment because Apple uses two
-    distinct host endpoints (`api.sandbox.push.apple.com` for development
-    builds, `api.push.apple.com` for TestFlight + App Store) — the same
-    .p8 key authenticates against both, but tokens issued in one
-    environment bounce on the other. The dispatcher uses this enum value
-    to route to the right host. FCM has no equivalent split."""
+    `mobile_push` is the single, platform-agnostic mobile destination —
+    the channel binds to a Sheaf account at redemption, and the dispatcher
+    fans out across every `push_device_tokens` row for that account,
+    routing each token to FCM (Android) or APNs (iOS, dev/prod per-token)
+    automatically. There is no per-channel platform choice; one channel
+    rings every device the recipient signs into. Distinct from `web_push`,
+    which is anonymous-capable and tied to a single browser subscription.
+
+    The legacy `fcm` / `apns_dev` / `apns_prod` values are kept in the
+    enum so existing audit logs / exports remain interpretable, but
+    channel creation refuses them — use `mobile_push` instead. A migration
+    flips any existing rows over."""
 
     WEB_PUSH = "web_push"
     WEBHOOK = "webhook"
     NTFY = "ntfy"
     PUSHOVER = "pushover"
     EMAIL = "email"
+    MOBILE_PUSH = "mobile_push"
+    DISCORD = "discord"
+    # Deprecated, retained for migration / read-back of historical rows.
+    # Channel creation rejects these; the migration moves any existing
+    # data to MOBILE_PUSH.
     APNS_DEV = "apns_dev"
     APNS_PROD = "apns_prod"
     FCM = "fcm"
-    DISCORD = "discord"
 
 
 class DestinationState(enum.StrEnum):
@@ -75,6 +85,17 @@ class NotificationChannel(UUIDMixin, TimestampMixin, Base):
         nullable=False,
         default=DestinationState.PENDING_REGISTRATION.value,
         server_default=DestinationState.PENDING_REGISTRATION.value,
+    )
+    # Splits the meaning of `destination_state = DISABLED` between the
+    # owner pausing the channel (True) and the recipient unsubscribing
+    # (False — also covers legacy rows where the cause is unknown). The
+    # recipient-facing label renders differently for each: "Paused by
+    # sender" vs "Unsubscribed". Cleared on re-enable.
+    paused_by_sender: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
     )
 
     # Forward-compat: only "front_change" in v1.

--- a/sheaf/models/push_device_token.py
+++ b/sheaf/models/push_device_token.py
@@ -15,7 +15,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -59,4 +59,15 @@ class PushDeviceToken(UUIDMixin, TimestampMixin, Base):
 
     last_seen_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
+    )
+
+    # User-visible device name set by the mobile app at registration
+    # (e.g. "Sarah's iPhone", "Pixel 7"). Optional — rendering code
+    # falls back to a platform-based default when absent.
+    label: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
+    # Soft mute: if False, dispatcher fan-out skips this row. The row
+    # stays registered so the user can re-enable without re-installing.
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
     )

--- a/sheaf/schemas/notifications.py
+++ b/sheaf/schemas/notifications.py
@@ -45,7 +45,17 @@ class WatchTokenRead(BaseModel):
 
 
 _DESTINATION_TYPES = Literal[
-    "web_push", "webhook", "ntfy", "pushover", "fcm", "apns_dev", "apns_prod"
+    "web_push",
+    "webhook",
+    "ntfy",
+    "pushover",
+    "mobile_push",
+    # Legacy mobile types retained so read-back of any historical row
+    # (export, audit) still validates. Channel creation refuses them;
+    # a migration collapsed any existing channel rows to mobile_push.
+    "fcm",
+    "apns_dev",
+    "apns_prod",
 ]
 _PAYLOAD_SENSITIVITIES = Literal["full", "minimal", "bare"]
 _COFRONT_REDACTIONS = Literal["count", "someone", "suppress"]
@@ -151,6 +161,10 @@ class ChannelRead(BaseModel):
     name: str
     destination_type: str
     destination_state: str
+    # True when destination_state == 'disabled' was caused by the owner
+    # pausing the channel (not the recipient unsubscribing). Lets the
+    # recipient UI render "Paused by sender" instead of "Unsubscribed".
+    paused_by_sender: bool = False
     # destination_config is echoed back for non-secret types (ntfy server URL,
     # webhook URL minus secret, pushover user key). Secrets never leak here.
     destination_config: dict[str, Any]
@@ -258,6 +272,7 @@ class ManageChannelView(BaseModel):
     system_label: str | None = None
     destination_type: str
     destination_state: str
+    paused_by_sender: bool = False
 
 
 class ReceivingChannelView(BaseModel):
@@ -274,5 +289,6 @@ class ReceivingChannelView(BaseModel):
     system_label: str | None = None
     destination_type: str
     destination_state: str
+    paused_by_sender: bool = False
     redeemed_at: datetime | None
     last_delivered_at: datetime | None

--- a/sheaf/schemas/push_device.py
+++ b/sheaf/schemas/push_device.py
@@ -15,6 +15,16 @@ class PushDeviceRegisterRequest(BaseModel):
     token: str = Field(min_length=1, max_length=4096)
     install_id: str | None = Field(default=None, max_length=64)
     app_version: str | None = Field(default=None, max_length=32)
+    label: str | None = Field(default=None, max_length=80)
+
+
+class PushDeviceUpdateRequest(BaseModel):
+    """PATCH body for /v1/devices/push/{id}. Owner-only fields the
+    recipient toggles from the Receiving tab — does not accept token
+    or platform (those rotate via the register endpoint)."""
+
+    enabled: bool | None = None
+    label: str | None = Field(default=None, max_length=80)
 
 
 class PushDeviceDeleteRequest(BaseModel):
@@ -24,6 +34,8 @@ class PushDeviceDeleteRequest(BaseModel):
 class PushDeviceRead(BaseModel):
     id: uuid.UUID
     platform: PushPlatform
+    label: str | None
+    enabled: bool
     install_id: str | None
     app_version: str | None
     last_seen_at: datetime

--- a/sheaf/services/notifications/activation.py
+++ b/sheaf/services/notifications/activation.py
@@ -17,6 +17,7 @@ import secrets
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from urllib.parse import quote
 
 from sheaf.config import settings
 
@@ -94,6 +95,30 @@ def activation_url(base_url: str, channel_id: uuid.UUID, code: str) -> str:
     """
     base = base_url.rstrip("/")
     return f"{base}/notifications/redeem?code={code}&channel={channel_id}"
+
+
+def mobile_activation_url(
+    *,
+    mobile_link_base_url: str,
+    instance_base_url: str,
+    channel_id: uuid.UUID,
+    code: str,
+) -> str:
+    """Activation URL for mobile_push channels, routed through the shared
+    Universal Link / App Link host (sheaf.sh by default).
+
+    The mobile apps' associated-domains entitlement is baked in at build
+    time and only trusts a single host. Self-hosters' arbitrary domains
+    cannot be claimed, so every mobile_push activation link funnels
+    through that one host; the app intercepts, reads `instance=`, then
+    calls that instance's `/v1/notifications/redeem` to actually redeem.
+
+    Format: {mobile_link_base_url}/redeem?code=...&channel={uuid}&instance=
+    {url-encoded instance origin}
+    """
+    base = mobile_link_base_url.rstrip("/")
+    instance = quote(instance_base_url.rstrip("/"), safe="")
+    return f"{base}/redeem?code={code}&channel={channel_id}&instance={instance}"
 
 
 def management_url(base_url: str, token: str) -> str:

--- a/sheaf/services/notifications/apns.py
+++ b/sheaf/services/notifications/apns.py
@@ -145,23 +145,39 @@ def _classify_response(status_code: int, body: str) -> ApnsSendResult:
     return ApnsSendResult(transient=True, error=f"APNs {status_code}: {body[:200]}")
 
 
-def _build_payload(title: str, body: str, event_id: str) -> dict:
+def _build_payload(
+    title: str,
+    body: str,
+    event_id: str,
+    channel_id: str,
+    channel_name: str,
+    event_type: str,
+) -> dict:
     """Mutable-content alert + custom keys, per the design doc.
 
     iOS clients are expected to ship a Notification Service Extension
     that reads `data.title` / `data.body` (and any future custom fields)
     and rewrites the user-visible alert. The placeholder in `aps.alert`
     is what shows if the NSE is missing or times out — keep it neutral.
+
+    `channel_id` / `channel_name` / `event_type` mirror the FCM payload
+    so the iOS client can drive thread-id / interruption-level / sound
+    overrides per-subscription rather than collapsing everything into
+    one bucket.
     """
     return {
         "aps": {
             "alert": {"title": title, "body": body},
             "mutable-content": 1,
+            "thread-id": channel_id,
         },
         "data": {
             "title": title,
             "body": body,
             "event_id": event_id,
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "event_type": event_type,
         },
     }
 
@@ -173,6 +189,9 @@ async def send_to_token(
     title: str,
     body: str,
     event_id: str,
+    channel_id: str,
+    channel_name: str,
+    event_type: str,
 ) -> ApnsSendResult:
     """Send one APNs message to one device token. Platform must be
     `apns_dev` or `apns_prod` and selects the host."""
@@ -189,7 +208,9 @@ async def send_to_token(
 
     host = _HOST_DEV if platform == "apns_dev" else _HOST_PROD
     url = f"https://{host}:{_PORT}/3/device/{device_token}"
-    payload = _build_payload(title, body, event_id)
+    payload = _build_payload(
+        title, body, event_id, channel_id, channel_name, event_type
+    )
     try:
         async with httpx.AsyncClient(http2=True, timeout=15.0) as client:
             resp = await client.post(

--- a/sheaf/services/notifications/dispatcher.py
+++ b/sheaf/services/notifications/dispatcher.py
@@ -46,7 +46,17 @@ _BACKOFF_BASE_SECONDS = 30
 
 
 def _semaphores() -> dict[str, asyncio.Semaphore]:
+    # mobile_push fans out per-token to FCM and APNs (dev or prod, per
+    # token); the per-device dispatch happens inside the handler under
+    # the dedicated FCM / APNs sub-semaphores so per-provider concurrency
+    # budgets still apply. The outer channel-level semaphore is sized
+    # generously since the real work is delegated.
     apns_sem = asyncio.Semaphore(settings.notifications_concurrency_apns)
+    fcm_sem = asyncio.Semaphore(settings.notifications_concurrency_fcm)
+    mobile_sem = asyncio.Semaphore(
+        settings.notifications_concurrency_apns
+        + settings.notifications_concurrency_fcm
+    )
     return {
         DestinationType.WEB_PUSH.value: asyncio.Semaphore(
             settings.notifications_concurrency_web_push
@@ -60,11 +70,11 @@ def _semaphores() -> dict[str, asyncio.Semaphore]:
         DestinationType.PUSHOVER.value: asyncio.Semaphore(
             settings.notifications_concurrency_pushover
         ),
-        DestinationType.FCM.value: asyncio.Semaphore(
-            settings.notifications_concurrency_fcm
-        ),
-        # APNs dev + prod share one semaphore — same backend, same key,
-        # just different hosts. Concurrency budget is shared across both.
+        DestinationType.MOBILE_PUSH.value: mobile_sem,
+        # Legacy entries retained for read-back / replay of any pre-
+        # migration outbox rows still in flight at upgrade time. New
+        # channels never land here.
+        DestinationType.FCM.value: fcm_sem,
         DestinationType.APNS_DEV.value: apns_sem,
         DestinationType.APNS_PROD.value: apns_sem,
     }

--- a/sheaf/services/notifications/fcm.py
+++ b/sheaf/services/notifications/fcm.py
@@ -191,7 +191,14 @@ def _classify_response(status_code: int, body: str) -> FcmSendResult:
 
 
 async def send_to_token(
-    *, device_token: str, title: str, body: str, event_id: str
+    *,
+    device_token: str,
+    title: str,
+    body: str,
+    event_id: str,
+    channel_id: str,
+    channel_name: str,
+    event_type: str,
 ) -> FcmSendResult:
     """Send one FCM message to one device token.
 
@@ -199,6 +206,12 @@ async def send_to_token(
     data payload — Android clients build the user-visible notification
     locally from these fields, matching the design's "client formats
     title/body" requirement.
+
+    `channel_id` / `channel_name` / `event_type` identify the originating
+    Sheaf NotificationChannel so the Android client can route into a
+    per-subscription Android NotificationChannel (mute one Sheaf channel
+    without muting them all). Clients that don't read these fields are
+    unaffected — FCM data dicts ignore unknown keys.
     """
     account = _load_service_account()
     if account is None:
@@ -215,6 +228,9 @@ async def send_to_token(
                 "title": title,
                 "body": body,
                 "event_id": event_id,
+                "channel_id": channel_id,
+                "channel_name": channel_name,
+                "event_type": event_type,
             },
             "android": {"priority": "high"},
         }

--- a/sheaf/services/notifications/handlers.py
+++ b/sheaf/services/notifications/handlers.py
@@ -449,6 +449,11 @@ async def _deliver_mobile_push(
     last_error: str | None = None
     dead_ids: list[uuid.UUID] = []
 
+    # Captured once outside the per-device loop so the channel-routing
+    # metadata is consistent across every device the same event reaches.
+    channel_id_str = str(channel.id)
+    channel_name = channel.name
+    channel_event_type = channel.event_type
     for row in rows:
         if row.platform == "fcm":
             outcome = await fcm_send(
@@ -456,6 +461,9 @@ async def _deliver_mobile_push(
                 title=message.title,
                 body=message.body,
                 event_id=event_id,
+                channel_id=channel_id_str,
+                channel_name=channel_name,
+                event_type=channel_event_type,
             )
         elif row.platform in ("apns_dev", "apns_prod"):
             outcome = await apns_send(
@@ -464,6 +472,9 @@ async def _deliver_mobile_push(
                 title=message.title,
                 body=message.body,
                 event_id=event_id,
+                channel_id=channel_id_str,
+                channel_name=channel_name,
+                event_type=channel_event_type,
             )
         else:
             # Unknown platform on the device row — skip, don't treat as

--- a/sheaf/services/notifications/handlers.py
+++ b/sheaf/services/notifications/handlers.py
@@ -85,17 +85,16 @@ async def deliver(
         return await _deliver_pushover(
             channel, message, owner_user_id=owner_user_id, owner_tier=owner_tier
         )
-    if dtype == DestinationType.FCM:
+    if dtype in (
+        DestinationType.MOBILE_PUSH,
+        # Defensive: any legacy rows that somehow survive the migration
+        # collapse-to-mobile_push fall through to the same fan-out.
+        DestinationType.FCM,
+        DestinationType.APNS_DEV,
+        DestinationType.APNS_PROD,
+    ):
         return await _deliver_mobile_push(
-            channel, message, event_id=event_id, db=db, platform="fcm"
-        )
-    if dtype == DestinationType.APNS_DEV:
-        return await _deliver_mobile_push(
-            channel, message, event_id=event_id, db=db, platform="apns_dev"
-        )
-    if dtype == DestinationType.APNS_PROD:
-        return await _deliver_mobile_push(
-            channel, message, event_id=event_id, db=db, platform="apns_prod"
+            channel, message, event_id=event_id, db=db
         )
     return permanent(f"unsupported destination type {dtype}")
 
@@ -393,15 +392,20 @@ async def _deliver_mobile_push(
     *,
     event_id: str,
     db: AsyncSession | None,
-    platform: str,
 ) -> DeliveryResult:
     """Fan-out one notification to every push_device_tokens row matching
-    the channel's redeemed_by_account_id and the given platform.
+    the channel's redeemed_by_account_id, regardless of platform.
+
+    The channel is platform-agnostic: a single mobile_push channel rings
+    every device the recipient has signed into, whether iOS or Android.
+    Per-row, we route to FCM (android tokens) or APNs (ios_* tokens,
+    sandbox vs prod determined per-token) and call the matching handler.
 
     Aggregation rule: any-success-is-success. Permanent only when every
     device returned a permanent error AND there was at least one device.
     Zero-device case is success-with-no-effect (the user might just not
-    have any registered devices for this platform yet).
+    have any registered devices yet — e.g. account exists but the app
+    hasn't been installed).
 
     410 / Unregistered responses delete the dead row in-line so the next
     delivery doesn't re-attempt against it.
@@ -421,65 +425,65 @@ async def _deliver_mobile_push(
     result = await db.execute(
         select(PushDeviceToken).where(
             PushDeviceToken.account_id == channel.redeemed_by_account_id,
-            PushDeviceToken.platform == platform,
+            # Recipients can mute individual devices from the Receiving tab
+            # without unregistering them; disabled rows skip fan-out.
+            PushDeviceToken.enabled.is_(True),
         )
     )
     rows = list(result.scalars().all())
     if not rows:
-        # No registered devices for this platform — not a delivery
+        # No registered devices for this account — not a delivery
         # failure; the user might still have a web-push channel to the
         # same account or just hasn't installed the app yet.
         logger.info(
-            "mobile push: no devices for account=%s platform=%s",
+            "mobile push: no devices registered for account=%s",
             channel.redeemed_by_account_id,
-            platform,
         )
         return SUCCESS
+
+    from sheaf.services.notifications.apns import send_to_token as apns_send
+    from sheaf.services.notifications.fcm import send_to_token as fcm_send
 
     any_ok = False
     all_dead = True
     last_error: str | None = None
     dead_ids: list[uuid.UUID] = []
 
-    if platform == "fcm":
-        from sheaf.services.notifications.fcm import send_to_token as fcm_send
-
-        for row in rows:
+    for row in rows:
+        if row.platform == "fcm":
             outcome = await fcm_send(
                 device_token=row.token,
                 title=message.title,
                 body=message.body,
                 event_id=event_id,
             )
-            if outcome.ok:
-                any_ok = True
-                all_dead = False
-            elif outcome.dead:
-                dead_ids.append(row.id)
-                last_error = outcome.error
-            else:
-                all_dead = False
-                last_error = outcome.error
-    else:
-        from sheaf.services.notifications.apns import send_to_token as apns_send
-
-        for row in rows:
+        elif row.platform in ("apns_dev", "apns_prod"):
             outcome = await apns_send(
-                platform=platform,
+                platform=row.platform,
                 device_token=row.token,
                 title=message.title,
                 body=message.body,
                 event_id=event_id,
             )
-            if outcome.ok:
-                any_ok = True
-                all_dead = False
-            elif outcome.dead:
-                dead_ids.append(row.id)
-                last_error = outcome.error
-            else:
-                all_dead = False
-                last_error = outcome.error
+        else:
+            # Unknown platform on the device row — skip, don't treat as
+            # a delivery failure for this channel.
+            logger.warning(
+                "mobile push: unknown device platform=%s for account=%s",
+                row.platform,
+                channel.redeemed_by_account_id,
+            )
+            continue
+
+        if outcome.ok:
+            any_ok = True
+            all_dead = False
+        elif outcome.dead:
+            dead_ids.append(row.id)
+            last_error = outcome.error
+        else:
+            all_dead = False
+            last_error = outcome.error
 
     if dead_ids:
         await db.execute(

--- a/tests/test_apns_dev_gate.py
+++ b/tests/test_apns_dev_gate.py
@@ -1,78 +1,25 @@
 """Unit tests for the APNS_DEV_ENABLED feature flag.
 
-The flag gates two surfaces:
-- POST /v1/watch-tokens/{id}/channels with destination_type=apns_dev
+After the mobile_push collapse, the flag only matters at one surface:
+
 - POST /v1/devices/push with platform=apns_dev
 
-Integration tests in the test stack run with APNS_DEV_ENABLED=true so the
-"on" paths are already exercised end-to-end. These unit tests cover the
-"off" path, where the gate should reject sandbox-token registration so
-production deployments don't accrue orphaned dev rows.
+The channel-creation gate is gone — there's no per-channel apns_dev
+type anymore (the unified mobile_push type covers all platforms and
+the dispatcher routes per-token via the device's `platform` column).
+The device-registration gate still exists so a prod deployment can't
+accrue orphaned sandbox device-token rows that APNs would bounce at
+delivery time.
 """
 
 from __future__ import annotations
 
-import pytest
-from fastapi import HTTPException
 
-from sheaf.api.v1.notification_channels import _validate_destination
-from sheaf.config import settings
-
-
-@pytest.fixture
-def apns_creds_configured(monkeypatch):
-    """Pretend APNs credentials are present so the gate reaches the
-    apns_dev_enabled check rather than tripping the earlier creds gate."""
-    monkeypatch.setattr(settings, "apns_team_id", "TESTTEAM01")
-    monkeypatch.setattr(settings, "apns_key_id", "TESTKEY001")
-    monkeypatch.setattr(settings, "apns_bundle_id", "com.sheaftest.app")
-    monkeypatch.setattr(
-        settings,
-        "apns_p8_key",
-        "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
-    )
-
-
-def test_channel_apns_dev_rejected_when_flag_off(apns_creds_configured, monkeypatch):
-    monkeypatch.setattr(settings, "apns_dev_enabled", False)
-    with pytest.raises(HTTPException) as exc:
-        _validate_destination("apns_dev")
-    assert exc.value.status_code == 501
-    assert "apns_dev" in exc.value.detail
-
-
-def test_channel_apns_dev_allowed_when_flag_on(apns_creds_configured, monkeypatch):
-    monkeypatch.setattr(settings, "apns_dev_enabled", True)
-    # Should not raise.
-    _validate_destination("apns_dev")
-
-
-def test_channel_apns_prod_not_affected_by_flag(apns_creds_configured, monkeypatch):
-    """The gate is apns_dev-only; apns_prod passes regardless of the flag."""
-    monkeypatch.setattr(settings, "apns_dev_enabled", False)
-    _validate_destination("apns_prod")
-
-
-def test_channel_apns_dev_creds_check_runs_before_flag(monkeypatch):
-    """If APNs creds are not configured at all, the earlier creds gate
-    fires first. Flag state shouldn't matter."""
-    monkeypatch.setattr(settings, "apns_team_id", "")
-    monkeypatch.setattr(settings, "apns_key_id", "")
-    monkeypatch.setattr(settings, "apns_bundle_id", "")
-    monkeypatch.setattr(settings, "apns_p8_key", "")
-    monkeypatch.setattr(settings, "apns_dev_enabled", True)
-    with pytest.raises(HTTPException) as exc:
-        _validate_destination("apns_dev")
-    assert exc.value.status_code == 501
-    assert "APNs is not configured" in exc.value.detail
-
-
-def test_device_endpoint_gate_matches_channel_gate():
-    """The device-registration endpoint shares the same gate pattern as
-    the channel-creation endpoint. This is a structural assertion: both
-    sites read `settings.apns_dev_enabled` and both raise on apns_dev when
-    the flag is off, keeping the surfaces symmetric so prod deployments
-    don't get a sneaky half-open door."""
+def test_device_endpoint_still_gates_apns_dev():
+    """The device-registration endpoint must consult `apns_dev_enabled`
+    and compare against `PushPlatform.APNS_DEV` — structural assertion
+    so a future refactor that drops the gate is caught here rather than
+    by an operator discovering orphaned dev rows in prod."""
     import inspect
 
     from sheaf.api.v1 import devices

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -180,3 +180,125 @@ def test_unauthenticated_requests_rejected(client: httpx.Client):
         json={"platform": "fcm", "token": "anon-tok"},
     )
     assert resp.status_code in {401, 403}
+
+
+# --- enabled / label / per-id PATCH + DELETE ---------------------------------
+
+
+def test_register_accepts_label(auth_client: httpx.Client):
+    """The mobile app supplies a user-visible device name at
+    registration; the server stores it and `enabled` defaults to True."""
+    resp = auth_client.post(
+        "/v1/devices/push",
+        json={
+            "platform": "fcm",
+            "token": "tok-labelled",
+            "install_id": "i-lbl",
+            "label": "Sarah's Pixel",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["label"] == "Sarah's Pixel"
+    assert body["enabled"] is True
+
+
+def test_patch_toggles_enabled(auth_client: httpx.Client):
+    """Recipient mutes a device by flipping `enabled` to False; the
+    row stays registered so re-enabling later is a one-click action."""
+    created = auth_client.post(
+        "/v1/devices/push",
+        json={"platform": "fcm", "token": "tok-mute", "install_id": "i-mute"},
+    ).json()
+    assert created["enabled"] is True
+
+    patched = auth_client.patch(
+        f"/v1/devices/push/{created['id']}", json={"enabled": False}
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["enabled"] is False
+
+    listing = auth_client.get("/v1/devices/push").json()
+    row = next(r for r in listing if r["id"] == created["id"])
+    assert row["enabled"] is False
+
+    # And back on.
+    auth_client.patch(
+        f"/v1/devices/push/{created['id']}", json={"enabled": True}
+    )
+    listing = auth_client.get("/v1/devices/push").json()
+    row = next(r for r in listing if r["id"] == created["id"])
+    assert row["enabled"] is True
+
+
+def test_patch_renames_device(auth_client: httpx.Client):
+    """Recipient renames a device from the Receiving tab. Empty string
+    clears the label back to platform-derived default at render time."""
+    created = auth_client.post(
+        "/v1/devices/push",
+        json={
+            "platform": "fcm",
+            "token": "tok-rename",
+            "install_id": "i-rn",
+            "label": "Old name",
+        },
+    ).json()
+    patched = auth_client.patch(
+        f"/v1/devices/push/{created['id']}", json={"label": "New name"}
+    ).json()
+    assert patched["label"] == "New name"
+
+    cleared = auth_client.patch(
+        f"/v1/devices/push/{created['id']}", json={"label": ""}
+    ).json()
+    assert cleared["label"] is None
+
+
+def test_patch_404_for_other_account(auth_client: httpx.Client, client: httpx.Client):
+    """A device row belonging to another user 404s — no leak of the
+    existence of cross-account rows."""
+    import uuid as _uuid
+
+    other_email = f"patch-other-{_uuid.uuid4().hex[:8]}@sheaf.dev"
+    reg = client.post(
+        "/v1/auth/register",
+        json={"email": other_email, "password": "testpassword123"},
+    )
+    client.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+    other = client.post(
+        "/v1/devices/push",
+        json={
+            "platform": "fcm",
+            "token": "tok-other",
+            "install_id": "i-other",
+        },
+    ).json()
+
+    resp = auth_client.patch(
+        f"/v1/devices/push/{other['id']}", json={"enabled": False}
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_by_id_removes_row(auth_client: httpx.Client):
+    """DELETE /v1/devices/push/{id} drops the row — the web UI variant
+    of the existing logout-time token-based DELETE."""
+    created = auth_client.post(
+        "/v1/devices/push",
+        json={"platform": "fcm", "token": "tok-drop", "install_id": "i-drop"},
+    ).json()
+
+    resp = auth_client.delete(f"/v1/devices/push/{created['id']}")
+    assert resp.status_code == 204
+
+    listing = auth_client.get("/v1/devices/push").json()
+    assert not any(r["id"] == created["id"] for r in listing)
+
+
+def test_delete_by_id_is_idempotent(auth_client: httpx.Client):
+    """Deleting a non-existent device id returns 204 too — matches the
+    token-based DELETE's idempotent semantics so retries don't 404."""
+    import uuid as _uuid
+
+    resp = auth_client.delete(f"/v1/devices/push/{_uuid.uuid4()}")
+    assert resp.status_code == 204

--- a/tests/test_notifications_api.py
+++ b/tests/test_notifications_api.py
@@ -322,6 +322,29 @@ def test_redeem_used_code_rejected(auth_client: httpx.Client, client: httpx.Clie
 # -------------------------------------------------------- isolation / authz
 
 
+def test_owner_pause_sets_paused_by_sender(auth_client: httpx.Client):
+    """`POST /channels/{id}/disable` (owner action) flips the channel
+    into the DISABLED state AND sets paused_by_sender=true. Recipient
+    UIs use the flag to render "Paused by sender" instead of
+    "Unsubscribed"."""
+    tok = _create_token(auth_client)
+    channel = _create_webhook_channel(auth_client, tok["id"])
+    channel_id = channel["channel"]["id"]
+
+    resp = auth_client.post(f"/v1/channels/{channel_id}/disable")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["destination_state"] == "disabled"
+    assert body["paused_by_sender"] is True
+
+    # Re-enable clears the flag — next disable gets its own attribution.
+    resp = auth_client.post(f"/v1/channels/{channel_id}/enable")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["destination_state"] == "active"
+    assert body["paused_by_sender"] is False
+
+
 def test_other_user_cannot_see_token(auth_client: httpx.Client):
     tok = _create_token(auth_client, "Mine")
 

--- a/tests/test_notifications_mobile.py
+++ b/tests/test_notifications_mobile.py
@@ -1,7 +1,16 @@
-"""Tests for the mobile-push (FCM / APNs) channel creation + redemption
-flow. The test stack injects dummy FCM + APNs creds at startup so the
-feature-flag gate passes; the actual transport is stubbed in dispatch
-handler tests."""
+"""Tests for the mobile_push channel creation + redemption flow.
+
+`mobile_push` is the single platform-agnostic mobile destination — the
+channel binds to a Sheaf account at redemption, and the dispatcher fans
+out across every push_device_tokens row for that account at delivery
+time. The legacy fcm / apns_dev / apns_prod destination types are
+rejected at channel creation; a migration collapsed any existing rows
+to mobile_push.
+
+The test stack injects dummy FCM + APNs creds at startup so the
+configured() gate passes; the actual transport is stubbed in dispatch
+handler tests.
+"""
 
 from __future__ import annotations
 
@@ -27,9 +36,9 @@ def _create_token(client: httpx.Client) -> dict:
 
 
 def _create_channel(
-    client: httpx.Client, *, destination_type: str
+    client: httpx.Client, *, destination_type: str = "mobile_push"
 ) -> tuple[str, str]:
-    """Create a channel of the given type, return (channel_id, activation_code)."""
+    """Create a channel and return (channel_id, activation_code)."""
     tok = _create_token(client)
     resp = client.post(
         f"/v1/watch-tokens/{tok['id']}/channels",
@@ -44,38 +53,43 @@ def _create_channel(
     return body["channel"]["id"], code
 
 
-def test_fcm_channel_creates_pending(auth_client: httpx.Client):
+def test_mobile_push_channel_creates_pending(auth_client: httpx.Client):
     tok = _create_token(auth_client)
     resp = auth_client.post(
         f"/v1/watch-tokens/{tok['id']}/channels",
         json={
             "name": "phone",
-            "destination_type": "fcm",
+            "destination_type": "mobile_push",
             "base_all_members": True,
         },
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
+    assert body["channel"]["destination_type"] == "mobile_push"
     assert body["channel"]["destination_state"] == "pending_registration"
     assert body["activation_url"] is not None
     assert "code=" in body["activation_url"]
 
 
-def test_apns_channels_create_pending(auth_client: httpx.Client):
+def test_legacy_mobile_types_rejected(auth_client: httpx.Client):
+    """fcm / apns_dev / apns_prod are no longer accepted at channel
+    creation — clients should use mobile_push. The error message points
+    at the replacement so callers know what to switch to."""
     tok = _create_token(auth_client)
-    for dt in ("apns_dev", "apns_prod"):
+    for dt in ("fcm", "apns_dev", "apns_prod"):
         resp = auth_client.post(
             f"/v1/watch-tokens/{tok['id']}/channels",
-            json={"name": f"phone-{dt}", "destination_type": dt},
+            json={"name": f"legacy-{dt}", "destination_type": dt},
         )
-        assert resp.status_code == 201, resp.text
-        assert resp.json()["channel"]["destination_state"] == "pending_registration"
+        assert resp.status_code == 400, f"{dt}: {resp.text}"
+        assert "mobile_push" in resp.json()["detail"]
 
 
 def test_redeem_mobile_requires_session(auth_client: httpx.Client):
     """Mobile-push redemption is account-anchored — the redeemer must be
-    logged in (session cookie). Anonymous redemption is rejected."""
-    _, code = _create_channel(auth_client, destination_type="fcm")
+    logged in (session cookie or Bearer token). Anonymous redemption is
+    rejected."""
+    _, code = _create_channel(auth_client)
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as anon:
         resp = anon.post(
             "/v1/notifications/redeem",
@@ -88,7 +102,7 @@ def test_redeem_mobile_requires_session(auth_client: httpx.Client):
 def test_redeem_mobile_rejects_push_subscription(auth_client: httpx.Client):
     """push_subscription is meaningless for mobile push (transport lives
     on push_device_tokens, not the channel) and must be refused."""
-    _, code = _create_channel(auth_client, destination_type="fcm")
+    _, code = _create_channel(auth_client)
     email = f"mobile-redeem-{_uuid.uuid4().hex[:8]}@sheaf.dev"
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as c:
         reg = c.post(
@@ -114,11 +128,8 @@ def test_redeem_mobile_succeeds_with_bearer_token(auth_client: httpx.Client):
     """Mobile clients authenticate with Bearer access tokens, not cookies.
     Redemption must accept Bearer auth for the mobile sheaf:// deep-link
     handoff to work — the native app has no session cookie to send."""
-    channel_id, code = _create_channel(auth_client, destination_type="apns_prod")
+    channel_id, code = _create_channel(auth_client)
     email = f"mobile-redeem-bearer-{_uuid.uuid4().hex[:8]}@sheaf.dev"
-    # Register on one client to get a token, then move to a *fresh* client
-    # so no session cookie is carried. Only the Authorization header
-    # authenticates the request, matching the mobile-app shape.
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as register_c:
         reg = register_c.post(
             "/v1/auth/register",
@@ -142,7 +153,7 @@ def test_redeem_mobile_succeeds_with_session(auth_client: httpx.Client):
     """Logged-in redemption with no push_subscription succeeds, binds
     redeemed_by_account_id, and returns an empty management_url (mobile
     channels do not get an anonymous /manage URL)."""
-    channel_id, code = _create_channel(auth_client, destination_type="apns_prod")
+    channel_id, code = _create_channel(auth_client)
     email = f"mobile-redeem-ok-{_uuid.uuid4().hex[:8]}@sheaf.dev"
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as c:
         reg = c.post(
@@ -157,7 +168,6 @@ def test_redeem_mobile_succeeds_with_session(auth_client: httpx.Client):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["management_url"] == ""
-    # The channel is now ACTIVE and bound to the redeeming account.
     fresh = auth_client.get(f"/v1/channels/{channel_id}").json()
     assert fresh["destination_state"] == "active"
     assert fresh["redeemed_by_account_id"] is not None
@@ -165,27 +175,20 @@ def test_redeem_mobile_succeeds_with_session(auth_client: httpx.Client):
 
 def test_redeem_preview_returns_destination_type(auth_client: httpx.Client):
     """Public preview reveals destination_type so the recipient page can
-    branch (web push -> in-browser flow; mobile push -> deep link)."""
-    _, fcm_code = _create_channel(auth_client, destination_type="fcm")
-    _, apns_code = _create_channel(auth_client, destination_type="apns_prod")
-
+    branch (web push -> in-browser flow; mobile_push -> deep link)."""
+    _, code = _create_channel(auth_client)
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as anon:
-        fcm_preview = anon.get(
-            "/v1/notifications/redeem-preview", params={"code": fcm_code}
+        preview = anon.get(
+            "/v1/notifications/redeem-preview", params={"code": code}
         )
-        apns_preview = anon.get(
-            "/v1/notifications/redeem-preview", params={"code": apns_code}
-        )
-    assert fcm_preview.status_code == 200, fcm_preview.text
-    assert fcm_preview.json()["destination_type"] == "fcm"
-    assert apns_preview.status_code == 200, apns_preview.text
-    assert apns_preview.json()["destination_type"] == "apns_prod"
+    assert preview.status_code == 200, preview.text
+    assert preview.json()["destination_type"] == "mobile_push"
 
 
 def test_redeem_preview_does_not_consume_code(auth_client: httpx.Client):
     """Preview is read-only — the same code can still be redeemed
     afterward."""
-    _, code = _create_channel(auth_client, destination_type="fcm")
+    _, code = _create_channel(auth_client)
 
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as anon:
         preview = anon.get(
@@ -193,8 +196,6 @@ def test_redeem_preview_does_not_consume_code(auth_client: httpx.Client):
         )
     assert preview.status_code == 200
 
-    # Redeem succeeds with that same code (using the existing
-    # session-cookie + register flow established elsewhere).
     email = f"preview-noconsume-{_uuid.uuid4().hex[:8]}@sheaf.dev"
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as c:
         reg = c.post(
@@ -227,30 +228,16 @@ def test_redeem_preview_for_web_push_channel(auth_client: httpx.Client):
     assert resp.json()["destination_type"] == "web_push"
 
 
-def test_unit_validate_destination_rejects_unconfigured_fcm(monkeypatch):
-    """Unit test for the feature-flag gate: when FCM creds are absent,
-    channel creation rejects with 501. Integration tests can't easily
-    flip container-side env vars at runtime; this exercises the validator
-    directly."""
+def test_unit_validate_destination_rejects_when_no_mobile_provider(monkeypatch):
+    """Unit test for the configured() gate: when neither FCM nor APNs
+    credentials are present, mobile_push channel creation rejects with
+    501. Integration tests can't easily flip container-side env vars at
+    runtime; this exercises the validator directly."""
     from sheaf.api.v1 import notification_channels as nc
     from sheaf.config import settings
 
     monkeypatch.setattr(settings, "fcm_service_account_path", "")
     monkeypatch.setattr(settings, "fcm_service_account_json", "")
-
-    import pytest
-    from fastapi import HTTPException
-
-    with pytest.raises(HTTPException) as exc:
-        nc._validate_destination("fcm")
-    assert exc.value.status_code == 501
-
-
-def test_unit_validate_destination_rejects_unconfigured_apns(monkeypatch):
-    from sheaf.api.v1 import notification_channels as nc
-    from sheaf.config import settings
-
-    # Wipe out every APNs setting so the configured() helper returns False.
     monkeypatch.setattr(settings, "apns_team_id", "")
     monkeypatch.setattr(settings, "apns_key_id", "")
     monkeypatch.setattr(settings, "apns_bundle_id", "")
@@ -260,7 +247,28 @@ def test_unit_validate_destination_rejects_unconfigured_apns(monkeypatch):
     import pytest
     from fastapi import HTTPException
 
-    for dt in ("apns_dev", "apns_prod"):
-        with pytest.raises(HTTPException) as exc:
-            nc._validate_destination(dt)
-        assert exc.value.status_code == 501
+    with pytest.raises(HTTPException) as exc:
+        nc._validate_destination("mobile_push")
+    assert exc.value.status_code == 501
+    assert "not configured" in exc.value.detail.lower()
+
+
+def test_unit_validate_destination_allows_single_provider(monkeypatch):
+    """A deployment with only FCM configured (or only APNs) still
+    accepts mobile_push channels — fan-out at delivery time gracefully
+    no-ops for missing-provider devices. We don't require both."""
+    from sheaf.api.v1 import notification_channels as nc
+    from sheaf.config import settings
+
+    # FCM only.
+    monkeypatch.setattr(
+        settings,
+        "fcm_service_account_json",
+        '{"project_id":"x","client_email":"y","private_key":"z"}',
+    )
+    monkeypatch.setattr(settings, "apns_team_id", "")
+    monkeypatch.setattr(settings, "apns_key_id", "")
+    monkeypatch.setattr(settings, "apns_bundle_id", "")
+    monkeypatch.setattr(settings, "apns_p8_path", "")
+    monkeypatch.setattr(settings, "apns_p8_key", "")
+    nc._validate_destination("mobile_push")  # does not raise

--- a/tests/test_notifications_mobile.py
+++ b/tests/test_notifications_mobile.py
@@ -71,6 +71,48 @@ def test_mobile_push_channel_creates_pending(auth_client: httpx.Client):
     assert "code=" in body["activation_url"]
 
 
+def test_mobile_push_activation_url_routes_through_universal_link_host(
+    auth_client: httpx.Client,
+):
+    """mobile_push activation URLs must funnel through the shared
+    Universal Link host (settings.mobile_link_base_url) rather than the
+    instance's own frontend, since only that host is trusted by the
+    apps' associated-domains / asset-links entitlements at build time.
+    The instance origin is carried as a query param so the app can call
+    the right `/v1/notifications/redeem` after intercepting."""
+    from sheaf.config import settings
+
+    tok = _create_token(auth_client)
+    resp = auth_client.post(
+        f"/v1/watch-tokens/{tok['id']}/channels",
+        json={"name": "phone", "destination_type": "mobile_push"},
+    )
+    assert resp.status_code == 201, resp.text
+    url = resp.json()["activation_url"]
+    assert url.startswith(settings.mobile_link_base_url.rstrip("/") + "/redeem?"), (
+        f"expected mobile_push URL to route through "
+        f"{settings.mobile_link_base_url}, got {url}"
+    )
+    assert "code=" in url
+    assert "channel=" in url
+    assert "instance=" in url
+
+
+def test_web_push_activation_url_stays_on_instance(auth_client: httpx.Client):
+    """web_push, by contrast, redeems via the instance's own frontend —
+    no Universal Link funnel involved, since it's a browser-side
+    service-worker flow scoped to whichever origin the recipient opens."""
+    tok = _create_token(auth_client)
+    resp = auth_client.post(
+        f"/v1/watch-tokens/{tok['id']}/channels",
+        json={"name": "browser", "destination_type": "web_push"},
+    )
+    assert resp.status_code == 201, resp.text
+    url = resp.json()["activation_url"]
+    assert "/notifications/redeem?" in url
+    assert "instance=" not in url
+
+
 def test_legacy_mobile_types_rejected(auth_client: httpx.Client):
     """fcm / apns_dev / apns_prod are no longer accepted at channel
     creation — clients should use mobile_push. The error message points

--- a/tests/test_notifications_mobile_dispatch.py
+++ b/tests/test_notifications_mobile_dispatch.py
@@ -160,7 +160,7 @@ def test_fan_out_to_all_fcm_devices(auth_client, monkeypatch):
 
     sent: list[str] = []
 
-    async def fake_send(*, device_token, title, body, event_id):
+    async def fake_send(*, device_token, title, body, event_id, **_):
         from sheaf.services.notifications.fcm import FcmSendResult
 
         sent.append(device_token)
@@ -181,7 +181,7 @@ def test_dead_token_evicted_from_account(auth_client, monkeypatch):
         devices=[("fcm", "fcm-good"), ("fcm", "fcm-dead")],
     )
 
-    async def fake_send(*, device_token, title, body, event_id):
+    async def fake_send(*, device_token, title, body, event_id, **_):
         from sheaf.services.notifications.fcm import FcmSendResult
 
         if device_token == "fcm-dead":
@@ -242,7 +242,7 @@ def test_all_transient_fails_transient(auth_client, monkeypatch):
         devices=[("fcm", "fcm-x"), ("fcm", "fcm-y")],
     )
 
-    async def fake_send(*, device_token, title, body, event_id):
+    async def fake_send(*, device_token, title, body, event_id, **_):
         from sheaf.services.notifications.fcm import FcmSendResult
 
         return FcmSendResult(transient=True, error="upstream 503")
@@ -271,13 +271,13 @@ def test_fan_out_rings_both_fcm_and_apns(auth_client, monkeypatch):
     fcm_sent: list[str] = []
     apns_sent: list[tuple[str, str]] = []
 
-    async def fake_fcm(*, device_token, title, body, event_id):
+    async def fake_fcm(*, device_token, title, body, event_id, **_):
         from sheaf.services.notifications.fcm import FcmSendResult
 
         fcm_sent.append(device_token)
         return FcmSendResult(ok=True)
 
-    async def fake_apns(*, platform, device_token, title, body, event_id):
+    async def fake_apns(*, platform, device_token, title, body, event_id, **_):
         from sheaf.services.notifications.apns import ApnsSendResult
 
         apns_sent.append((platform, device_token))
@@ -340,7 +340,7 @@ def test_disabled_devices_skipped(auth_client, monkeypatch):
 
     sent: list[str] = []
 
-    async def fake_fcm(*, device_token, title, body, event_id):
+    async def fake_fcm(*, device_token, title, body, event_id, **_):
         from sheaf.services.notifications.fcm import FcmSendResult
 
         sent.append(device_token)
@@ -353,3 +353,44 @@ def test_disabled_devices_skipped(auth_client, monkeypatch):
     assert sent == ["active-tok"], (
         f"muted device should be skipped, got sent={sent}"
     )
+
+
+def test_channel_metadata_threaded_to_send_to_token(auth_client, monkeypatch):
+    """Every dispatched push carries the originating channel's id, name,
+    and event_type so the Android client can route into a per-subscription
+    NotificationChannel rather than bucketing every push onto one fallback.
+    Regression test for the Android v0.1.11+ contract."""
+    channel_id, _ = _setup_channel_with_devices(
+        auth_client,
+        devices=[("fcm", "fcm-meta-A"), ("apns_prod", "apns-meta-B")],
+    )
+
+    fcm_calls: list[dict] = []
+    apns_calls: list[dict] = []
+
+    async def fake_fcm(**kwargs):
+        from sheaf.services.notifications.fcm import FcmSendResult
+
+        fcm_calls.append(kwargs)
+        return FcmSendResult(ok=True)
+
+    async def fake_apns(**kwargs):
+        from sheaf.services.notifications.apns import ApnsSendResult
+
+        apns_calls.append(kwargs)
+        return ApnsSendResult(ok=True)
+
+    monkeypatch.setattr("sheaf.services.notifications.fcm.send_to_token", fake_fcm)
+    monkeypatch.setattr("sheaf.services.notifications.apns.send_to_token", fake_apns)
+
+    result = asyncio.run(_run_dispatch(channel_id))
+    assert result.ok, result.error
+
+    for call in fcm_calls + apns_calls:
+        assert call["channel_id"] == str(channel_id), (
+            f"expected channel_id={channel_id!s}, got {call.get('channel_id')!r}"
+        )
+        # The channel's name is "phone" via _create_mobile_channel.
+        assert call["channel_name"] == "phone"
+        # event_type defaults to "front_change" on creation.
+        assert call["event_type"] == "front_change"

--- a/tests/test_notifications_mobile_dispatch.py
+++ b/tests/test_notifications_mobile_dispatch.py
@@ -1,9 +1,13 @@
 """Tests for the mobile-push dispatch handler (`_deliver_mobile_push`).
 
-These cover the orchestration logic — fan-out across an account's
-push_device_tokens, dead-row eviction, success / transient aggregation —
-by stubbing the FCM and APNs send_to_token primitives. The transport
-modules themselves get separate, narrower tests against a mocked httpx.
+The post-collapse fan-out: a single `mobile_push` channel iterates every
+`push_device_tokens` row matching the redeemed account, routing each row
+to FCM (Android) or APNs (iOS, sandbox vs prod per-token) by the device's
+own `platform` column. Channel never picks a platform — the channel is
+account-anchored and the devices carry the platform metadata.
+
+Stubs the FCM and APNs send_to_token primitives. The transport modules
+themselves get separate, narrower tests against a mocked httpx.
 """
 
 from __future__ import annotations
@@ -20,16 +24,14 @@ def _system_id(client: httpx.Client) -> str:
     return client.get("/v1/systems/me").json()["id"]
 
 
-def _create_token_and_channel(
-    client: httpx.Client, *, destination_type: str
-) -> tuple[str, str]:
+def _create_mobile_channel(client: httpx.Client) -> tuple[str, str]:
     sid = _system_id(client)
     tok = client.post(
         f"/v1/systems/{sid}/watch-tokens", json={"label": "x"}
     ).json()
     resp = client.post(
         f"/v1/watch-tokens/{tok['id']}/channels",
-        json={"name": "phone", "destination_type": destination_type},
+        json={"name": "phone", "destination_type": "mobile_push"},
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
@@ -40,12 +42,14 @@ def _create_token_and_channel(
 
 
 def _redeem_and_register_devices(
-    *, code: str, email: str, platform: str, device_tokens: list[str]
+    *,
+    code: str,
+    email: str,
+    devices: list[tuple[str, str]],
 ) -> None:
-    """Single-client flow: register a user (sets session cookie + bearer
-    on the client), redeem the activation code (uses the cookie), then
-    register the device tokens (uses the bearer). The redemption-time
-    session check is what forces a single-client setup here."""
+    """Register a recipient, redeem the activation code, register the
+    given (platform, token) device pairs. The redemption-time session
+    check is what forces a single-client setup here."""
     with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as c:
         reg = c.post(
             "/v1/auth/register",
@@ -53,10 +57,9 @@ def _redeem_and_register_devices(
         )
         assert reg.status_code == 201, reg.text
         c.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
-        # Redeem (uses session cookie set by register).
         red = c.post("/v1/notifications/redeem", json={"activation_code": code})
         assert red.status_code == 200, red.text
-        for tok in device_tokens:
+        for platform, tok in devices:
             r = c.post(
                 "/v1/devices/push",
                 json={
@@ -68,30 +71,18 @@ def _redeem_and_register_devices(
             assert r.status_code == 200, r.text
 
 
-# --- Unit tests on _deliver_mobile_push -----------------------------------
-
-
 def _setup_channel_with_devices(
     auth_client: httpx.Client,
     *,
-    destination_type: str,
-    platform: str,
-    device_tokens: list[str],
+    devices: list[tuple[str, str]],
 ) -> tuple[uuid.UUID, uuid.UUID]:
-    """Register a recipient, redeem a channel for them, register N
-    devices. Returns (channel_id, recipient_user_id)."""
-    channel_id, code = _create_token_and_channel(
-        auth_client, destination_type=destination_type
-    )
+    """Returns (channel_id, recipient_user_id)."""
+    channel_id, code = _create_mobile_channel(auth_client)
     recipient_email = f"recipient-{uuid.uuid4().hex[:8]}@sheaf.dev"
     _redeem_and_register_devices(
-        code=code,
-        email=recipient_email,
-        platform=platform,
-        device_tokens=device_tokens,
+        code=code, email=recipient_email, devices=devices
     )
 
-    # Look up the recipient user_id for the test's later use.
     from sheaf.crypto import blind_index
 
     async def _lookup() -> uuid.UUID:
@@ -108,7 +99,9 @@ def _setup_channel_with_devices(
         async with async_session() as db:
             user = (
                 await db.execute(
-                    select(User).where(User.email_hash == blind_index(recipient_email))
+                    select(User).where(
+                        User.email_hash == blind_index(recipient_email)
+                    )
                 )
             ).scalar_one()
         await engine.dispose()
@@ -118,11 +111,8 @@ def _setup_channel_with_devices(
     return uuid.UUID(channel_id), user_id
 
 
-async def _run_dispatch(
-    channel_id: uuid.UUID,
-) -> object:
-    """Invoke _deliver_mobile_push directly with a fresh DB session and
-    a synthetic RenderedMessage. Returns the DeliveryResult."""
+async def _run_dispatch(channel_id: uuid.UUID) -> object:
+    """Invoke _deliver_mobile_push directly with a fresh DB session."""
     from sqlalchemy import select
     from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
     from sqlalchemy.orm import sessionmaker
@@ -144,30 +134,28 @@ async def _run_dispatch(
                     )
                 )
             ).scalar_one()
-            platform = channel.destination_type
-            if platform == "fcm":
-                handler_platform = "fcm"
-            elif platform in {"apns_dev", "apns_prod"}:
-                handler_platform = platform
-            else:
-                pytest.fail(f"unexpected destination_type {platform}")
             return await _deliver_mobile_push(
                 channel,
                 RenderedMessage(title="hello", body="world"),
                 event_id=str(uuid.uuid4()),
                 db=db,
-                platform=handler_platform,
             )
     finally:
         await engine.dispose()
 
 
-def test_fcm_dispatch_fan_out_all_succeed(auth_client, monkeypatch):
+# --- Tests ----------------------------------------------------------------
+
+
+def test_fan_out_to_all_fcm_devices(auth_client, monkeypatch):
+    """All FCM devices on the account receive."""
     channel_id, _ = _setup_channel_with_devices(
         auth_client,
-        destination_type="fcm",
-        platform="fcm",
-        device_tokens=["fcm-tok-A", "fcm-tok-B", "fcm-tok-C"],
+        devices=[
+            ("fcm", "fcm-tok-A"),
+            ("fcm", "fcm-tok-B"),
+            ("fcm", "fcm-tok-C"),
+        ],
     )
 
     sent: list[str] = []
@@ -185,12 +173,12 @@ def test_fcm_dispatch_fan_out_all_succeed(auth_client, monkeypatch):
     assert sorted(sent) == ["fcm-tok-A", "fcm-tok-B", "fcm-tok-C"]
 
 
-def test_fcm_dispatch_dead_token_evicted(auth_client, monkeypatch):
+def test_dead_token_evicted_from_account(auth_client, monkeypatch):
+    """A 410 / Unregistered response permanently drops the token row so
+    the next dispatch doesn't re-attempt it."""
     channel_id, recipient_id = _setup_channel_with_devices(
         auth_client,
-        destination_type="fcm",
-        platform="fcm",
-        device_tokens=["fcm-good", "fcm-dead"],
+        devices=[("fcm", "fcm-good"), ("fcm", "fcm-dead")],
     )
 
     async def fake_send(*, device_token, title, body, event_id):
@@ -201,11 +189,9 @@ def test_fcm_dispatch_dead_token_evicted(auth_client, monkeypatch):
         return FcmSendResult(ok=True)
 
     monkeypatch.setattr("sheaf.services.notifications.fcm.send_to_token", fake_send)
-
     result = asyncio.run(_run_dispatch(channel_id))
     assert result.ok, result.error
 
-    # The dead row was deleted in-line.
     async def _remaining() -> list[str]:
         from sqlalchemy import select
         from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -221,42 +207,39 @@ def test_fcm_dispatch_dead_token_evicted(auth_client, monkeypatch):
             rows = (
                 await db.execute(
                     select(PushDeviceToken.token).where(
-                        PushDeviceToken.account_id == recipient_id,
+                        PushDeviceToken.account_id == recipient_id
                     )
                 )
-            ).all()
+            ).scalars().all()
         await engine.dispose()
-        return sorted(r[0] for r in rows)
+        return sorted(rows)
 
     remaining = asyncio.run(_remaining())
     assert remaining == ["fcm-good"]
 
 
-def test_fcm_dispatch_no_devices_is_success(auth_client, monkeypatch):
-    """Channel with zero registered devices is success-with-no-effect,
-    not a failure."""
-    channel_id, _ = _setup_channel_with_devices(
-        auth_client,
-        destination_type="fcm",
-        platform="fcm",
-        device_tokens=[],
-    )
+def test_no_devices_is_success(auth_client, monkeypatch):
+    """Channel with zero registered devices is success-with-no-effect."""
+    channel_id, _ = _setup_channel_with_devices(auth_client, devices=[])
 
     async def fake_send(*args, **kwargs):
-        pytest.fail("send_to_token should not be invoked when there are no devices")
+        pytest.fail(
+            "send_to_token should not be invoked when there are no devices"
+        )
 
     monkeypatch.setattr("sheaf.services.notifications.fcm.send_to_token", fake_send)
+    monkeypatch.setattr("sheaf.services.notifications.apns.send_to_token", fake_send)
 
     result = asyncio.run(_run_dispatch(channel_id))
     assert result.ok, result.error
 
 
-def test_fcm_dispatch_all_transient_fails_transient(auth_client, monkeypatch):
+def test_all_transient_fails_transient(auth_client, monkeypatch):
+    """If every device returns transient, the channel result is transient
+    so the dispatcher retries later."""
     channel_id, _ = _setup_channel_with_devices(
         auth_client,
-        destination_type="fcm",
-        platform="fcm",
-        device_tokens=["fcm-x", "fcm-y"],
+        devices=[("fcm", "fcm-x"), ("fcm", "fcm-y")],
     )
 
     async def fake_send(*, device_token, title, body, event_id):
@@ -272,25 +255,55 @@ def test_fcm_dispatch_all_transient_fails_transient(auth_client, monkeypatch):
     assert "503" in (result.error or "")
 
 
-def test_apns_dispatch_routes_per_platform(auth_client, monkeypatch):
-    """apns_dev channel only fans out to apns_dev tokens, not apns_prod
-    tokens (or vice versa). Cross-platform routing matters because dev
-    tokens delivered to the prod host would bounce."""
-    # Set up an apns_dev channel + two apns_dev devices on the recipient.
+def test_fan_out_rings_both_fcm_and_apns(auth_client, monkeypatch):
+    """One mobile_push channel rings every device on the account,
+    regardless of platform. Replaces the old per-channel-platform
+    routing — the account is the routing key now."""
+    channel_id, _ = _setup_channel_with_devices(
+        auth_client,
+        devices=[
+            ("fcm", "android-A"),
+            ("fcm", "android-B"),
+            ("apns_prod", "iphone-X"),
+        ],
+    )
+
+    fcm_sent: list[str] = []
+    apns_sent: list[tuple[str, str]] = []
+
+    async def fake_fcm(*, device_token, title, body, event_id):
+        from sheaf.services.notifications.fcm import FcmSendResult
+
+        fcm_sent.append(device_token)
+        return FcmSendResult(ok=True)
+
+    async def fake_apns(*, platform, device_token, title, body, event_id):
+        from sheaf.services.notifications.apns import ApnsSendResult
+
+        apns_sent.append((platform, device_token))
+        return ApnsSendResult(ok=True)
+
+    monkeypatch.setattr("sheaf.services.notifications.fcm.send_to_token", fake_fcm)
+    monkeypatch.setattr("sheaf.services.notifications.apns.send_to_token", fake_apns)
+
+    result = asyncio.run(_run_dispatch(channel_id))
+    assert result.ok, result.error
+    assert sorted(fcm_sent) == ["android-A", "android-B"]
+    assert apns_sent == [("apns_prod", "iphone-X")]
+
+
+def test_disabled_devices_skipped(auth_client, monkeypatch):
+    """A device with enabled=False is excluded from fan-out so the
+    recipient can soft-mute a single device without unregistering it."""
     channel_id, recipient_id = _setup_channel_with_devices(
         auth_client,
-        destination_type="apns_dev",
-        platform="apns_dev",
-        device_tokens=["apns-dev-A", "apns-dev-B"],
+        devices=[("fcm", "active-tok"), ("fcm", "muted-tok")],
     )
-    # Also register an apns_prod device on the same recipient to confirm
-    # the apns_dev channel ignores it. The API path would require
-    # re-authenticating the recipient's session (we discarded the client
-    # after _setup_channel_with_devices), so we insert via the DB
-    # directly — same end state, less ceremony.
-    async def _insert_extra() -> None:
-        from datetime import UTC, datetime
 
+    # Flip the muted device's `enabled` to False directly via DB; the
+    # API path is exercised separately in test_devices.py.
+    async def _mute() -> None:
+        from sqlalchemy import select, update
         from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
         from sqlalchemy.orm import sessionmaker
 
@@ -301,35 +314,42 @@ def test_apns_dispatch_routes_per_platform(auth_client, monkeypatch):
             engine, class_=AsyncSession, expire_on_commit=False
         )
         async with async_session() as db:
-            db.add(
-                PushDeviceToken(
-                    id=uuid.uuid4(),
-                    account_id=recipient_id,
-                    platform="apns_prod",
-                    token="apns-prod-X",
-                    install_id="prod-X",
-                    last_seen_at=datetime.now(UTC),
+            await db.execute(
+                update(PushDeviceToken)
+                .where(
+                    PushDeviceToken.account_id == recipient_id,
+                    PushDeviceToken.token == "muted-tok",
                 )
+                .values(enabled=False)
             )
             await db.commit()
+            # Sanity: confirm the row still exists.
+            row = (
+                await db.execute(
+                    select(PushDeviceToken).where(
+                        PushDeviceToken.account_id == recipient_id,
+                        PushDeviceToken.token == "muted-tok",
+                    )
+                )
+            ).scalar_one_or_none()
+            assert row is not None
+            assert row.enabled is False
         await engine.dispose()
 
-    asyncio.run(_insert_extra())
+    asyncio.run(_mute())
 
-    sent: list[tuple[str, str]] = []
+    sent: list[str] = []
 
-    async def fake_apns(*, platform, device_token, title, body, event_id):
-        from sheaf.services.notifications.apns import ApnsSendResult
+    async def fake_fcm(*, device_token, title, body, event_id):
+        from sheaf.services.notifications.fcm import FcmSendResult
 
-        sent.append((platform, device_token))
-        return ApnsSendResult(ok=True)
+        sent.append(device_token)
+        return FcmSendResult(ok=True)
 
-    monkeypatch.setattr("sheaf.services.notifications.apns.send_to_token", fake_apns)
+    monkeypatch.setattr("sheaf.services.notifications.fcm.send_to_token", fake_fcm)
 
     result = asyncio.run(_run_dispatch(channel_id))
     assert result.ok, result.error
-    # Only the two dev tokens were used; the prod one was filtered out.
-    assert {(p, t) for p, t in sent} == {
-        ("apns_dev", "apns-dev-A"),
-        ("apns_dev", "apns-dev-B"),
-    }
+    assert sent == ["active-tok"], (
+        f"muted device should be skipped, got sent={sent}"
+    )

--- a/tests/test_notifications_mobile_transport.py
+++ b/tests/test_notifications_mobile_transport.py
@@ -111,6 +111,9 @@ async def test_fcm_send_success(fcm_settings, monkeypatch):
         title="hi",
         body="there",
         event_id="evt-1",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.ok, result.error
 
@@ -134,6 +137,9 @@ async def test_fcm_send_404_unregistered_marks_dead(fcm_settings, monkeypatch):
         title="x",
         body="y",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.dead
     assert not result.ok
@@ -158,6 +164,9 @@ async def test_fcm_send_5xx_marks_transient(fcm_settings, monkeypatch):
         title="x",
         body="y",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.transient
     assert not result.ok
@@ -173,7 +182,13 @@ async def test_fcm_unconfigured_returns_transient(monkeypatch):
     fcm._reset_cache_for_tests()
 
     result = await fcm.send_to_token(
-        device_token="x", title="t", body="b", event_id="e"
+        device_token="x",
+        title="t",
+        body="b",
+        event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.transient
     assert "FCM" in (result.error or "")
@@ -253,6 +268,9 @@ async def test_apns_dev_routes_to_sandbox_host(apns_settings, monkeypatch):
         title="t",
         body="b",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.ok, result.error
     assert "api.sandbox.push.apple.com" in captured_url[0]
@@ -292,6 +310,9 @@ async def test_apns_prod_routes_to_prod_host(apns_settings, monkeypatch):
         title="t",
         body="b",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.ok, result.error
     assert "api.push.apple.com" in captured_url[0]
@@ -310,6 +331,9 @@ async def test_apns_410_marks_dead(apns_settings, monkeypatch):
         title="t",
         body="b",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.dead
 
@@ -327,6 +351,9 @@ async def test_apns_400_bad_device_token_marks_dead(apns_settings, monkeypatch):
         title="t",
         body="b",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.dead
 
@@ -342,6 +369,9 @@ async def test_apns_5xx_marks_transient(apns_settings, monkeypatch):
         title="t",
         body="b",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert result.transient
 
@@ -393,6 +423,9 @@ async def test_apns_dev_uses_dev_bundle_when_set(monkeypatch):
         title="t",
         body="b",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     await send_to_token(
         platform="apns_prod",
@@ -400,6 +433,9 @@ async def test_apns_dev_uses_dev_bundle_when_set(monkeypatch):
         title="t",
         body="b",
         event_id="e",
+        channel_id="ch-1",
+        channel_name="test",
+        event_type="front_change",
     )
     assert captured[0]["apns-topic"] == "com.example.sheaf.dev"
     assert captured[1]["apns-topic"] == "com.example.sheaf"

--- a/web/src/components/notifications/destination-icon.tsx
+++ b/web/src/components/notifications/destination-icon.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { Apple, Bell, Globe, MessageSquare, Smartphone, Webhook } from "lucide-react";
+import { Bell, Globe, MessageSquare, Smartphone, Webhook } from "lucide-react";
 
 import type { DestinationType } from "@/types/api";
 
@@ -8,9 +8,12 @@ const icons: Record<DestinationType, ComponentType<{ className?: string }>> = {
   webhook: Webhook,
   ntfy: MessageSquare,
   pushover: Globe,
+  mobile_push: Smartphone,
+  // Legacy mobile types — same icon since the recipient experience is
+  // identical now.
   fcm: Smartphone,
-  apns_dev: Apple,
-  apns_prod: Apple,
+  apns_dev: Smartphone,
+  apns_prod: Smartphone,
 };
 
 export function DestinationIcon({

--- a/web/src/components/notifications/destination-meta.ts
+++ b/web/src/components/notifications/destination-meta.ts
@@ -5,9 +5,11 @@ const labels: Record<DestinationType, string> = {
   webhook: "Webhook",
   ntfy: "ntfy",
   pushover: "Pushover",
-  fcm: "Android push",
-  apns_dev: "iOS push (dev)",
-  apns_prod: "iOS push",
+  mobile_push: "Mobile push",
+  // Legacy labels — still rendered if a pre-migration row leaks through.
+  fcm: "Mobile push (Android, legacy)",
+  apns_dev: "Mobile push (iOS dev, legacy)",
+  apns_prod: "Mobile push (iOS, legacy)",
 };
 
 export function destinationLabel(type: DestinationType): string {

--- a/web/src/components/notifications/device-list.tsx
+++ b/web/src/components/notifications/device-list.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Pencil, Smartphone, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  deletePushDevice,
+  listPushDevices,
+  updatePushDevice,
+  type PushDevice,
+} from "@/lib/devices";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+
+const PLATFORM_LABELS: Record<PushDevice["platform"], string> = {
+  fcm: "Android",
+  apns_prod: "iOS",
+  apns_dev: "iOS (dev)",
+};
+
+function deviceDisplayName(d: PushDevice): string {
+  if (d.label) return d.label;
+  const plat = PLATFORM_LABELS[d.platform] ?? d.platform;
+  // install_id is opaque but a 6-char prefix is enough to distinguish
+  // multiple unlabeled devices of the same platform.
+  const tail = d.install_id ? ` (${d.install_id.slice(0, 6)})` : "";
+  return `${plat} device${tail}`;
+}
+
+function relativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const secs = Math.max(0, Math.round((now - then) / 1000));
+  if (secs < 60) return "just now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+export function DeviceList() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ["push-devices"],
+    queryFn: listPushDevices,
+  });
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+
+  const patch = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: { enabled?: boolean; label?: string | null } }) =>
+      updatePushDevice(id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["push-devices"] });
+    },
+  });
+  const drop = useMutation({
+    mutationFn: deletePushDevice,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["push-devices"] });
+      toast.success("Device removed");
+    },
+  });
+
+  function commitRename(d: PushDevice) {
+    const next = editValue.trim();
+    if (next === (d.label ?? "")) {
+      setEditingId(null);
+      return;
+    }
+    patch.mutate(
+      { id: d.id, body: { label: next || null } },
+      {
+        onSuccess: () => setEditingId(null),
+      },
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Your devices</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {[1, 2].map((i) => (
+            <Skeleton key={i} className="h-12" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    // No registered devices yet — don't render the card at all. The
+    // mobile app populates this on first sign-in; nothing to manage
+    // until then.
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <Smartphone className="size-4" />
+          Your devices
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-xs text-muted-foreground">
+          Mobile push channels ring every device you've signed into. Toggle
+          one off to mute it without unregistering (e.g. silence the work
+          phone over the weekend). Remove a device to drop its registration
+          entirely.
+        </p>
+        <ul className="divide-y rounded-md border">
+          {data.map((d) => (
+            <li
+              key={d.id}
+              className="flex flex-wrap items-center gap-3 p-3 text-sm"
+            >
+              <div className="min-w-0 flex-1">
+                {editingId === d.id ? (
+                  <div className="flex items-center gap-2">
+                    <Input
+                      autoFocus
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitRename(d);
+                        if (e.key === "Escape") setEditingId(null);
+                      }}
+                      onBlur={() => commitRename(d)}
+                      maxLength={80}
+                      placeholder="Device name"
+                      className="h-8 max-w-[16rem]"
+                    />
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingId(d.id);
+                      setEditValue(d.label ?? "");
+                    }}
+                    className="text-left font-medium hover:underline"
+                    title="Rename device"
+                  >
+                    {deviceDisplayName(d)}
+                    <Pencil className="ml-1.5 inline size-3 text-muted-foreground" />
+                  </button>
+                )}
+                <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+                  <Badge variant="outline" className="font-normal">
+                    {PLATFORM_LABELS[d.platform] ?? d.platform}
+                  </Badge>
+                  <span>Last seen {relativeTime(d.last_seen_at)}</span>
+                  {!d.enabled && (
+                    <span className="text-amber-600 dark:text-amber-400">
+                      Muted
+                    </span>
+                  )}
+                </div>
+              </div>
+              <Checkbox
+                checked={d.enabled}
+                disabled={patch.isPending}
+                onCheckedChange={(v) =>
+                  patch.mutate({ id: d.id, body: { enabled: v === true } })
+                }
+                aria-label={d.enabled ? "Mute this device" : "Unmute this device"}
+              />
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-destructive-foreground"
+                disabled={drop.isPending}
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      `Remove "${deviceDisplayName(d)}" from your account? Push notifications will stop until you sign in on the device again.`,
+                    )
+                  ) {
+                    drop.mutate(d.id);
+                  }
+                }}
+                aria-label="Remove device"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/notifications/new-channel-dialog.tsx
+++ b/web/src/components/notifications/new-channel-dialog.tsx
@@ -135,9 +135,7 @@ export function NewChannelDialog({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="web_push">Web push (browser)</SelectItem>
-                <SelectItem value="fcm">Android push</SelectItem>
-                <SelectItem value="apns_prod">iOS push</SelectItem>
-                <SelectItem value="apns_dev">iOS push (dev build)</SelectItem>
+                <SelectItem value="mobile_push">Mobile push (iOS + Android)</SelectItem>
                 <SelectItem value="webhook">Webhook</SelectItem>
                 <SelectItem value="ntfy">ntfy</SelectItem>
                 <SelectItem value="pushover">Pushover</SelectItem>
@@ -296,14 +294,14 @@ export function NewChannelDialog({
             </p>
           )}
 
-          {(type === "fcm" || type === "apns_dev" || type === "apns_prod") && (
+          {type === "mobile_push" && (
             <p className="text-sm text-muted-foreground">
               You'll get a one-time activation link to send to the recipient.
               They open it on their phone (with the Sheaf app installed and
               signed in to their account), the app handles redemption, and
-              the channel becomes active. The recipient's account is bound
-              to the channel; deliveries go to whichever device they have
-              registered.
+              the channel becomes active. The link works on both iOS and
+              Android — one channel rings every device the recipient has
+              signed into.
             </p>
           )}
 

--- a/web/src/components/notifications/receiving-list.tsx
+++ b/web/src/components/notifications/receiving-list.tsx
@@ -12,11 +12,19 @@ import { DestinationIcon } from "./destination-icon";
 
 const STATE_LABELS: Record<string, { label: string; tone: string }> = {
   active: { label: "Active", tone: "text-emerald-600 dark:text-emerald-400" },
+  // For `disabled`, the receiving row decides between "Paused by sender"
+  // and "Unsubscribed" based on the paused_by_sender flag — this entry
+  // is the fallback for the recipient-initiated case.
   disabled: { label: "Unsubscribed", tone: "text-muted-foreground" },
   pending_registration: {
     label: "Pending",
     tone: "text-amber-600 dark:text-amber-400",
   },
+};
+
+const PAUSED_BY_SENDER_LABEL = {
+  label: "Paused by sender",
+  tone: "text-amber-600 dark:text-amber-400",
 };
 
 export function ReceivingList() {
@@ -64,10 +72,13 @@ function ReceivingRow({
   channel: ReceivingChannelView;
   onUnsubscribe: (channelId: string) => void;
 }) {
-  const state = STATE_LABELS[channel.destination_state] ?? {
-    label: channel.destination_state,
-    tone: "text-muted-foreground",
-  };
+  const state =
+    channel.destination_state === "disabled" && channel.paused_by_sender
+      ? PAUSED_BY_SENDER_LABEL
+      : (STATE_LABELS[channel.destination_state] ?? {
+          label: channel.destination_state,
+          tone: "text-muted-foreground",
+        });
   return (
     <Card>
       <CardContent className="flex items-center gap-4 p-4">

--- a/web/src/lib/devices.ts
+++ b/web/src/lib/devices.ts
@@ -1,0 +1,34 @@
+import { apiFetch } from "./api-client";
+
+export type PushPlatform = "fcm" | "apns_dev" | "apns_prod";
+
+export interface PushDevice {
+  id: string;
+  platform: PushPlatform;
+  label: string | null;
+  enabled: boolean;
+  install_id: string | null;
+  app_version: string | null;
+  last_seen_at: string;
+  created_at: string;
+}
+
+export interface PushDeviceUpdate {
+  enabled?: boolean;
+  label?: string | null;
+}
+
+export function listPushDevices() {
+  return apiFetch<PushDevice[]>("/v1/devices/push");
+}
+
+export function updatePushDevice(id: string, body: PushDeviceUpdate) {
+  return apiFetch<PushDevice>(`/v1/devices/push/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export function deletePushDevice(id: string) {
+  return apiFetch<void>(`/v1/devices/push/${id}`, { method: "DELETE" });
+}

--- a/web/src/routes/notifications.manage.$mgmtToken.tsx
+++ b/web/src/routes/notifications.manage.$mgmtToken.tsx
@@ -91,8 +91,15 @@ export function NotificationsManagePage() {
 
               <div className="rounded border bg-muted/30 px-3 py-2 text-sm">
                 Status:{" "}
-                <strong className="capitalize">
-                  {view.destination_state.replace("_", " ")}
+                <strong>
+                  {view.destination_state === "disabled" &&
+                  view.paused_by_sender
+                    ? "Paused by sender"
+                    : view.destination_state === "disabled"
+                      ? "Unsubscribed"
+                      : view.destination_state
+                          .replace("_", " ")
+                          .replace(/^./, (c) => c.toUpperCase())}
                 </strong>
               </div>
 
@@ -105,6 +112,13 @@ export function NotificationsManagePage() {
                 >
                   {unsubscribing ? "Unsubscribing..." : "Unsubscribe"}
                 </Button>
+              ) : view.destination_state === "disabled" &&
+                view.paused_by_sender ? (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                  The sender has paused this channel. You'll start receiving
+                  again automatically if they resume it. To opt out
+                  permanently, ask them to remove you.
+                </p>
               ) : (
                 <p className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Check className="h-4 w-4 text-emerald-500" />

--- a/web/src/routes/notifications.redeem.tsx
+++ b/web/src/routes/notifications.redeem.tsx
@@ -26,6 +26,8 @@ type Phase =
   | { kind: "error"; message: string };
 
 const MOBILE_DESTINATION_TYPES = new Set<DestinationType>([
+  "mobile_push",
+  // Legacy types kept for read-back of any pre-migration link.
   "fcm",
   "apns_dev",
   "apns_prod",

--- a/web/src/routes/notifications.tsx
+++ b/web/src/routes/notifications.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { PageHeader } from "@/components/page-header";
+import { DeviceList } from "@/components/notifications/device-list";
 import { ReceivingList } from "@/components/notifications/receiving-list";
 import { WatchTokenCard } from "@/components/notifications/watch-token-card";
 import { Button } from "@/components/ui/button";
@@ -119,13 +120,14 @@ export function NotificationsPage() {
           )}
         </TabsContent>
 
-        <TabsContent value="receiving" className="mt-4">
-          <p className="text-sm text-muted-foreground mb-4 max-w-prose">
+        <TabsContent value="receiving" className="mt-4 space-y-4">
+          <p className="text-sm text-muted-foreground max-w-prose">
             Notifications you receive from other systems. Channels show up
             here when you redeem an activation link while signed in to your
             account &mdash; the owner sees you as a recipient and you can
             manage everything from one place.
           </p>
+          <DeviceList />
           <ReceivingList />
         </TabsContent>
       </Tabs>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -565,6 +565,9 @@ export type DestinationType =
   | "webhook"
   | "ntfy"
   | "pushover"
+  | "mobile_push"
+  // Legacy mobile types kept so the type covers any pre-migration row that
+  // somehow survives. Channel creation no longer produces these.
   | "fcm"
   | "apns_dev"
   | "apns_prod";
@@ -714,6 +717,10 @@ export interface ManageChannelView {
   system_label: string | null;
   destination_type: string;
   destination_state: string;
+  /** True when the channel was disabled by the owner pausing it (not the
+   *  recipient unsubscribing). Lets the recipient UI render "Paused by
+   *  sender" instead of "Unsubscribed". */
+  paused_by_sender: boolean;
 }
 
 export interface ReceivingChannelView {
@@ -722,6 +729,8 @@ export interface ReceivingChannelView {
   system_label: string | null;
   destination_type: string;
   destination_state: string;
+  /** See ManageChannelView.paused_by_sender. */
+  paused_by_sender: boolean;
   redeemed_at: string | null;
   last_delivered_at: string | null;
 }


### PR DESCRIPTION
## Summary

- Collapses `fcm` / `apns_dev` / `apns_prod` into a single `mobile_push` destination type that fans out across every device on the redeemer's account. Legacy types stay readable in the enum for historical rows; channel creation refuses them with a pointer at `mobile_push`. Migration `f2g3h4i5j6k7` rewrites any existing rows.
- Adds device-list management on the Receiving tab: registered devices can be renamed, soft-muted via `enabled=false`, or removed individually. Backed by a new `PATCH /v1/devices/push/{id}` endpoint; the existing token-based DELETE stays for logout-time cleanup.
- `paused_by_sender` on `notification_channels` so the recipient UI can render "Paused by sender" instead of the misleading "Unsubscribed" when the owner pauses a channel.
- Routes `mobile_push` activation URLs through a configurable shared host (default `https://sheaf.sh`, override via `MOBILE_LINK_BASE_URL`). The app's associated-domains entitlement is baked in at build time so it can only trust one host; the URL carries `instance=` as a query param so after the OS intercepts, the app calls the originating instance's redemption endpoint. `web_push` activation URLs are unaffected.
- FCM and APNs payloads now carry the originating `channel_id`, `channel_name`, and `event_type` so the Android v0.1.11+ client can route into per-subscription `NotificationChannel`s (mute "Alice's fronts" without muting them all). iOS additionally gets `aps.thread-id` for tray grouping.

Migrations chain off the current head `e1f2g3h4i5j6`:
- `f2g3h4i5j6k7` collapse legacy mobile destination types to `mobile_push`
- `g3h4i5j6k7l8` add `enabled` + `label` to `push_device_tokens`
- `h4i5j6k7l8m9` add `paused_by_sender` to `notification_channels`

The matching iOS / Android Universal Link / App Link manifests are landing under `/.well-known/` on `sheaf.sh` in a separate website commit.

## Test plan

- [x] `alembic upgrade head` against an existing db with legacy `fcm` / `apns_*` channel rows: they end up as `mobile_push`, no orphaned references.
- [x] `POST /v1/watch-tokens/{id}/channels` with `destination_type=mobile_push` returns 201 + an `activation_url` whose host is the configured `MOBILE_LINK_BASE_URL` and whose query includes `code=`, `channel=`, and a url-encoded `instance=`.
- [x] `POST /v1/watch-tokens/{id}/channels` with `destination_type=web_push` still returns an activation URL on the instance's own frontend (no `instance=` query param).
- [x] `POST /v1/watch-tokens/{id}/channels` with `destination_type=fcm` (or `apns_*`) is rejected with a 400 referencing `mobile_push`.
- [x] Redeem a `mobile_push` activation on a fresh account with two device tokens registered (one fcm, one apns_prod): dispatcher fan-out reaches both.
- [ ] Inspect a dispatched FCM `data` block: contains `channel_id`, `channel_name`, `event_type` alongside `title` / `body` / `event_id`.
- [ ] Inspect a dispatched APNs payload: `aps.thread-id == channel_id` and the `data` block matches the FCM shape.
- [ ] Receiving tab: rename a device, toggle `enabled` off, send a test push -> the disabled device is skipped. Re-enable -> next push reaches it.
- [ ] Owner pause: disable a channel on the owner side -> recipient `/notifications/manage/{token}` view reads "Paused by sender" rather than "Unsubscribed". Re-enable -> reverts.

All 50 backend mobile-push tests pass (`tests/test_notifications_mobile{,_dispatch,_transport}.py` + `tests/test_notifications_api.py`).