### PR TITLE
Retry transient cosign signing failures in CI

### DIFF
--- a/.github/scripts/with-retry.sh
+++ b/.github/scripts/with-retry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run a command with bounded retries + exponential backoff.
+#
+# Used by CI to wrap cosign sign / attest calls. The GitHub Actions OIDC
+# token endpoint occasionally returns a non-JSON error body under load,
+# which cosign surfaces as "invalid character 'u' looking for beginning
+# of value" and fails the job outright. The signing operation itself is
+# idempotent at the registry layer (same digest, same identity, same
+# annotations), so a blind retry is safe.
+#
+# Usage:  ./with-retry.sh <command> [args...]
+# Tuning: WITH_RETRY_MAX_ATTEMPTS (default 4), WITH_RETRY_INITIAL_DELAY_S
+#         (default 5). Delay doubles between attempts.
+
+set -u
+
+max_attempts="${WITH_RETRY_MAX_ATTEMPTS:-4}"
+delay="${WITH_RETRY_INITIAL_DELAY_S:-5}"
+attempt=1
+
+while true; do
+    # Capture the command's exit code directly. Using `if "$@"; then` would
+    # clobber $? because the `if` construct itself completes successfully.
+    "$@"
+    rc=$?
+    if (( rc == 0 )); then
+        exit 0
+    fi
+    if (( attempt >= max_attempts )); then
+        echo "::error::command failed after ${attempt} attempts (rc=${rc}): $*"
+        exit "$rc"
+    fi
+    echo "::warning::attempt ${attempt}/${max_attempts} failed (rc=${rc}), retrying in ${delay}s: $*"
+    sleep "$delay"
+    delay=$(( delay * 2 ))
+    attempt=$(( attempt + 1 ))
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,13 @@ jobs:
 
       # Sign by digest. cosign stores the signature at <repo>:sha256-DIGEST.sig
       # so a single sign call covers every tag pointing at the same digest.
+      # The retry wrapper covers the GH Actions OIDC token endpoint flaking
+      # under load - signing is idempotent at the registry layer.
       - name: Sign image
         env:
           REF: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes \
+          ./.github/scripts/with-retry.sh cosign sign --yes \
             -a "git_sha=${{ github.sha }}" \
             -a "git_ref=${{ github.ref }}" \
             -a "workflow=${{ github.workflow }}" \
@@ -174,7 +176,7 @@ jobs:
         env:
           REF: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
         run: |
-          cosign attest --yes \
+          ./.github/scripts/with-retry.sh cosign attest --yes \
             --predicate sbom.spdx.json \
             --type spdxjson \
             "$REF"
@@ -207,7 +209,7 @@ jobs:
         env:
           REF: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
         run: |
-          cosign attest --yes \
+          ./.github/scripts/with-retry.sh cosign attest --yes \
             --predicate web/dist/build-manifest.json \
             --type custom \
             "$REF"


### PR DESCRIPTION
The Sign image step on the sheaf-devtools build in run 25834858851 failed at the keyless OIDC handshake with 'invalid character u looking for beginning of value' - Go JSON decoder's way of saying the GH Actions OIDC token endpoint returned a plain-text error instead of a JSON token. The other two matrix jobs in the same run succeeded at the same step with identical permissions, so this was a transient upstream hiccup, not a workflow bug. It's a known-flaky failure mode in the sigstore/cosign keyless flow under load.

Adds a small bash retry wrapper (.github/scripts/with-retry.sh) and threads cosign sign + both cosign attest calls through it. Up to 4 attempts with exponential backoff (5s, 10s, 20s). Signing and SBOM / manifest attestation are all idempotent at the registry layer - same digest, same identity, same annotations - so blind retries are safe.

Surfaces each failed attempt as a workflow ::warning:: so transient blips stay visible in the run summary instead of disappearing into 'eventually succeeded' silence.

tl;dr: AAAAAAAAAAAAAAAAAAAA

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of the main changes -->

-
-

## Testing

<!-- How was this tested? -->

- [ ] `ruff check sheaf/` passes
- [ ] `cd web && npm run lint && npx tsc --noEmit` passes
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Tested manually

## Security / privacy impact

<!--
Sheaf handles GDPR Article 9 data. If this PR touches authentication,
authorisation, encryption, data storage, or anything user-facing, describe
the impact here. Otherwise, write "none".
-->

## Screenshots

<!-- If this changes the UI, include before/after screenshots -->
