### PR TITLE
Harden the import runner: idempotency race, pagination, stale recovery

### DIFF
--- a/sheaf/api/v1/imports.py
+++ b/sheaf/api/v1/imports.py
@@ -23,6 +23,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile, status
 from pydantic import ValidationError
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
@@ -37,7 +38,11 @@ from sheaf.schemas.imports import (
     ImportJobRead,
     ImportJobSummary,
 )
-from sheaf.services.import_storage import make_payload_key, put_payload
+from sheaf.services.import_storage import (
+    delete_payload,
+    make_payload_key,
+    put_payload,
+)
 
 logger = logging.getLogger("sheaf.imports.api")
 
@@ -63,6 +68,39 @@ async def _find_existing_idempotent(
         ImportJob.idempotency_key == str(idempotency_key),
     )
     return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def _commit_new_job(
+    db: AsyncSession,
+    job: ImportJob,
+    *,
+    user_id: uuid.UUID,
+    idempotency_key: uuid.UUID,
+) -> ImportJob:
+    """Commit a freshly-built ImportJob, resolving the idempotency race.
+
+    The pre-insert _find_existing_idempotent check is not atomic with
+    the INSERT: two concurrent requests carrying the same key can both
+    miss it and both try to insert. The uq_import_jobs_user_idempotency
+    constraint rejects the loser — turn that IntegrityError into the
+    dedupe behaviour the constraint promises (return the row the winner
+    created) instead of letting it surface as a 500.
+    """
+    db.add(job)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        existing = await _find_existing_idempotent(
+            db, user_id=user_id, idempotency_key=idempotency_key
+        )
+        if existing is None:
+            # Not the idempotency constraint — some other integrity
+            # violation. Don't swallow it.
+            raise
+        return existing
+    await db.refresh(job)
+    return job
 
 
 async def _load_owned_job(
@@ -171,9 +209,15 @@ async def create_file_import(
         counts={},
         events=[],
     )
-    db.add(job)
-    await db.commit()
-    await db.refresh(job)
+    job = await _commit_new_job(
+        db, job, user_id=user.id, idempotency_key=body.idempotency_key
+    )
+    if job.id != job_id:
+        # Lost the idempotency race — the winning job has its own
+        # payload; the blob we just uploaded for this losing attempt is
+        # now orphaned. Best-effort delete it rather than leave litter.
+        await delete_payload(storage_key)
+        return ImportJobRead.model_validate(job)
     logger.info(
         "import_job %s enqueued (source=%s, user=%s, size=%d)",
         job.id,
@@ -208,7 +252,11 @@ async def create_api_import(
 
     encrypted_token = encrypt(body.pk_token)
 
+    # Explicit id so the post-commit race check can compare against it
+    # (the UUIDMixin default is only applied at flush time).
+    new_id = uuid.uuid4()
     job = ImportJob(
+        id=new_id,
         user_id=user.id,
         source=body.source.value,
         status=ImportJobStatus.PENDING.value,
@@ -221,9 +269,14 @@ async def create_api_import(
         counts={},
         events=[],
     )
-    db.add(job)
-    await db.commit()
-    await db.refresh(job)
+    job = await _commit_new_job(
+        db, job, user_id=user.id, idempotency_key=body.idempotency_key
+    )
+    if job.id != new_id:
+        # Lost the idempotency race — return the winner. The losing
+        # row (with its encrypted token) was rolled back, nothing to
+        # clean up.
+        return ImportJobRead.model_validate(job)
     logger.info(
         "import_job %s enqueued (source=%s, user=%s, credential-based)",
         job.id,
@@ -242,11 +295,17 @@ async def list_imports(
     db: AsyncSession = Depends(get_db),
     limit: int = 25,
     include_archived: bool = False,
+    cursor: str | None = None,
 ) -> ImportJobList:
     """List the current user's imports, most-recent first.
 
     Excludes archived rows by default — the UI shows them via a
     separate "show archived" toggle.
+
+    Cursor pagination: when the response carries a `next_cursor`, pass
+    it back as the `cursor` query param to fetch the next page. The
+    cursor is the ISO timestamp of the last row on the current page;
+    the next page is everything strictly older than it.
     """
     if not 1 <= limit <= 100:
         raise HTTPException(
@@ -261,13 +320,22 @@ async def list_imports(
     )
     if not include_archived:
         stmt = stmt.where(ImportJob.archived_at.is_(None))
+    if cursor is not None:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="cursor must be an ISO-8601 timestamp",
+            ) from exc
+        stmt = stmt.where(ImportJob.created_at < cursor_dt)
     rows = list((await db.execute(stmt)).scalars().all())
     next_cursor = None
     if len(rows) > limit:
         # Drop the trailing peek row and synthesize a continuation cursor
-        # from the last-included item's created_at. Keeping the cursor
-        # opaque (datetime ISO string is fine for v1) — the client doesn't
-        # interpret it.
+        # from the last-included item's created_at. created_at carries
+        # enough precision (microseconds) that a strict `<` comparison
+        # won't skip or repeat rows at realistic enqueue rates.
         rows = rows[:limit]
         next_cursor = rows[-1].created_at.isoformat()
     return ImportJobList(

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -297,6 +297,12 @@ class Settings(BaseSettings):
     # 30 days matches the job_runs log retention so 'what was happening
     # around the same time' queries line up.
     import_job_retention_days: int = 30
+
+    # A job stuck in `running` longer than this is presumed orphaned by
+    # a crashed worker; the recovery sweep resets it to `pending` for a
+    # retry. Generous — a large PluralKit API import paginating switch
+    # history legitimately runs tens of seconds, never minutes.
+    import_stale_running_minutes: int = 15
     activation_code_ttl_days: int = 7
     # VAPID keys for web push. Generate with `vapid --gen` (py-vapid) or any
     # WebPush helper. Empty = web_push destination type is rejected.

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import uuid
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
@@ -27,6 +28,7 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from sheaf.config import settings
 from sheaf.models.import_job import ImportJob, ImportJobStatus
+from sheaf.models.system import System
 from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.import_storage import delete_payload
 
@@ -104,6 +106,23 @@ def append_event(
     events.append(entry)
     job.events = events
     flag_modified(job, "events")
+
+
+async def load_user_system(db: AsyncSession, user_id: uuid.UUID) -> System:
+    """Locate the importing user's system, or raise ImportPayloadError.
+
+    Shared by every per-source handler — an import has to land somewhere,
+    and "you haven't created a system yet" is a user-facing precondition
+    failure, not a bug. Raising ImportPayloadError gets it surfaced as a
+    clean failed-job message rather than an unhandled traceback.
+    """
+    result = await db.execute(select(System).where(System.user_id == user_id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise ImportPayloadError(
+            "no system found on this account — create a system before importing"
+        )
+    return system
 
 
 def update_counts(job: ImportJob, **deltas: int) -> None:
@@ -321,6 +340,7 @@ __all__ = [
     "MAX_EVENTS_PER_JOB",
     "append_event",
     "import_runner_loop",
+    "load_user_system",
     "register_handler",
     "run_import_tick",
     "update_counts",

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -676,6 +676,80 @@ async def _cleanup_import_jobs(db: AsyncSession) -> dict:
     return {"items_processed": result.rowcount or 0}
 
 
+# A job that has crashed the worker this many times is parked as
+# failed rather than reset again — otherwise a payload that
+# reliably kills the runner would loop forever.
+_IMPORT_MAX_ATTEMPTS = 3
+
+
+async def _recover_stale_imports(db: AsyncSession) -> dict:
+    """Reset ImportJob rows stuck in `running` after a worker crash.
+
+    A worker killed mid-import leaves the row at status=running (the
+    claim committed) but the import data never committed (the killed
+    transaction rolled back) — so resetting to `pending` is a clean
+    retry, no risk of double-import.
+
+    failed_attempts is bumped on each reset; once it would exceed
+    _IMPORT_MAX_ATTEMPTS the job is parked as `failed` instead, so a
+    payload that reliably crashes the runner doesn't cycle forever.
+    """
+    from sheaf.models.import_job import ImportJob, ImportJobStatus
+    from sheaf.services.import_runner import append_event
+
+    cutoff = datetime.now(UTC) - timedelta(
+        minutes=settings.import_stale_running_minutes
+    )
+    result = await db.execute(
+        select(ImportJob).where(
+            ImportJob.status == ImportJobStatus.RUNNING.value,
+            ImportJob.claimed_at.is_not(None),
+            ImportJob.claimed_at < cutoff,
+        )
+    )
+    stale = list(result.scalars().all())
+    if not stale:
+        return {"items_processed": 0}
+
+    reset = 0
+    parked = 0
+    for job in stale:
+        job.failed_attempts += 1
+        if job.failed_attempts >= _IMPORT_MAX_ATTEMPTS:
+            job.status = ImportJobStatus.FAILED.value
+            job.finished_at = datetime.now(UTC)
+            job.last_error = (
+                f"import worker did not finish; gave up after "
+                f"{job.failed_attempts} stalled attempts"
+            )
+            append_event(
+                job,
+                level="error",
+                stage="runner",
+                message=(
+                    "import abandoned — the worker stalled on this job "
+                    f"{job.failed_attempts} times"
+                ),
+            )
+            parked += 1
+        else:
+            job.status = ImportJobStatus.PENDING.value
+            job.claimed_at = None
+            job.claimed_by = None
+            reset += 1
+        logger.warning(
+            "recovered stale import_job %s (attempt %d) -> %s",
+            job.id,
+            job.failed_attempts,
+            job.status,
+        )
+    await db.commit()
+    return {
+        "items_processed": len(stale),
+        "details": f"{reset} reset to pending, {parked} parked failed",
+    }
+
+
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -805,6 +879,13 @@ def _register_all_jobs() -> None:
         description="Delete ImportJob rows past their retention window",
         func=_cleanup_import_jobs,
         interval_seconds=lambda: 86400,  # daily
+    )
+
+    register_job(
+        name="recover_stale_imports",
+        description="Reset ImportJob rows stuck running after a worker crash",
+        func=_recover_stale_imports,
+        interval_seconds=lambda: settings.import_stale_running_minutes * 60,
     )
 
     # Dev-only jobs — sheaf_dev is NOT installed in production Docker images

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -50,7 +50,7 @@ logger = logging.getLogger("sheaf.import.pk")
 _PKID_MAX_LEN = 8
 
 
-def _list(data: dict, key: str) -> list[dict]:
+def get_list(data: dict, key: str) -> list[dict]:
     """Get a list-typed collection from PK data, defaulting to empty."""
     value = data.get(key)
     return value if isinstance(value, list) else []
@@ -74,9 +74,9 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
     minimum-known count when only one page was fetched. The file path
     leaves it None so the count comes straight from the parsed JSON.
     """
-    members = _list(data, "members")
-    groups = _list(data, "groups")
-    switches = _list(data, "switches")
+    members = get_list(data, "members")
+    groups = get_list(data, "groups")
+    switches = get_list(data, "switches")
 
     timestamps = [_parse_iso(s.get("timestamp")) for s in switches]
     timestamps = [t for t in timestamps if t is not None]
@@ -109,7 +109,7 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
 # --- System profile ----------------------------------------------------------
 
 
-def _apply_system_profile(data: dict, system: System) -> None:
+def apply_system_profile(data: dict, system: System) -> None:
     """Copy a few non-destructive fields from the PK system onto Sheaf's.
 
     We never overwrite a name the user has already set (their Sheaf system
@@ -137,7 +137,7 @@ def _apply_system_profile(data: dict, system: System) -> None:
 # --- Members -----------------------------------------------------------------
 
 
-def _build_member(pk_m: dict, system_id: uuid.UUID) -> Member | None:
+def build_member(pk_m: dict, system_id: uuid.UUID) -> Member | None:
     """Construct a Sheaf Member from a PK member object.
 
     Returns None if the source row lacks a usable name. Encryption,
@@ -170,7 +170,7 @@ def _build_member(pk_m: dict, system_id: uuid.UUID) -> Member | None:
 # --- Groups ------------------------------------------------------------------
 
 
-async def _import_groups(
+async def import_groups(
     pk_groups: list[dict],
     system_id: uuid.UUID,
     hid_to_member: dict[str, Member],
@@ -210,7 +210,7 @@ async def _import_groups(
         # - The export file inlines `members` as a list of member HIDs.
         # - The /v2/groups?with_members=true response inlines them as full
         #   member objects, in which case we still want HIDs.
-        for entry in _list(pk_g, "members"):
+        for entry in get_list(pk_g, "members"):
             hid = entry if isinstance(entry, str) else _clean_str(
                 entry.get("id") if isinstance(entry, dict) else None
             )
@@ -229,7 +229,7 @@ async def _import_groups(
 # --- Switches → fronts -------------------------------------------------------
 
 
-async def _import_switches(
+async def import_switches(
     pk_switches: list[dict],
     system_id: uuid.UUID,
     hid_to_member: dict[str, Member],

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -5,10 +5,9 @@ one post-parse processor (`_process_pk_export`): the file handler
 parses an uploaded blob, the API handler fetches the same shape live
 from PluralKit, then both walk members / groups / switches identically.
 
-Bridges the existing per-section importer helpers (`_build_member`,
-`_import_groups`, `_import_switches`) onto the ImportJob runner. The
-legacy synchronous `pk_import.run_import` + `/v1/import/pluralkit*`
-endpoints live alongside this until Phase 6 cleanup.
+Bridges the per-section importer helpers (`build_member`,
+`import_groups`, `import_switches`, `apply_system_profile`,
+`get_list`) in pk_import.py onto the ImportJob runner.
 
 Per-record errors land in `job.events` rather than aborting. Hard
 failures (bad JSON, no system, PK API rejection) raise; the runner's
@@ -19,13 +18,11 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import decrypt
 from sheaf.models.import_job import ImportJob, ImportJobSource
 from sheaf.models.member import Member
-from sheaf.models.system import System
 from sheaf.schemas.pk_import import PKImportOptions
 from sheaf.services.import_parsing import (
     ImportPayloadError,
@@ -33,31 +30,23 @@ from sheaf.services.import_parsing import (
     parse_options,
     safe_json_loads,
 )
-from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_runner import (
+    append_event,
+    load_user_system,
+    register_handler,
+    update_counts,
+)
 from sheaf.services.import_storage import get_payload
 from sheaf.services.pk_api import PKApiError, fetch_export
 from sheaf.services.pk_import import (
-    _apply_system_profile,
-    _build_member,
-    _import_groups,
-    _import_switches,
-    _list,
+    apply_system_profile,
+    build_member,
+    get_list,
+    import_groups,
+    import_switches,
 )
 
 logger = logging.getLogger("sheaf.imports.pk")
-
-
-async def _load_user_system(db: AsyncSession, user_id) -> System:
-    """Mirror of the legacy endpoint's lookup. Raises ImportPayloadError
-    so the runner surfaces it as a parse-stage user-facing failure
-    rather than an unhandled traceback."""
-    result = await db.execute(select(System).where(System.user_id == user_id))
-    system = result.scalar_one_or_none()
-    if system is None:
-        raise ImportPayloadError(
-            "no system found on this account — create a system before importing"
-        )
-    return system
 
 
 async def _process_pk_export(
@@ -78,10 +67,10 @@ async def _process_pk_export(
     the handler returns; per-section flushes keep the unit of work
     happy without locking in partial state on failure.
     """
-    system = await _load_user_system(db, job.user_id)
+    system = await load_user_system(db, job.user_id)
 
     if options.system_profile:
-        _apply_system_profile(parsed, system)
+        apply_system_profile(parsed, system)
         append_event(
             job,
             level="info",
@@ -91,7 +80,7 @@ async def _process_pk_export(
 
     # --- Members ---------------------------------------------------------
 
-    pk_members = _list(parsed, "members")
+    pk_members = get_list(parsed, "members")
     if options.member_ids is not None:
         wanted = set(options.member_ids)
         pk_members = [m for m in pk_members if m.get("id") in wanted]
@@ -103,7 +92,7 @@ async def _process_pk_export(
         # with the HID so the user can see what got skipped.
         hid_for_event = pk_m.get("id") if isinstance(pk_m, dict) else None
         try:
-            member = _build_member(pk_m, system.id)
+            member = build_member(pk_m, system.id)
         except Exception as exc:
             update_counts(job, members_failed=1)
             append_event(
@@ -115,7 +104,7 @@ async def _process_pk_export(
             )
             continue
         if member is None:
-            # _build_member returns None for unusable rows (no name, no id).
+            # build_member returns None for unusable rows (no name, no id).
             update_counts(job, members_failed=1)
             append_event(
                 job,
@@ -137,8 +126,8 @@ async def _process_pk_export(
 
     if options.groups:
         try:
-            count = await _import_groups(
-                _list(parsed, "groups"), system.id, hid_to_member, db
+            count = await import_groups(
+                get_list(parsed, "groups"), system.id, hid_to_member, db
             )
             update_counts(job, groups_imported=count)
             append_event(
@@ -160,8 +149,8 @@ async def _process_pk_export(
 
     if options.front_history:
         try:
-            fronts, warnings = await _import_switches(
-                _list(parsed, "switches"), system.id, hid_to_member, db
+            fronts, warnings = await import_switches(
+                get_list(parsed, "switches"), system.id, hid_to_member, db
             )
             update_counts(job, fronts_imported=fronts)
             append_event(
@@ -256,9 +245,9 @@ async def handle_pluralkit_api(job: ImportJob, db: AsyncSession) -> None:
         level="info",
         stage="fetch",
         message=(
-            f"fetched {len(_list(parsed, 'members'))} members, "
-            f"{len(_list(parsed, 'groups'))} groups, "
-            f"{len(_list(parsed, 'switches'))} switches"
+            f"fetched {len(get_list(parsed, 'members'))} members, "
+            f"{len(get_list(parsed, 'groups'))} groups, "
+            f"{len(get_list(parsed, 'switches'))} switches"
         ),
     )
     await _process_pk_export(job, db, parsed, options)

--- a/sheaf/services/sheaf_import_runner.py
+++ b/sheaf/services/sheaf_import_runner.py
@@ -13,11 +13,9 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.models.import_job import ImportJob, ImportJobSource
-from sheaf.models.system import System
 from sheaf.schemas.sheaf_import import SheafImportOptions
 from sheaf.services.import_parsing import (
     ImportPayloadError,
@@ -25,21 +23,16 @@ from sheaf.services.import_parsing import (
     parse_options,
     safe_json_loads,
 )
-from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_runner import (
+    append_event,
+    load_user_system,
+    register_handler,
+    update_counts,
+)
 from sheaf.services.import_storage import get_payload
 from sheaf.services.sheaf_import import run_import as sheaf_run_import
 
 logger = logging.getLogger("sheaf.imports.sheaf")
-
-
-async def _load_user_system(db: AsyncSession, user_id) -> System:
-    result = await db.execute(select(System).where(System.user_id == user_id))
-    system = result.scalar_one_or_none()
-    if system is None:
-        raise ImportPayloadError(
-            "no system found on this account — create a system before importing"
-        )
-    return system
 
 
 async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
@@ -65,7 +58,7 @@ async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
 
     parsed = expect_dict(safe_json_loads(blob), descriptor="Sheaf export")
     options = parse_options(job.payload_metadata, SheafImportOptions)
-    system = await _load_user_system(db, job.user_id)
+    system = await load_user_system(db, job.user_id)
 
     result = await sheaf_run_import(
         parsed,

--- a/sheaf/services/sp_import_runner.py
+++ b/sheaf/services/sp_import_runner.py
@@ -13,11 +13,9 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.models.import_job import ImportJob, ImportJobSource
-from sheaf.models.system import System
 from sheaf.schemas.sp_import import SPImportOptions
 from sheaf.services.import_parsing import (
     ImportPayloadError,
@@ -25,21 +23,16 @@ from sheaf.services.import_parsing import (
     parse_options,
     safe_json_loads,
 )
-from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_runner import (
+    append_event,
+    load_user_system,
+    register_handler,
+    update_counts,
+)
 from sheaf.services.import_storage import get_payload
 from sheaf.services.sp_import import run_import as sp_run_import
 
 logger = logging.getLogger("sheaf.imports.sp")
-
-
-async def _load_user_system(db: AsyncSession, user_id) -> System:
-    result = await db.execute(select(System).where(System.user_id == user_id))
-    system = result.scalar_one_or_none()
-    if system is None:
-        raise ImportPayloadError(
-            "no system found on this account — create a system before importing"
-        )
-    return system
 
 
 async def handle_simplyplural_file(job: ImportJob, db: AsyncSession) -> None:
@@ -65,7 +58,7 @@ async def handle_simplyplural_file(job: ImportJob, db: AsyncSession) -> None:
 
     parsed = expect_dict(safe_json_loads(blob), descriptor="SimplyPlural export")
     options = parse_options(job.payload_metadata, SPImportOptions)
-    system = await _load_user_system(db, job.user_id)
+    system = await load_user_system(db, job.user_id)
 
     result = await sp_run_import(parsed, options, system, db)
 

--- a/sheaf/services/tb_import_runner.py
+++ b/sheaf/services/tb_import_runner.py
@@ -12,11 +12,9 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.models.import_job import ImportJob, ImportJobSource
-from sheaf.models.system import System
 from sheaf.schemas.tb_import import TBImportOptions
 from sheaf.services.import_parsing import (
     ImportPayloadError,
@@ -24,21 +22,16 @@ from sheaf.services.import_parsing import (
     parse_options,
     safe_json_loads,
 )
-from sheaf.services.import_runner import append_event, register_handler, update_counts
+from sheaf.services.import_runner import (
+    append_event,
+    load_user_system,
+    register_handler,
+    update_counts,
+)
 from sheaf.services.import_storage import get_payload
 from sheaf.services.tb_import import run_import as tb_run_import
 
 logger = logging.getLogger("sheaf.imports.tb")
-
-
-async def _load_user_system(db: AsyncSession, user_id) -> System:
-    result = await db.execute(select(System).where(System.user_id == user_id))
-    system = result.scalar_one_or_none()
-    if system is None:
-        raise ImportPayloadError(
-            "no system found on this account — create a system before importing"
-        )
-    return system
 
 
 async def handle_tupperbox_file(job: ImportJob, db: AsyncSession) -> None:
@@ -64,7 +57,7 @@ async def handle_tupperbox_file(job: ImportJob, db: AsyncSession) -> None:
 
     parsed = expect_dict(safe_json_loads(blob), descriptor="Tupperbox export")
     options = parse_options(job.payload_metadata, TBImportOptions)
-    system = await _load_user_system(db, job.user_id)
+    system = await load_user_system(db, job.user_id)
 
     result = await tb_run_import(parsed, options, system, db)
 

--- a/tests/_import_runner_helpers.py
+++ b/tests/_import_runner_helpers.py
@@ -1,0 +1,66 @@
+"""Shared helpers for the import-runner test suites.
+
+The import-runner background loop is disabled in the test stack
+(IMPORT_RUNNER_ENABLED=false), so tests drive it explicitly. This
+module owns the single copy of that drive logic — previously
+copy-pasted across every test_imports_*_runner.py file.
+
+Not a `test_*.py` module, so pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+import httpx
+
+
+def drive_import_runner(*, setup: str = "") -> None:
+    """Drain the import runner inside the test container until empty.
+
+    Each pass claims and processes one pending job; we loop until a
+    tick reports nothing processed, so a test's job is fully handled
+    before the call returns.
+
+    `setup` is optional Python injected before the drain loop — used
+    by the PK-API tests to monkeypatch `fetch_export` so the runner
+    doesn't make a real network call.
+    """
+    script = f"""
+import asyncio
+from sheaf.database import async_session_factory
+from sheaf.services.import_runner import run_import_tick
+{setup}
+async def main():
+    while True:
+        async with async_session_factory() as db:
+            result = await run_import_tick(db)
+        if result.get("items_processed", 0) == 0:
+            return
+asyncio.run(main())
+"""
+    subprocess.run(
+        [
+            "docker", "compose", "-p", "sheaf-test", "exec", "-T", "app",
+            "python", "-c", script,
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+def wait_for_terminal(
+    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
+) -> dict:
+    """Poll GET /v1/imports/{id} until the job reaches a terminal
+    status, then return the final job body."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/imports/{job_id}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        if body["status"] in ("complete", "failed", "cancelled"):
+            return body
+        time.sleep(0.2)
+    raise AssertionError(f"import job {job_id} did not finish in {timeout_s}s")

--- a/tests/test_imports_api.py
+++ b/tests/test_imports_api.py
@@ -189,14 +189,33 @@ def test_list_returns_user_jobs_most_recent_first(auth_client: httpx.Client):
 
 
 def test_list_paginates_via_next_cursor(auth_client: httpx.Client):
-    """limit=1 with 2+ jobs surfaces next_cursor; raising the limit
-    drops it."""
-    _post_file(auth_client, source="pluralkit_file")
-    _post_file(auth_client, source="tupperbox_file")
-    one = auth_client.get("/v1/imports", params={"limit": 1})
-    assert one.status_code == 200, one.text
-    assert one.json()["next_cursor"] is not None
-    assert len(one.json()["items"]) == 1
+    """limit=1 surfaces next_cursor; passing it back as ?cursor= fetches
+    the next page, and the two pages partition the jobs without overlap."""
+    first = _post_file(auth_client, source="pluralkit_file")
+    second = _post_file(auth_client, source="tupperbox_file")
+
+    page1 = auth_client.get("/v1/imports", params={"limit": 1})
+    assert page1.status_code == 200, page1.text
+    p1 = page1.json()
+    assert len(p1["items"]) == 1
+    assert p1["next_cursor"] is not None
+    # Newest first — page 1 is the second-created job.
+    assert p1["items"][0]["id"] == second.json()["id"]
+
+    # Page 2 via the cursor — the older job, no overlap.
+    page2 = auth_client.get(
+        "/v1/imports", params={"limit": 1, "cursor": p1["next_cursor"]}
+    )
+    assert page2.status_code == 200, page2.text
+    p2 = page2.json()
+    assert len(p2["items"]) == 1
+    assert p2["items"][0]["id"] == first.json()["id"]
+    assert p2["items"][0]["id"] != p1["items"][0]["id"]
+
+
+def test_list_rejects_bad_cursor(auth_client: httpx.Client):
+    resp = auth_client.get("/v1/imports", params={"cursor": "not-a-timestamp"})
+    assert resp.status_code == 422, resp.text
 
 
 def test_list_excludes_archived_by_default(auth_client: httpx.Client):

--- a/tests/test_imports_pk_api_runner.py
+++ b/tests/test_imports_pk_api_runner.py
@@ -11,10 +11,11 @@ take) with a stub before ticking the runner.
 from __future__ import annotations
 
 import subprocess
-import time
 import uuid
 
 import httpx
+
+from tests._import_runner_helpers import drive_import_runner, wait_for_terminal
 
 # Minimal valid PK-export shape the stub fetch returns. One member,
 # no groups, no switches — enough to prove the handler walks the
@@ -34,45 +35,29 @@ _STUB_EXPORT_PY = """{
 
 
 def _drive_runner_pk_api(*, fail_mode: str = "") -> None:
-    """Tick the import runner inside the container with fetch_export
-    stubbed.
+    """Drive the runner with `fetch_export` monkeypatched.
+
+    pk_import_runner does `from ... import fetch_export`, so the stub
+    has to replace *that module's* binding, not pk_api's. The patch is
+    injected via the shared helper's `setup` hook.
 
     fail_mode="" -> stub returns the export above (success path).
     fail_mode="pkapi" -> stub raises PKApiError (rejection path).
     """
     if fail_mode == "pkapi":
-        stub = (
-            "async def fake_fetch(token, *, include_switches=True):\n"
+        body = (
             "    from sheaf.services.pk_api import PKApiError\n"
             "    raise PKApiError('PluralKit token rejected (401).', 401)\n"
         )
     else:
-        stub = (
-            "async def fake_fetch(token, *, include_switches=True):\n"
-            f"    return {_STUB_EXPORT_PY}\n"
-        )
-    script = f"""
-import asyncio
-from sheaf.database import async_session_factory
-from sheaf.services.import_runner import run_import_tick
-import sheaf.services.pk_import_runner as pir
-
-{stub}
-pir.fetch_export = fake_fetch
-
-async def main():
-    while True:
-        async with async_session_factory() as db:
-            result = await run_import_tick(db)
-        if result.get("items_processed", 0) == 0:
-            return
-asyncio.run(main())
-"""
-    subprocess.run(
-        ["docker", "compose", "-p", "sheaf-test", "exec", "-T", "app", "python", "-c", script],
-        check=True,
-        timeout=60,
+        body = f"    return {_STUB_EXPORT_PY}\n"
+    setup = (
+        "import sheaf.services.pk_import_runner as pir\n"
+        "async def fake_fetch(token, *, include_switches=True):\n"
+        f"{body}"
+        "pir.fetch_export = fake_fetch\n"
     )
+    drive_import_runner(setup=setup)
 
 
 def _post_api_import(client: httpx.Client, *, idem_key: str | None = None) -> dict:
@@ -88,20 +73,6 @@ def _post_api_import(client: httpx.Client, *, idem_key: str | None = None) -> di
     return resp.json()
 
 
-def _wait_for_terminal(
-    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
-) -> dict:
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        resp = client.get(f"/v1/imports/{job_id}")
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        if body["status"] in ("complete", "failed", "cancelled"):
-            return body
-        time.sleep(0.2)
-    raise AssertionError(f"job {job_id} not terminal in {timeout_s}s")
-
-
 # --- Happy path ------------------------------------------------------------
 
 
@@ -110,7 +81,7 @@ def test_pk_api_runner_imports_fetched_system(auth_client: httpx.Client):
     into the user's system exactly like the file handler would."""
     job = _post_api_import(auth_client)
     _drive_runner_pk_api()
-    final = _wait_for_terminal(auth_client, job["id"])
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "complete", final
     assert final["counts"]["members_imported"] == 2, final["counts"]
@@ -125,7 +96,7 @@ def test_pk_api_runner_emits_fetch_events(auth_client: httpx.Client):
     the live-pull step distinctly from the file-parse step."""
     job = _post_api_import(auth_client)
     _drive_runner_pk_api()
-    final = _wait_for_terminal(auth_client, job["id"])
+    final = wait_for_terminal(auth_client, job["id"])
 
     fetch_events = [e for e in final["events"] if e["stage"] == "fetch"]
     assert fetch_events, final["events"]
@@ -140,7 +111,7 @@ def test_pk_api_runner_fails_on_pk_rejection(auth_client: httpx.Client):
     failure — status=failed with the PK-provided message surfaced."""
     job = _post_api_import(auth_client)
     _drive_runner_pk_api(fail_mode="pkapi")
-    final = _wait_for_terminal(auth_client, job["id"])
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any(
@@ -158,7 +129,7 @@ def test_pk_api_runner_wipes_credential_on_finalize(auth_client: httpx.Client):
     API response never exposes payload_metadata."""
     job = _post_api_import(auth_client)
     _drive_runner_pk_api()
-    final = _wait_for_terminal(auth_client, job["id"])
+    final = wait_for_terminal(auth_client, job["id"])
     assert final["status"] == "complete"
 
     # Inspect the row in-container: encrypted_credential must be absent.

--- a/tests/test_imports_pk_runner.py
+++ b/tests/test_imports_pk_runner.py
@@ -15,52 +15,16 @@ from __future__ import annotations
 
 import json
 import pathlib
-import subprocess
-import time
 import uuid
 
 import httpx
 
+from tests._import_runner_helpers import (
+    drive_import_runner,
+    wait_for_terminal,
+)
+
 PK_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "pk_export_sample.json"
-
-
-def _drive_runner() -> None:
-    """Force one tick of the import runner inside the test container.
-
-    Avoids the wall-clock wait for the 5s production tick. The
-    in-container helper imports run_import_tick + grabs a session
-    out of the database module so it sees committed state from the
-    host-side HTTP client."""
-    subprocess.run(
-        [
-            "docker",
-            "compose",
-            "-p",
-            "sheaf-test",
-            "exec",
-            "-T",
-            "app",
-            "python",
-            "-c",
-            """
-import asyncio
-from sheaf.database import async_session_factory
-from sheaf.services.import_runner import run_import_tick
-
-async def main():
-    # Drain until empty so each test gets fully processed (not just one
-    # claimed-but-incomplete job left behind by a prior call).
-    while True:
-        async with async_session_factory() as db:
-            result = await run_import_tick(db)
-        if result.get("items_processed", 0) == 0:
-            return
-asyncio.run(main())
-""",
-        ],
-        check=True,
-        timeout=60,
-    )
 
 
 def _post_pk_file(
@@ -90,24 +54,6 @@ def _post_pk_file(
     return resp.json()
 
 
-def _wait_for_terminal(
-    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
-) -> dict:
-    """Poll GET /v1/imports/{id} until status is terminal. Used after
-    `_drive_runner()` to read back the final state. Timeout exists in
-    case something hangs; the runner is direct-invoked so this should
-    return within a single poll in practice."""
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        resp = client.get(f"/v1/imports/{job_id}")
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        if body["status"] in ("complete", "failed", "cancelled"):
-            return body
-        time.sleep(0.2)
-    raise AssertionError(f"job {job_id} did not reach terminal status in {timeout_s}s")
-
-
 # --- Happy path ------------------------------------------------------------
 
 
@@ -115,8 +61,8 @@ def test_pk_file_runner_imports_members_and_groups(auth_client: httpx.Client):
     """Defaults (system_profile=True, groups=True, front_history=False)
     bring in members + groups but not switch history."""
     job = _post_pk_file(auth_client)
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "complete", final
     assert final["counts"]["members_imported"] == 3, final["counts"]
@@ -135,8 +81,8 @@ def test_pk_file_runner_with_front_history(auth_client: httpx.Client):
     """front_history=True walks the switches array and emits Front rows
     with member associations."""
     job = _post_pk_file(auth_client, options={"front_history": True})
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "complete", final
     assert final["counts"]["members_imported"] == 3
@@ -147,8 +93,8 @@ def test_pk_file_runner_emits_info_events_per_section(auth_client: httpx.Client)
     """The runner records info-level events for each phase so the user-
     facing report has a coherent breadcrumb trail, not just final counts."""
     job = _post_pk_file(auth_client, options={"front_history": True})
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     stages = {e["stage"] for e in final["events"] if e["level"] == "info"}
     assert {"parse", "system_profile", "groups", "switches"}.issubset(stages), stages
@@ -157,8 +103,8 @@ def test_pk_file_runner_emits_info_events_per_section(auth_client: httpx.Client)
 def test_pk_file_runner_member_deselection(auth_client: httpx.Client):
     """member_ids filter from the preview screen narrows the import set."""
     job = _post_pk_file(auth_client, options={"member_ids": ["alice"]})
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "complete"
     assert final["counts"]["members_imported"] == 1
@@ -178,8 +124,8 @@ def test_pk_file_runner_fails_on_invalid_json(auth_client: httpx.Client):
     error event at the parse stage. The job doesn't blow up the runner
     — subsequent jobs still tick through."""
     job = _post_pk_file(auth_client, payload=b"this isn't json at all")
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any(
@@ -192,8 +138,8 @@ def test_pk_file_runner_fails_on_non_object_root(auth_client: httpx.Client):
     """PK exports are JSON objects at the root. An array / scalar gets a
     clear error rather than a downstream `.get()` AttributeError."""
     job = _post_pk_file(auth_client, payload=b'["not", "an", "object"]')
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any("must be a JSON object" in e["message"] for e in final["events"])
@@ -205,8 +151,8 @@ def test_pk_file_runner_idempotency_after_complete(auth_client: httpx.Client):
     a duplicate import."""
     key = str(uuid.uuid4())
     first = _post_pk_file(auth_client, idem_key=key)
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, first["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, first["id"])
     assert final["status"] == "complete"
 
     second = _post_pk_file(auth_client, idem_key=key)
@@ -218,8 +164,8 @@ def test_pk_file_runner_finalize_wipes_storage_key(auth_client: httpx.Client):
     """After a successful run, the runner clears payload_storage_key
     on the row so the storage blob can be deleted independently."""
     job = _post_pk_file(auth_client)
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
     assert final["status"] == "complete"
     # The API surface doesn't expose payload_storage_key, but we can
     # observe that re-fetching the (terminal) job is still a 200 — the

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -8,11 +8,14 @@ a fixture file, matching the existing test_sheaf_import.py convention.
 from __future__ import annotations
 
 import json
-import subprocess
-import time
 import uuid
 
 import httpx
+
+from tests._import_runner_helpers import (
+    drive_import_runner,
+    wait_for_terminal,
+)
 
 # Minimal valid Sheaf export — version + a couple of members. Other
 # sections empty; enough to prove the runner walks the canonical
@@ -31,30 +34,6 @@ _SHEAF_EXPORT = {
 }
 
 
-def _drive_runner() -> None:
-    subprocess.run(
-        [
-            "docker", "compose", "-p", "sheaf-test", "exec", "-T", "app",
-            "python", "-c",
-            """
-import asyncio
-from sheaf.database import async_session_factory
-from sheaf.services.import_runner import run_import_tick
-
-async def main():
-    while True:
-        async with async_session_factory() as db:
-            result = await run_import_tick(db)
-        if result.get("items_processed", 0) == 0:
-            return
-asyncio.run(main())
-""",
-        ],
-        check=True,
-        timeout=60,
-    )
-
-
 def _post_file(client: httpx.Client, *, payload: bytes) -> dict:
     resp = client.post(
         "/v1/imports/file",
@@ -65,24 +44,10 @@ def _post_file(client: httpx.Client, *, payload: bytes) -> dict:
     return resp.json()
 
 
-def _wait_for_terminal(
-    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
-) -> dict:
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        resp = client.get(f"/v1/imports/{job_id}")
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        if body["status"] in ("complete", "failed", "cancelled"):
-            return body
-        time.sleep(0.2)
-    raise AssertionError(f"job {job_id} not terminal in {timeout_s}s")
-
-
 def test_sheaf_runner_imports_members(auth_client: httpx.Client):
     job = _post_file(auth_client, payload=json.dumps(_SHEAF_EXPORT).encode())
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "complete", final
     assert final["counts"]["members_imported"] == 2, final["counts"]
@@ -101,8 +66,8 @@ def test_sheaf_runner_roundtrip_from_export(auth_client: httpx.Client):
     assert export.status_code == 200, export.text
 
     job = _post_file(auth_client, payload=export.content)
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
     assert final["status"] == "complete", final
     # The exported member comes back in on re-import (alongside the
     # original — re-import is additive, not a replace).
@@ -111,8 +76,8 @@ def test_sheaf_runner_roundtrip_from_export(auth_client: httpx.Client):
 
 def test_sheaf_runner_fails_on_invalid_json(auth_client: httpx.Client):
     job = _post_file(auth_client, payload=b"not json")
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any("invalid JSON" in e["message"] for e in final["events"])
@@ -120,8 +85,8 @@ def test_sheaf_runner_fails_on_invalid_json(auth_client: httpx.Client):
 
 def test_sheaf_runner_fails_on_non_object_root(auth_client: httpx.Client):
     job = _post_file(auth_client, payload=b'"just a string"')
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any("must be a JSON object" in e["message"] for e in final["events"])

--- a/tests/test_imports_tb_sp_runner.py
+++ b/tests/test_imports_tb_sp_runner.py
@@ -11,39 +11,17 @@ task).
 from __future__ import annotations
 
 import pathlib
-import subprocess
-import time
 import uuid
 
 import httpx
 
+from tests._import_runner_helpers import (
+    drive_import_runner,
+    wait_for_terminal,
+)
+
 TB_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "tupperbox_export_sample.json"
 SP_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "sp_export_sample.json"
-
-
-def _drive_runner() -> None:
-    """Drain the import runner inside the test container until empty."""
-    subprocess.run(
-        [
-            "docker", "compose", "-p", "sheaf-test", "exec", "-T", "app",
-            "python", "-c",
-            """
-import asyncio
-from sheaf.database import async_session_factory
-from sheaf.services.import_runner import run_import_tick
-
-async def main():
-    while True:
-        async with async_session_factory() as db:
-            result = await run_import_tick(db)
-        if result.get("items_processed", 0) == 0:
-            return
-asyncio.run(main())
-""",
-        ],
-        check=True,
-        timeout=60,
-    )
 
 
 def _post_file(
@@ -62,20 +40,6 @@ def _post_file(
     return resp.json()
 
 
-def _wait_for_terminal(
-    client: httpx.Client, job_id: str, *, timeout_s: float = 10.0
-) -> dict:
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        resp = client.get(f"/v1/imports/{job_id}")
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        if body["status"] in ("complete", "failed", "cancelled"):
-            return body
-        time.sleep(0.2)
-    raise AssertionError(f"job {job_id} not terminal in {timeout_s}s")
-
-
 # --- Tupperbox -------------------------------------------------------------
 
 
@@ -83,8 +47,8 @@ def test_tupperbox_runner_imports_members(auth_client: httpx.Client):
     job = _post_file(
         auth_client, source="tupperbox_file", payload=TB_FIXTURE.read_bytes()
     )
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "complete", final
     assert final["counts"]["members_imported"] >= 1, final["counts"]
@@ -98,8 +62,8 @@ def test_tupperbox_runner_fails_on_invalid_json(auth_client: httpx.Client):
     job = _post_file(
         auth_client, source="tupperbox_file", payload=b"definitely not json"
     )
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any("invalid JSON" in e["message"] for e in final["events"])
@@ -107,8 +71,8 @@ def test_tupperbox_runner_fails_on_invalid_json(auth_client: httpx.Client):
 
 def test_tupperbox_runner_fails_on_non_object_root(auth_client: httpx.Client):
     job = _post_file(auth_client, source="tupperbox_file", payload=b"[1, 2, 3]")
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any("must be a JSON object" in e["message"] for e in final["events"])
@@ -121,8 +85,8 @@ def test_simplyplural_runner_imports_members(auth_client: httpx.Client):
     job = _post_file(
         auth_client, source="simplyplural_file", payload=SP_FIXTURE.read_bytes()
     )
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "complete", final
     assert final["counts"]["members_imported"] == 2, final["counts"]
@@ -136,8 +100,8 @@ def test_simplyplural_runner_fails_on_invalid_json(auth_client: httpx.Client):
     job = _post_file(
         auth_client, source="simplyplural_file", payload=b"{ broken"
     )
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any("invalid JSON" in e["message"] for e in final["events"])
@@ -149,8 +113,8 @@ def test_simplyplural_runner_summary_event(auth_client: httpx.Client):
     job = _post_file(
         auth_client, source="simplyplural_file", payload=SP_FIXTURE.read_bytes()
     )
-    _drive_runner()
-    final = _wait_for_terminal(auth_client, job["id"])
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
 
     summary = [
         e for e in final["events"]

--- a/tests/test_patch_null_rejection.py
+++ b/tests/test_patch_null_rejection.py
@@ -10,7 +10,6 @@ asserting 422 (schema-layer rejection) instead of 500."""
 
 from __future__ import annotations
 
-import os
 import uuid as _uuid
 
 import httpx

--- a/tests/test_sp_gap_bundle.py
+++ b/tests/test_sp_gap_bundle.py
@@ -151,9 +151,9 @@ def _run_file_import(client: httpx.Client, *, source: str, payload: bytes) -> di
     off synchronous endpoints onto the job runner — these SP-gap
     regression tests follow the same enqueue + drive + poll shape as the
     dedicated import-runner tests."""
-    import subprocess
-    import time
     import uuid
+
+    from tests._import_runner_helpers import drive_import_runner, wait_for_terminal
 
     resp = client.post(
         "/v1/imports/file",
@@ -163,35 +163,8 @@ def _run_file_import(client: httpx.Client, *, source: str, payload: bytes) -> di
     assert resp.status_code == 202, resp.text
     job_id = resp.json()["id"]
 
-    subprocess.run(
-        [
-            "docker", "compose", "-p", "sheaf-test", "exec", "-T", "app",
-            "python", "-c",
-            """
-import asyncio
-from sheaf.database import async_session_factory
-from sheaf.services.import_runner import run_import_tick
-
-async def main():
-    while True:
-        async with async_session_factory() as db:
-            result = await run_import_tick(db)
-        if result.get("items_processed", 0) == 0:
-            return
-asyncio.run(main())
-""",
-        ],
-        check=True,
-        timeout=60,
-    )
-
-    deadline = time.monotonic() + 10
-    while time.monotonic() < deadline:
-        body = client.get(f"/v1/imports/{job_id}").json()
-        if body["status"] in ("complete", "failed", "cancelled"):
-            return body
-        time.sleep(0.2)
-    raise AssertionError(f"import job {job_id} did not finish in time")
+    drive_import_runner()
+    return wait_for_terminal(client, job_id)
 
 
 def _sp_export_with_custom_fronts() -> bytes:

--- a/web/src/lib/imports.ts
+++ b/web/src/lib/imports.ts
@@ -124,10 +124,12 @@ export async function createApiImport(params: {
 }
 
 export async function listImportJobs(
-  includeArchived = false,
+  opts: { cursor?: string; includeArchived?: boolean } = {},
 ): Promise<ImportJobList> {
   const params = new URLSearchParams({ limit: "50" });
-  if (includeArchived) params.set("include_archived", "true");
+  if (opts.includeArchived) params.set("include_archived", "true");
+  // Pass the previous page's next_cursor here to fetch the next page.
+  if (opts.cursor) params.set("cursor", opts.cursor);
   return apiFetch<ImportJobList>(`/v1/imports?${params.toString()}`);
 }
 

--- a/web/src/routes/imports.tsx
+++ b/web/src/routes/imports.tsx
@@ -3,10 +3,11 @@
  *
  * Lists the user's past + in-flight imports, polling while any are
  * still active so a freshly-queued job animates toward done without a
- * manual refresh. Each row links to the detail page.
+ * manual refresh. Cursor-paginated via "Load more". Each row links to
+ * the detail page.
  */
 import { Link } from "react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -31,11 +32,18 @@ function StatusBadge({ status }: { status: ImportJobStatus }) {
   return <Badge variant={variant}>{status}</Badge>;
 }
 
-/** Compact "12 members, 3 groups" summary from a counts dict. */
+/** Compact "12 members, 3 groups" summary from a counts dict.
+ *
+ * Includes every non-zero counter, not just the *_imported ones — a
+ * job whose only counts are failures (e.g. members_failed) still has
+ * something worth showing in the list rather than a bare "—". */
 function countsSummary(counts: Record<string, number>): string {
   const parts = Object.entries(counts)
-    .filter(([key, v]) => v > 0 && key.endsWith("_imported"))
-    .map(([key, v]) => `${v} ${key.replace(/_imported$/, "").replace(/_/g, " ")}`);
+    .filter(([, v]) => v > 0)
+    .map(
+      ([key, v]) =>
+        `${v} ${key.replace(/_imported$/, "").replace(/_/g, " ")}`,
+    );
   return parts.length > 0 ? parts.join(", ") : "—";
 }
 
@@ -60,19 +68,31 @@ function ImportRow({ job }: { job: ImportJobSummary }) {
 }
 
 export function ImportsPage() {
-  const { data, isLoading } = useQuery({
+  const {
+    data,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
     queryKey: ["import-jobs"],
-    queryFn: () => listImportJobs(),
+    queryFn: ({ pageParam }) => listImportJobs({ cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
     refetchInterval: (query) => {
-      const items = query.state.data?.items ?? [];
-      const active = items.some(
-        (j) => j.status === "pending" || j.status === "running",
+      // Poll while any loaded job is still in flight. Refetch covers
+      // every loaded page, but pages are small so that's cheap.
+      const pages = query.state.data?.pages ?? [];
+      const active = pages.some((p) =>
+        p.items.some(
+          (j) => j.status === "pending" || j.status === "running",
+        ),
       );
       return active ? 2000 : false;
     },
   });
 
-  const items = data?.items ?? [];
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
 
   return (
     <>
@@ -97,13 +117,25 @@ export function ImportsPage() {
           </CardContent>
         </Card>
       ) : (
-        <Card className="max-w-3xl">
-          <CardContent className="px-0 py-0">
-            {items.map((job) => (
-              <ImportRow key={job.id} job={job} />
-            ))}
-          </CardContent>
-        </Card>
+        <div className="max-w-3xl space-y-3">
+          <Card>
+            <CardContent className="px-0 py-0">
+              {items.map((job) => (
+                <ImportRow key={job.id} job={job} />
+              ))}
+            </CardContent>
+          </Card>
+          {hasNextPage && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+            >
+              {isFetchingNextPage ? "Loading…" : "Load older imports"}
+            </Button>
+          )}
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Follow-up hardening on the async import runner (merged in #65), addressing issues found in code review.

- **Idempotency race fixed.** The pre-insert existence check on `POST /v1/imports/*` wasn't atomic with the INSERT — two concurrent requests with the same key could both miss it, and the loser surfaced the unique-constraint `IntegrityError` as an unhandled 500. Commits now go through a helper that catches `IntegrityError`, rolls back, re-SELECTs, and returns the winning row. The file path also cleans up the orphaned payload blob it uploaded for the losing attempt.

- **Cursor pagination finished.** `GET /v1/imports` returned `next_cursor` but never accepted a `cursor` param — pages 2+ were unreachable. It now takes `?cursor=` (ISO timestamp, 422 on malformed), and the frontend list switched to `useInfiniteQuery` with a "Load older imports" button. Audited the other paginated endpoints: `fronts` and `journals` both already consume their cursors; `imports` was the only half-wired one.

- **Stale-running recovery.** Nothing reset jobs stuck in `running` after a worker crash. New `recover_stale_imports` sweep resets them to `pending` for a retry — safe, because the claim commits `status=running` but the import data only commits at finalize, so a stuck job has no partial state — and parks them as `failed` after `IMPORT_MAX_ATTEMPTS` stalls so a runner-crashing payload can't loop forever.

- **Dedup.** `load_user_system` was copy-pasted across four runner modules → moved into `import_runner`. The test drive/wait helpers were copy-pasted across five test files → moved into a shared `tests/_import_runner_helpers` module.

- **`pk_import` section helpers made public.** `apply_system_profile`, `build_member`, `import_groups`, `import_switches`, `get_list` lost their underscore prefixes — with the synchronous `run_import` gone they are the module's real public surface, imported cross-module by the runner.

- **`countsSummary`** on the history list now shows any non-zero counter, so a job whose only counts are failures no longer renders a bare "—".

## Test plan

- [x] Full backend suite: `724 passed, 32 skipped`.
- [x] New tests: cursor pagination actually fetches page 2 and the pages partition without overlap; malformed cursor → 422.
- [x] `ruff`, `eslint`, `tsc`, frontend production build all clean.