### PR TITLE
Async import job runner: PluralKit / Tupperbox / SimplyPlural / Sheaf

### DIFF
--- a/alembic/versions/i5j6k7l8m9n0_add_import_jobs.py
+++ b/alembic/versions/i5j6k7l8m9n0_add_import_jobs.py
@@ -1,0 +1,113 @@
+"""Add import_jobs table
+
+Revision ID: i5j6k7l8m9n0
+Revises: h4i5j6k7l8m9
+Create Date: 2026-05-13
+
+Moves all importers (PluralKit file, PluralKit API, Tupperbox,
+SimplyPlural, Sheaf native re-import) onto the async job runner.
+Replaces fire-and-forget inline result objects with a persisted job
+row that the user can poll, surfacing structured counts + per-record
+events in the UI rather than disappearing on response.
+
+Idempotency-key uniqueness per user catches the double-click case
+where the same upload was POSTed twice in quick succession; the
+second submission returns the original job row rather than starting
+a second concurrent import.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "i5j6k7l8m9n0"
+down_revision = "h4i5j6k7l8m9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "import_jobs",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String(32), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("idempotency_key", sa.String(64), nullable=False),
+        sa.Column("payload_storage_key", sa.String(256), nullable=True),
+        sa.Column("payload_metadata", postgresql.JSONB, nullable=True),
+        sa.Column(
+            "counts",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "events",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claimed_by", sa.String(64), nullable=True),
+        sa.Column(
+            "failed_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "user_id", "idempotency_key", name="uq_import_jobs_user_idempotency"
+        ),
+    )
+    op.create_index("ix_import_jobs_user_id", "import_jobs", ["user_id"])
+    op.create_index(
+        "ix_import_jobs_pending",
+        "import_jobs",
+        ["created_at"],
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+    op.create_index(
+        "ix_import_jobs_user_history",
+        "import_jobs",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_import_jobs_user_history", table_name="import_jobs")
+    op.drop_index("ix_import_jobs_pending", table_name="import_jobs")
+    op.drop_index("ix_import_jobs_user_id", table_name="import_jobs")
+    op.drop_table("import_jobs")

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -36,6 +36,11 @@ services:
       # sandbox tokens). The test stack mimics a dev/staging deploy by
       # flipping it on so apns_dev paths get exercised.
       APNS_DEV_ENABLED: "true"
+      # Import-runner background loop OFF in the test stack: the
+      # import-runner tests drive the runner manually (often with a
+      # stubbed PK API). A live loop would race them and process a job
+      # with the real handler before the stubbed drive gets to it.
+      IMPORT_RUNNER_ENABLED: "false"
     volumes: []
     depends_on:
       db:

--- a/sheaf/api/v1/imports.py
+++ b/sheaf/api/v1/imports.py
@@ -1,0 +1,327 @@
+"""Unified import endpoints.
+
+All four importer flavours (PluralKit file, PluralKit API, Tupperbox,
+SimplyPlural, Sheaf native re-import) enqueue through this router and
+get processed asynchronously by the import job runner. The user then
+polls `/v1/imports/{id}` to watch progress and read the per-record
+report.
+
+The legacy per-source endpoints (under `/v1/import/...`) are scheduled
+for removal in a later phase; see migration notes in the design doc.
+For now they exist side by side, with the legacy ones marked
+deprecated and the recommended path going through this router.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile, status
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_current_user
+from sheaf.crypto import encrypt
+from sheaf.database import get_db
+from sheaf.models.import_job import ImportJob, ImportJobStatus
+from sheaf.models.user import User
+from sheaf.schemas.imports import (
+    ImportApiCreateRequest,
+    ImportFileCreateRequest,
+    ImportJobList,
+    ImportJobRead,
+    ImportJobSummary,
+)
+from sheaf.services.import_storage import make_payload_key, put_payload
+
+logger = logging.getLogger("sheaf.imports.api")
+
+router = APIRouter(prefix="/imports", tags=["imports"])
+
+
+# Hard cap on uploaded file size. The global MaxBodySizeMiddleware
+# rejects oversize requests upstream of this handler, but enforcing
+# here too gives a clearer per-endpoint error than the generic 413.
+MAX_IMPORT_UPLOAD_BYTES = 100 * 1024 * 1024  # 100MB
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+async def _find_existing_idempotent(
+    db: AsyncSession, *, user_id: uuid.UUID, idempotency_key: uuid.UUID
+) -> ImportJob | None:
+    """Look up an existing job by (user, idempotency_key). The unique
+    constraint guarantees at most one match."""
+    stmt = select(ImportJob).where(
+        ImportJob.user_id == user_id,
+        ImportJob.idempotency_key == str(idempotency_key),
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def _load_owned_job(
+    db: AsyncSession, *, user_id: uuid.UUID, job_id: uuid.UUID
+) -> ImportJob:
+    job = await db.get(ImportJob, job_id)
+    if job is None or job.user_id != user_id:
+        # Same 404 either way — don't leak the existence of someone
+        # else's job ids.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Import job not found"
+        )
+    return job
+
+
+# --- POST endpoints ---------------------------------------------------------
+
+
+@router.post(
+    "/file",
+    response_model=ImportJobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_file_import(
+    file: Annotated[UploadFile, File()],
+    source: Annotated[str, Form()],
+    idempotency_key: Annotated[uuid.UUID, Form()],
+    options: Annotated[str | None, Form()] = None,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ImportJobRead:
+    """Enqueue a file-based import. Returns 202 + the newly-created
+    job row (or the existing one if `idempotency_key` matches).
+
+    The file is read into memory once, sanity-checked for size, and
+    handed to the storage backend under the imports/ prefix. The
+    runner picks the job up on its next tick and walks the payload.
+
+    `options` is a JSON-encoded form field — source-specific shape.
+    """
+    options_dict: dict | None = None
+    if options is not None and options.strip():
+        try:
+            options_dict = json.loads(options)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"options field is not valid JSON: {exc}",
+            ) from exc
+        if not isinstance(options_dict, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="options must be a JSON object",
+            )
+
+    try:
+        body = ImportFileCreateRequest(
+            source=source,  # type: ignore[arg-type]
+            idempotency_key=idempotency_key,
+            options=options_dict,
+        )
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()
+        ) from exc
+
+    # Idempotency: if the same (user, key) has been seen, return the
+    # existing job rather than creating a duplicate. This is the
+    # double-click defence.
+    existing = await _find_existing_idempotent(
+        db, user_id=user.id, idempotency_key=body.idempotency_key
+    )
+    if existing is not None:
+        return ImportJobRead.model_validate(existing)
+
+    data = await file.read()
+    if len(data) > MAX_IMPORT_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=(
+                f"Import file too large ({len(data)} bytes). "
+                f"Max {MAX_IMPORT_UPLOAD_BYTES} bytes."
+            ),
+        )
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Import file is empty.",
+        )
+
+    job_id = uuid.uuid4()
+    storage_key = make_payload_key(job_id, file.filename or "import")
+    # Default content-type for our known importer formats is JSON. The
+    # storage backend doesn't actually care — the type is metadata for
+    # operators inspecting the bucket.
+    await put_payload(storage_key, data, content_type="application/json")
+
+    job = ImportJob(
+        id=job_id,
+        user_id=user.id,
+        source=body.source.value,
+        status=ImportJobStatus.PENDING.value,
+        idempotency_key=str(body.idempotency_key),
+        payload_storage_key=storage_key,
+        payload_metadata={"options": body.options} if body.options is not None else None,
+        counts={},
+        events=[],
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    logger.info(
+        "import_job %s enqueued (source=%s, user=%s, size=%d)",
+        job.id,
+        job.source,
+        user.id,
+        len(data),
+    )
+    return ImportJobRead.model_validate(job)
+
+
+@router.post(
+    "/api",
+    response_model=ImportJobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_api_import(
+    body: ImportApiCreateRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ImportJobRead:
+    """Enqueue a credential-based import (currently PluralKit API).
+
+    The token is encrypted at rest in payload_metadata while the job
+    runs and gets wiped at finalize time, so a post-completion DB dump
+    can't leak it.
+    """
+    existing = await _find_existing_idempotent(
+        db, user_id=user.id, idempotency_key=body.idempotency_key
+    )
+    if existing is not None:
+        return ImportJobRead.model_validate(existing)
+
+    encrypted_token = encrypt(body.pk_token)
+
+    job = ImportJob(
+        user_id=user.id,
+        source=body.source.value,
+        status=ImportJobStatus.PENDING.value,
+        idempotency_key=str(body.idempotency_key),
+        payload_storage_key=None,
+        payload_metadata={
+            "encrypted_credential": encrypted_token,
+            "options": body.options if body.options is not None else {},
+        },
+        counts={},
+        events=[],
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    logger.info(
+        "import_job %s enqueued (source=%s, user=%s, credential-based)",
+        job.id,
+        job.source,
+        user.id,
+    )
+    return ImportJobRead.model_validate(job)
+
+
+# --- GET endpoints ----------------------------------------------------------
+
+
+@router.get("", response_model=ImportJobList)
+async def list_imports(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    limit: int = 25,
+    include_archived: bool = False,
+) -> ImportJobList:
+    """List the current user's imports, most-recent first.
+
+    Excludes archived rows by default — the UI shows them via a
+    separate "show archived" toggle.
+    """
+    if not 1 <= limit <= 100:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="limit must be between 1 and 100",
+        )
+    stmt = (
+        select(ImportJob)
+        .where(ImportJob.user_id == user.id)
+        .order_by(ImportJob.created_at.desc())
+        .limit(limit + 1)
+    )
+    if not include_archived:
+        stmt = stmt.where(ImportJob.archived_at.is_(None))
+    rows = list((await db.execute(stmt)).scalars().all())
+    next_cursor = None
+    if len(rows) > limit:
+        # Drop the trailing peek row and synthesize a continuation cursor
+        # from the last-included item's created_at. Keeping the cursor
+        # opaque (datetime ISO string is fine for v1) — the client doesn't
+        # interpret it.
+        rows = rows[:limit]
+        next_cursor = rows[-1].created_at.isoformat()
+    return ImportJobList(
+        items=[ImportJobSummary.model_validate(r) for r in rows],
+        next_cursor=next_cursor,
+    )
+
+
+@router.get("/{job_id}", response_model=ImportJobRead)
+async def get_import(
+    job_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ImportJobRead:
+    job = await _load_owned_job(db, user_id=user.id, job_id=job_id)
+    return ImportJobRead.model_validate(job)
+
+
+# --- DELETE ----------------------------------------------------------------
+
+
+@router.delete("/{job_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def cancel_or_archive_import(
+    job_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """For pending jobs: cancel before the runner picks them up.
+    For terminal jobs (complete / failed / cancelled): archive — they
+    drop out of the default history list. Running jobs can't be
+    cancelled mid-flight in v1; user has to wait for the runner to
+    finish or fail."""
+    job = await _load_owned_job(db, user_id=user.id, job_id=job_id)
+
+    if job.status == ImportJobStatus.PENDING.value:
+        job.status = ImportJobStatus.CANCELLED.value
+        job.finished_at = datetime.now(UTC)
+        await db.commit()
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    if job.status == ImportJobStatus.RUNNING.value:
+        # Mid-flight cancel needs a cooperative cancellation channel
+        # that we don't have in v1. Refuse rather than do something
+        # surprising — the runner will finish in seconds anyway.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Import is currently running and cannot be cancelled. "
+                "Wait for it to finish, then archive."
+            ),
+        )
+
+    # Terminal state: archive.
+    if job.archived_at is None:
+        job.archived_at = datetime.now(UTC)
+        await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/sheaf/api/v1/pk_import.py
+++ b/sheaf/api/v1/pk_import.py
@@ -100,6 +100,16 @@ async def preview_api_import(
         data = await fetch_export(body.token, include_switches=False)
         switch_sample, has_more = await fetch_switch_sample(body.token)
     except PKApiError as exc:
+        # Log so a PK outage / rate-limiting (as opposed to a user's bad
+        # token) is visible to operators. The token itself is never
+        # logged — only the status code (when it's an HTTP error) and
+        # the message.
+        where = (
+            f"HTTP {exc.status_code}"
+            if exc.status_code is not None
+            else "connection error"
+        )
+        logger.warning("PK API preview failed (%s): %s", where, exc)
         raise _api_error_to_http(exc) from exc
 
     data["switches"] = switch_sample

--- a/sheaf/api/v1/pk_import.py
+++ b/sheaf/api/v1/pk_import.py
@@ -1,14 +1,10 @@
-"""PluralKit data import endpoints.
+"""PluralKit import — preview endpoints.
 
-Two ingestion paths share a single importer:
-
-  - File: multipart upload of a PK data export JSON. Mirrors SP file import.
-  - API: JSON body containing the user's PK token. We forward the token
-    to PluralKit on a single round of requests, never log it, and never
-    persist it.
-
-Both paths use the same options/preview/result schemas because they
-produce the same canonical PK-shaped dict that the importer consumes.
+The actual import runs asynchronously through the unified job runner
+(POST /v1/imports/file or /v1/imports/api). What's left here is the
+synchronous *preview* step: parse an export (file or live API) and
+return a summary so the user can review + deselect members before
+enqueueing the real import. Preview does not write anything.
 """
 
 import json
@@ -16,18 +12,11 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
-from sheaf.database import get_db
-from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.pk_import import (
-    PKApiImportRequest,
     PKApiPreviewRequest,
-    PKImportOptions,
-    PKImportResult,
     PKPreviewSummary,
 )
 from sheaf.services.pk_api import (
@@ -36,7 +25,6 @@ from sheaf.services.pk_api import (
     fetch_switch_sample,
 )
 from sheaf.services.pk_import import preview as build_preview
-from sheaf.services.pk_import import run_import
 
 logger = logging.getLogger("sheaf.import.pk")
 
@@ -68,41 +56,15 @@ async def _parse_upload(file: UploadFile) -> dict[str, Any]:
     return parsed
 
 
-async def _get_system(user: User, db: AsyncSession) -> System:
-    result = await db.execute(select(System).where(System.user_id == user.id))
-    system = result.scalar_one_or_none()
-    if not system:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Create a system first.",
-        )
-    return system
-
-
-def _options_from_query(
-    system_profile: bool,
-    member_ids: str | None,
-    groups: bool,
-    front_history: bool,
-) -> PKImportOptions:
-    parsed_member_ids: list[str] | None = None
-    if member_ids is not None:
-        parsed_member_ids = [m.strip() for m in member_ids.split(",") if m.strip()]
-    return PKImportOptions(
-        system_profile=system_profile,
-        member_ids=parsed_member_ids,
-        groups=groups,
-        front_history=front_history,
-    )
-
-
 def _api_error_to_http(exc: PKApiError) -> HTTPException:
     if exc.status_code in (401, 403):
         return HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc))
     if exc.status_code == 404:
         return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     if exc.status_code == 429:
-        return HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc))
+        return HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc)
+        )
     return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
 
 
@@ -117,27 +79,6 @@ async def preview_file_import(
     """Parse a PK export file and return a summary."""
     data = await _parse_upload(file)
     return build_preview(data)
-
-
-@router.post("/pluralkit", response_model=PKImportResult)
-async def do_file_import(
-    file: UploadFile,
-    user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    system_profile: bool = True,
-    member_ids: str | None = None,
-    groups: bool = True,
-    front_history: bool = False,
-):
-    """Import data from a PluralKit export file.
-
-    Use the preview endpoint first to see what's in the file and to gather
-    HIDs for the optional member_ids parameter (comma-separated).
-    """
-    data = await _parse_upload(file)
-    system = await _get_system(user, db)
-    options = _options_from_query(system_profile, member_ids, groups, front_history)
-    return await run_import(data, options, system, db)
 
 
 # --- API path ----------------------------------------------------------------
@@ -170,23 +111,3 @@ async def preview_api_import(
         # Set the count to the page size; UI will format "100+".
         summary.switch_count = len(switch_sample)
     return summary
-
-
-@router.post("/pluralkit-api", response_model=PKImportResult)
-async def do_api_import(
-    body: PKApiImportRequest,
-    user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-):
-    """Import a system via the PluralKit API.
-
-    The token is forwarded for the duration of this request and then
-    discarded. Nothing about the token is persisted to the database.
-    """
-    try:
-        data = await fetch_export(body.token, include_switches=body.options.front_history)
-    except PKApiError as exc:
-        raise _api_error_to_http(exc) from exc
-
-    system = await _get_system(user, db)
-    return await run_import(data, body.options, system, db)

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -13,6 +13,7 @@ from sheaf.api.v1 import (
     files,
     fronts,
     groups,
+    imports,
     journals,
     members,
     messages,
@@ -115,6 +116,13 @@ v1_router.include_router(
 )
 v1_router.include_router(
     tb_import.router,
+    dependencies=[Depends(require_scope("import:write"))],
+)
+# Unified async-job import router. Replaces the per-source legacy
+# routes above incrementally — they coexist while the runners and
+# frontend are migrated.
+v1_router.include_router(
+    imports.router,
     dependencies=[Depends(require_scope("import:write"))],
 )
 v1_router.include_router(webhooks.router)

--- a/sheaf/api/v1/sheaf_import.py
+++ b/sheaf/api/v1/sheaf_import.py
@@ -1,16 +1,18 @@
-"""Sheaf data import endpoints."""
+"""Sheaf native re-import — preview endpoint.
+
+The actual import runs asynchronously through the unified job runner
+(POST /v1/imports/file). What's left here is the synchronous preview:
+parse a Sheaf export and return a summary of importable data. Preview
+writes nothing.
+"""
 
 import json
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
-from sheaf.database import get_db
-from sheaf.models.system import System
 from sheaf.models.user import User
-from sheaf.services.sheaf_import import preview, run_import
+from sheaf.services.sheaf_import import preview
 
 router = APIRouter(prefix="/import", tags=["import"])
 
@@ -40,10 +42,7 @@ async def _parse_upload(file: UploadFile) -> dict:
     # silently ignores extras, so accepting v2 is forward-compatible
     # without requiring per-field handlers for the not-yet-importable
     # surfaces. New format versions should be added here as they ship.
-    if (
-        not isinstance(parsed, dict)
-        or parsed.get("version") not in {"1", "2"}
-    ):
+    if not isinstance(parsed, dict) or parsed.get("version") not in {"1", "2"}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
@@ -52,17 +51,6 @@ async def _parse_upload(file: UploadFile) -> dict:
             ),
         )
     return parsed
-
-
-async def _get_system(user: User, db: AsyncSession) -> System:
-    result = await db.execute(select(System).where(System.user_id == user.id))
-    system = result.scalar_one_or_none()
-    if not system:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Create a system first.",
-        )
-    return system
 
 
 @router.post("/sheaf/preview")
@@ -81,51 +69,4 @@ async def preview_import(
         "group_count": p.group_count,
         "tag_count": p.tag_count,
         "custom_field_count": p.custom_field_count,
-    }
-
-
-@router.post("/sheaf")
-async def do_import(
-    file: UploadFile,
-    user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    system_profile: bool = True,
-    member_ids: str | None = None,
-    fronts: bool = True,
-    groups: bool = True,
-    tags: bool = True,
-    custom_fields: bool = True,
-):
-    """Import data from a Sheaf export file.
-
-    Upload the JSON export file with query parameters controlling what to import.
-    Use the preview endpoint first to see what's in the file and get member IDs
-    for selective import.
-    """
-    data = await _parse_upload(file)
-    system = await _get_system(user, db)
-
-    parsed_member_ids = None
-    if member_ids is not None:
-        parsed_member_ids = [mid.strip() for mid in member_ids.split(",") if mid.strip()]
-
-    result = await run_import(
-        data,
-        system,
-        db,
-        system_profile=system_profile,
-        member_ids=parsed_member_ids,
-        fronts=fronts,
-        groups=groups,
-        tags=tags,
-        custom_fields=custom_fields,
-    )
-
-    return {
-        "members_imported": result.members_imported,
-        "fronts_imported": result.fronts_imported,
-        "groups_imported": result.groups_imported,
-        "tags_imported": result.tags_imported,
-        "custom_fields_imported": result.custom_fields_imported,
-        "warnings": result.warnings,
     }

--- a/sheaf/api/v1/sp_import.py
+++ b/sheaf/api/v1/sp_import.py
@@ -1,17 +1,19 @@
-"""SimplyPlural data import endpoints."""
+"""SimplyPlural import — preview endpoint.
+
+The actual import runs asynchronously through the unified job runner
+(POST /v1/imports/file). What's left here is the synchronous preview:
+parse an SP export and return a summary of importable data. Preview
+writes nothing.
+"""
 
 import json
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
-from sheaf.database import get_db
-from sheaf.models.system import System
 from sheaf.models.user import User
-from sheaf.schemas.sp_import import SPImportOptions, SPImportResult, SPPreviewSummary
-from sheaf.services.sp_import import preview, run_import
+from sheaf.schemas.sp_import import SPPreviewSummary
+from sheaf.services.sp_import import preview
 
 router = APIRouter(prefix="/import", tags=["import"])
 
@@ -35,18 +37,6 @@ async def _parse_upload(file: UploadFile) -> dict:
         ) from exc
 
 
-async def _get_system(user: User, db: AsyncSession) -> System:
-    """Get the user's system, or 404."""
-    result = await db.execute(select(System).where(System.user_id == user.id))
-    system = result.scalar_one_or_none()
-    if not system:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Create a system first.",
-        )
-    return system
-
-
 @router.post("/simplyplural/preview", response_model=SPPreviewSummary)
 async def preview_import(
     file: UploadFile,
@@ -55,42 +45,3 @@ async def preview_import(
     """Parse an SP export file and return a summary of importable data."""
     data = await _parse_upload(file)
     return preview(data)
-
-
-@router.post("/simplyplural", response_model=SPImportResult)
-async def do_import(
-    file: UploadFile,
-    user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    system_profile: bool = True,
-    member_ids: str | None = None,  # Comma-separated SP member IDs, or omit for all
-    custom_fronts: bool = True,
-    custom_fields: bool = True,
-    groups: bool = True,
-    front_history: bool = False,
-    notes: bool = False,
-):
-    """Import data from a SimplyPlural export file.
-
-    Upload the JSON export file with query parameters controlling what to import.
-    Use the preview endpoint first to see what's in the file and get member IDs
-    for selective import.
-    """
-    data = await _parse_upload(file)
-    system = await _get_system(user, db)
-
-    parsed_member_ids = None
-    if member_ids is not None:
-        parsed_member_ids = [mid.strip() for mid in member_ids.split(",") if mid.strip()]
-
-    options = SPImportOptions(
-        system_profile=system_profile,
-        member_ids=parsed_member_ids,
-        custom_fronts=custom_fronts,
-        custom_fields=custom_fields,
-        groups=groups,
-        front_history=front_history,
-        notes=notes,
-    )
-
-    return await run_import(data, options, system, db)

--- a/sheaf/api/v1/tb_import.py
+++ b/sheaf/api/v1/tb_import.py
@@ -1,8 +1,9 @@
-"""Tupperbox data import endpoints.
+"""Tupperbox import — preview endpoint.
 
-File-upload only: Tupperbox has no public API for third-party clients,
-so a `tb!export` JSON dump is the only path. The shape is simple
-enough that one preview + one import endpoint is all we need.
+The actual import runs asynchronously through the unified job runner
+(POST /v1/imports/file). What's left here is the synchronous preview:
+parse a `tb!export` JSON dump and return a summary so the user can
+review + deselect tuppers before enqueueing. Preview writes nothing.
 """
 
 import json
@@ -10,20 +11,11 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
-from sheaf.database import get_db
-from sheaf.models.system import System
 from sheaf.models.user import User
-from sheaf.schemas.tb_import import (
-    TBImportOptions,
-    TBImportResult,
-    TBPreviewSummary,
-)
+from sheaf.schemas.tb_import import TBPreviewSummary
 from sheaf.services.tb_import import preview as build_preview
-from sheaf.services.tb_import import run_import
 
 logger = logging.getLogger("sheaf.import.tb")
 
@@ -55,30 +47,6 @@ async def _parse_upload(file: UploadFile) -> dict[str, Any]:
     return parsed
 
 
-async def _get_system(user: User, db: AsyncSession) -> System:
-    result = await db.execute(select(System).where(System.user_id == user.id))
-    system = result.scalar_one_or_none()
-    if not system:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Create a system first.",
-        )
-    return system
-
-
-def _options_from_query(
-    member_ids: str | None,
-    groups: bool,
-) -> TBImportOptions:
-    parsed_member_ids: list[str] | None = None
-    if member_ids is not None:
-        parsed_member_ids = [m.strip() for m in member_ids.split(",") if m.strip()]
-    return TBImportOptions(
-        member_ids=parsed_member_ids,
-        groups=groups,
-    )
-
-
 @router.post("/tupperbox/preview", response_model=TBPreviewSummary)
 async def preview_file_import(
     file: UploadFile,
@@ -87,22 +55,3 @@ async def preview_file_import(
     """Parse a Tupperbox export file and return a summary."""
     data = await _parse_upload(file)
     return build_preview(data)
-
-
-@router.post("/tupperbox", response_model=TBImportResult)
-async def do_file_import(
-    file: UploadFile,
-    user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    member_ids: str | None = None,
-    groups: bool = True,
-):
-    """Import data from a Tupperbox export file.
-
-    Use the preview endpoint first to see what's in the file and to
-    gather IDs for the optional member_ids parameter (comma-separated).
-    """
-    data = await _parse_upload(file)
-    system = await _get_system(user, db)
-    options = _options_from_query(member_ids, groups)
-    return await run_import(data, options, system, db)

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -278,6 +278,19 @@ class Settings(BaseSettings):
 
     # Front-change notifications
     notifications_dispatch_interval_seconds: int = 5
+
+    # Import runner tick interval. Short by default because a user
+    # who just clicked "import" expects something to happen within a
+    # few seconds, not a minute. Empty-queue ticks are a single indexed
+    # query returning no rows.
+    import_runner_interval_seconds: int = 5
+
+    # How long terminal ImportJob rows live before the cleanup job
+    # deletes them. The uploaded payload blob is wiped at finalize
+    # time independently; this only controls the user-visible report.
+    # 30 days matches the job_runs log retention so 'what was happening
+    # around the same time' queries line up.
+    import_job_retention_days: int = 30
     activation_code_ttl_days: int = 7
     # VAPID keys for web push. Generate with `vapid --gen` (py-vapid) or any
     # WebPush helper. Empty = web_push destination type is rejected.

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -285,6 +285,12 @@ class Settings(BaseSettings):
     # query returning no rows.
     import_runner_interval_seconds: int = 5
 
+    # Whether the in-process import-runner loop starts at app boot.
+    # On in production. The test stack flips this off so the import
+    # tests can drive the runner deterministically (manually, often
+    # with a stubbed PK API) without a live loop racing them.
+    import_runner_enabled: bool = True
+
     # How long terminal ImportJob rows live before the cleanup job
     # deletes them. The uploaded payload blob is wiped at finalize
     # time independently; this only controls the user-visible report.

--- a/sheaf/main.py
+++ b/sheaf/main.py
@@ -74,20 +74,36 @@ async def lifespan(app: FastAPI):
     except ImportError:
         pass
 
+    from sheaf.services.import_runner import import_runner_loop
     from sheaf.services.jobs import job_runner_loop
     from sheaf.services.notifications.dispatcher import dispatcher_loop
 
     jobs_task = asyncio.create_task(job_runner_loop())
     dispatcher_task = asyncio.create_task(dispatcher_loop())
+    # Imports get their own fast loop, not the slow jobs.py registry —
+    # the registry only wakes every job_check_interval_minutes, far too
+    # slow for an import a user is actively waiting on. The test stack
+    # disables the loop so import tests can drive the runner manually
+    # without a live loop racing them.
+    import_task = (
+        asyncio.create_task(import_runner_loop())
+        if settings.import_runner_enabled
+        else None
+    )
 
     yield
 
     jobs_task.cancel()
     dispatcher_task.cancel()
+    if import_task is not None:
+        import_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await jobs_task
     with contextlib.suppress(asyncio.CancelledError):
         await dispatcher_task
+    if import_task is not None:
+        with contextlib.suppress(asyncio.CancelledError):
+            await import_task
     logger.info("Sheaf shutting down")
 
 

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -9,6 +9,7 @@ from sheaf.models.export_job import ExportJob, ExportJobStatus
 from sheaf.models.front import Front
 from sheaf.models.front_audit_event import FrontAuditEvent
 from sheaf.models.group import Group
+from sheaf.models.import_job import ImportJob, ImportJobSource, ImportJobStatus
 from sheaf.models.invite_code import InviteCode
 from sheaf.models.job_run import JobRun
 from sheaf.models.journal_entry import JournalEntry
@@ -74,6 +75,9 @@ __all__ = [
     "FrontAuditEvent",
     "Group",
     "GroupRuleAction",
+    "ImportJob",
+    "ImportJobSource",
+    "ImportJobStatus",
     "IncludePrivate",
     "InviteCode",
     "JobRun",

--- a/sheaf/models/import_job.py
+++ b/sheaf/models/import_job.py
@@ -1,0 +1,135 @@
+"""One row per user-initiated import run.
+
+Replaces the old inline-result pattern. Every import (PluralKit file,
+PluralKit API fetch, Tupperbox, SimplyPlural, Sheaf re-import) now
+enqueues an `ImportJob`, returns 202 immediately, and the user polls
+or watches the detail page for status + counts + per-record events.
+
+The job runner claims rows where status = 'pending' with FOR UPDATE
+SKIP LOCKED, so this is forward-compatible with multi-worker rollout
+without a separate leader-election layer.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sheaf.models.base import Base, TimestampMixin, UUIDMixin
+
+
+class ImportJobSource(enum.StrEnum):
+    PLURALKIT_FILE = "pluralkit_file"
+    PLURALKIT_API = "pluralkit_api"
+    TUPPERBOX_FILE = "tupperbox_file"
+    SIMPLYPLURAL_FILE = "simplyplural_file"
+    SHEAF_FILE = "sheaf_file"
+
+
+class ImportJobStatus(enum.StrEnum):
+    # Awaiting pickup by the runner.
+    PENDING = "pending"
+    # Runner has claimed and is processing.
+    RUNNING = "running"
+    # Finished cleanly (may still contain per-record errors in `events`).
+    COMPLETE = "complete"
+    # Aborted at the file / schema / unrecoverable level. `last_error` is set.
+    FAILED = "failed"
+    # User cancelled before the runner picked it up.
+    CANCELLED = "cancelled"
+
+
+class ImportJob(UUIDMixin, TimestampMixin, Base):
+    __tablename__ = "import_jobs"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=ImportJobStatus.PENDING.value
+    )
+
+    # Client-supplied dedup token. Submitting the same key twice for the
+    # same user returns the original job row instead of a new one, so
+    # double-click on the upload button doesn't create two imports.
+    idempotency_key: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # Storage key for the uploaded payload (file-based imports), or NULL
+    # for API-based imports where the credential / config is carried in
+    # payload_metadata instead. Cleared once the job reaches a terminal
+    # state to free storage.
+    payload_storage_key: Mapped[str | None] = mapped_column(String(256), nullable=True)
+
+    # Source-specific config: options dict, encrypted PK API token,
+    # selected member ids, etc. Cleared on terminal state for any
+    # credential-bearing fields.
+    payload_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Running tallies, e.g.
+    # {"members_imported": N, "members_failed": M, "switches_imported": ...}.
+    # Updated periodically while the job runs so the UI shows live progress.
+    counts: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default="{}"
+    )
+
+    # Per-record warnings and errors:
+    # [{"level": "warning"|"error", "stage": str, "record_ref": str|None,
+    #   "message": str}, ...]
+    # Capped at ~10k entries — beyond that a "log truncated" marker is
+    # appended and further events are dropped.
+    events: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
+
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # FOR UPDATE SKIP LOCKED bookkeeping. claimed_by is the worker id
+    # for crash recovery / observability.
+    claimed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    claimed_by: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    failed_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Soft-delete: user-archived terminal jobs are hidden from the
+    # default history list but stay queryable.
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "idempotency_key", name="uq_import_jobs_user_idempotency"
+        ),
+        # Claim query: pending jobs, oldest first.
+        Index(
+            "ix_import_jobs_pending",
+            "created_at",
+            postgresql_where="status = 'pending'",
+        ),
+        # History list: user's most-recent jobs.
+        Index(
+            "ix_import_jobs_user_history",
+            "user_id",
+            "created_at",
+        ),
+    )

--- a/sheaf/schemas/imports.py
+++ b/sheaf/schemas/imports.py
@@ -1,0 +1,127 @@
+"""Pydantic schemas for the async import job runner.
+
+A single set of request/response shapes describes every import source.
+Source-specific options (PK selected member ids, TB user-key, etc.)
+ride along under `options: dict` because each importer's option schema
+is independent and validated by the handler itself when it deserializes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from sheaf.models.import_job import ImportJobSource, ImportJobStatus
+
+# `extra="forbid"` everywhere user-controlled — catch typos and refuse
+# stowaway fields rather than ignoring them silently. The defensive
+# logging value of "your JSON had `option_id` not `options_id`, here's
+# the 422" beats the tiny convenience of accepting either.
+_strict = ConfigDict(extra="forbid")
+
+
+# --- Request schemas --------------------------------------------------------
+
+
+class ImportFileCreateRequest(BaseModel):
+    """Form fields submitted alongside the multipart `file` upload.
+
+    Carried as separate form fields (not a JSON body) because the file
+    rides on the multipart envelope and FastAPI doesn't merge the two
+    cleanly. The actual file is `UploadFile = File(...)` on the handler.
+    """
+
+    model_config = _strict
+
+    source: Literal[
+        ImportJobSource.PLURALKIT_FILE,
+        ImportJobSource.TUPPERBOX_FILE,
+        ImportJobSource.SIMPLYPLURAL_FILE,
+        ImportJobSource.SHEAF_FILE,
+    ]
+    idempotency_key: uuid.UUID
+    # Source-specific options as JSON string in the form field. Parsed
+    # and validated by the source's importer when it deserializes; we
+    # store it raw so a new option doesn't require a schema bump here.
+    options: dict[str, Any] | None = None
+
+
+class ImportApiCreateRequest(BaseModel):
+    """Credential-based imports (currently PluralKit API).
+
+    The credential field (`pk_token` for PK) is encrypted at rest in
+    payload_metadata while the job runs, and wiped at finalize time.
+    """
+
+    model_config = _strict
+
+    source: Literal[ImportJobSource.PLURALKIT_API]
+    idempotency_key: uuid.UUID
+    pk_token: str = Field(min_length=1, max_length=128)
+    options: dict[str, Any] | None = None
+
+
+# --- Response schemas -------------------------------------------------------
+
+
+class ImportJobEvent(BaseModel):
+    """One entry from the events JSONB array — surfaced unchanged to
+    the UI so it can render the per-record warnings / errors table.
+
+    `record_ref` is source-specific (PK HID, TB tupper id, member
+    display name, ...). When set, the UI can render it as a clickable
+    pointer; when null, the event is general (parse-level, schema-level)
+    and just gets shown with its message.
+    """
+
+    model_config = ConfigDict(extra="allow")  # forward-compat
+
+    level: Literal["info", "warning", "error"]
+    stage: str
+    message: str
+    record_ref: str | None = None
+
+
+class ImportJobRead(BaseModel):
+    """Full user-visible state of one import job."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    source: ImportJobSource
+    status: ImportJobStatus
+    counts: dict[str, int] = Field(default_factory=dict)
+    events: list[ImportJobEvent] = Field(default_factory=list)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    last_error: str | None = None
+    archived_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ImportJobSummary(BaseModel):
+    """Lighter shape for the history list — drops the events array
+    which can be 10k entries long. Detail view fetches the full record
+    via /v1/imports/{id}."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    source: ImportJobSource
+    status: ImportJobStatus
+    counts: dict[str, int] = Field(default_factory=dict)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    archived_at: datetime | None = None
+    created_at: datetime
+
+
+class ImportJobList(BaseModel):
+    items: list[ImportJobSummary]
+    # Cursor pagination, matches the fronts-history pattern. Null when
+    # there's nothing more behind the last item.
+    next_cursor: str | None = None

--- a/sheaf/schemas/pk_import.py
+++ b/sheaf/schemas/pk_import.py
@@ -7,15 +7,21 @@ preview/options/result regardless of source.
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PKImportOptions(BaseModel):
     """What to import from a PluralKit export."""
 
+    # Strict by default so typos in option names from a hand-rolled
+    # client land as a 422 instead of being silently ignored. Pre-async
+    # the importer just dropped unknown keys; this is a tightening.
+    model_config = ConfigDict(extra="forbid")
+
     system_profile: bool = True
     member_ids: list[str] | None = Field(
         default=None,
+        max_length=10_000,
         description=(
             "PK member HIDs to import. None = all. Used to let the user "
             "deselect specific members on the preview screen."

--- a/sheaf/schemas/sheaf_import.py
+++ b/sheaf/schemas/sheaf_import.py
@@ -1,0 +1,29 @@
+"""Pydantic models for Sheaf native re-import.
+
+Sheaf's own export format round-trips through this importer. The
+legacy `/v1/import/sheaf` endpoint took these as query params; the
+async runner carries them as an options dict in the ImportJob's
+payload_metadata, validated against this model.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SheafImportOptions(BaseModel):
+    """What to import from a Sheaf export. Each flag gates one section;
+    member_ids optionally narrows the member set (and everything that
+    references it) to a deselected subset chosen on the preview screen.
+    """
+
+    # Strict: a typo'd option key from a hand-rolled client 422s rather
+    # than being silently ignored.
+    model_config = ConfigDict(extra="forbid")
+
+    system_profile: bool = True
+    member_ids: list[str] | None = Field(default=None, max_length=10_000)
+    fronts: bool = True
+    groups: bool = True
+    tags: bool = True
+    custom_fields: bool = True

--- a/sheaf/schemas/sp_import.py
+++ b/sheaf/schemas/sp_import.py
@@ -1,14 +1,18 @@
 """Pydantic models for SimplyPlural data import."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SPImportOptions(BaseModel):
     """What to import from the SP export."""
 
+    # Strict: a typo'd option key from a hand-rolled client 422s rather
+    # than being silently ignored.
+    model_config = ConfigDict(extra="forbid")
+
     system_profile: bool = True
     member_ids: list[str] | None = Field(
-        None, description="SP member IDs to import. None = all."
+        None, max_length=10_000, description="SP member IDs to import. None = all."
     )
     custom_fronts: bool = True
     custom_fields: bool = True

--- a/sheaf/schemas/tb_import.py
+++ b/sheaf/schemas/tb_import.py
@@ -7,14 +7,19 @@ no privacy model — just identity + grouping data. The schemas here
 mirror that smaller surface.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TBImportOptions(BaseModel):
     """What to import from a Tupperbox export."""
 
+    # Strict: a typo'd option key from a hand-rolled client 422s rather
+    # than being silently ignored.
+    model_config = ConfigDict(extra="forbid")
+
     member_ids: list[str] | None = Field(
         default=None,
+        max_length=10_000,
         description=(
             "Tupperbox tupper IDs (as strings) to import. None = all. Used "
             "to let the user deselect specific tuppers on the preview screen."

--- a/sheaf/services/import_parsing.py
+++ b/sheaf/services/import_parsing.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from pydantic import BaseModel, ValidationError
+
 # Per-payload element cap. PK / TB / SP / Sheaf exports of plausible
 # real systems are in the low tens of thousands of elements at most;
 # 5M leaves headroom for an order-of-magnitude growth without making
@@ -68,6 +70,31 @@ def safe_json_loads(
         elif isinstance(node, list):
             stack.extend(node)
     return parsed
+
+
+def parse_options[OptionsT: BaseModel](
+    payload_metadata: dict | None, model_cls: type[OptionsT]
+) -> OptionsT:
+    """Pull the `options` dict out of an ImportJob's payload_metadata and
+    Pydantic-validate it against the source's options model.
+
+    Missing / null / empty options means 'all defaults'. Invalid options
+    is a hard `ImportPayloadError` — the frontend shouldn't be able to
+    produce them, so a raise here means a client bug or hand-rolled
+    request, and failing the job loudly beats importing with a silently
+    wrong option set.
+    """
+    raw = (payload_metadata or {}).get("options")
+    if raw is None or raw == {}:
+        return model_cls()
+    if not isinstance(raw, dict):
+        raise ImportPayloadError(
+            f"options must be a JSON object (got {type(raw).__name__})"
+        )
+    try:
+        return model_cls.model_validate(raw)
+    except ValidationError as exc:
+        raise ImportPayloadError(f"invalid import options: {exc.errors()}") from exc
 
 
 def expect_dict(parsed: Any, *, descriptor: str) -> dict:

--- a/sheaf/services/import_parsing.py
+++ b/sheaf/services/import_parsing.py
@@ -1,0 +1,82 @@
+"""Shared parsing utilities for import handlers.
+
+Defensive primitives every importer (PK / TB / SP / Sheaf) leans on:
+JSON parsing with element-count caps, schema-shape sanity checks,
+helpers for normalising string fields.
+
+JSON parsing notes: CPython's `json.loads` is iterative under the hood,
+so deeply-nested JSON doesn't blow the call stack. The DoS vector we
+actually care about is the size of the resulting Python object graph
+— a 1KB input that decodes to millions of nested objects. We cap the
+*element count* post-parse with a cheap stack walk; the upstream
+100MB request-body cap covers the input byte count.
+
+The defaults here are sized for real-world import payloads with a
+generous margin: PK exports with ~10k switches plus a few hundred
+members + groups still come in well under 100k elements.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Per-payload element cap. PK / TB / SP / Sheaf exports of plausible
+# real systems are in the low tens of thousands of elements at most;
+# 5M leaves headroom for an order-of-magnitude growth without making
+# the walk slow.
+DEFAULT_MAX_ELEMENTS = 5_000_000
+
+
+class ImportPayloadError(ValueError):
+    """Raised when an import payload fails defensive parsing — bad JSON,
+    too many elements, wrong top-level shape.
+
+    The runner catches this and maps it to a `level='error', stage='parse'`
+    event plus a failed job status. The message is user-facing, so keep
+    it short and specific (no stack traces, no library names)."""
+
+
+def safe_json_loads(
+    data: bytes | str,
+    *,
+    max_elements: int = DEFAULT_MAX_ELEMENTS,
+) -> Any:
+    """Parse JSON and cap the element count of the resulting object graph.
+
+    Raises `ImportPayloadError` on parse failure or cap overflow. The
+    caller is responsible for shape validation (e.g. "this should be a
+    dict with key X"); this helper only guards against the parse-time
+    DoS surface.
+    """
+    try:
+        parsed = json.loads(data)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ImportPayloadError(f"invalid JSON: {exc}") from exc
+
+    count = 0
+    stack: list[Any] = [parsed]
+    while stack:
+        node = stack.pop()
+        count += 1
+        if count > max_elements:
+            raise ImportPayloadError(
+                f"payload exceeds {max_elements} elements (DoS guard)"
+            )
+        if isinstance(node, dict):
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return parsed
+
+
+def expect_dict(parsed: Any, *, descriptor: str) -> dict:
+    """Assert the parsed top-level is a JSON object (dict). PK exports,
+    TB exports, SP exports, and Sheaf re-imports all share this shape;
+    refusing arrays / scalars early is cleaner than letting `.get()`
+    fail mid-import."""
+    if not isinstance(parsed, dict):
+        raise ImportPayloadError(
+            f"{descriptor} must be a JSON object (got {type(parsed).__name__})"
+        )
+    return parsed

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from sheaf.config import settings
 from sheaf.models.import_job import ImportJob, ImportJobStatus
+from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.import_storage import delete_payload
 
 logger = logging.getLogger("sheaf.imports")
@@ -222,7 +223,17 @@ async def run_import_tick(db: AsyncSession) -> dict:
     try:
         await handler(job, db)
     except Exception as exc:
-        logger.exception("import_job %s failed", job_id)
+        # ImportPayloadError is a *classified, expected* failure — bad
+        # payload, PK API unreachable, no system on the account. It is
+        # not a bug. Log it as a clean one-line warning (the message
+        # already names the cause) rather than a 60-line traceback, and
+        # don't dress it up as an "unhandled exception" in the report.
+        # Anything else is an actual bug: full traceback, loud.
+        expected = isinstance(exc, ImportPayloadError)
+        if expected:
+            logger.warning("import_job %s failed: %s", job_id, exc)
+        else:
+            logger.exception("import_job %s failed", job_id)
         # Roll back the importer's uncommitted state, then write the
         # terminal failed record from a *fresh* session. The handler's
         # session is in an unknown state after the raise — reusing it
@@ -245,7 +256,9 @@ async def run_import_tick(db: AsyncSession) -> dict:
                 fresh_job,
                 level="error",
                 stage="runner",
-                message=f"unhandled exception: {exc!s}"[:1000],
+                message=(
+                    str(exc) if expected else f"unhandled exception: {exc!s}"
+                )[:1000],
             )
             await _finalize(
                 fresh_job,

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -285,10 +285,10 @@ def _register_builtin_handlers() -> None:
     # pk_import_runner registers both pluralkit_file and pluralkit_api.
     from sheaf.services import (
         pk_import_runner,  # noqa: F401
+        sheaf_import_runner,  # noqa: F401
         sp_import_runner,  # noqa: F401
         tb_import_runner,  # noqa: F401
     )
-    # Phase 6: from sheaf.services import sheaf_import_runner  # noqa: F401
 
 
 _register_builtin_handlers()

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -14,6 +14,7 @@ per-record errors land in events with level=error.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from collections.abc import Awaitable, Callable
@@ -24,6 +25,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
+from sheaf.config import settings
 from sheaf.models.import_job import ImportJob, ImportJobStatus
 from sheaf.services.import_storage import delete_payload
 
@@ -260,12 +262,52 @@ async def run_import_tick(db: AsyncSession) -> dict:
     return {"items_processed": 1, "details": f"complete: {job.id}"}
 
 
+async def import_runner_loop(stop_event: asyncio.Event | None = None) -> None:
+    """Dedicated import-runner loop, run as its own asyncio task in the
+    FastAPI lifespan — NOT registered in the jobs.py periodic registry.
+
+    The jobs.py registry only wakes every `job_check_interval_minutes`
+    (15m default), which is fine for hourly/daily housekeeping but far
+    too slow for an import the user is actively waiting on. This loop
+    mirrors the notification dispatcher: a tight interval, its own
+    session per tick.
+
+    Each pass drains the queue — keep claiming until empty — so a
+    backlog of N pending jobs clears in one pass rather than taking
+    N * interval seconds. `run_import_tick` claims exactly one pending
+    job and drives it to a terminal state, so the drain always
+    terminates (a processed job is no longer pending).
+    """
+    from sheaf.database import async_session_factory
+
+    interval = max(1, settings.import_runner_interval_seconds)
+    logger.info("Import runner started (interval=%ds)", interval)
+    while True:
+        if stop_event is not None and stop_event.is_set():
+            return
+        try:
+            while True:
+                async with async_session_factory() as db:
+                    result = await run_import_tick(db)
+                if result.get("items_processed", 0) == 0:
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Import runner tick failed")
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+
+
 # Public re-export so the importer modules don't reach into the
 # private name when registering themselves at module import time.
 __all__ = [
     "ImportHandler",
     "MAX_EVENTS_PER_JOB",
     "append_event",
+    "import_runner_loop",
     "register_handler",
     "run_import_tick",
     "update_counts",

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -1,0 +1,279 @@
+"""Async import job runner.
+
+Polled by the existing jobs.py dispatcher every few seconds. On each
+tick, claims one pending ImportJob with FOR UPDATE SKIP LOCKED, looks
+up the registered handler for that job's source, and runs it. The
+handler is responsible for the actual import work; this module is just
+the lifecycle + bookkeeping wrapper.
+
+Handlers are registered at module import time via `register_handler`.
+Each handler takes the claimed ImportJob plus its own db session and
+mutates job.counts / job.events as it goes. Hard failures raise; soft
+per-record errors land in events with level=error.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
+
+from sheaf.models.import_job import ImportJob, ImportJobStatus
+from sheaf.services.import_storage import delete_payload
+
+logger = logging.getLogger("sheaf.imports")
+
+# Soft cap on the per-job events array. Past this, info + warning
+# events stop being appended (after a single "_truncated" marker) so
+# the JSONB row can't grow unboundedly on a pathological import.
+# Errors always keep appending past this cap with full detail — losing
+# diagnostic info on the actual failures defeats the point of having
+# the report.
+MAX_EVENTS_PER_JOB = 10_000
+
+# Handler signature: takes the loaded job and an open db session.
+# Mutates job.counts / job.events as it processes; raises on hard
+# failure (which the runner catches and converts to status=failed).
+ImportHandler = Callable[[ImportJob, AsyncSession], Awaitable[None]]
+
+_HANDLERS: dict[str, ImportHandler] = {}
+
+
+def register_handler(source: str, handler: ImportHandler) -> None:
+    """Register a handler for a given ImportJobSource value. Idempotent;
+    re-registering the same source replaces the previous handler."""
+    _HANDLERS[source] = handler
+
+
+def append_event(
+    job: ImportJob,
+    *,
+    level: str,
+    stage: str,
+    message: str,
+    record_ref: str | None = None,
+    **extra: Any,
+) -> None:
+    """Append a structured event to job.events with bounded length.
+
+    `level` is one of "info" | "warning" | "error". `stage` names the
+    importer phase ("parse", "members", "switches", ...). `record_ref`
+    is a source-specific identifier (HID, tupper id, member name) so
+    the UI can point the user at the problem row.
+    """
+    if level not in ("info", "warning", "error"):
+        raise ValueError(f"invalid event level: {level!r}")
+    events = job.events or []
+    over_cap = len(events) >= MAX_EVENTS_PER_JOB
+    if over_cap and level != "error":
+        # Info / warning past the cap: append the truncation marker
+        # exactly once, then drop further low-priority events. Errors
+        # still go through (handled below).
+        if not events or events[-1].get("stage") != "_truncated":
+            events.append(
+                {
+                    "level": "warning",
+                    "stage": "_truncated",
+                    "message": (
+                        f"event log truncated at {MAX_EVENTS_PER_JOB} entries; "
+                        "subsequent info / warning events dropped — "
+                        "errors still recorded below"
+                    ),
+                }
+            )
+            job.events = events
+            flag_modified(job, "events")
+        return
+    entry: dict[str, Any] = {"level": level, "stage": stage, "message": message}
+    if record_ref is not None:
+        entry["record_ref"] = record_ref
+    if extra:
+        entry.update(extra)
+    # Errors past the cap still get appended (they appear after the
+    # _truncated marker so the report has the full failure context the
+    # user actually needs to debug).
+    events.append(entry)
+    job.events = events
+    flag_modified(job, "events")
+
+
+def update_counts(job: ImportJob, **deltas: int) -> None:
+    """Increment named counters on job.counts. Missing keys start at 0.
+
+    Mark the JSONB column dirty so SQLAlchemy flushes the in-place
+    mutation; without flag_modified() the change is invisible at
+    commit time.
+    """
+    counts = dict(job.counts or {})
+    for key, delta in deltas.items():
+        counts[key] = counts.get(key, 0) + delta
+    job.counts = counts
+    flag_modified(job, "counts")
+
+
+def _worker_id() -> str:
+    """Identifier for the current process used to populate claimed_by."""
+    return f"{os.uname().nodename}:{os.getpid()}"
+
+
+async def _claim_next_pending(db: AsyncSession) -> ImportJob | None:
+    """Claim one pending ImportJob row using FOR UPDATE SKIP LOCKED.
+
+    Multi-worker safe: two workers ticking at the same time will pick
+    different rows (or one picks nothing) because SKIP LOCKED makes
+    each transaction see only rows the other hasn't grabbed.
+    """
+    stmt = (
+        select(ImportJob)
+        .where(ImportJob.status == ImportJobStatus.PENDING.value)
+        .order_by(ImportJob.created_at)
+        .limit(1)
+        .with_for_update(skip_locked=True)
+    )
+    result = await db.execute(stmt)
+    job = result.scalar_one_or_none()
+    if job is None:
+        return None
+    now = datetime.now(UTC)
+    job.status = ImportJobStatus.RUNNING.value
+    job.started_at = now
+    job.claimed_at = now
+    job.claimed_by = _worker_id()
+    await db.flush()
+    await db.commit()
+    return job
+
+
+async def _finalize(
+    job: ImportJob,
+    db: AsyncSession,
+    *,
+    status: ImportJobStatus,
+    last_error: str | None = None,
+) -> None:
+    """Mark a job done (or failed/cancelled), clear sensitive payload
+    metadata, and best-effort delete the storage blob."""
+    job.status = status.value
+    job.finished_at = datetime.now(UTC)
+    if last_error is not None:
+        job.last_error = last_error[:8000]
+    # Wipe credential-bearing metadata once the job is terminal so a
+    # compromised DB dump after the fact doesn't leak the PK API token
+    # the user passed at upload time. The storage blob is also deleted.
+    if job.payload_metadata:
+        # Keep non-secret metadata (options, selected ids) — only strip
+        # the encrypted-credential blob if present.
+        scrubbed = {
+            k: v for k, v in job.payload_metadata.items() if k != "encrypted_credential"
+        }
+        job.payload_metadata = scrubbed or None
+        flag_modified(job, "payload_metadata")
+    storage_key = job.payload_storage_key
+    job.payload_storage_key = None
+    await db.commit()
+    if storage_key:
+        await delete_payload(storage_key)
+
+
+async def run_import_tick(db: AsyncSession) -> dict:
+    """One scheduler tick: claim a pending job (if any) and run it.
+
+    Returns the jobs.py-style result dict so the existing job_runs
+    log table picks up `items_processed` and `details`.
+    """
+    job = await _claim_next_pending(db)
+    if job is None:
+        return {"items_processed": 0}
+
+    handler = _HANDLERS.get(job.source)
+    if handler is None:
+        # Unregistered source — this is a deployment / migration bug,
+        # not a user error. Mark failed loudly so it shows up.
+        append_event(
+            job,
+            level="error",
+            stage="dispatch",
+            message=f"no handler registered for source={job.source!r}",
+        )
+        await _finalize(
+            job,
+            db,
+            status=ImportJobStatus.FAILED,
+            last_error=f"no handler registered for source={job.source!r}",
+        )
+        logger.error("import_job %s has no handler for source=%s", job.id, job.source)
+        return {"items_processed": 1, "details": f"no handler: {job.source}"}
+
+    logger.info(
+        "import_job %s starting (source=%s, user=%s)",
+        job.id,
+        job.source,
+        job.user_id,
+    )
+    try:
+        await handler(job, db)
+    except Exception as exc:
+        logger.exception("import_job %s failed", job.id)
+        append_event(
+            job,
+            level="error",
+            stage="runner",
+            message=f"unhandled exception: {exc!s}"[:1000],
+        )
+        # Roll back any uncommitted importer state so the failure mode
+        # is consistent: either we committed up to a savepoint the
+        # importer chose, or nothing.
+        await db.rollback()
+        # Reload the (rolled-back) job row so we can write terminal state.
+        job = await db.get(ImportJob, job.id)
+        if job is None:
+            return {"items_processed": 1, "details": "job vanished mid-run"}
+        await _finalize(
+            job, db, status=ImportJobStatus.FAILED, last_error=str(exc)[:8000]
+        )
+        return {"items_processed": 1, "details": f"failed: {job.id}"}
+
+    await _finalize(job, db, status=ImportJobStatus.COMPLETE)
+    logger.info(
+        "import_job %s complete (counts=%s)", job.id, job.counts
+    )
+    return {"items_processed": 1, "details": f"complete: {job.id}"}
+
+
+# Public re-export so the importer modules don't reach into the
+# private name when registering themselves at module import time.
+__all__ = [
+    "ImportHandler",
+    "MAX_EVENTS_PER_JOB",
+    "append_event",
+    "register_handler",
+    "run_import_tick",
+    "update_counts",
+]
+
+
+def _register_builtin_handlers() -> None:
+    """Import the per-source handler modules so their module-level
+    `register_handler(...)` calls land. Lazy import avoids a circular
+    import between this module and the importer modules at startup.
+
+    Each phase of the larger import migration adds one entry here.
+    Phase 1 lands the runner with no handlers wired up — the runner
+    no-ops on any pending row, marks it failed with 'no handler', and
+    that's an explicit error the developer sees immediately.
+    """
+    # Phase 3: from sheaf.services import pk_import_runner  # noqa: F401
+    # Phase 4: from sheaf.services import pk_api_runner  # noqa: F401
+    # Phase 5: from sheaf.services import tb_import_runner  # noqa: F401
+    # Phase 5: from sheaf.services import sp_import_runner  # noqa: F401
+    # Phase 6: from sheaf.services import sheaf_import_runner  # noqa: F401
+    pass
+
+
+_register_builtin_handlers()

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -216,28 +216,42 @@ async def run_import_tick(db: AsyncSession) -> dict:
         job.source,
         job.user_id,
     )
+    job_id = job.id
     try:
         await handler(job, db)
     except Exception as exc:
-        logger.exception("import_job %s failed", job.id)
-        append_event(
-            job,
-            level="error",
-            stage="runner",
-            message=f"unhandled exception: {exc!s}"[:1000],
-        )
-        # Roll back any uncommitted importer state so the failure mode
-        # is consistent: either we committed up to a savepoint the
-        # importer chose, or nothing.
-        await db.rollback()
-        # Reload the (rolled-back) job row so we can write terminal state.
-        job = await db.get(ImportJob, job.id)
-        if job is None:
-            return {"items_processed": 1, "details": "job vanished mid-run"}
-        await _finalize(
-            job, db, status=ImportJobStatus.FAILED, last_error=str(exc)[:8000]
-        )
-        return {"items_processed": 1, "details": f"failed: {job.id}"}
+        logger.exception("import_job %s failed", job_id)
+        # Roll back the importer's uncommitted state, then write the
+        # terminal failed record from a *fresh* session. The handler's
+        # session is in an unknown state after the raise — reusing it
+        # risks an expired-attribute sync lazy-load (MissingGreenlet).
+        # All-or-nothing: a hard failure discards everything the
+        # importer did, including any progress events; the terminal
+        # error event names the stage so the report still says where
+        # it broke.
+        try:
+            await db.rollback()
+        except Exception:  # noqa: BLE001
+            logger.exception("rollback after import_job %s failure failed", job_id)
+        from sheaf.database import async_session_factory
+
+        async with async_session_factory() as fresh:
+            fresh_job = await fresh.get(ImportJob, job_id)
+            if fresh_job is None:
+                return {"items_processed": 1, "details": "job vanished mid-run"}
+            append_event(
+                fresh_job,
+                level="error",
+                stage="runner",
+                message=f"unhandled exception: {exc!s}"[:1000],
+            )
+            await _finalize(
+                fresh_job,
+                fresh,
+                status=ImportJobStatus.FAILED,
+                last_error=str(exc)[:8000],
+            )
+        return {"items_processed": 1, "details": f"failed: {job_id}"}
 
     await _finalize(job, db, status=ImportJobStatus.COMPLETE)
     logger.info(
@@ -268,12 +282,11 @@ def _register_builtin_handlers() -> None:
     no-ops on any pending row, marks it failed with 'no handler', and
     that's an explicit error the developer sees immediately.
     """
-    # Phase 3: from sheaf.services import pk_import_runner  # noqa: F401
+    from sheaf.services import pk_import_runner  # noqa: F401
     # Phase 4: from sheaf.services import pk_api_runner  # noqa: F401
     # Phase 5: from sheaf.services import tb_import_runner  # noqa: F401
     # Phase 5: from sheaf.services import sp_import_runner  # noqa: F401
     # Phase 6: from sheaf.services import sheaf_import_runner  # noqa: F401
-    pass
 
 
 _register_builtin_handlers()

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -282,8 +282,8 @@ def _register_builtin_handlers() -> None:
     no-ops on any pending row, marks it failed with 'no handler', and
     that's an explicit error the developer sees immediately.
     """
+    # pk_import_runner registers both pluralkit_file and pluralkit_api.
     from sheaf.services import pk_import_runner  # noqa: F401
-    # Phase 4: from sheaf.services import pk_api_runner  # noqa: F401
     # Phase 5: from sheaf.services import tb_import_runner  # noqa: F401
     # Phase 5: from sheaf.services import sp_import_runner  # noqa: F401
     # Phase 6: from sheaf.services import sheaf_import_runner  # noqa: F401

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -283,9 +283,11 @@ def _register_builtin_handlers() -> None:
     that's an explicit error the developer sees immediately.
     """
     # pk_import_runner registers both pluralkit_file and pluralkit_api.
-    from sheaf.services import pk_import_runner  # noqa: F401
-    # Phase 5: from sheaf.services import tb_import_runner  # noqa: F401
-    # Phase 5: from sheaf.services import sp_import_runner  # noqa: F401
+    from sheaf.services import (
+        pk_import_runner,  # noqa: F401
+        sp_import_runner,  # noqa: F401
+        tb_import_runner,  # noqa: F401
+    )
     # Phase 6: from sheaf.services import sheaf_import_runner  # noqa: F401
 
 

--- a/sheaf/services/import_storage.py
+++ b/sheaf/services/import_storage.py
@@ -1,0 +1,55 @@
+"""Storage helpers for import-job payloads.
+
+Uploaded import files (PluralKit dumps, Tupperbox JSON, etc.) need to
+live somewhere between the HTTP upload and the runner picking the job
+up. Reusing the existing file-storage abstraction means selfhosters'
+configured backend (local-fs or S3) handles both; no separate path,
+no Postgres bytea bloat in backups.
+
+Payloads land under the `imports/` prefix with a UUID-derived key and
+are cleaned up when the job reaches a terminal state, or by the
+orphan-sweep job for anything left behind by a crashed runner.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+
+from sheaf.storage import get_storage
+
+# All import payloads share this prefix in the storage backend, so a
+# self-hoster with S3 can apply lifecycle rules / IAM policies against
+# the whole import-payload corpus rather than the whole bucket.
+IMPORT_PAYLOAD_PREFIX = "imports/"
+
+
+def make_payload_key(job_id: uuid.UUID, filename: str) -> str:
+    """Compose the storage key for an uploaded import payload.
+
+    Includes the job UUID for uniqueness and a sanitized filename
+    suffix so an operator browsing the storage backend can tell what
+    each blob is without cracking the row.
+    """
+    safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in filename)[:64]
+    return f"{IMPORT_PAYLOAD_PREFIX}{job_id}/{safe}"
+
+
+async def put_payload(key: str, data: bytes, content_type: str = "application/json") -> None:
+    """Store a payload blob. The returned URL is discarded — we look up
+    by key (the storage backend is internal to the runner)."""
+    await get_storage().put(key, data, content_type)
+
+
+async def get_payload(key: str) -> bytes | None:
+    return await get_storage().get(key)
+
+
+async def delete_payload(key: str) -> None:
+    """Best-effort cleanup. Backend exceptions are swallowed because
+    the job row is the source of truth for whether an import 'happened';
+    a leftover payload blob is harmless and the orphan sweep will
+    eventually catch it."""
+    # Don't let storage cleanup take down a finalize path.
+    with contextlib.suppress(Exception):
+        await get_storage().delete(key)

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -124,8 +124,12 @@ async def job_runner_loop() -> None:
             if not job.enabled():
                 continue
 
-            interval = job.interval_seconds()
-            if interval <= 0:
+            # Use a job-scoped name — assigning to the outer `interval`
+            # here would corrupt the loop's own wake cadence on the next
+            # `asyncio.sleep(interval)`, drifting it to whatever the
+            # last-registered job's interval happens to be.
+            job_interval = job.interval_seconds()
+            if job_interval <= 0:
                 # Treat non-positive intervals as "disabled" — prevents a
                 # misconfigured 0 from running the job every tick.
                 continue
@@ -137,7 +141,7 @@ async def job_runner_loop() -> None:
                     # Run if never run before, or if enough time has elapsed
                     if last_success is not None:
                         elapsed = (datetime.now(UTC) - last_success).total_seconds()
-                        if elapsed < interval:
+                        if elapsed < job_interval:
                             continue
 
                     logger.info("Running job: %s", name)
@@ -639,14 +643,6 @@ async def _purge_expired_polls(db: AsyncSession) -> dict:
     return {"items_processed": purged}
 
 
-async def _run_import_tick(db: AsyncSession) -> dict:
-    """One tick of the import runner — claim a pending ImportJob (if any)
-    and dispatch to its per-source handler."""
-    from sheaf.services.import_runner import run_import_tick
-
-    return await run_import_tick(db)
-
-
 async def _cleanup_import_jobs(db: AsyncSession) -> dict:
     """Drop ImportJob rows past the retention window.
 
@@ -798,22 +794,12 @@ def _register_all_jobs() -> None:
         interval_seconds=lambda: settings.poll_cleanup_interval_hours * 3600,
     )
 
-    # Imports run async via this tick — uploaded payload is stashed in
-    # the file-storage backend, a pending ImportJob row is created, and
-    # this job claims the next pending row each interval. The interval
-    # is intentionally short so a new-user upload doesn't sit there for
-    # tens of seconds before the runner notices. The empty-queue case
-    # is a single indexed query returning no rows.
-    register_job(
-        name="run_import_jobs",
-        description=(
-            "Process queued user data imports "
-            "(PluralKit / Tupperbox / SimplyPlural / Sheaf)"
-        ),
-        func=_run_import_tick,
-        interval_seconds=lambda: settings.import_runner_interval_seconds,
-    )
-
+    # NOTE: the import *runner* is NOT registered here. It needs a
+    # few-second tick, but this registry only wakes every
+    # job_check_interval_minutes — far too slow for an import a user is
+    # waiting on. It runs as its own loop (import_runner_loop) in the
+    # FastAPI lifespan, same pattern as the notification dispatcher.
+    # Only the slow daily cleanup of old ImportJob rows belongs here.
     register_job(
         name="cleanup_import_jobs",
         description="Delete ImportJob rows past their retention window",

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -639,6 +639,47 @@ async def _purge_expired_polls(db: AsyncSession) -> dict:
     return {"items_processed": purged}
 
 
+async def _run_import_tick(db: AsyncSession) -> dict:
+    """One tick of the import runner — claim a pending ImportJob (if any)
+    and dispatch to its per-source handler."""
+    from sheaf.services.import_runner import run_import_tick
+
+    return await run_import_tick(db)
+
+
+async def _cleanup_import_jobs(db: AsyncSession) -> dict:
+    """Drop ImportJob rows past the retention window.
+
+    Matches the cleanup_job_logs pattern (30 days). The user-facing
+    /imports/{id} report is the value here — keeping it around long
+    enough to be useful when someone says 'why is my system weird,
+    let me check what that import did three weeks ago' — but the row
+    isn't immortal.
+
+    The uploaded payload blob was already deleted at finalize time, so
+    this is purely DB row cleanup. CASCADE will sweep nothing because
+    nothing references import_jobs.
+    """
+    from sheaf.models.import_job import ImportJob, ImportJobStatus
+
+    cutoff = datetime.now(UTC) - timedelta(days=settings.import_job_retention_days)
+    result = await db.execute(
+        delete(ImportJob).where(
+            ImportJob.finished_at.is_not(None),
+            ImportJob.finished_at < cutoff,
+            ImportJob.status.in_(
+                [
+                    ImportJobStatus.COMPLETE.value,
+                    ImportJobStatus.FAILED.value,
+                    ImportJobStatus.CANCELLED.value,
+                ]
+            ),
+        )
+    )
+    await db.commit()
+    return {"items_processed": result.rowcount or 0}
+
+
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -755,6 +796,29 @@ def _register_all_jobs() -> None:
         description="Delete polls past their retention window post-close",
         func=_purge_expired_polls,
         interval_seconds=lambda: settings.poll_cleanup_interval_hours * 3600,
+    )
+
+    # Imports run async via this tick — uploaded payload is stashed in
+    # the file-storage backend, a pending ImportJob row is created, and
+    # this job claims the next pending row each interval. The interval
+    # is intentionally short so a new-user upload doesn't sit there for
+    # tens of seconds before the runner notices. The empty-queue case
+    # is a single indexed query returning no rows.
+    register_job(
+        name="run_import_jobs",
+        description=(
+            "Process queued user data imports "
+            "(PluralKit / Tupperbox / SimplyPlural / Sheaf)"
+        ),
+        func=_run_import_tick,
+        interval_seconds=lambda: settings.import_runner_interval_seconds,
+    )
+
+    register_job(
+        name="cleanup_import_jobs",
+        description="Delete ImportJob rows past their retention window",
+        func=_cleanup_import_jobs,
+        interval_seconds=lambda: 86400,  # daily
     )
 
     # Dev-only jobs — sheaf_dev is NOT installed in production Docker images

--- a/sheaf/services/pk_api.py
+++ b/sheaf/services/pk_api.py
@@ -32,6 +32,13 @@ SWITCHES_PAGE_SIZE = 100
 RATE_LIMIT_DELAY_SECONDS = 0.6
 REQUEST_TIMEOUT_SECONDS = 30.0
 
+# Cap on a single PK API response body before we parse it. A PK
+# member / group / switch-page response for even an unusually large
+# system is well under 10MB; 50MB is generous headroom that still
+# refuses a pathological or hostile response before it becomes a
+# multi-GB Python object graph.
+MAX_RESPONSE_BYTES = 50 * 1024 * 1024
+
 
 class PKApiError(Exception):
     """Raised when the PluralKit API returns an error or is unreachable."""
@@ -86,6 +93,12 @@ async def _get(client: httpx.AsyncClient, path: str, token: str, **params: Any) 
         raise PKApiError(
             f"PluralKit returned {resp.status_code}: {resp.text[:200]}",
             resp.status_code,
+        )
+
+    if len(resp.content) > MAX_RESPONSE_BYTES:
+        raise PKApiError(
+            f"PluralKit response too large "
+            f"({len(resp.content)} bytes > {MAX_RESPONSE_BYTES} cap)."
         )
 
     try:

--- a/sheaf/services/pk_api.py
+++ b/sheaf/services/pk_api.py
@@ -39,6 +39,18 @@ REQUEST_TIMEOUT_SECONDS = 30.0
 # multi-GB Python object graph.
 MAX_RESPONSE_BYTES = 50 * 1024 * 1024
 
+# Transport-level retries. A *connection* failure (DNS, TCP connect,
+# read timeout) is transient — a cold dial racing flaky egress, the
+# kind of thing a retry usually clears. HTTP status errors (401, 404,
+# 429, 5xx) are NOT retried here: a bad token won't fix itself, and
+# the status-code branch below already classifies them. Only the
+# `httpx.HTTPError` raised by `client.get` itself is retried.
+# Delay grows exponentially from the base, capped — 5 attempts at
+# base 1s give gaps of ~1s, 2s, 4s, 5s before the final failure.
+_CONNECT_RETRY_ATTEMPTS = 5
+_CONNECT_RETRY_BASE_DELAY_SECONDS = 1.0
+_CONNECT_RETRY_MAX_DELAY_SECONDS = 5.0
+
 
 class PKApiError(Exception):
     """Raised when the PluralKit API returns an error or is unreachable."""
@@ -65,16 +77,48 @@ def _headers(token: str) -> dict[str, str]:
 
 
 async def _get(client: httpx.AsyncClient, path: str, token: str, **params: Any) -> Any:
-    """Issue one GET against the PK API, mapping HTTP errors to PKApiError."""
-    try:
-        resp = await client.get(
-            f"{PK_API_BASE}{path}",
-            headers=_headers(token),
-            params=params or None,
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-    except httpx.HTTPError as exc:
-        raise PKApiError(f"Could not reach PluralKit API: {exc}") from exc
+    """Issue one GET against the PK API, mapping HTTP errors to PKApiError.
+
+    Transport failures (connect / timeout) are retried up to
+    `_CONNECT_RETRY_ATTEMPTS` times with exponential backoff before
+    giving up — they're usually a transient cold-connect hiccup. An
+    actual HTTP response, even an error status, is never retried here;
+    the status-code branch below handles those.
+    """
+    resp: httpx.Response | None = None
+    for attempt in range(1, _CONNECT_RETRY_ATTEMPTS + 1):
+        try:
+            resp = await client.get(
+                f"{PK_API_BASE}{path}",
+                headers=_headers(token),
+                params=params or None,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            break
+        except httpx.HTTPError as exc:
+            if attempt >= _CONNECT_RETRY_ATTEMPTS:
+                raise PKApiError(
+                    f"Could not reach PluralKit API after "
+                    f"{_CONNECT_RETRY_ATTEMPTS} attempts: {exc}"
+                ) from exc
+            delay = min(
+                _CONNECT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
+                _CONNECT_RETRY_MAX_DELAY_SECONDS,
+            )
+            logger.warning(
+                "PK API %s: connection attempt %d/%d failed (%s), "
+                "retrying in %.1fs",
+                path,
+                attempt,
+                _CONNECT_RETRY_ATTEMPTS,
+                exc,
+                delay,
+            )
+            await asyncio.sleep(delay)
+
+    # The loop either set `resp` and broke, or raised on the last
+    # attempt — so `resp` is never None here.
+    assert resp is not None
 
     if resp.status_code == 401:
         raise PKApiError("PluralKit token rejected (401). Check the token and try again.", 401)

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -39,8 +39,6 @@ from sheaf.models.group import Group
 from sheaf.models.member import Member, front_members, group_members
 from sheaf.models.system import PrivacyLevel, System
 from sheaf.schemas.pk_import import (
-    PKImportOptions,
-    PKImportResult,
     PKPreviewMember,
     PKPreviewSummary,
 )
@@ -101,61 +99,11 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
     )
 
 
-async def run_import(
-    data: dict,
-    options: PKImportOptions,
-    system: System,
-    db: AsyncSession,
-) -> PKImportResult:
-    """Import a parsed PK export into the user's system."""
-    result = PKImportResult()
-    warnings: list[str] = []
-
-    if options.system_profile:
-        _apply_system_profile(data, system)
-
-    pk_members = _list(data, "members")
-    if options.member_ids is not None:
-        wanted = set(options.member_ids)
-        pk_members = [m for m in pk_members if m.get("id") in wanted]
-
-    hid_to_member: dict[str, Member] = {}
-    for pk_m in pk_members:
-        member = _build_member(pk_m, system.id)
-        if member is None:
-            continue
-        db.add(member)
-        hid = str(pk_m.get("id") or "")
-        if hid:
-            hid_to_member[hid] = member
-        result.members_imported += 1
-
-    await db.flush()
-
-    if options.groups:
-        group_imported = await _import_groups(
-            _list(data, "groups"), system.id, hid_to_member, db
-        )
-        result.groups_imported = group_imported
-
-    if options.front_history:
-        fronts_imported, switch_warnings = await _import_switches(
-            _list(data, "switches"), system.id, hid_to_member, db
-        )
-        result.fronts_imported = fronts_imported
-        warnings.extend(switch_warnings)
-
-    result.warnings = warnings
-    # Commit explicitly here, before the handler returns. `get_db` does
-    # auto-commit on successful exit, but for `yield` dependencies that
-    # cleanup runs *after* the response has been sent to the client.
-    # Without an explicit commit inside the handler, a follow-up request
-    # (e.g. the test's GET /v1/members right after import) can race the
-    # cleanup-commit and see an empty members list. The window is
-    # microseconds locally and milliseconds on slow CI runners, so the
-    # symptom is a flaky test, not a deterministic one.
-    await db.commit()
-    return result
+# The synchronous run_import that used to live here is gone — the
+# PluralKit import now runs through the async job runner, whose handler
+# (pk_import_runner.handle_pluralkit_file) calls the per-section
+# helpers below directly. `preview` above is still used by the
+# /v1/import/pluralkit/preview endpoint.
 
 
 # --- System profile ----------------------------------------------------------

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -1,26 +1,29 @@
-"""Async runner handler for PluralKit file imports.
+"""Async runner handlers for PluralKit imports — file upload + API fetch.
+
+Both sources produce the same canonical PK-export dict, so they share
+one post-parse processor (`_process_pk_export`): the file handler
+parses an uploaded blob, the API handler fetches the same shape live
+from PluralKit, then both walk members / groups / switches identically.
 
 Bridges the existing per-section importer helpers (`_build_member`,
 `_import_groups`, `_import_switches`) onto the ImportJob runner. The
-legacy synchronous `pk_import.run_import` still exists for the older
-`/v1/import/pluralkit` endpoint and lives alongside this until Phase 6
-cleanup deletes the legacy surface.
+legacy synchronous `pk_import.run_import` + `/v1/import/pluralkit*`
+endpoints live alongside this until Phase 6 cleanup.
 
-Per-record errors land in `job.events` rather than aborting the
-import. Hard failures (bad JSON, no system, schema-level validation)
-raise; the runner's outer try/except converts that into status=failed
-and a single error event.
+Per-record errors land in `job.events` rather than aborting. Hard
+failures (bad JSON, no system, PK API rejection) raise; the runner's
+outer try/except converts that into status=failed.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sheaf.crypto import decrypt
 from sheaf.models.import_job import ImportJob, ImportJobSource
 from sheaf.models.member import Member
 from sheaf.models.system import System
@@ -32,6 +35,7 @@ from sheaf.services.import_parsing import (
 )
 from sheaf.services.import_runner import append_event, register_handler, update_counts
 from sheaf.services.import_storage import get_payload
+from sheaf.services.pk_api import PKApiError, fetch_export
 from sheaf.services.pk_import import (
     _apply_system_profile,
     _build_member,
@@ -39,9 +43,6 @@ from sheaf.services.pk_import import (
     _import_switches,
     _list,
 )
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger("sheaf.imports.pk")
 
@@ -79,48 +80,24 @@ def _parse_options(job: ImportJob) -> PKImportOptions:
         raise ImportPayloadError(f"invalid import options: {exc.errors()}") from exc
 
 
-async def handle_pluralkit_file(job: ImportJob, db: AsyncSession) -> None:
-    """Run a PluralKit-file import for a claimed ImportJob.
+async def _process_pk_export(
+    job: ImportJob,
+    db: AsyncSession,
+    parsed: dict,
+    options: PKImportOptions,
+) -> None:
+    """Walk a parsed PK-export dict into the owner's system.
 
-    Phases:
-      1. Load + parse the payload (safe_json_loads guards element count)
-      2. Validate options
-      3. Locate the owner's system
-      4. Apply system profile (optional)
-      5. Walk members, building hid -> Member map; per-record errors
-         land in events
-      6. Walk groups (optional)
-      7. Walk switches (optional, the biggest section)
+    Shared by the file and API handlers — by the time this runs the
+    source-specific bit (read a blob vs fetch from the API) is done and
+    `parsed` is the canonical export shape either way.
 
-    The runner commits all DB mutations once the handler returns; per-
-    section flushes keep the SQLAlchemy unit of work happy without
-    locking in partial state on failure (the runner does a rollback
-    when the handler raises).
+    Phases: locate system -> system profile (optional) -> members
+    (per-record errors -> events) -> groups (optional) -> switches
+    (optional, the biggest section). The runner commits everything once
+    the handler returns; per-section flushes keep the unit of work
+    happy without locking in partial state on failure.
     """
-    if job.payload_storage_key is None:
-        raise ImportPayloadError(
-            "PluralKit file job has no payload — was the upload step skipped?"
-        )
-
-    blob = await get_payload(job.payload_storage_key)
-    if blob is None:
-        raise ImportPayloadError(
-            "PluralKit file payload missing from storage — "
-            "the blob may have been swept by orphan cleanup"
-        )
-
-    append_event(
-        job,
-        level="info",
-        stage="parse",
-        message=f"parsed {len(blob)} bytes of payload",
-    )
-
-    parsed = expect_dict(
-        safe_json_loads(blob), descriptor="PluralKit export"
-    )
-    options = _parse_options(job)
-
     system = await _load_user_system(db, job.user_id)
 
     if options.system_profile:
@@ -227,6 +204,87 @@ async def handle_pluralkit_file(job: ImportJob, db: AsyncSession) -> None:
             raise
 
 
+async def handle_pluralkit_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run a PluralKit-file import: load the stashed payload, parse it
+    with the element-count guard, then hand off to the shared processor."""
+    if job.payload_storage_key is None:
+        raise ImportPayloadError(
+            "PluralKit file job has no payload — was the upload step skipped?"
+        )
+
+    blob = await get_payload(job.payload_storage_key)
+    if blob is None:
+        raise ImportPayloadError(
+            "PluralKit file payload missing from storage — "
+            "the blob may have been swept by orphan cleanup"
+        )
+
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=f"parsed {len(blob)} bytes of payload",
+    )
+
+    parsed = expect_dict(safe_json_loads(blob), descriptor="PluralKit export")
+    options = _parse_options(job)
+    await _process_pk_export(job, db, parsed, options)
+
+
+async def handle_pluralkit_api(job: ImportJob, db: AsyncSession) -> None:
+    """Run a PluralKit-API import: decrypt the stashed token, fetch the
+    system live from PluralKit, then hand off to the shared processor.
+
+    This is the migration that actually fixes a bug rather than just
+    hardening one — the live fetch paginates switch history with rate-
+    limit sleeps, which on a big system runs tens of seconds and would
+    blow the HTTP request timeout on the old synchronous endpoint.
+    Off the request path, it just takes as long as it takes.
+    """
+    meta = job.payload_metadata or {}
+    encrypted = meta.get("encrypted_credential")
+    if not encrypted:
+        raise ImportPayloadError(
+            "PluralKit API job has no stored credential — "
+            "the token may have already been wiped by a prior run"
+        )
+    try:
+        token = decrypt(encrypted)
+    except Exception as exc:
+        raise ImportPayloadError(
+            "could not decrypt the stored PluralKit token"
+        ) from exc
+
+    options = _parse_options(job)
+
+    append_event(
+        job,
+        level="info",
+        stage="fetch",
+        message="fetching system from the PluralKit API",
+    )
+    try:
+        parsed = await fetch_export(token, include_switches=options.front_history)
+    except PKApiError as exc:
+        # PK API rejections (bad token, 404, rate limit, upstream 5xx)
+        # are hard failures — surface the PK-provided message verbatim,
+        # it's already user-readable.
+        raise ImportPayloadError(f"PluralKit API: {exc}") from exc
+
+    append_event(
+        job,
+        level="info",
+        stage="fetch",
+        message=(
+            f"fetched {len(_list(parsed, 'members'))} members, "
+            f"{len(_list(parsed, 'groups'))} groups, "
+            f"{len(_list(parsed, 'switches'))} switches"
+        ),
+    )
+    await _process_pk_export(job, db, parsed, options)
+
+
 # Register at module-import time so importing this module from
-# import_runner._register_builtin_handlers wires it up.
+# import_runner._register_builtin_handlers wires both handlers up.
 register_handler(ImportJobSource.PLURALKIT_FILE.value, handle_pluralkit_file)
+register_handler(ImportJobSource.PLURALKIT_API.value, handle_pluralkit_api)

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import logging
 
-from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,6 +30,7 @@ from sheaf.schemas.pk_import import PKImportOptions
 from sheaf.services.import_parsing import (
     ImportPayloadError,
     expect_dict,
+    parse_options,
     safe_json_loads,
 )
 from sheaf.services.import_runner import append_event, register_handler, update_counts
@@ -58,26 +58,6 @@ async def _load_user_system(db: AsyncSession, user_id) -> System:
             "no system found on this account — create a system before importing"
         )
     return system
-
-
-def _parse_options(job: ImportJob) -> PKImportOptions:
-    """Pull options out of payload_metadata and Pydantic-validate them.
-
-    Missing / null options means 'all defaults' which matches the legacy
-    endpoint's no-options-passed behaviour. Invalid options is a hard
-    failure (the frontend shouldn't be able to produce them, so this
-    being raised in production means a client bug or hand-rolled curl)."""
-    raw = (job.payload_metadata or {}).get("options")
-    if raw is None or raw == {}:
-        return PKImportOptions()
-    if not isinstance(raw, dict):
-        raise ImportPayloadError(
-            f"options must be a JSON object (got {type(raw).__name__})"
-        )
-    try:
-        return PKImportOptions.model_validate(raw)
-    except ValidationError as exc:
-        raise ImportPayloadError(f"invalid import options: {exc.errors()}") from exc
 
 
 async def _process_pk_export(
@@ -227,7 +207,7 @@ async def handle_pluralkit_file(job: ImportJob, db: AsyncSession) -> None:
     )
 
     parsed = expect_dict(safe_json_loads(blob), descriptor="PluralKit export")
-    options = _parse_options(job)
+    options = parse_options(job.payload_metadata, PKImportOptions)
     await _process_pk_export(job, db, parsed, options)
 
 
@@ -255,7 +235,7 @@ async def handle_pluralkit_api(job: ImportJob, db: AsyncSession) -> None:
             "could not decrypt the stored PluralKit token"
         ) from exc
 
-    options = _parse_options(job)
+    options = parse_options(job.payload_metadata, PKImportOptions)
 
     append_event(
         job,

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -1,0 +1,232 @@
+"""Async runner handler for PluralKit file imports.
+
+Bridges the existing per-section importer helpers (`_build_member`,
+`_import_groups`, `_import_switches`) onto the ImportJob runner. The
+legacy synchronous `pk_import.run_import` still exists for the older
+`/v1/import/pluralkit` endpoint and lives alongside this until Phase 6
+cleanup deletes the legacy surface.
+
+Per-record errors land in `job.events` rather than aborting the
+import. Hard failures (bad JSON, no system, schema-level validation)
+raise; the runner's outer try/except converts that into status=failed
+and a single error event.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.models.import_job import ImportJob, ImportJobSource
+from sheaf.models.member import Member
+from sheaf.models.system import System
+from sheaf.schemas.pk_import import PKImportOptions
+from sheaf.services.import_parsing import (
+    ImportPayloadError,
+    expect_dict,
+    safe_json_loads,
+)
+from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_storage import get_payload
+from sheaf.services.pk_import import (
+    _apply_system_profile,
+    _build_member,
+    _import_groups,
+    _import_switches,
+    _list,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("sheaf.imports.pk")
+
+
+async def _load_user_system(db: AsyncSession, user_id) -> System:
+    """Mirror of the legacy endpoint's lookup. Raises ImportPayloadError
+    so the runner surfaces it as a parse-stage user-facing failure
+    rather than an unhandled traceback."""
+    result = await db.execute(select(System).where(System.user_id == user_id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise ImportPayloadError(
+            "no system found on this account — create a system before importing"
+        )
+    return system
+
+
+def _parse_options(job: ImportJob) -> PKImportOptions:
+    """Pull options out of payload_metadata and Pydantic-validate them.
+
+    Missing / null options means 'all defaults' which matches the legacy
+    endpoint's no-options-passed behaviour. Invalid options is a hard
+    failure (the frontend shouldn't be able to produce them, so this
+    being raised in production means a client bug or hand-rolled curl)."""
+    raw = (job.payload_metadata or {}).get("options")
+    if raw is None or raw == {}:
+        return PKImportOptions()
+    if not isinstance(raw, dict):
+        raise ImportPayloadError(
+            f"options must be a JSON object (got {type(raw).__name__})"
+        )
+    try:
+        return PKImportOptions.model_validate(raw)
+    except ValidationError as exc:
+        raise ImportPayloadError(f"invalid import options: {exc.errors()}") from exc
+
+
+async def handle_pluralkit_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run a PluralKit-file import for a claimed ImportJob.
+
+    Phases:
+      1. Load + parse the payload (safe_json_loads guards element count)
+      2. Validate options
+      3. Locate the owner's system
+      4. Apply system profile (optional)
+      5. Walk members, building hid -> Member map; per-record errors
+         land in events
+      6. Walk groups (optional)
+      7. Walk switches (optional, the biggest section)
+
+    The runner commits all DB mutations once the handler returns; per-
+    section flushes keep the SQLAlchemy unit of work happy without
+    locking in partial state on failure (the runner does a rollback
+    when the handler raises).
+    """
+    if job.payload_storage_key is None:
+        raise ImportPayloadError(
+            "PluralKit file job has no payload — was the upload step skipped?"
+        )
+
+    blob = await get_payload(job.payload_storage_key)
+    if blob is None:
+        raise ImportPayloadError(
+            "PluralKit file payload missing from storage — "
+            "the blob may have been swept by orphan cleanup"
+        )
+
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=f"parsed {len(blob)} bytes of payload",
+    )
+
+    parsed = expect_dict(
+        safe_json_loads(blob), descriptor="PluralKit export"
+    )
+    options = _parse_options(job)
+
+    system = await _load_user_system(db, job.user_id)
+
+    if options.system_profile:
+        _apply_system_profile(parsed, system)
+        append_event(
+            job,
+            level="info",
+            stage="system_profile",
+            message="applied PK system fields to Sheaf system row",
+        )
+
+    # --- Members ---------------------------------------------------------
+
+    pk_members = _list(parsed, "members")
+    if options.member_ids is not None:
+        wanted = set(options.member_ids)
+        pk_members = [m for m in pk_members if m.get("id") in wanted]
+
+    hid_to_member: dict[str, Member] = {}
+    for pk_m in pk_members:
+        # Defensive: each member runs in its own try so one bad row
+        # doesn't kill the whole batch. Bad rows append an error event
+        # with the HID so the user can see what got skipped.
+        hid_for_event = pk_m.get("id") if isinstance(pk_m, dict) else None
+        try:
+            member = _build_member(pk_m, system.id)
+        except Exception as exc:
+            update_counts(job, members_failed=1)
+            append_event(
+                job,
+                level="error",
+                stage="members",
+                message=f"failed to build member: {exc!s}"[:500],
+                record_ref=str(hid_for_event) if hid_for_event else None,
+            )
+            continue
+        if member is None:
+            # _build_member returns None for unusable rows (no name, no id).
+            update_counts(job, members_failed=1)
+            append_event(
+                job,
+                level="warning",
+                stage="members",
+                message="member row had no usable name / id, skipped",
+                record_ref=str(hid_for_event) if hid_for_event else None,
+            )
+            continue
+        db.add(member)
+        hid = str(hid_for_event or "")
+        if hid:
+            hid_to_member[hid] = member
+        update_counts(job, members_imported=1)
+
+    await db.flush()
+
+    # --- Groups ----------------------------------------------------------
+
+    if options.groups:
+        try:
+            count = await _import_groups(
+                _list(parsed, "groups"), system.id, hid_to_member, db
+            )
+            update_counts(job, groups_imported=count)
+            append_event(
+                job,
+                level="info",
+                stage="groups",
+                message=f"imported {count} groups",
+            )
+        except Exception as exc:
+            append_event(
+                job,
+                level="error",
+                stage="groups",
+                message=f"group import failed: {exc!s}"[:500],
+            )
+            raise
+
+    # --- Switches → fronts ----------------------------------------------
+
+    if options.front_history:
+        try:
+            fronts, warnings = await _import_switches(
+                _list(parsed, "switches"), system.id, hid_to_member, db
+            )
+            update_counts(job, fronts_imported=fronts)
+            append_event(
+                job,
+                level="info",
+                stage="switches",
+                message=f"imported {fronts} front intervals from switch history",
+            )
+            for warning in warnings:
+                append_event(
+                    job, level="warning", stage="switches", message=warning
+                )
+        except Exception as exc:
+            append_event(
+                job,
+                level="error",
+                stage="switches",
+                message=f"switch import failed: {exc!s}"[:500],
+            )
+            raise
+
+
+# Register at module-import time so importing this module from
+# import_runner._register_builtin_handlers wires it up.
+register_handler(ImportJobSource.PLURALKIT_FILE.value, handle_pluralkit_file)

--- a/sheaf/services/sheaf_import_runner.py
+++ b/sheaf/services/sheaf_import_runner.py
@@ -1,0 +1,106 @@
+"""Async runner handler for Sheaf native re-imports.
+
+Wrap-pattern handler (see project_future_work.md). Defensive parse +
+hard-failure surfacing + counts + warning-events land here; the
+per-record walk stays inside the existing `sheaf_import.run_import`.
+
+`sheaf_import.run_import` takes keyword options rather than an options
+object, so the handler unpacks the validated SheafImportOptions model
+into kwargs.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.models.import_job import ImportJob, ImportJobSource
+from sheaf.models.system import System
+from sheaf.schemas.sheaf_import import SheafImportOptions
+from sheaf.services.import_parsing import (
+    ImportPayloadError,
+    expect_dict,
+    parse_options,
+    safe_json_loads,
+)
+from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_storage import get_payload
+from sheaf.services.sheaf_import import run_import as sheaf_run_import
+
+logger = logging.getLogger("sheaf.imports.sheaf")
+
+
+async def _load_user_system(db: AsyncSession, user_id) -> System:
+    result = await db.execute(select(System).where(System.user_id == user_id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise ImportPayloadError(
+            "no system found on this account — create a system before importing"
+        )
+    return system
+
+
+async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run a Sheaf native re-import for a claimed ImportJob."""
+    if job.payload_storage_key is None:
+        raise ImportPayloadError(
+            "Sheaf file job has no payload — was the upload step skipped?"
+        )
+
+    blob = await get_payload(job.payload_storage_key)
+    if blob is None:
+        raise ImportPayloadError(
+            "Sheaf file payload missing from storage — "
+            "the blob may have been swept by orphan cleanup"
+        )
+
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=f"parsed {len(blob)} bytes of payload",
+    )
+
+    parsed = expect_dict(safe_json_loads(blob), descriptor="Sheaf export")
+    options = parse_options(job.payload_metadata, SheafImportOptions)
+    system = await _load_user_system(db, job.user_id)
+
+    result = await sheaf_run_import(
+        parsed,
+        system,
+        db,
+        system_profile=options.system_profile,
+        member_ids=options.member_ids,
+        fronts=options.fronts,
+        groups=options.groups,
+        tags=options.tags,
+        custom_fields=options.custom_fields,
+    )
+
+    update_counts(
+        job,
+        members_imported=result.members_imported,
+        fronts_imported=result.fronts_imported,
+        groups_imported=result.groups_imported,
+        tags_imported=result.tags_imported,
+        custom_fields_imported=result.custom_fields_imported,
+    )
+    for warning in result.warnings:
+        append_event(job, level="warning", stage="import", message=warning)
+    append_event(
+        job,
+        level="info",
+        stage="import",
+        message=(
+            f"imported {result.members_imported} members, "
+            f"{result.fronts_imported} fronts, "
+            f"{result.groups_imported} groups, "
+            f"{result.tags_imported} tags, "
+            f"{result.custom_fields_imported} custom fields"
+        ),
+    )
+
+
+register_handler(ImportJobSource.SHEAF_FILE.value, handle_sheaf_file)

--- a/sheaf/services/sp_import_runner.py
+++ b/sheaf/services/sp_import_runner.py
@@ -1,0 +1,97 @@
+"""Async runner handler for SimplyPlural file imports.
+
+Wrap-pattern handler (see project_future_work.md "Deep per-record
+instrumentation"): defensive parse + hard-failure surfacing + counts +
+warning-events land here, but the per-record member / custom-front /
+group / front walk still happens inside the existing
+`sp_import.run_import`. Deeper per-record instrumentation is a logged
+follow-up — SP's run_import is a ~230-line monolith and restructuring
+it is its own task.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.models.import_job import ImportJob, ImportJobSource
+from sheaf.models.system import System
+from sheaf.schemas.sp_import import SPImportOptions
+from sheaf.services.import_parsing import (
+    ImportPayloadError,
+    expect_dict,
+    parse_options,
+    safe_json_loads,
+)
+from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_storage import get_payload
+from sheaf.services.sp_import import run_import as sp_run_import
+
+logger = logging.getLogger("sheaf.imports.sp")
+
+
+async def _load_user_system(db: AsyncSession, user_id) -> System:
+    result = await db.execute(select(System).where(System.user_id == user_id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise ImportPayloadError(
+            "no system found on this account — create a system before importing"
+        )
+    return system
+
+
+async def handle_simplyplural_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run a SimplyPlural-file import for a claimed ImportJob."""
+    if job.payload_storage_key is None:
+        raise ImportPayloadError(
+            "SimplyPlural file job has no payload — was the upload step skipped?"
+        )
+
+    blob = await get_payload(job.payload_storage_key)
+    if blob is None:
+        raise ImportPayloadError(
+            "SimplyPlural file payload missing from storage — "
+            "the blob may have been swept by orphan cleanup"
+        )
+
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=f"parsed {len(blob)} bytes of payload",
+    )
+
+    parsed = expect_dict(safe_json_loads(blob), descriptor="SimplyPlural export")
+    options = parse_options(job.payload_metadata, SPImportOptions)
+    system = await _load_user_system(db, job.user_id)
+
+    result = await sp_run_import(parsed, options, system, db)
+
+    update_counts(
+        job,
+        members_imported=result.members_imported,
+        custom_fronts_imported=result.custom_fronts_imported,
+        fronts_imported=result.fronts_imported,
+        groups_imported=result.groups_imported,
+        custom_fields_imported=result.custom_fields_imported,
+        notes_skipped=result.notes_skipped,
+    )
+    for warning in result.warnings:
+        append_event(job, level="warning", stage="import", message=warning)
+    append_event(
+        job,
+        level="info",
+        stage="import",
+        message=(
+            f"imported {result.members_imported} members, "
+            f"{result.custom_fronts_imported} custom fronts, "
+            f"{result.fronts_imported} front intervals, "
+            f"{result.groups_imported} groups, "
+            f"{result.custom_fields_imported} custom fields"
+        ),
+    )
+
+
+register_handler(ImportJobSource.SIMPLYPLURAL_FILE.value, handle_simplyplural_file)

--- a/sheaf/services/tb_import_runner.py
+++ b/sheaf/services/tb_import_runner.py
@@ -1,0 +1,89 @@
+"""Async runner handler for Tupperbox file imports.
+
+Wrap-pattern handler (see project_future_work.md "Deep per-record
+instrumentation"): the defensive parse + hard-failure surfacing +
+counts + warning-events all land here, but the per-record member walk
+still happens inside the existing `tb_import.run_import`, which skips
+malformed rows silently rather than emitting a per-record error event.
+Deeper instrumentation is a logged follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.models.import_job import ImportJob, ImportJobSource
+from sheaf.models.system import System
+from sheaf.schemas.tb_import import TBImportOptions
+from sheaf.services.import_parsing import (
+    ImportPayloadError,
+    expect_dict,
+    parse_options,
+    safe_json_loads,
+)
+from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_storage import get_payload
+from sheaf.services.tb_import import run_import as tb_run_import
+
+logger = logging.getLogger("sheaf.imports.tb")
+
+
+async def _load_user_system(db: AsyncSession, user_id) -> System:
+    result = await db.execute(select(System).where(System.user_id == user_id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise ImportPayloadError(
+            "no system found on this account — create a system before importing"
+        )
+    return system
+
+
+async def handle_tupperbox_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run a Tupperbox-file import for a claimed ImportJob."""
+    if job.payload_storage_key is None:
+        raise ImportPayloadError(
+            "Tupperbox file job has no payload — was the upload step skipped?"
+        )
+
+    blob = await get_payload(job.payload_storage_key)
+    if blob is None:
+        raise ImportPayloadError(
+            "Tupperbox file payload missing from storage — "
+            "the blob may have been swept by orphan cleanup"
+        )
+
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=f"parsed {len(blob)} bytes of payload",
+    )
+
+    parsed = expect_dict(safe_json_loads(blob), descriptor="Tupperbox export")
+    options = parse_options(job.payload_metadata, TBImportOptions)
+    system = await _load_user_system(db, job.user_id)
+
+    result = await tb_run_import(parsed, options, system, db)
+
+    update_counts(
+        job,
+        members_imported=result.members_imported,
+        groups_imported=result.groups_imported,
+    )
+    for warning in result.warnings:
+        append_event(job, level="warning", stage="import", message=warning)
+    append_event(
+        job,
+        level="info",
+        stage="import",
+        message=(
+            f"imported {result.members_imported} members, "
+            f"{result.groups_imported} groups"
+        ),
+    )
+
+
+register_handler(ImportJobSource.TUPPERBOX_FILE.value, handle_tupperbox_file)

--- a/tests/fixtures/sp_export_sample.json
+++ b/tests/fixtures/sp_export_sample.json
@@ -1,0 +1,34 @@
+{
+  "version": 2,
+  "users": [
+    {
+      "_id": "spuser1",
+      "username": "SP Test System",
+      "desc": "Synthetic SimplyPlural export for import-runner tests.",
+      "color": "#aabbcc"
+    }
+  ],
+  "members": [
+    {
+      "_id": "spm1",
+      "name": "SpAlice",
+      "displayName": "Alice (SP)",
+      "desc": "First SP member.",
+      "pronouns": "she/her",
+      "color": "#ff0000",
+      "private": false
+    },
+    {
+      "_id": "spm2",
+      "name": "SpBob",
+      "desc": "Second SP member, private.",
+      "pronouns": "he/him",
+      "private": true
+    }
+  ],
+  "frontStatuses": [],
+  "frontHistory": [],
+  "groups": [],
+  "customFields": [],
+  "notes": []
+}

--- a/tests/test_imports_api.py
+++ b/tests/test_imports_api.py
@@ -1,0 +1,314 @@
+"""Tests for the unified /v1/imports endpoints.
+
+These cover the enqueue + lifecycle surface only. The per-source
+runners (PluralKit, Tupperbox, etc.) get their own tests in
+phases 3-6 — at this phase the runner is registered but has no
+handler for any source, so jobs sit pending and never run.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import httpx
+
+PK_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "pk_export_sample.json"
+
+
+def _post_file(
+    client: httpx.Client,
+    *,
+    source: str,
+    idem_key: str | None = None,
+    payload: bytes | None = None,
+    options: dict | None = None,
+    filename: str = "import.json",
+) -> httpx.Response:
+    """Helper for POST /v1/imports/file. Defaults to the PK fixture for
+    the payload so callers can override on a per-test basis."""
+    # b"" is intentional empty-file test input — only fall back to the
+    # fixture when payload was not explicitly passed.
+    actual = payload if payload is not None else PK_FIXTURE.read_bytes()
+    files = {"file": (filename, actual, "application/json")}
+    form: dict[str, str] = {
+        "source": source,
+        "idempotency_key": idem_key or str(uuid.uuid4()),
+    }
+    if options is not None:
+        form["options"] = json.dumps(options)
+    return client.post("/v1/imports/file", files=files, data=form)
+
+
+# --- POST /v1/imports/file -------------------------------------------------
+
+
+def test_file_create_returns_202_and_pending_job(auth_client: httpx.Client):
+    resp = _post_file(auth_client, source="pluralkit_file")
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["source"] == "pluralkit_file"
+    assert body["counts"] == {}
+    assert body["events"] == []
+    assert uuid.UUID(body["id"])  # is a UUID
+
+
+def test_file_create_idempotent_returns_same_job(auth_client: httpx.Client):
+    """Same idempotency_key, same user, two POSTs -> same job id, not
+    a duplicate. This is the double-click-the-upload-button defence."""
+    key = str(uuid.uuid4())
+    first = _post_file(auth_client, source="pluralkit_file", idem_key=key)
+    assert first.status_code == 202, first.text
+    first_id = first.json()["id"]
+
+    second = _post_file(auth_client, source="pluralkit_file", idem_key=key)
+    assert second.status_code == 202, second.text
+    assert second.json()["id"] == first_id
+
+
+def test_file_create_rejects_unknown_source(auth_client: httpx.Client):
+    resp = _post_file(auth_client, source="bogus_source")
+    assert resp.status_code == 422, resp.text
+
+
+def test_file_create_rejects_legacy_source(auth_client: httpx.Client):
+    """The legacy single-source endpoints kept their /v1/import/* prefix.
+    The new unified router refuses the deprecated 'pluralkit_api' value
+    here — that one's only valid via /v1/imports/api with a token, not
+    a file upload."""
+    resp = _post_file(auth_client, source="pluralkit_api")
+    assert resp.status_code == 422, resp.text
+
+
+def test_file_create_rejects_empty_file(auth_client: httpx.Client):
+    resp = _post_file(auth_client, source="pluralkit_file", payload=b"")
+    assert resp.status_code == 400, resp.text
+
+
+def test_file_create_rejects_bad_options_json(auth_client: httpx.Client):
+    """`options` ships as a form field with JSON inside — bad JSON is a
+    400, not a 422, because the schema-level validation never gets
+    reached. Same shape as the legacy importers' early bail."""
+    files = {"file": ("x.json", PK_FIXTURE.read_bytes(), "application/json")}
+    resp = auth_client.post(
+        "/v1/imports/file",
+        files=files,
+        data={
+            "source": "pluralkit_file",
+            "idempotency_key": str(uuid.uuid4()),
+            "options": "this is not json",
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "not valid JSON" in resp.json()["detail"]
+
+
+def test_file_create_accepts_options_json(auth_client: httpx.Client):
+    resp = _post_file(
+        auth_client,
+        source="pluralkit_file",
+        options={"system_profile": True, "front_history": False},
+    )
+    assert resp.status_code == 202, resp.text
+
+
+# --- POST /v1/imports/api --------------------------------------------------
+
+
+def test_api_create_returns_202_and_pending_job(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/imports/api",
+        json={
+            "source": "pluralkit_api",
+            "idempotency_key": str(uuid.uuid4()),
+            "pk_token": "fake-pk-token-not-real",
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["source"] == "pluralkit_api"
+
+
+def test_api_create_idempotent_returns_same_job(auth_client: httpx.Client):
+    key = str(uuid.uuid4())
+    first = auth_client.post(
+        "/v1/imports/api",
+        json={
+            "source": "pluralkit_api",
+            "idempotency_key": key,
+            "pk_token": "tok",
+        },
+    )
+    assert first.status_code == 202, first.text
+    second = auth_client.post(
+        "/v1/imports/api",
+        json={
+            "source": "pluralkit_api",
+            "idempotency_key": key,
+            "pk_token": "tok-different",  # ignored on idempotent match
+        },
+    )
+    assert second.status_code == 202, second.text
+    assert second.json()["id"] == first.json()["id"]
+
+
+def test_api_create_rejects_extra_fields(auth_client: httpx.Client):
+    """ImportApiCreateRequest is extra='forbid' — stowaway fields get
+    a 422, not a silent drop."""
+    resp = auth_client.post(
+        "/v1/imports/api",
+        json={
+            "source": "pluralkit_api",
+            "idempotency_key": str(uuid.uuid4()),
+            "pk_token": "tok",
+            "bogus_extra_field": True,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+
+
+# --- GET /v1/imports -------------------------------------------------------
+
+
+def test_list_returns_user_jobs_most_recent_first(auth_client: httpx.Client):
+    first = _post_file(auth_client, source="pluralkit_file")
+    second = _post_file(auth_client, source="tupperbox_file")
+    assert first.status_code == 202 and second.status_code == 202
+
+    resp = auth_client.get("/v1/imports", params={"limit": 50})
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    ids = [item["id"] for item in items]
+    # Newest first; both should appear.
+    assert second.json()["id"] in ids
+    assert first.json()["id"] in ids
+    assert ids.index(second.json()["id"]) < ids.index(first.json()["id"])
+
+
+def test_list_paginates_via_next_cursor(auth_client: httpx.Client):
+    """limit=1 with 2+ jobs surfaces next_cursor; raising the limit
+    drops it."""
+    _post_file(auth_client, source="pluralkit_file")
+    _post_file(auth_client, source="tupperbox_file")
+    one = auth_client.get("/v1/imports", params={"limit": 1})
+    assert one.status_code == 200, one.text
+    assert one.json()["next_cursor"] is not None
+    assert len(one.json()["items"]) == 1
+
+
+def test_list_excludes_archived_by_default(auth_client: httpx.Client):
+    created = _post_file(auth_client, source="pluralkit_file")
+    job_id = created.json()["id"]
+    # Cancel pending -> moves to cancelled (terminal). Then DELETE again
+    # to archive. The archived row should drop out of the default list.
+    cancel = auth_client.delete(f"/v1/imports/{job_id}")
+    assert cancel.status_code == 204
+    archive = auth_client.delete(f"/v1/imports/{job_id}")
+    assert archive.status_code == 204
+
+    default = auth_client.get("/v1/imports", params={"limit": 50}).json()
+    assert all(item["id"] != job_id for item in default["items"])
+
+    with_archived = auth_client.get(
+        "/v1/imports", params={"limit": 50, "include_archived": True}
+    ).json()
+    assert any(item["id"] == job_id for item in with_archived["items"])
+
+
+# --- GET /v1/imports/{id} --------------------------------------------------
+
+
+def test_get_returns_full_detail(auth_client: httpx.Client):
+    created = _post_file(auth_client, source="pluralkit_file")
+    job_id = created.json()["id"]
+    resp = auth_client.get(f"/v1/imports/{job_id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == job_id
+    assert body["events"] == []
+
+
+def test_get_404_for_other_user(auth_client: httpx.Client, client: httpx.Client):
+    """A job belonging to another account 404s — no leak of cross-user
+    id existence."""
+    import os
+
+    other_email = f"imports-other-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as other:
+        reg = other.post(
+            "/v1/auth/register",
+            json={"email": other_email, "password": "testpassword123"},
+        )
+        assert reg.status_code == 201, reg.text
+        other.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+        other_job = _post_file(other, source="pluralkit_file")
+        assert other_job.status_code == 202, other_job.text
+        other_id = other_job.json()["id"]
+
+    resp = auth_client.get(f"/v1/imports/{other_id}")
+    assert resp.status_code == 404
+
+
+def test_get_404_for_random_uuid(auth_client: httpx.Client):
+    resp = auth_client.get(f"/v1/imports/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# --- DELETE /v1/imports/{id} -----------------------------------------------
+
+
+def test_delete_pending_cancels(auth_client: httpx.Client):
+    created = _post_file(auth_client, source="pluralkit_file")
+    job_id = created.json()["id"]
+    resp = auth_client.delete(f"/v1/imports/{job_id}")
+    assert resp.status_code == 204
+    fresh = auth_client.get(f"/v1/imports/{job_id}").json()
+    assert fresh["status"] == "cancelled"
+    assert fresh["finished_at"] is not None
+
+
+def test_delete_terminal_archives(auth_client: httpx.Client):
+    created = _post_file(auth_client, source="pluralkit_file")
+    job_id = created.json()["id"]
+    auth_client.delete(f"/v1/imports/{job_id}")  # cancel -> terminal
+    archive = auth_client.delete(f"/v1/imports/{job_id}")
+    assert archive.status_code == 204
+    # Default list excludes archived; include_archived surfaces it.
+    listing = auth_client.get(
+        "/v1/imports", params={"include_archived": True, "limit": 50}
+    ).json()
+    matched = [item for item in listing["items"] if item["id"] == job_id]
+    assert matched and matched[0]["archived_at"] is not None
+
+
+def test_delete_other_user_404(auth_client: httpx.Client):
+    """Same 404 leak protection as GET — can't even discover ids."""
+    import os
+
+    other_email = f"imports-delother-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as other:
+        reg = other.post(
+            "/v1/auth/register",
+            json={"email": other_email, "password": "testpassword123"},
+        )
+        other.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+        other_id = _post_file(other, source="pluralkit_file").json()["id"]
+
+    resp = auth_client.delete(f"/v1/imports/{other_id}")
+    assert resp.status_code == 404
+
+
+# --- Authn / scope ---------------------------------------------------------
+
+
+def test_anon_create_rejected(client: httpx.Client):
+    resp = _post_file(client, source="pluralkit_file")
+    assert resp.status_code in (401, 403)
+
+
+def test_anon_list_rejected(client: httpx.Client):
+    resp = client.get("/v1/imports")
+    assert resp.status_code in (401, 403)

--- a/tests/test_imports_pk_api_runner.py
+++ b/tests/test_imports_pk_api_runner.py
@@ -1,0 +1,191 @@
+"""End-to-end tests for the PluralKit API import runner handler.
+
+The handler calls `fetch_export`, which in production hits
+api.pluralkit.me. These tests can't reach the real API, so the
+in-container runner-drive script monkeypatches
+`pk_import_runner.fetch_export` (the name the handler actually
+resolves — it's a `from`-import, so patching pk_api directly wouldn't
+take) with a stub before ticking the runner.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+import uuid
+
+import httpx
+
+# Minimal valid PK-export shape the stub fetch returns. One member,
+# no groups, no switches — enough to prove the handler walks the
+# canonical export dict the same way the file handler does.
+_STUB_EXPORT_PY = """{
+    "version": 2,
+    "id": "stubsy",
+    "name": "Stub API System",
+    "tag": "stub",
+    "members": [
+        {"id": "stbm1", "name": "ApiAlice"},
+        {"id": "stbm2", "name": "ApiBob"}
+    ],
+    "groups": [],
+    "switches": []
+}"""
+
+
+def _drive_runner_pk_api(*, fail_mode: str = "") -> None:
+    """Tick the import runner inside the container with fetch_export
+    stubbed.
+
+    fail_mode="" -> stub returns the export above (success path).
+    fail_mode="pkapi" -> stub raises PKApiError (rejection path).
+    """
+    if fail_mode == "pkapi":
+        stub = (
+            "async def fake_fetch(token, *, include_switches=True):\n"
+            "    from sheaf.services.pk_api import PKApiError\n"
+            "    raise PKApiError('PluralKit token rejected (401).', 401)\n"
+        )
+    else:
+        stub = (
+            "async def fake_fetch(token, *, include_switches=True):\n"
+            f"    return {_STUB_EXPORT_PY}\n"
+        )
+    script = f"""
+import asyncio
+from sheaf.database import async_session_factory
+from sheaf.services.import_runner import run_import_tick
+import sheaf.services.pk_import_runner as pir
+
+{stub}
+pir.fetch_export = fake_fetch
+
+async def main():
+    while True:
+        async with async_session_factory() as db:
+            result = await run_import_tick(db)
+        if result.get("items_processed", 0) == 0:
+            return
+asyncio.run(main())
+"""
+    subprocess.run(
+        ["docker", "compose", "-p", "sheaf-test", "exec", "-T", "app", "python", "-c", script],
+        check=True,
+        timeout=60,
+    )
+
+
+def _post_api_import(client: httpx.Client, *, idem_key: str | None = None) -> dict:
+    resp = client.post(
+        "/v1/imports/api",
+        json={
+            "source": "pluralkit_api",
+            "idempotency_key": idem_key or str(uuid.uuid4()),
+            "pk_token": "fake-token-for-test",
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+def _wait_for_terminal(
+    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
+) -> dict:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/imports/{job_id}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        if body["status"] in ("complete", "failed", "cancelled"):
+            return body
+        time.sleep(0.2)
+    raise AssertionError(f"job {job_id} not terminal in {timeout_s}s")
+
+
+# --- Happy path ------------------------------------------------------------
+
+
+def test_pk_api_runner_imports_fetched_system(auth_client: httpx.Client):
+    """The stub fetch returns a 2-member export; the handler walks it
+    into the user's system exactly like the file handler would."""
+    job = _post_api_import(auth_client)
+    _drive_runner_pk_api()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 2, final["counts"]
+
+    members = auth_client.get("/v1/members").json()
+    names = {m["name"] for m in members}
+    assert {"ApiAlice", "ApiBob"}.issubset(names), names
+
+
+def test_pk_api_runner_emits_fetch_events(auth_client: httpx.Client):
+    """The handler records fetch-stage info events so the report shows
+    the live-pull step distinctly from the file-parse step."""
+    job = _post_api_import(auth_client)
+    _drive_runner_pk_api()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    fetch_events = [e for e in final["events"] if e["stage"] == "fetch"]
+    assert fetch_events, final["events"]
+    assert any("fetched 2 members" in e["message"] for e in fetch_events)
+
+
+# --- Failure path ----------------------------------------------------------
+
+
+def test_pk_api_runner_fails_on_pk_rejection(auth_client: httpx.Client):
+    """A PKApiError (bad token, 404, rate limit, upstream 5xx) is a hard
+    failure — status=failed with the PK-provided message surfaced."""
+    job = _post_api_import(auth_client)
+    _drive_runner_pk_api(fail_mode="pkapi")
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any(
+        e["level"] == "error" and "PluralKit" in e["message"]
+        for e in final["events"]
+    ), final["events"]
+
+
+# --- Credential handling ---------------------------------------------------
+
+
+def test_pk_api_runner_wipes_credential_on_finalize(auth_client: httpx.Client):
+    """After the job finalizes, the encrypted PK token must be gone from
+    payload_metadata — checked directly against the DB row since the
+    API response never exposes payload_metadata."""
+    job = _post_api_import(auth_client)
+    _drive_runner_pk_api()
+    final = _wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete"
+
+    # Inspect the row in-container: encrypted_credential must be absent.
+    script = f"""
+import asyncio
+from sqlalchemy import select
+from sheaf.database import async_session_factory
+from sheaf.models.import_job import ImportJob
+
+async def main():
+    async with async_session_factory() as db:
+        row = (await db.execute(
+            select(ImportJob).where(ImportJob.id == '{job["id"]}')
+        )).scalar_one()
+        meta = row.payload_metadata or {{}}
+        assert 'encrypted_credential' not in meta, (
+            f'credential not wiped: {{list(meta)}}'
+        )
+        print('credential-wiped-ok')
+
+asyncio.run(main())
+"""
+    result = subprocess.run(
+        ["docker", "compose", "-p", "sheaf-test", "exec", "-T", "app", "python", "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert "credential-wiped-ok" in result.stdout, result.stdout + result.stderr

--- a/tests/test_imports_pk_runner.py
+++ b/tests/test_imports_pk_runner.py
@@ -1,0 +1,228 @@
+"""End-to-end tests for the PluralKit file import runner handler.
+
+Uploads a PK export via /v1/imports/file, waits for the runner tick
+to claim and process it, then asserts on the resulting ImportJob
+state (status, counts, events) plus the actual Sheaf rows the
+importer was supposed to create.
+
+The test runner pokes the in-container job dispatcher directly via
+`docker compose exec` rather than waiting on the 5s production tick,
+so a per-test wait is bounded to a single function call rather than
+real-time polling.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import time
+import uuid
+
+import httpx
+
+PK_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "pk_export_sample.json"
+
+
+def _drive_runner() -> None:
+    """Force one tick of the import runner inside the test container.
+
+    Avoids the wall-clock wait for the 5s production tick. The
+    in-container helper imports run_import_tick + grabs a session
+    out of the database module so it sees committed state from the
+    host-side HTTP client."""
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-p",
+            "sheaf-test",
+            "exec",
+            "-T",
+            "app",
+            "python",
+            "-c",
+            """
+import asyncio
+from sheaf.database import async_session_factory
+from sheaf.services.import_runner import run_import_tick
+
+async def main():
+    # Drain until empty so each test gets fully processed (not just one
+    # claimed-but-incomplete job left behind by a prior call).
+    while True:
+        async with async_session_factory() as db:
+            result = await run_import_tick(db)
+        if result.get("items_processed", 0) == 0:
+            return
+asyncio.run(main())
+""",
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+def _post_pk_file(
+    client: httpx.Client,
+    *,
+    options: dict | None = None,
+    idem_key: str | None = None,
+    payload: bytes | None = None,
+) -> dict:
+    """POST a PK file import, returning the parsed ImportJobRead body.
+    Asserts 202 so test bodies stay focused on post-run state."""
+    form: dict[str, str] = {
+        "source": "pluralkit_file",
+        "idempotency_key": idem_key or str(uuid.uuid4()),
+    }
+    if options is not None:
+        form["options"] = json.dumps(options)
+    files = {
+        "file": (
+            "pk.json",
+            payload if payload is not None else PK_FIXTURE.read_bytes(),
+            "application/json",
+        )
+    }
+    resp = client.post("/v1/imports/file", files=files, data=form)
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+def _wait_for_terminal(
+    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
+) -> dict:
+    """Poll GET /v1/imports/{id} until status is terminal. Used after
+    `_drive_runner()` to read back the final state. Timeout exists in
+    case something hangs; the runner is direct-invoked so this should
+    return within a single poll in practice."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/imports/{job_id}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        if body["status"] in ("complete", "failed", "cancelled"):
+            return body
+        time.sleep(0.2)
+    raise AssertionError(f"job {job_id} did not reach terminal status in {timeout_s}s")
+
+
+# --- Happy path ------------------------------------------------------------
+
+
+def test_pk_file_runner_imports_members_and_groups(auth_client: httpx.Client):
+    """Defaults (system_profile=True, groups=True, front_history=False)
+    bring in members + groups but not switch history."""
+    job = _post_pk_file(auth_client)
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 3, final["counts"]
+    # Groups in the fixture: "Test Group" exists.
+    assert final["counts"].get("groups_imported", 0) >= 1, final["counts"]
+    # Switches off by default — fronts_imported either missing or 0.
+    assert final["counts"].get("fronts_imported", 0) == 0
+
+    # Sheaf rows actually exist after the run.
+    members = auth_client.get("/v1/members").json()
+    names = {m["name"] for m in members}
+    assert {"Alice", "Bob", "Carol"}.issubset(names), names
+
+
+def test_pk_file_runner_with_front_history(auth_client: httpx.Client):
+    """front_history=True walks the switches array and emits Front rows
+    with member associations."""
+    job = _post_pk_file(auth_client, options={"front_history": True})
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 3
+    assert final["counts"]["fronts_imported"] >= 1
+
+
+def test_pk_file_runner_emits_info_events_per_section(auth_client: httpx.Client):
+    """The runner records info-level events for each phase so the user-
+    facing report has a coherent breadcrumb trail, not just final counts."""
+    job = _post_pk_file(auth_client, options={"front_history": True})
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    stages = {e["stage"] for e in final["events"] if e["level"] == "info"}
+    assert {"parse", "system_profile", "groups", "switches"}.issubset(stages), stages
+
+
+def test_pk_file_runner_member_deselection(auth_client: httpx.Client):
+    """member_ids filter from the preview screen narrows the import set."""
+    job = _post_pk_file(auth_client, options={"member_ids": ["alice"]})
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete"
+    assert final["counts"]["members_imported"] == 1
+
+    members = auth_client.get("/v1/members").json()
+    names = {m["name"] for m in members}
+    assert "Alice" in names
+    assert "Bob" not in names
+    assert "Carol" not in names
+
+
+# --- Failure paths ---------------------------------------------------------
+
+
+def test_pk_file_runner_fails_on_invalid_json(auth_client: httpx.Client):
+    """Bad JSON in the payload turns into status=failed plus a single
+    error event at the parse stage. The job doesn't blow up the runner
+    — subsequent jobs still tick through."""
+    job = _post_pk_file(auth_client, payload=b"this isn't json at all")
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any(
+        e["level"] == "error" and "invalid JSON" in e["message"]
+        for e in final["events"]
+    ), final["events"]
+
+
+def test_pk_file_runner_fails_on_non_object_root(auth_client: httpx.Client):
+    """PK exports are JSON objects at the root. An array / scalar gets a
+    clear error rather than a downstream `.get()` AttributeError."""
+    job = _post_pk_file(auth_client, payload=b'["not", "an", "object"]')
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any("must be a JSON object" in e["message"] for e in final["events"])
+
+
+def test_pk_file_runner_idempotency_after_complete(auth_client: httpx.Client):
+    """Re-POSTing the same idempotency_key after the first run completed
+    returns the original (already-complete) job rather than scheduling
+    a duplicate import."""
+    key = str(uuid.uuid4())
+    first = _post_pk_file(auth_client, idem_key=key)
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, first["id"])
+    assert final["status"] == "complete"
+
+    second = _post_pk_file(auth_client, idem_key=key)
+    assert second["id"] == first["id"]
+    assert second["status"] == "complete"  # not pending again
+
+
+def test_pk_file_runner_finalize_wipes_storage_key(auth_client: httpx.Client):
+    """After a successful run, the runner clears payload_storage_key
+    on the row so the storage blob can be deleted independently."""
+    job = _post_pk_file(auth_client)
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete"
+    # The API surface doesn't expose payload_storage_key, but we can
+    # observe that re-fetching the (terminal) job is still a 200 — the
+    # row stays even after the blob is gone.
+    resp = auth_client.get(f"/v1/imports/{job['id']}")
+    assert resp.status_code == 200

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -1,0 +1,127 @@
+"""End-to-end tests for the Sheaf native re-import runner handler.
+
+Wrap-pattern handler (Phase 6). Verifies the runner plumbing + the
+failure paths. The Sheaf export shape is built inline rather than from
+a fixture file, matching the existing test_sheaf_import.py convention.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import uuid
+
+import httpx
+
+# Minimal valid Sheaf export — version + a couple of members. Other
+# sections empty; enough to prove the runner walks the canonical
+# export dict.
+_SHEAF_EXPORT = {
+    "version": 2,
+    "system": {"name": "Reimport System"},
+    "members": [
+        {"id": "m1", "name": "ReAlice", "pronouns": "she/her"},
+        {"id": "m2", "name": "ReBob"},
+    ],
+    "fronts": [],
+    "groups": [],
+    "tags": [],
+    "custom_fields": [],
+}
+
+
+def _drive_runner() -> None:
+    subprocess.run(
+        [
+            "docker", "compose", "-p", "sheaf-test", "exec", "-T", "app",
+            "python", "-c",
+            """
+import asyncio
+from sheaf.database import async_session_factory
+from sheaf.services.import_runner import run_import_tick
+
+async def main():
+    while True:
+        async with async_session_factory() as db:
+            result = await run_import_tick(db)
+        if result.get("items_processed", 0) == 0:
+            return
+asyncio.run(main())
+""",
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+def _post_file(client: httpx.Client, *, payload: bytes) -> dict:
+    resp = client.post(
+        "/v1/imports/file",
+        files={"file": ("sheaf.json", payload, "application/json")},
+        data={"source": "sheaf_file", "idempotency_key": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+def _wait_for_terminal(
+    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
+) -> dict:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/imports/{job_id}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        if body["status"] in ("complete", "failed", "cancelled"):
+            return body
+        time.sleep(0.2)
+    raise AssertionError(f"job {job_id} not terminal in {timeout_s}s")
+
+
+def test_sheaf_runner_imports_members(auth_client: httpx.Client):
+    job = _post_file(auth_client, payload=json.dumps(_SHEAF_EXPORT).encode())
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 2, final["counts"]
+
+    members = auth_client.get("/v1/members").json()
+    names = {m["name"] for m in members}
+    assert {"ReAlice", "ReBob"}.issubset(names), names
+
+
+def test_sheaf_runner_roundtrip_from_export(auth_client: httpx.Client):
+    """The realistic path: build a system, hit /v1/export, feed those
+    exact bytes back through the async import. Exercises the format the
+    exporter actually emits, not a hand-written approximation."""
+    auth_client.post("/v1/members", json={"name": "RoundtripMember"})
+    export = auth_client.get("/v1/export")
+    assert export.status_code == 200, export.text
+
+    job = _post_file(auth_client, payload=export.content)
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+    # The exported member comes back in on re-import (alongside the
+    # original — re-import is additive, not a replace).
+    assert final["counts"]["members_imported"] >= 1, final["counts"]
+
+
+def test_sheaf_runner_fails_on_invalid_json(auth_client: httpx.Client):
+    job = _post_file(auth_client, payload=b"not json")
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any("invalid JSON" in e["message"] for e in final["events"])
+
+
+def test_sheaf_runner_fails_on_non_object_root(auth_client: httpx.Client):
+    job = _post_file(auth_client, payload=b'"just a string"')
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any("must be a JSON object" in e["message"] for e in final["events"])

--- a/tests/test_imports_tb_sp_runner.py
+++ b/tests/test_imports_tb_sp_runner.py
@@ -1,0 +1,160 @@
+"""End-to-end tests for the Tupperbox + SimplyPlural import runner handlers.
+
+Both took the wrap-pattern path (Phase 5): defensive parse + hard-
+failure surfacing + counts + warning-events, with the per-record walk
+still inside the existing run_import. These tests verify the runner
+plumbing + the failure paths, not per-record error attribution (which
+those importers don't have yet — see the deferred deep-instrumentation
+task).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import time
+import uuid
+
+import httpx
+
+TB_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "tupperbox_export_sample.json"
+SP_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "sp_export_sample.json"
+
+
+def _drive_runner() -> None:
+    """Drain the import runner inside the test container until empty."""
+    subprocess.run(
+        [
+            "docker", "compose", "-p", "sheaf-test", "exec", "-T", "app",
+            "python", "-c",
+            """
+import asyncio
+from sheaf.database import async_session_factory
+from sheaf.services.import_runner import run_import_tick
+
+async def main():
+    while True:
+        async with async_session_factory() as db:
+            result = await run_import_tick(db)
+        if result.get("items_processed", 0) == 0:
+            return
+asyncio.run(main())
+""",
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+def _post_file(
+    client: httpx.Client,
+    *,
+    source: str,
+    payload: bytes,
+    idem_key: str | None = None,
+) -> dict:
+    resp = client.post(
+        "/v1/imports/file",
+        files={"file": ("import.json", payload, "application/json")},
+        data={"source": source, "idempotency_key": idem_key or str(uuid.uuid4())},
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+def _wait_for_terminal(
+    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
+) -> dict:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/imports/{job_id}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        if body["status"] in ("complete", "failed", "cancelled"):
+            return body
+        time.sleep(0.2)
+    raise AssertionError(f"job {job_id} not terminal in {timeout_s}s")
+
+
+# --- Tupperbox -------------------------------------------------------------
+
+
+def test_tupperbox_runner_imports_members(auth_client: httpx.Client):
+    job = _post_file(
+        auth_client, source="tupperbox_file", payload=TB_FIXTURE.read_bytes()
+    )
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] >= 1, final["counts"]
+    # An info event summarising the import lands at the import stage.
+    assert any(
+        e["stage"] == "import" and e["level"] == "info" for e in final["events"]
+    ), final["events"]
+
+
+def test_tupperbox_runner_fails_on_invalid_json(auth_client: httpx.Client):
+    job = _post_file(
+        auth_client, source="tupperbox_file", payload=b"definitely not json"
+    )
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any("invalid JSON" in e["message"] for e in final["events"])
+
+
+def test_tupperbox_runner_fails_on_non_object_root(auth_client: httpx.Client):
+    job = _post_file(auth_client, source="tupperbox_file", payload=b"[1, 2, 3]")
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any("must be a JSON object" in e["message"] for e in final["events"])
+
+
+# --- SimplyPlural ----------------------------------------------------------
+
+
+def test_simplyplural_runner_imports_members(auth_client: httpx.Client):
+    job = _post_file(
+        auth_client, source="simplyplural_file", payload=SP_FIXTURE.read_bytes()
+    )
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 2, final["counts"]
+
+    members = auth_client.get("/v1/members").json()
+    names = {m["name"] for m in members}
+    assert {"SpAlice", "SpBob"}.issubset(names), names
+
+
+def test_simplyplural_runner_fails_on_invalid_json(auth_client: httpx.Client):
+    job = _post_file(
+        auth_client, source="simplyplural_file", payload=b"{ broken"
+    )
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any("invalid JSON" in e["message"] for e in final["events"])
+
+
+def test_simplyplural_runner_summary_event(auth_client: httpx.Client):
+    """The import-stage info event names every count bucket so the
+    report reads coherently even for collections that were empty."""
+    job = _post_file(
+        auth_client, source="simplyplural_file", payload=SP_FIXTURE.read_bytes()
+    )
+    _drive_runner()
+    final = _wait_for_terminal(auth_client, job["id"])
+
+    summary = [
+        e for e in final["events"]
+        if e["stage"] == "import" and e["level"] == "info"
+    ]
+    assert summary, final["events"]
+    assert "members" in summary[-1]["message"]

--- a/tests/test_pk_import.py
+++ b/tests/test_pk_import.py
@@ -1,20 +1,12 @@
-"""Integration tests for the PluralKit data importer.
+"""Integration tests for the PluralKit import *preview* endpoint.
 
-These tests cover the file-upload path end-to-end via the public HTTP
-API. The live-API path (which would forward a real PK token to
-api.pluralkit.me) is not exercised here — that path's behaviour is
-tested at the unit level in test_pk_import_unit.py.
-
-The fixture in tests/fixtures/pk_export_sample.json is a small, synthetic
-PK export designed to cover:
-  - mixed public/private members
-  - a member with a year-less PK birthday (0004-MM-DD sentinel)
-  - a group referencing two of the three members
-  - a switch log that exercises join, leave, replace, and "nobody fronting"
-    transitions
+The actual import now runs through the async job runner — its
+behaviour is covered end-to-end in test_imports_pk_runner.py and
+test_imports_pk_api_runner.py, and the per-field normalisation helpers
+have unit coverage in test_pk_import_unit.py. What's left here is the
+synchronous preview path: parse an export, summarise it, write nothing.
 """
 
-import json
 import pathlib
 
 import httpx
@@ -26,11 +18,6 @@ FIXTURE_PATH = pathlib.Path(__file__).parent / "fixtures" / "pk_export_sample.js
 @pytest.fixture
 def pk_export_bytes() -> bytes:
     return FIXTURE_PATH.read_bytes()
-
-
-@pytest.fixture
-def pk_export() -> dict:
-    return json.loads(FIXTURE_PATH.read_text())
 
 
 def _upload(client: httpx.Client, path: str, payload: bytes, **params):
@@ -75,182 +62,3 @@ def test_preview_rejects_non_object(auth_client: httpx.Client):
         files={"file": ("array.json", b"[1, 2, 3]", "application/json")},
     )
     assert resp.status_code == 400
-
-
-# --- Default import (members + groups; no front history by default) ---------
-
-
-def test_import_default_creates_members_and_groups(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    resp = _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
-    assert resp.status_code == 200, resp.text
-    result = resp.json()
-    assert result["members_imported"] == 3
-    assert result["groups_imported"] == 1
-    assert result["fronts_imported"] == 0  # front_history default is False
-    assert result["warnings"] == []
-
-    members = auth_client.get("/v1/members").json()
-    by_name = {m["name"]: m for m in members}
-    assert set(by_name) == {"Alice", "Bob", "Carol"}
-
-
-def test_import_populates_pluralkit_id(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
-    members = auth_client.get("/v1/members").json()
-    by_name = {m["name"]: m for m in members}
-    assert by_name["Alice"]["pluralkit_id"] == "alice"
-    assert by_name["Bob"]["pluralkit_id"] == "bobxyz"
-    assert by_name["Carol"]["pluralkit_id"] == "carol1"
-
-
-def test_import_maps_per_field_data(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
-    members = auth_client.get("/v1/members").json()
-    alice = next(m for m in members if m["name"] == "Alice")
-    assert alice["display_name"] == "Alice the First"
-    assert alice["pronouns"] == "she/her"
-    assert alice["color"] == "#ff0000"
-    assert alice["birthday"] == "1990-04-15"
-    assert alice["privacy"] == "public"
-
-
-def test_import_collapses_year_less_birthday(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    """PK uses 0004-MM-DD as the year-less sentinel; we collapse to MM-DD."""
-    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
-    members = auth_client.get("/v1/members").json()
-    bob = next(m for m in members if m["name"] == "Bob")
-    assert bob["birthday"] == "07-20"
-
-
-def test_import_resolves_visibility_to_privacy_enum(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
-    members = auth_client.get("/v1/members").json()
-    by_name = {m["name"]: m for m in members}
-    assert by_name["Alice"]["privacy"] == "public"
-    assert by_name["Bob"]["privacy"] == "private"
-    assert by_name["Carol"]["privacy"] == "public"
-
-
-def test_import_groups_link_correct_members(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    _upload(auth_client, "/v1/import/pluralkit", pk_export_bytes)
-    groups = auth_client.get("/v1/groups").json()
-    assert len(groups) == 1
-    inner = groups[0]
-    assert inner["name"] == "Inner Circle"
-    members = auth_client.get(f"/v1/groups/{inner['id']}/members").json()
-    names = sorted(m["name"] for m in members)
-    assert names == ["Alice", "Bob"]
-
-
-# --- Front history path ------------------------------------------------------
-
-
-def test_import_with_front_history_emits_intervals(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    """The four-switch fixture should produce three intervals once converted.
-
-    Switch log oldest-to-newest:
-      09:00  alice
-      10:00  alice + bobxyz   <- Front #1 (alice solo) ends here, Front #2 starts
-      11:00  carol1            <- Front #2 ends here, Front #3 starts
-      12:00  []                <- Front #3 ends here (nobody fronting)
-    """
-    resp = _upload(
-        auth_client,
-        "/v1/import/pluralkit",
-        pk_export_bytes,
-        front_history="true",
-    )
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["fronts_imported"] == 3
-
-    fronts = auth_client.get("/v1/fronts").json()
-    members = auth_client.get("/v1/members").json()
-    name_by_id = {m["id"]: m["name"] for m in members}
-
-    fronts_sorted = sorted(fronts, key=lambda f: f["started_at"])
-    assert len(fronts_sorted) == 3
-
-    first, second, third = fronts_sorted
-    assert {name_by_id[mid] for mid in first["member_ids"]} == {"Alice"}
-    assert first["ended_at"] is not None  # closed by next switch
-
-    assert {name_by_id[mid] for mid in second["member_ids"]} == {"Alice", "Bob"}
-    assert second["ended_at"] is not None
-
-    assert {name_by_id[mid] for mid in third["member_ids"]} == {"Carol"}
-    # Last switch was "nobody fronting", so the third Front is closed too.
-    assert third["ended_at"] is not None
-
-
-# --- Selective import (member_ids filter) ------------------------------------
-
-
-def test_member_ids_filter_drops_unselected(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    resp = _upload(
-        auth_client,
-        "/v1/import/pluralkit",
-        pk_export_bytes,
-        member_ids="alice,carol1",
-    )
-    assert resp.status_code == 200
-    result = resp.json()
-    assert result["members_imported"] == 2
-
-    names = sorted(m["name"] for m in auth_client.get("/v1/members").json())
-    assert names == ["Alice", "Carol"]
-
-
-def test_filter_warns_when_switches_reference_dropped_members(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    """Switches mentioning Bob should produce a warning, not a hard error,
-    when Bob was deselected at preview time."""
-    resp = _upload(
-        auth_client,
-        "/v1/import/pluralkit",
-        pk_export_bytes,
-        member_ids="alice,carol1",
-        front_history="true",
-    )
-    assert resp.status_code == 200
-    result = resp.json()
-    # The Alice + Bob switch becomes effectively Alice-only after filtering,
-    # which means we still get three intervals; only the warning differs.
-    assert any("not selected" in w.lower() for w in result["warnings"])
-
-
-# --- System-profile copy -----------------------------------------------------
-
-
-def test_system_profile_does_not_overwrite_existing_name(
-    auth_client: httpx.Client, pk_export_bytes: bytes
-):
-    """If the user already named their Sheaf system, leave it alone."""
-    auth_client.patch("/v1/systems/me", json={"name": "Existing Name"})
-    _upload(
-        auth_client,
-        "/v1/import/pluralkit",
-        pk_export_bytes,
-        system_profile="true",
-    )
-    system = auth_client.get("/v1/systems/me").json()
-    assert system["name"] == "Existing Name"
-    # The PK tag/color did fill in (since they were unset).
-    assert system["tag"] == "tst"
-    assert system["color"] == "#ffaa00"

--- a/tests/test_sheaf_import.py
+++ b/tests/test_sheaf_import.py
@@ -1,8 +1,10 @@
-"""Integration tests for the Sheaf-to-Sheaf import endpoint.
+"""Integration tests for the Sheaf-to-Sheaf import *preview* endpoint.
 
-Covers the version-check gate (v1 + v2 accepted, anything else rejected),
-forward-compat with v2-only top-level keys (reminders / polls / etc. are
-silently ignored), and a basic round-trip on the importable subset.
+Covers the version-check gate (v1 + v2 accepted, anything else
+rejected) and forward-compat with v2-only top-level keys (reminders /
+polls / etc. silently ignored). The actual re-import now runs through
+the async job runner — covered end-to-end, including a real
+export-then-reimport round-trip, in test_imports_sheaf_runner.py.
 """
 
 from __future__ import annotations
@@ -82,133 +84,3 @@ def test_preview_accepts_v2_with_extra_keys(auth_client: httpx.Client):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["member_count"] == 1
-
-
-def test_roundtrip_export_then_import(auth_client: httpx.Client):
-    """Build a non-trivial system, hit /v1/export, then feed the bytes
-    straight back into /v1/import/sheaf. The format that the export
-    emits today must be accepted by the importer that ships with it.
-    Future v→v+1 bumps that break this test catch a forgotten import-
-    side update."""
-    # Build the source system: members in a group, with a tag, a custom
-    # field, and an open front. Mix of fields the importer handles.
-    alice = auth_client.post(
-        "/v1/members",
-        json={"name": "Alice", "pronouns": "she/her", "color": "#ff0066"},
-    ).json()
-    bob = auth_client.post(
-        "/v1/members",
-        json={"name": "Bob", "is_custom_front": False},
-    ).json()
-
-    auth_client.patch(
-        "/v1/systems/me",
-        json={
-            "name": "Source System",
-            "description": "before-export",
-            "note": "household scratchpad",
-        },
-    )
-    auth_client.patch(
-        f"/v1/members/{alice['id']}",
-        json={"note": "alice's quick reference"},
-    )
-
-    group = auth_client.post(
-        "/v1/groups", json={"name": "Inner circle"},
-    ).json()
-    auth_client.put(
-        f"/v1/groups/{group['id']}/members",
-        json={"member_ids": [alice["id"], bob["id"]]},
-    )
-
-    tag = auth_client.post("/v1/tags", json={"name": "Trusted"}).json()
-    auth_client.put(
-        f"/v1/tags/{tag['id']}/members",
-        json={"member_ids": [alice["id"]]},
-    )
-
-    field = auth_client.post(
-        "/v1/fields",
-        json={"name": "Birthstone", "field_type": "text"},
-    ).json()
-    auth_client.put(
-        f"/v1/members/{alice['id']}/fields",
-        json=[{"field_id": field["id"], "value": "amethyst"}],
-    )
-
-    auth_client.post("/v1/fronts", json={"member_ids": [alice["id"]]})
-
-    # Export.
-    export_resp = auth_client.get("/v1/export")
-    assert export_resp.status_code == 200, export_resp.text
-    payload = export_resp.json()
-    assert payload["version"] == "2"
-
-    # Importer wipe-or-merge semantics: import into the same system. The
-    # importer creates fresh entities (new UUIDs), so we expect counts
-    # to double rather than fail.
-    members_before = len(auth_client.get("/v1/members").json())
-
-    resp = _upload(auth_client, "/v1/import/sheaf", payload)
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["members_imported"] == 2
-    assert body["fronts_imported"] >= 1
-    assert body["groups_imported"] == 1
-    assert body["tags_imported"] == 1
-    assert body["custom_fields_imported"] == 1
-
-    # New members landed alongside the originals.
-    after = auth_client.get("/v1/members").json()
-    assert len(after) == members_before + 2
-    names = sorted(m["name"] for m in after)
-    assert names.count("Alice") == 2
-    assert names.count("Bob") == 2
-
-    # Notes round-trip through encryption: every imported Alice has the
-    # original note text, and the system note re-decrypts to the original.
-    alice_notes = [m["note"] for m in after if m["name"] == "Alice"]
-    assert alice_notes == ["alice's quick reference"] * 2
-    system_after = auth_client.get("/v1/systems/me").json()
-    assert system_after["note"] == "household scratchpad"
-
-
-def test_run_import_v2_imports_known_fields(auth_client: httpx.Client):
-    resp = _upload(
-        auth_client,
-        "/v1/import/sheaf",
-        {
-            "version": "2",
-            "system": {"name": "Imported System"},
-            "members": [
-                {"id": "m1", "name": "Alice"},
-                {"id": "m2", "name": "Bob"},
-            ],
-            "fronts": [
-                {
-                    "id": "f1",
-                    "started_at": "2026-05-01T12:00:00+00:00",
-                    "ended_at": None,
-                    "member_ids": ["m1"],
-                }
-            ],
-            "groups": [
-                {"id": "g1", "name": "Inner circle", "member_ids": ["m1", "m2"]}
-            ],
-            "tags": [],
-            "custom_fields": [],
-            # v2-only fields the importer ignores by design — must not crash.
-            "reminders": [{"id": "r1", "name": "ignored"}],
-            "polls": [{"id": "p1"}],
-            "watch_tokens": [],
-            "journals": [],
-            "revisions": [],
-            "uploaded_files": [],
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["members_imported"] == 2
-    assert body["fronts_imported"] == 1
-    assert body["groups_imported"] == 1

--- a/tests/test_sp_gap_bundle.py
+++ b/tests/test_sp_gap_bundle.py
@@ -145,6 +145,55 @@ def test_front_custom_status_optional(auth_client: httpx.Client):
 # --- SP-import path: frontStatuses -> is_custom_front=True ------------------
 
 
+def _run_file_import(client: httpx.Client, *, source: str, payload: bytes) -> dict:
+    """Enqueue a file import through the async runner, drive the runner
+    inside the test container, and return the terminal job. Imports moved
+    off synchronous endpoints onto the job runner — these SP-gap
+    regression tests follow the same enqueue + drive + poll shape as the
+    dedicated import-runner tests."""
+    import subprocess
+    import time
+    import uuid
+
+    resp = client.post(
+        "/v1/imports/file",
+        files={"file": ("import.json", payload, "application/json")},
+        data={"source": source, "idempotency_key": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 202, resp.text
+    job_id = resp.json()["id"]
+
+    subprocess.run(
+        [
+            "docker", "compose", "-p", "sheaf-test", "exec", "-T", "app",
+            "python", "-c",
+            """
+import asyncio
+from sheaf.database import async_session_factory
+from sheaf.services.import_runner import run_import_tick
+
+async def main():
+    while True:
+        async with async_session_factory() as db:
+            result = await run_import_tick(db)
+        if result.get("items_processed", 0) == 0:
+            return
+asyncio.run(main())
+""",
+        ],
+        check=True,
+        timeout=60,
+    )
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        body = client.get(f"/v1/imports/{job_id}").json()
+        if body["status"] in ("complete", "failed", "cancelled"):
+            return body
+        time.sleep(0.2)
+    raise AssertionError(f"import job {job_id} did not finish in time")
+
+
 def _sp_export_with_custom_fronts() -> bytes:
     return json.dumps(
         {
@@ -164,14 +213,10 @@ def test_sp_import_marks_frontstatuses_as_custom_fronts(
     auth_client: httpx.Client,
 ):
     payload = _sp_export_with_custom_fronts()
-    resp = auth_client.post(
-        "/v1/import/simplyplural",
-        files={"file": ("sp.json", payload, "application/json")},
-    )
-    assert resp.status_code == 200, resp.text
-    result = resp.json()
-    assert result["members_imported"] == 1
-    assert result["custom_fronts_imported"] == 2
+    job = _run_file_import(auth_client, source="simplyplural_file", payload=payload)
+    assert job["status"] == "complete", job
+    assert job["counts"]["members_imported"] == 1
+    assert job["counts"]["custom_fronts_imported"] == 2
 
     members = auth_client.get("/v1/members").json()
     by_name = {m["name"]: m for m in members}
@@ -196,11 +241,8 @@ def test_sp_import_no_longer_prefixes_custom_front_descriptions(
             ],
         }
     ).encode()
-    resp = auth_client.post(
-        "/v1/import/simplyplural",
-        files={"file": ("sp.json", payload, "application/json")},
-    )
-    assert resp.status_code == 200
+    job = _run_file_import(auth_client, source="simplyplural_file", payload=payload)
+    assert job["status"] == "complete", job
 
     members = auth_client.get("/v1/members").json()
     by_name = {m["name"]: m for m in members}
@@ -266,9 +308,9 @@ def test_pk_import_does_not_set_custom_front(auth_client: httpx.Client):
     fixture = (
         pathlib.Path(__file__).parent / "fixtures" / "pk_export_sample.json"
     )
-    auth_client.post(
-        "/v1/import/pluralkit",
-        files={"file": ("pk.json", fixture.read_bytes(), "application/json")},
+    job = _run_file_import(
+        auth_client, source="pluralkit_file", payload=fixture.read_bytes()
     )
+    assert job["status"] == "complete", job
     members = auth_client.get("/v1/members").json()
     assert all(m["is_custom_front"] is False for m in members)

--- a/tests/test_tb_import.py
+++ b/tests/test_tb_import.py
@@ -1,15 +1,10 @@
-"""Integration tests for the Tupperbox data importer.
+"""Integration tests for the Tupperbox import *preview* endpoint.
 
-These cover the file-upload path end-to-end via the public HTTP API.
-The fixture in tests/fixtures/tupperbox_export_sample.json is a small
-synthetic Tupperbox export covering:
-  - a fully-populated tupper (display name, description, birthday, avatar)
-  - a minimal tupper (no nick, no description, no avatar, no birthday)
-  - a group-less tupper that also exercises dropped fields (banner, tag)
-  - two groups (one with an avatar that gets dropped, one without)
+The actual import now runs through the async job runner — covered
+end-to-end in test_imports_tb_sp_runner.py. What's left here is the
+synchronous preview path: parse an export, summarise it, write nothing.
 """
 
-import json
 import pathlib
 
 import httpx
@@ -21,11 +16,6 @@ FIXTURE_PATH = pathlib.Path(__file__).parent / "fixtures" / "tupperbox_export_sa
 @pytest.fixture
 def tb_export_bytes() -> bytes:
     return FIXTURE_PATH.read_bytes()
-
-
-@pytest.fixture
-def tb_export() -> dict:
-    return json.loads(FIXTURE_PATH.read_text())
 
 
 def _upload(client: httpx.Client, path: str, payload: bytes, **params):
@@ -70,117 +60,3 @@ def test_preview_rejects_non_object(auth_client: httpx.Client):
         files={"file": ("array.json", b"[1, 2, 3]", "application/json")},
     )
     assert resp.status_code == 400
-
-
-# --- Default import ----------------------------------------------------------
-
-
-def test_import_default_creates_members_and_groups(
-    auth_client: httpx.Client, tb_export_bytes: bytes
-):
-    resp = _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
-    assert resp.status_code == 200, resp.text
-    result = resp.json()
-    assert result["members_imported"] == 3
-    assert result["groups_imported"] == 2
-    assert result["warnings"] == []
-
-    members = auth_client.get("/v1/members").json()
-    by_name = {m["name"]: m for m in members}
-    assert set(by_name) == {"Alpha", "Beta", "Gamma"}
-
-
-def test_import_maps_per_field_data(
-    auth_client: httpx.Client, tb_export_bytes: bytes
-):
-    _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
-    members = auth_client.get("/v1/members").json()
-    alpha = next(m for m in members if m["name"] == "Alpha")
-    assert alpha["display_name"] == "Alpha the First"
-    assert alpha["avatar_url"] == "https://cdn.tupperbox.app/example/alpha.webp"
-    assert alpha["birthday"] == "1990-04-15"
-    # Tupperbox has no privacy model — everything defaults to private.
-    assert alpha["privacy"] == "private"
-    # Tupperbox has no member colour or pronouns.
-    assert alpha["color"] is None
-    assert alpha["pronouns"] is None
-
-
-def test_import_handles_minimal_member(
-    auth_client: httpx.Client, tb_export_bytes: bytes
-):
-    """Beta has no nick, no description, no avatar, no birthday."""
-    _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
-    members = auth_client.get("/v1/members").json()
-    beta = next(m for m in members if m["name"] == "Beta")
-    assert beta["display_name"] is None
-    assert beta["description"] is None
-    assert beta["avatar_url"] is None
-    assert beta["birthday"] is None
-
-
-def test_import_groups_link_correct_members(
-    auth_client: httpx.Client, tb_export_bytes: bytes
-):
-    """Alpha + Beta are in 'Core'; Gamma is group-less."""
-    _upload(auth_client, "/v1/import/tupperbox", tb_export_bytes)
-    groups = auth_client.get("/v1/groups").json()
-    by_name = {g["name"]: g for g in groups}
-    assert set(by_name) == {"Core", "Visitors"}
-
-    core_members = auth_client.get(f"/v1/groups/{by_name['Core']['id']}/members").json()
-    assert sorted(m["name"] for m in core_members) == ["Alpha", "Beta"]
-
-    visitors_members = auth_client.get(
-        f"/v1/groups/{by_name['Visitors']['id']}/members"
-    ).json()
-    assert visitors_members == []
-
-
-def test_import_skips_groups_when_disabled(
-    auth_client: httpx.Client, tb_export_bytes: bytes
-):
-    resp = _upload(
-        auth_client,
-        "/v1/import/tupperbox",
-        tb_export_bytes,
-        groups="false",
-    )
-    assert resp.status_code == 200
-    assert resp.json()["groups_imported"] == 0
-    assert auth_client.get("/v1/groups").json() == []
-
-
-# --- Selective import (member_ids filter) ------------------------------------
-
-
-def test_member_ids_filter_drops_unselected(
-    auth_client: httpx.Client, tb_export_bytes: bytes
-):
-    resp = _upload(
-        auth_client,
-        "/v1/import/tupperbox",
-        tb_export_bytes,
-        member_ids="200001,200003",
-    )
-    assert resp.status_code == 200
-    assert resp.json()["members_imported"] == 2
-
-    names = sorted(m["name"] for m in auth_client.get("/v1/members").json())
-    assert names == ["Alpha", "Gamma"]
-
-
-def test_filter_drops_group_memberships_for_unselected(
-    auth_client: httpx.Client, tb_export_bytes: bytes
-):
-    """When Beta is deselected, the Core group keeps Alpha but not Beta."""
-    _upload(
-        auth_client,
-        "/v1/import/tupperbox",
-        tb_export_bytes,
-        member_ids="200001",
-    )
-    groups = auth_client.get("/v1/groups").json()
-    core = next(g for g in groups if g["name"] == "Core")
-    members = auth_client.get(f"/v1/groups/{core['id']}/members").json()
-    assert sorted(m["name"] for m in members) == ["Alpha"]

--- a/web/src/lib/imports.ts
+++ b/web/src/lib/imports.ts
@@ -1,0 +1,151 @@
+/**
+ * API client for the async import job runner.
+ *
+ * Replaces the synchronous per-source import calls (pk-import.ts etc.
+ * still own the *preview* step, which stays synchronous). Enqueue an
+ * import here, then poll getImportJob until it reaches a terminal
+ * status.
+ */
+import { apiFetch } from "./api-client";
+
+export type ImportJobSource =
+  | "pluralkit_file"
+  | "pluralkit_api"
+  | "tupperbox_file"
+  | "simplyplural_file"
+  | "sheaf_file";
+
+export type ImportJobStatus =
+  | "pending"
+  | "running"
+  | "complete"
+  | "failed"
+  | "cancelled";
+
+export interface ImportJobEvent {
+  level: "info" | "warning" | "error";
+  stage: string;
+  message: string;
+  record_ref?: string | null;
+}
+
+export interface ImportJob {
+  id: string;
+  source: ImportJobSource;
+  status: ImportJobStatus;
+  counts: Record<string, number>;
+  events: ImportJobEvent[];
+  started_at: string | null;
+  finished_at: string | null;
+  last_error: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Lighter shape returned by the list endpoint — no events array. */
+export interface ImportJobSummary {
+  id: string;
+  source: ImportJobSource;
+  status: ImportJobStatus;
+  counts: Record<string, number>;
+  started_at: string | null;
+  finished_at: string | null;
+  archived_at: string | null;
+  created_at: string;
+}
+
+export interface ImportJobList {
+  items: ImportJobSummary[];
+  next_cursor: string | null;
+}
+
+/** A terminal status is one the runner will never move a job out of. */
+export function isTerminal(status: ImportJobStatus): boolean {
+  return status === "complete" || status === "failed" || status === "cancelled";
+}
+
+/** User-facing label for each import source. */
+export const SOURCE_LABELS: Record<ImportJobSource, string> = {
+  pluralkit_file: "PluralKit (file)",
+  pluralkit_api: "PluralKit (API)",
+  tupperbox_file: "Tupperbox",
+  simplyplural_file: "SimplyPlural",
+  sheaf_file: "Sheaf",
+};
+
+const TERMINAL = new Set<ImportJobStatus>(["complete", "failed", "cancelled"]);
+
+/**
+ * Generate an idempotency key for an import attempt. Call once per
+ * attempt and reuse the value across retries / double-clicks so the
+ * server dedupes rather than enqueueing twice.
+ */
+export function newIdempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
+/** Enqueue a file-based import. Returns the created (pending) job. */
+export async function createFileImport(params: {
+  source: Exclude<ImportJobSource, "pluralkit_api">;
+  file: File;
+  idempotencyKey: string;
+  options?: Record<string, unknown>;
+}): Promise<ImportJob> {
+  const form = new FormData();
+  form.append("file", params.file);
+  form.append("source", params.source);
+  form.append("idempotency_key", params.idempotencyKey);
+  if (params.options !== undefined) {
+    form.append("options", JSON.stringify(params.options));
+  }
+  return apiFetch<ImportJob>("/v1/imports/file", {
+    method: "POST",
+    headers: {},
+    body: form,
+  });
+}
+
+/** Enqueue a credential-based import (PluralKit API). */
+export async function createApiImport(params: {
+  pkToken: string;
+  idempotencyKey: string;
+  options?: Record<string, unknown>;
+}): Promise<ImportJob> {
+  return apiFetch<ImportJob>("/v1/imports/api", {
+    method: "POST",
+    body: JSON.stringify({
+      source: "pluralkit_api",
+      idempotency_key: params.idempotencyKey,
+      pk_token: params.pkToken,
+      options: params.options ?? null,
+    }),
+  });
+}
+
+export async function listImportJobs(
+  includeArchived = false,
+): Promise<ImportJobList> {
+  const params = new URLSearchParams({ limit: "50" });
+  if (includeArchived) params.set("include_archived", "true");
+  return apiFetch<ImportJobList>(`/v1/imports?${params.toString()}`);
+}
+
+export async function getImportJob(id: string): Promise<ImportJob> {
+  return apiFetch<ImportJob>(`/v1/imports/${id}`);
+}
+
+/** Cancel a pending job, or archive a terminal one. */
+export async function deleteImportJob(id: string): Promise<void> {
+  await apiFetch<void>(`/v1/imports/${id}`, { method: "DELETE" });
+}
+
+/**
+ * refetchInterval callback for TanStack Query — poll every 2s while a
+ * job is non-terminal, stop once it settles. Shared by the list and
+ * detail pages.
+ */
+export function pollWhileActive(status: ImportJobStatus | undefined): number | false {
+  if (status === undefined) return 2000;
+  return TERMINAL.has(status) ? false : 2000;
+}

--- a/web/src/lib/pk-import.ts
+++ b/web/src/lib/pk-import.ts
@@ -1,3 +1,10 @@
+/**
+ * PluralKit import — preview calls.
+ *
+ * The actual import is enqueued via lib/imports.ts (the async job
+ * runner). What's left here is the synchronous preview step used by
+ * the import flow's review screen.
+ */
 import { apiFetch } from "./api-client";
 
 export interface PKPreviewMember {
@@ -15,22 +22,6 @@ export interface PKPreviewSummary {
   latest_switch: string | null;
 }
 
-export interface PKImportResult {
-  members_imported: number;
-  groups_imported: number;
-  fronts_imported: number;
-  warnings: string[];
-}
-
-export interface PKImportOptions {
-  system_profile: boolean;
-  member_ids: string[] | null;
-  groups: boolean;
-  front_history: boolean;
-}
-
-// --- File path ---------------------------------------------------------------
-
 export async function previewImportFromFile(file: File): Promise<PKPreviewSummary> {
   const form = new FormData();
   form.append("file", file);
@@ -41,43 +32,9 @@ export async function previewImportFromFile(file: File): Promise<PKPreviewSummar
   });
 }
 
-export async function runImportFromFile(
-  file: File,
-  options: PKImportOptions,
-): Promise<PKImportResult> {
-  const params = new URLSearchParams();
-  params.set("system_profile", String(options.system_profile));
-  params.set("groups", String(options.groups));
-  params.set("front_history", String(options.front_history));
-  if (options.member_ids !== null) {
-    params.set("member_ids", options.member_ids.join(","));
-  }
-
-  const form = new FormData();
-  form.append("file", file);
-
-  return apiFetch<PKImportResult>(`/v1/import/pluralkit?${params.toString()}`, {
-    method: "POST",
-    headers: {},
-    body: form,
-  });
-}
-
-// --- API path ----------------------------------------------------------------
-
 export async function previewImportFromApi(token: string): Promise<PKPreviewSummary> {
   return apiFetch<PKPreviewSummary>("/v1/import/pluralkit-api/preview", {
     method: "POST",
     body: JSON.stringify({ token }),
-  });
-}
-
-export async function runImportFromApi(
-  token: string,
-  options: PKImportOptions,
-): Promise<PKImportResult> {
-  return apiFetch<PKImportResult>("/v1/import/pluralkit-api", {
-    method: "POST",
-    body: JSON.stringify({ token, options }),
   });
 }

--- a/web/src/lib/sheaf-import.ts
+++ b/web/src/lib/sheaf-import.ts
@@ -1,3 +1,9 @@
+/**
+ * Sheaf native re-import — preview call.
+ *
+ * The actual import is enqueued via lib/imports.ts (the async job
+ * runner). What's left here is the synchronous preview step.
+ */
 import { apiFetch } from "./api-client";
 
 export interface SheafPreviewMember {
@@ -15,50 +21,10 @@ export interface SheafPreviewSummary {
   custom_field_count: number;
 }
 
-export interface SheafImportResult {
-  members_imported: number;
-  fronts_imported: number;
-  groups_imported: number;
-  tags_imported: number;
-  custom_fields_imported: number;
-  warnings: string[];
-}
-
 export async function previewSheafImport(file: File): Promise<SheafPreviewSummary> {
   const form = new FormData();
   form.append("file", file);
   return apiFetch<SheafPreviewSummary>("/v1/import/sheaf/preview", {
-    method: "POST",
-    headers: {},
-    body: form,
-  });
-}
-
-export async function runSheafImport(
-  file: File,
-  options: {
-    system_profile: boolean;
-    member_ids: string[] | null;
-    fronts: boolean;
-    groups: boolean;
-    tags: boolean;
-    custom_fields: boolean;
-  },
-): Promise<SheafImportResult> {
-  const params = new URLSearchParams();
-  params.set("system_profile", String(options.system_profile));
-  params.set("fronts", String(options.fronts));
-  params.set("groups", String(options.groups));
-  params.set("tags", String(options.tags));
-  params.set("custom_fields", String(options.custom_fields));
-  if (options.member_ids !== null) {
-    params.set("member_ids", options.member_ids.join(","));
-  }
-
-  const form = new FormData();
-  form.append("file", file);
-
-  return apiFetch<SheafImportResult>(`/v1/import/sheaf?${params.toString()}`, {
     method: "POST",
     headers: {},
     body: form,

--- a/web/src/lib/sp-import.ts
+++ b/web/src/lib/sp-import.ts
@@ -1,3 +1,9 @@
+/**
+ * SimplyPlural import — preview call.
+ *
+ * The actual import is enqueued via lib/imports.ts (the async job
+ * runner). What's left here is the synchronous preview step.
+ */
 import { apiFetch } from "./api-client";
 
 export interface SPPreviewMember {
@@ -17,51 +23,10 @@ export interface SPPreviewSummary {
   note_count: number;
 }
 
-export interface SPImportResult {
-  members_imported: number;
-  custom_fronts_imported: number;
-  fronts_imported: number;
-  groups_imported: number;
-  custom_fields_imported: number;
-  notes_skipped: number;
-  warnings: string[];
-}
-
 export async function previewImport(file: File): Promise<SPPreviewSummary> {
   const form = new FormData();
   form.append("file", file);
   return apiFetch<SPPreviewSummary>("/v1/import/simplyplural/preview", {
-    method: "POST",
-    headers: {},
-    body: form,
-  });
-}
-
-export async function runImport(
-  file: File,
-  options: {
-    system_profile: boolean;
-    member_ids: string[] | null;
-    custom_fronts: boolean;
-    custom_fields: boolean;
-    groups: boolean;
-    front_history: boolean;
-  },
-): Promise<SPImportResult> {
-  const params = new URLSearchParams();
-  params.set("system_profile", String(options.system_profile));
-  params.set("custom_fronts", String(options.custom_fronts));
-  params.set("custom_fields", String(options.custom_fields));
-  params.set("groups", String(options.groups));
-  params.set("front_history", String(options.front_history));
-  if (options.member_ids !== null) {
-    params.set("member_ids", options.member_ids.join(","));
-  }
-
-  const form = new FormData();
-  form.append("file", file);
-
-  return apiFetch<SPImportResult>(`/v1/import/simplyplural?${params.toString()}`, {
     method: "POST",
     headers: {},
     body: form,

--- a/web/src/lib/tb-import.ts
+++ b/web/src/lib/tb-import.ts
@@ -1,3 +1,9 @@
+/**
+ * Tupperbox import — preview call.
+ *
+ * The actual import is enqueued via lib/imports.ts (the async job
+ * runner). What's left here is the synchronous preview step.
+ */
 import { apiFetch } from "./api-client";
 
 export interface TBPreviewMember {
@@ -11,41 +17,10 @@ export interface TBPreviewSummary {
   group_count: number;
 }
 
-export interface TBImportResult {
-  members_imported: number;
-  groups_imported: number;
-  warnings: string[];
-}
-
-export interface TBImportOptions {
-  member_ids: string[] | null;
-  groups: boolean;
-}
-
 export async function previewImport(file: File): Promise<TBPreviewSummary> {
   const form = new FormData();
   form.append("file", file);
   return apiFetch<TBPreviewSummary>("/v1/import/tupperbox/preview", {
-    method: "POST",
-    headers: {},
-    body: form,
-  });
-}
-
-export async function runImport(
-  file: File,
-  options: TBImportOptions,
-): Promise<TBImportResult> {
-  const params = new URLSearchParams();
-  params.set("groups", String(options.groups));
-  if (options.member_ids !== null) {
-    params.set("member_ids", options.member_ids.join(","));
-  }
-
-  const form = new FormData();
-  form.append("file", file);
-
-  return apiFetch<TBImportResult>(`/v1/import/tupperbox?${params.toString()}`, {
     method: "POST",
     headers: {},
     body: form,

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -1,5 +1,6 @@
 import { type ChangeEvent, useState } from "react";
 import { Link, useNavigate } from "react-router";
+import { Loader2Icon } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -484,6 +485,10 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
   const [preview, setPreview] = useState<PKPreviewSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [idemKey] = useState(newIdempotencyKey);
+  // The PK API preview round-trips to pluralkit.me and can take a few
+  // seconds — without an explicit busy state the user gets no feedback
+  // and clicks again, firing duplicate calls (and sometimes a 429).
+  const [apiBusy, setApiBusy] = useState(false);
 
   const [systemProfile, setSystemProfile] = useState(true);
   const [allMembers, setAllMembers] = useState(true);
@@ -506,17 +511,24 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
   }
 
   async function handleApiPreview() {
-    if (!token.trim()) {
-      setError("Enter your PluralKit token first.");
+    if (!token.trim() || apiBusy) {
+      if (!token.trim()) setError("Enter your PluralKit token first.");
       return;
     }
     setError(null);
+    setApiBusy(true);
     try {
       const p = await previewPKApi(token);
       setPreview(p);
       setStep("preview");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not reach PluralKit");
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Could not reach PluralKit. Check the token and try again.",
+      );
+    } finally {
+      setApiBusy(false);
     }
   }
 
@@ -651,12 +663,19 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
               />
             </div>
             <div className="flex gap-2">
-              <Button onClick={handleApiPreview} disabled={!token.trim()}>
-                Continue
+              <Button
+                onClick={handleApiPreview}
+                disabled={!token.trim() || apiBusy}
+              >
+                {apiBusy && (
+                  <Loader2Icon className="size-4 animate-spin" />
+                )}
+                {apiBusy ? "Retrieving from PluralKit…" : "Continue"}
               </Button>
               <Button
                 variant="outline"
                 size="sm"
+                disabled={apiBusy}
                 onClick={() => {
                   setToken("");
                   setMethod("choose");
@@ -665,6 +684,12 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
                 Back
               </Button>
             </div>
+            {apiBusy && (
+              <p className="text-xs text-muted-foreground">
+                Fetching your system from the PluralKit API — this can
+                take a few seconds for systems with a long switch history.
+              </p>
+            )}
           </CardContent>
         </Card>
       )}

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -1,5 +1,5 @@
 import { type ChangeEvent, useState } from "react";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -7,34 +7,33 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import {
   type SPPreviewSummary,
-  type SPImportResult,
   previewImport as previewSP,
-  runImport as runSP,
 } from "@/lib/sp-import";
 import {
   type SheafPreviewSummary,
-  type SheafImportResult,
   previewSheafImport,
-  runSheafImport,
 } from "@/lib/sheaf-import";
 import {
   type PKPreviewSummary,
-  type PKImportResult,
   previewImportFromFile as previewPKFile,
-  runImportFromFile as runPKFile,
   previewImportFromApi as previewPKApi,
-  runImportFromApi as runPKApi,
 } from "@/lib/pk-import";
 import {
   type TBPreviewSummary,
-  type TBImportResult,
   previewImport as previewTB,
-  runImport as runTB,
 } from "@/lib/tb-import";
+import {
+  createApiImport,
+  createFileImport,
+  newIdempotencyKey,
+} from "@/lib/imports";
 import { Input } from "@/components/ui/input";
 
 type Source = "choose" | "sheaf" | "sp" | "pk" | "tb";
-type Step = "upload" | "preview" | "importing" | "done";
+// "importing" shows a brief spinner while the enqueue POST is in
+// flight; on success the flow navigates to /imports/:id, which owns
+// the running/done UI. There's no "done" step here any more.
+type Step = "upload" | "preview" | "importing";
 type PKMethod = "choose" | "file" | "api";
 
 export function ImportPage() {
@@ -42,7 +41,11 @@ export function ImportPage() {
 
   return (
     <>
-      <PageHeader title="Import data" />
+      <PageHeader title="Import data">
+        <Button variant="outline" size="sm" asChild>
+          <Link to="/imports">Import history</Link>
+        </Button>
+      </PageHeader>
       {source === "choose" && <SourcePicker onSelect={setSource} />}
       {source === "sheaf" && (
         <SheafImportFlow onBack={() => setSource("choose")} />
@@ -133,8 +136,10 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
   const [step, setStep] = useState<Step>("upload");
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<SheafPreviewSummary | null>(null);
-  const [result, setResult] = useState<SheafImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // One idempotency key per flow visit — a double-click on Import
+  // reuses it, so the server dedupes instead of enqueueing twice.
+  const [idemKey] = useState(newIdempotencyKey);
 
   const [systemProfile, setSystemProfile] = useState(true);
   const [allMembers, setAllMembers] = useState(true);
@@ -163,16 +168,20 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
     setStep("importing");
     setError(null);
     try {
-      const r = await runSheafImport(file, {
-        system_profile: systemProfile,
-        member_ids: allMembers ? null : Array.from(selectedMembers),
-        fronts: importFronts,
-        groups: importGroups,
-        tags: importTags,
-        custom_fields: importFields,
+      const job = await createFileImport({
+        source: "sheaf_file",
+        file,
+        idempotencyKey: idemKey,
+        options: {
+          system_profile: systemProfile,
+          member_ids: allMembers ? null : Array.from(selectedMembers),
+          fronts: importFronts,
+          groups: importGroups,
+          tags: importTags,
+          custom_fields: importFields,
+        },
       });
-      setResult(r);
-      setStep("done");
+      navigate(`/imports/${job.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Import failed");
       setStep("preview");
@@ -285,37 +294,6 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
       )}
 
       {step === "importing" && <ImportingCard />}
-
-      {step === "done" && result && (
-        <Card className="max-w-lg">
-          <CardHeader>
-            <CardTitle className="text-base">Import complete</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              {result.members_imported > 0 && (
-                <div>Members: <strong>{result.members_imported}</strong></div>
-              )}
-              {result.fronts_imported > 0 && (
-                <div>Fronts: <strong>{result.fronts_imported}</strong></div>
-              )}
-              {result.groups_imported > 0 && (
-                <div>Groups: <strong>{result.groups_imported}</strong></div>
-              )}
-              {result.tags_imported > 0 && (
-                <div>Tags: <strong>{result.tags_imported}</strong></div>
-              )}
-              {result.custom_fields_imported > 0 && (
-                <div>Custom fields: <strong>{result.custom_fields_imported}</strong></div>
-              )}
-            </div>
-            <Warnings warnings={result.warnings} />
-            <Button onClick={() => navigate("/members")} className="w-full">
-              View members
-            </Button>
-          </CardContent>
-        </Card>
-      )}
     </>
   );
 }
@@ -329,8 +307,8 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
   const [step, setStep] = useState<Step>("upload");
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<SPPreviewSummary | null>(null);
-  const [result, setResult] = useState<SPImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [idemKey] = useState(newIdempotencyKey);
 
   const [systemProfile, setSystemProfile] = useState(true);
   const [allMembers, setAllMembers] = useState(true);
@@ -359,16 +337,20 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
     setStep("importing");
     setError(null);
     try {
-      const r = await runSP(file, {
-        system_profile: systemProfile,
-        member_ids: allMembers ? null : Array.from(selectedMembers),
-        custom_fronts: customFronts,
-        custom_fields: customFields,
-        groups,
-        front_history: frontHistory,
+      const job = await createFileImport({
+        source: "simplyplural_file",
+        file,
+        idempotencyKey: idemKey,
+        options: {
+          system_profile: systemProfile,
+          member_ids: allMembers ? null : Array.from(selectedMembers),
+          custom_fronts: customFronts,
+          custom_fields: customFields,
+          groups,
+          front_history: frontHistory,
+        },
       });
-      setResult(r);
-      setStep("done");
+      navigate(`/imports/${job.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Import failed");
       setStep("preview");
@@ -482,37 +464,6 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
       )}
 
       {step === "importing" && <ImportingCard />}
-
-      {step === "done" && result && (
-        <Card className="max-w-lg">
-          <CardHeader>
-            <CardTitle className="text-base">Import complete</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              {result.members_imported > 0 && (
-                <div>Members: <strong>{result.members_imported}</strong></div>
-              )}
-              {result.custom_fronts_imported > 0 && (
-                <div>Custom fronts: <strong>{result.custom_fronts_imported}</strong></div>
-              )}
-              {result.fronts_imported > 0 && (
-                <div>Fronts: <strong>{result.fronts_imported}</strong></div>
-              )}
-              {result.groups_imported > 0 && (
-                <div>Groups: <strong>{result.groups_imported}</strong></div>
-              )}
-              {result.custom_fields_imported > 0 && (
-                <div>Custom fields: <strong>{result.custom_fields_imported}</strong></div>
-              )}
-            </div>
-            <Warnings warnings={result.warnings} />
-            <Button onClick={() => navigate("/members")} className="w-full">
-              View members
-            </Button>
-          </CardContent>
-        </Card>
-      )}
     </>
   );
 }
@@ -531,8 +482,8 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
   // when the user navigates away or finishes the flow.
   const [token, setToken] = useState<string>("");
   const [preview, setPreview] = useState<PKPreviewSummary | null>(null);
-  const [result, setResult] = useState<PKImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [idemKey] = useState(newIdempotencyKey);
 
   const [systemProfile, setSystemProfile] = useState(true);
   const [allMembers, setAllMembers] = useState(true);
@@ -579,15 +530,24 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
       front_history: frontHistory,
     };
     try {
-      const r =
+      const job =
         method === "file" && file
-          ? await runPKFile(file, options)
-          : await runPKApi(token, options);
-      setResult(r);
-      setStep("done");
-      // Token has served its purpose; clear it so it's not lingering on the
-      // page for the rest of the session.
+          ? await createFileImport({
+              source: "pluralkit_file",
+              file,
+              idempotencyKey: idemKey,
+              options,
+            })
+          : await createApiImport({
+              pkToken: token,
+              idempotencyKey: idemKey,
+              options,
+            });
+      // Token has served its purpose; clear it so it's not lingering on
+      // the page for the rest of the session. (It's also encrypted at
+      // rest server-side and wiped when the job finishes.)
       setToken("");
+      navigate(`/imports/${job.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Import failed");
       setStep("preview");
@@ -786,31 +746,6 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
       )}
 
       {step === "importing" && <ImportingCard />}
-
-      {step === "done" && result && (
-        <Card className="max-w-lg">
-          <CardHeader>
-            <CardTitle className="text-base">Import complete</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              {result.members_imported > 0 && (
-                <div>Members: <strong>{result.members_imported}</strong></div>
-              )}
-              {result.groups_imported > 0 && (
-                <div>Groups: <strong>{result.groups_imported}</strong></div>
-              )}
-              {result.fronts_imported > 0 && (
-                <div>Fronts: <strong>{result.fronts_imported}</strong></div>
-              )}
-            </div>
-            <Warnings warnings={result.warnings} />
-            <Button onClick={() => navigate("/members")} className="w-full">
-              View members
-            </Button>
-          </CardContent>
-        </Card>
-      )}
     </>
   );
 }
@@ -824,8 +759,8 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
   const [step, setStep] = useState<Step>("upload");
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<TBPreviewSummary | null>(null);
-  const [result, setResult] = useState<TBImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [idemKey] = useState(newIdempotencyKey);
 
   const [allMembers, setAllMembers] = useState(true);
   const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set());
@@ -850,12 +785,16 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
     setStep("importing");
     setError(null);
     try {
-      const r = await runTB(file, {
-        member_ids: allMembers ? null : Array.from(selectedMembers),
-        groups,
+      const job = await createFileImport({
+        source: "tupperbox_file",
+        file,
+        idempotencyKey: idemKey,
+        options: {
+          member_ids: allMembers ? null : Array.from(selectedMembers),
+          groups,
+        },
       });
-      setResult(r);
-      setStep("done");
+      navigate(`/imports/${job.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Import failed");
       setStep("preview");
@@ -944,28 +883,6 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
       )}
 
       {step === "importing" && <ImportingCard />}
-
-      {step === "done" && result && (
-        <Card className="max-w-lg">
-          <CardHeader>
-            <CardTitle className="text-base">Import complete</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              {result.members_imported > 0 && (
-                <div>Members: <strong>{result.members_imported}</strong></div>
-              )}
-              {result.groups_imported > 0 && (
-                <div>Groups: <strong>{result.groups_imported}</strong></div>
-              )}
-            </div>
-            <Warnings warnings={result.warnings} />
-            <Button onClick={() => navigate("/members")} className="w-full">
-              View members
-            </Button>
-          </CardContent>
-        </Card>
-      )}
     </>
   );
 }
@@ -989,18 +906,6 @@ function ImportingCard() {
         <p className="text-muted-foreground">Importing data...</p>
       </CardContent>
     </Card>
-  );
-}
-
-function Warnings({ warnings }: { warnings: string[] }) {
-  if (warnings.length === 0) return null;
-  return (
-    <div className="space-y-1">
-      <p className="text-sm font-medium text-yellow-500">Warnings:</p>
-      {warnings.map((w, i) => (
-        <p key={i} className="text-xs text-muted-foreground">{w}</p>
-      ))}
-    </div>
   );
 }
 

--- a/web/src/routes/imports.$id.tsx
+++ b/web/src/routes/imports.$id.tsx
@@ -1,0 +1,233 @@
+/**
+ * Import job detail page — /imports/:id.
+ *
+ * Polls the job while it's non-terminal so an in-flight import shows
+ * live counts, then settles into the final report: a summary card of
+ * what was imported plus a per-record events table grouped by level.
+ */
+import { useMemo } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  type ImportJobEvent,
+  type ImportJobStatus,
+  SOURCE_LABELS,
+  deleteImportJob,
+  getImportJob,
+  isTerminal,
+  pollWhileActive,
+} from "@/lib/imports";
+
+function StatusBadge({ status }: { status: ImportJobStatus }) {
+  const variant =
+    status === "failed"
+      ? "destructive"
+      : status === "cancelled"
+        ? "outline"
+        : status === "complete"
+          ? "default"
+          : "secondary";
+  return <Badge variant={variant}>{status}</Badge>;
+}
+
+/** Render a counts dict as a labelled grid. Keys are snake_case from
+ * the backend (members_imported, ...) — humanise them for display. */
+function CountsGrid({ counts }: { counts: Record<string, number> }) {
+  const entries = Object.entries(counts).filter(([, v]) => v !== 0);
+  if (entries.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Nothing imported yet.
+      </p>
+    );
+  }
+  return (
+    <div className="grid grid-cols-2 gap-2 text-sm">
+      {entries.map(([key, value]) => (
+        <div key={key}>
+          {key.replace(/_/g, " ")}: <strong>{value.toLocaleString()}</strong>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const LEVEL_ORDER: Record<ImportJobEvent["level"], number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+function EventRow({ event }: { event: ImportJobEvent }) {
+  const color =
+    event.level === "error"
+      ? "text-destructive"
+      : event.level === "warning"
+        ? "text-amber-600 dark:text-amber-500"
+        : "text-muted-foreground";
+  return (
+    <div className="flex gap-2 border-b border-border/50 py-1.5 text-sm last:border-0">
+      <span className={`w-16 shrink-0 font-medium ${color}`}>{event.level}</span>
+      <span className="w-24 shrink-0 text-muted-foreground">{event.stage}</span>
+      <span className="flex-1">
+        {event.message}
+        {event.record_ref ? (
+          <span className="ml-1 text-muted-foreground">({event.record_ref})</span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+export function ImportDetailPage() {
+  const { id = "" } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const { data: job, isLoading, isError } = useQuery({
+    queryKey: ["import-job", id],
+    queryFn: () => getImportJob(id),
+    refetchInterval: (query) => pollWhileActive(query.state.data?.status),
+  });
+
+  const mutate = useMutation({
+    mutationFn: () => deleteImportJob(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["import-job", id] });
+      qc.invalidateQueries({ queryKey: ["import-jobs"] });
+    },
+    onError: (e) =>
+      toast.error(e instanceof Error ? e.message : "Action failed"),
+  });
+
+  // Errors first, then warnings, then info — the user wants failures
+  // up top, not buried under a wall of "imported member X" lines.
+  const sortedEvents = useMemo(() => {
+    if (!job) return [];
+    return [...job.events].sort(
+      (a, b) => LEVEL_ORDER[a.level] - LEVEL_ORDER[b.level],
+    );
+  }, [job]);
+
+  if (isLoading) {
+    return (
+      <>
+        <PageHeader title="Import" />
+        <Skeleton className="h-48 max-w-2xl" />
+      </>
+    );
+  }
+
+  if (isError || !job) {
+    return (
+      <>
+        <PageHeader title="Import" />
+        <Card className="max-w-lg">
+          <CardContent className="py-6 text-sm text-muted-foreground">
+            Import not found. It may have been deleted, or the link is wrong.
+            <div className="mt-4">
+              <Button variant="outline" size="sm" asChild>
+                <Link to="/imports">Back to imports</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </>
+    );
+  }
+
+  const terminal = isTerminal(job.status);
+  const errorCount = job.events.filter((e) => e.level === "error").length;
+  const warningCount = job.events.filter((e) => e.level === "warning").length;
+
+  return (
+    <>
+      <PageHeader title={`Import — ${SOURCE_LABELS[job.source]}`}>
+        <Button variant="outline" size="sm" asChild>
+          <Link to="/imports">All imports</Link>
+        </Button>
+      </PageHeader>
+
+      <div className="grid max-w-2xl gap-4">
+        <Card>
+          <CardHeader className="flex-row items-center justify-between">
+            <CardTitle className="text-base">Status</CardTitle>
+            <StatusBadge status={job.status} />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {!terminal && (
+              <p className="text-sm text-muted-foreground">
+                {job.status === "pending"
+                  ? "Queued — the importer will pick this up shortly."
+                  : "Importing… this page updates automatically."}
+              </p>
+            )}
+            {job.status === "failed" && job.last_error && (
+              <p className="text-sm text-destructive">{job.last_error}</p>
+            )}
+            <CountsGrid counts={job.counts} />
+            {terminal && (errorCount > 0 || warningCount > 0) && (
+              <p className="text-sm text-muted-foreground">
+                {errorCount > 0 && `${errorCount} error(s)`}
+                {errorCount > 0 && warningCount > 0 && ", "}
+                {warningCount > 0 && `${warningCount} warning(s)`}
+                {" — see the report below."}
+              </p>
+            )}
+            <div className="flex gap-2 pt-1">
+              {job.status === "pending" && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => mutate.mutate()}
+                  disabled={mutate.isPending}
+                >
+                  Cancel
+                </Button>
+              )}
+              {terminal && !job.archived_at && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    mutate.mutate(undefined, {
+                      onSuccess: () => navigate("/imports"),
+                    })
+                  }
+                  disabled={mutate.isPending}
+                >
+                  Archive
+                </Button>
+              )}
+              <Button variant="outline" size="sm" asChild>
+                <Link to="/import">New import</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {job.events.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Report ({job.events.length} event
+                {job.events.length === 1 ? "" : "s"})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {sortedEvents.map((event, i) => (
+                <EventRow key={i} event={event} />
+              ))}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/routes/imports.tsx
+++ b/web/src/routes/imports.tsx
@@ -1,0 +1,110 @@
+/**
+ * Import history list — /imports.
+ *
+ * Lists the user's past + in-flight imports, polling while any are
+ * still active so a freshly-queued job animates toward done without a
+ * manual refresh. Each row links to the detail page.
+ */
+import { Link } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  type ImportJobStatus,
+  type ImportJobSummary,
+  SOURCE_LABELS,
+  listImportJobs,
+} from "@/lib/imports";
+
+function StatusBadge({ status }: { status: ImportJobStatus }) {
+  const variant =
+    status === "failed"
+      ? "destructive"
+      : status === "cancelled"
+        ? "outline"
+        : status === "complete"
+          ? "default"
+          : "secondary";
+  return <Badge variant={variant}>{status}</Badge>;
+}
+
+/** Compact "12 members, 3 groups" summary from a counts dict. */
+function countsSummary(counts: Record<string, number>): string {
+  const parts = Object.entries(counts)
+    .filter(([key, v]) => v > 0 && key.endsWith("_imported"))
+    .map(([key, v]) => `${v} ${key.replace(/_imported$/, "").replace(/_/g, " ")}`);
+  return parts.length > 0 ? parts.join(", ") : "—";
+}
+
+function ImportRow({ job }: { job: ImportJobSummary }) {
+  return (
+    <Link
+      to={`/imports/${job.id}`}
+      className="flex items-center gap-3 border-b border-border/50 px-4 py-3 text-sm transition-colors last:border-0 hover:bg-muted/50"
+    >
+      <span className="w-40 shrink-0 font-medium">
+        {SOURCE_LABELS[job.source]}
+      </span>
+      <StatusBadge status={job.status} />
+      <span className="flex-1 truncate text-muted-foreground">
+        {countsSummary(job.counts)}
+      </span>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {new Date(job.created_at).toLocaleString()}
+      </span>
+    </Link>
+  );
+}
+
+export function ImportsPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["import-jobs"],
+    queryFn: () => listImportJobs(),
+    refetchInterval: (query) => {
+      const items = query.state.data?.items ?? [];
+      const active = items.some(
+        (j) => j.status === "pending" || j.status === "running",
+      );
+      return active ? 2000 : false;
+    },
+  });
+
+  const items = data?.items ?? [];
+
+  return (
+    <>
+      <PageHeader title="Imports">
+        <Button size="sm" asChild>
+          <Link to="/import">New import</Link>
+        </Button>
+      </PageHeader>
+
+      {isLoading ? (
+        <Skeleton className="h-40 max-w-3xl" />
+      ) : items.length === 0 ? (
+        <Card className="max-w-lg">
+          <CardContent className="py-6 text-sm text-muted-foreground">
+            No imports yet. Bring in data from PluralKit, SimplyPlural,
+            Tupperbox, or a Sheaf export.
+            <div className="mt-4">
+              <Button size="sm" asChild>
+                <Link to="/import">Start an import</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="max-w-3xl">
+          <CardContent className="px-0 py-0">
+            {items.map((job) => (
+              <ImportRow key={job.id} job={job} />
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </>
+  );
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -15,6 +15,8 @@ import { SettingsAppearancePage } from "./settings/appearance";
 import { SettingsDataPage } from "./settings/data";
 import { SettingsDangerPage } from "./settings/danger";
 import { ImportPage } from "./import";
+import { ImportsPage } from "./imports";
+import { ImportDetailPage } from "./imports.$id";
 import { AboutPage } from "./about";
 import { JournalsPage } from "./journals";
 import { JournalDetailPage } from "./journals.$id";
@@ -93,6 +95,8 @@ export const router = createBrowserRouter([
         ],
       },
       { path: "import", element: <ImportPage /> },
+      { path: "imports", element: <ImportsPage /> },
+      { path: "imports/:id", element: <ImportDetailPage /> },
       { path: "about", element: <AboutPage /> },
       {
         path: "admin",


### PR DESCRIPTION
## Summary

Moves every data import (PluralKit file + API, Tupperbox, SimplyPlural, Sheaf native re-import) off synchronous request-blocking endpoints onto an async job runner. The user enqueues an import, gets a `202` immediately, and watches a persisted job with a per-record report — instead of a long-blocked HTTP request that times out on big PluralKit systems.

### Why

- The PK API import paginates switch history with rate-limit sleeps; on a large system it runs tens of seconds and blew the HTTP request timeout on the old synchronous endpoint.
- Imports had **no idempotency** — a double-clicked button created duplicate members / groups / fronts.
- Failures were fire-and-forget: no persisted record, nothing to come back to.
- JSON parsing was unbounded — a small deeply-nested payload could exhaust memory.

### What's in it

**Data model + runner**
- New `import_jobs` table: status (`pending`/`running`/`complete`/`failed`/`cancelled`), `idempotency_key` unique per user, `counts` + `events` JSONB for the report.
- Dedicated `import_runner_loop` in the FastAPI lifespan (a few-second tick, same pattern as the notification dispatcher) — NOT the slow 15-min jobs.py registry.
- `FOR UPDATE SKIP LOCKED` claim, so multi-worker is safe from day one.

**Endpoints**
- `POST /v1/imports/file` (multipart) and `/v1/imports/api` (credential-based) — both `202` + the job.
- `GET /v1/imports` (cursor-paginated history), `GET /v1/imports/{id}` (detail), `DELETE /v1/imports/{id}` (cancel pending / archive terminal).
- Legacy synchronous `/v1/import/*` POST endpoints removed; the `/preview` endpoints stay (preview is still synchronous, writes nothing).

**Hardening**
- Idempotency-key dedup (double-click defence).
- `safe_json_loads` element-count cap against nested-JSON expansion.
- `extra="forbid"` on every import options schema.
- PK API token encrypted at rest in `payload_metadata`, wiped on finalize.
- PK API: 50MB response cap; transport-failure retry (5×, exp backoff); HTTP status errors fail fast.
- Per-record error events (PluralKit); wrap-pattern with warnings-as-events for TB/SP/Sheaf.

**Frontend**
- `/imports` history list + `/imports/:id` detail page with live polling and a per-record report (errors sorted to top).
- The four import flows keep upload + preview, then enqueue-and-redirect.
- PK API preview button: spinner + disabled-while-in-flight feedback.

**Bugs fixed along the way**
- Import runner had been registered in the 15-min job registry — a queued import sat up to 15 minutes before being picked up.
- `job_runner_loop` reused its sleep-interval variable inside the per-job loop, drifting the runner's wake cadence.

## Test plan

- [x] `alembic upgrade head` — `import_jobs` table created cleanly.
- [x] Backend suite green: `723 passed` locally including the five `test_imports_*` suites.
- [x] PluralKit file import: upload an export → job goes `pending` → `complete`, counts + report correct.
- [x] PluralKit API import: paste a token → enqueues, fetches live, completes (verified on localdev).
- [x] Tupperbox / SimplyPlural / Sheaf re-import: each completes through the runner.
- [x] Idempotency: re-POST the same `idempotency_key` → same job id, no duplicate.
- [x] Failure path: a PK API connection error → job `failed`, clean one-line report, no scary traceback.
- [x] `ruff`, `eslint`, `tsc` clean.

## Follow-ups (deliberately not in this PR, tracked separately)

- Import deduplication / conflict handling — re-importing an overlapping system still creates duplicate members. Real fix lands with cross-service identifiers.
- Deep per-record instrumentation for the SP + TB runners (they took the lighter wrap path).
- Endpoint response-code audit; frontend error-surfacing improvements.
- Fuller SimplyPlural test fixture.