### PR TITLE
Security hardening for auth, webhooks, and job sweeps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,9 +147,17 @@ IMAGE_SERVING=signed
 # SendGrid settings (only used when EMAIL_BACKEND=sendgrid)
 # SENDGRID_API_KEY=SG.xxxxx
 # SENDGRID_FROM=noreply@example.com
-# Shared secret for the SendGrid Event Webhook. Configure SendGrid to POST to
-# /v1/webhooks/sendgrid/events?token=<this value>. When empty, the webhook
-# endpoint returns 404.
+# SendGrid Event Webhook authentication.
+# Preferred: enable "Signed Event Webhook" in the SendGrid UI and paste the
+# verification key (base64 DER ECDSA public key) here. When set, incoming
+# requests must carry a valid signature with a fresh timestamp.
+# SENDGRID_WEBHOOK_PUBLIC_KEY=
+# Max age (seconds) of a signed webhook request before it's rejected as a
+# possible replay. Defaults to 600.
+# SENDGRID_WEBHOOK_MAX_SKEW_SECONDS=600
+# Legacy fallback: a shared secret passed as ?token=<value> on the webhook
+# URL. Used only when SENDGRID_WEBHOOK_PUBLIC_KEY is unset. The endpoint
+# returns 404 when neither is configured.
 # SENDGRID_WEBHOOK_SECRET=
 
 # =============================================================================

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -21,6 +21,7 @@ from sheaf.auth.sessions import list_user_sessions
 from sheaf.auth.totp import verify_code
 from sheaf.crypto import blind_index, decrypt
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.api_key import ApiKey
 from sheaf.models.client_settings import ClientSettings
 from sheaf.models.email_suppression import EmailSuppression
@@ -44,7 +45,7 @@ class AccountDataRequest(BaseModel):
     totp_code: str | None = None
 
 
-@router.post("/data")
+@router.post("/data", dependencies=[rate_limit(5, 60, "user", fail_closed=True)])
 async def get_account_data(
     body: AccountDataRequest,
     request: Request,

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.auth.lockout import ensure_not_locked, record_login_failure
 from sheaf.auth.passwords import verify_password
 from sheaf.auth.sessions import list_user_sessions
 from sheaf.auth.totp import verify_code
@@ -91,9 +92,12 @@ async def get_account_data(
     # Step-up: always password, plus TOTP if enrolled. Independent of
     # System Safety's delete_confirmation tier — that gates deletes; this
     # gates the highest-value read.
+    ensure_not_locked(user)
+
     if not verify_password(body.password, user.password_hash):
         # 403: step-up auth denial. See system_safety.verify_destructive_auth
         # for full reasoning.
+        await record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Password incorrect",
@@ -106,6 +110,7 @@ async def get_account_data(
             )
         secret = decrypt(user.totp_secret)
         if not verify_code(secret, body.totp_code):
+            await record_login_failure(db, user)
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid TOTP code",

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -827,7 +827,10 @@ async def admin_change_email(
     if target is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    new_hash = blind_index(body.new_email)
+    # Normalize before indexing — mirrors self-service /change-email so the
+    # same address in different casings produces a single blind index.
+    normalized_email = body.new_email.strip().lower()
+    new_hash = blind_index(normalized_email)
 
     # Check for conflicts
     existing = await db.execute(select(User).where(User.email_hash == new_hash))
@@ -838,7 +841,7 @@ async def admin_change_email(
             detail="Email already in use by another account",
         )
 
-    target.email = encrypt(body.new_email)
+    target.email = encrypt(normalized_email)
     target.email_hash = new_hash
     target.email_verified = True
     # Clear any pending verification tokens
@@ -846,7 +849,7 @@ async def admin_change_email(
     target.email_verification_sent_at = None
     await db.commit()
 
-    return {"email": body.new_email}
+    return {"email": normalized_email}
 
 
 @router.post("/users/{user_id}/disable-totp")

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -7,7 +7,16 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import jwt
-from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Cookie,
+    Depends,
+    HTTPException,
+    Request,
+    Response,
+    status,
+)
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import and_, case, select, update
 from sqlalchemy.exc import IntegrityError
@@ -247,6 +256,24 @@ async def _record_login_failure(db: AsyncSession, user: User) -> None:
     )
     await db.commit()
     db.expire(user, ["failed_login_count", "locked_until"])
+
+
+def _ensure_not_locked(user: User) -> None:
+    """Raise 423 if the account is inside a failed-attempt lockout window.
+
+    Shared by the credentialed endpoints that verify a short TOTP/recovery
+    code so a stolen session can't be used to brute-force the 6-digit space.
+    """
+    now = datetime.now(UTC)
+    if user.locked_until is not None and user.locked_until > now:
+        mins = max(1, math.ceil((user.locked_until - now).total_seconds() / 60))
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail=(
+                f"Account temporarily locked after repeated failed attempts. "
+                f"Try again in {mins} minute{'s' if mins != 1 else ''}."
+            ),
+        )
 
 
 async def _validate_invite_code(db: AsyncSession, code: str):
@@ -498,15 +525,32 @@ class EmailChange(BaseModel):
     totp_code: str | None = None
 
 
+async def _deliver_password_reset_email(email: str, token: str, ip: str) -> None:
+    """Send the password-reset email. Runs as a background task so the
+    request handler returns before the SMTP round-trip — otherwise the
+    response time leaks whether the address mapped to a real account."""
+    try:
+        from sheaf.services.email import send_email
+        from sheaf.services.email_templates import password_reset_email
+
+        subject, html, text = password_reset_email(token, ip=ip)
+        await send_email(email, subject, html, text)
+    except Exception:
+        logger.exception("Failed to send password reset email")
+
+
 @router.post("/request-password-reset", dependencies=[rate_limit(3, 60, fail_closed=True)])
 async def request_password_reset(
     body: PasswordResetRequest,
     request: Request,
+    background: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
 ):
     """Request a password reset email.
 
-    Always returns 200 to avoid leaking whether the email exists.
+    Always returns 200 to avoid leaking whether the email exists. The
+    actual send is deferred to a background task so the response time is
+    the same whether or not the address matched an account.
     """
     if settings.email_backend == "none":
         raise HTTPException(
@@ -531,15 +575,14 @@ async def request_password_reset(
         user.password_reset_sent_at = datetime.now(UTC)
         await db.commit()
 
-        try:
-            from sheaf.services.email import send_email
-            from sheaf.services.email_templates import password_reset_email
-
-            requester_ip = client_ip(request)
-            subject, html, text = password_reset_email(token, ip=requester_ip)
-            await send_email(body.email, subject, html, text)
-        except Exception:
-            logger.exception("Failed to send password reset email")
+        background.add_task(
+            _deliver_password_reset_email, body.email, token, client_ip(request)
+        )
+    else:
+        # Symmetric work on the no-match branch so CPU cost matches the
+        # real path; the SMTP send is already off the request thread.
+        token = secrets.token_urlsafe(32)
+        hash_mail_token(token)
 
     return {"requested": True}
 
@@ -646,6 +689,11 @@ async def change_password(
     user.password_hash = hash_password(body.new_password)
     user.failed_login_count = 0
     user.locked_until = None
+    # Kill any live password-reset token — changing the password is proof
+    # the legit user has access, so a phished-but-unredeemed reset link
+    # must not outlive this.
+    user.password_reset_token = None
+    user.password_reset_sent_at = None
     # Revoke every trusted device — a password change is the canonical
     # "kick everything off" event.
     await revoke_all_trusted_devices(db, user.id)
@@ -833,6 +881,11 @@ async def login(
     user.failed_login_count = 0
     user.locked_until = None
     user.last_login_at = datetime.now(UTC)
+    # A successful login means the legit user has access; invalidate any
+    # outstanding password-reset token so a phished link can't be redeemed
+    # after the fact.
+    user.password_reset_token = None
+    user.password_reset_sent_at = None
 
     # Create session before committing so a Redis failure rolls back the DB
     session_id = await create_session(
@@ -1407,7 +1460,11 @@ async def totp_verify(
     await db.commit()
 
 
-@router.post("/totp/disable", status_code=status.HTTP_204_NO_CONTENT)
+@router.post(
+    "/totp/disable",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[rate_limit(5, 60, "user", fail_closed=True)],
+)
 async def totp_disable(
     body: UserLogin,
     user: User = Depends(get_current_user),
@@ -1420,7 +1477,10 @@ async def totp_disable(
             detail="2FA is not enabled",
         )
 
+    _ensure_not_locked(user)
+
     if not verify_password(body.password, user.password_hash):
+        await _record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid password",
@@ -1436,6 +1496,7 @@ async def totp_disable(
     if not verify_code(secret, body.totp_code) and not await _check_recovery_code(
         db, user, body.totp_code
     ):
+        await _record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid TOTP code",
@@ -1444,13 +1505,18 @@ async def totp_disable(
     user.totp_enabled = False
     user.totp_secret = None
     user.recovery_codes = None
+    user.failed_login_count = 0
+    user.locked_until = None
     # Trusted devices were minted under the old TOTP relationship; wipe
     # them so a stale cookie can't bypass anything if TOTP is re-enabled.
     await revoke_all_trusted_devices(db, user.id)
     await db.commit()
 
 
-@router.post("/totp/regenerate-recovery-codes")
+@router.post(
+    "/totp/regenerate-recovery-codes",
+    dependencies=[rate_limit(5, 60, "user", fail_closed=True)],
+)
 async def regenerate_recovery_codes(
     body: TOTPVerify,
     user: User = Depends(get_current_user),
@@ -1463,8 +1529,11 @@ async def regenerate_recovery_codes(
             detail="2FA is not enabled",
         )
 
+    _ensure_not_locked(user)
+
     secret = decrypt(user.totp_secret)
     if not verify_code(secret, body.code):
+        await _record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid TOTP code",
@@ -1472,6 +1541,8 @@ async def regenerate_recovery_codes(
 
     codes = generate_recovery_codes()
     _store_recovery_codes(user, codes)
+    user.failed_login_count = 0
+    user.locked_until = None
     await db.commit()
     return {"recovery_codes": codes}
 
@@ -1606,23 +1677,13 @@ async def request_account_deletion(
                 headers={"X-Sheaf-2FA": "required"},
             )
         totp_secret = decrypt(user.totp_secret)
-        if not verify_code(totp_secret, body.totp_code):
-            # Check recovery codes
-            valid_recovery = False
-            if user.recovery_codes:
-                stored_codes = json.loads(decrypt(user.recovery_codes))
-                candidate = hashlib.sha256(
-                    body.totp_code.strip().lower().encode()
-                ).hexdigest()
-                if candidate in stored_codes:
-                    stored_codes.remove(candidate)
-                    user.recovery_codes = encrypt(json.dumps(stored_codes))
-                    valid_recovery = True
-            if not valid_recovery:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Invalid TOTP code",
-                )
+        if not verify_code(
+            totp_secret, body.totp_code
+        ) and not await _check_recovery_code(db, user, body.totp_code):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Invalid TOTP code",
+            )
 
     now = datetime.now(UTC)
     user.account_status = AccountStatus.PENDING_DELETION

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import logging
-import math
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -18,12 +17,13 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, EmailStr
-from sqlalchemy import and_, case, select, update
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user, get_current_user_allow_unverified
 from sheaf.auth.jwt import TokenType, create_token, decode_token
+from sheaf.auth.lockout import ensure_not_locked, record_login_failure
 from sheaf.auth.passwords import hash_password, needs_rehash, verify_password
 from sheaf.auth.sessions import (
     cache_refresh_rotation,
@@ -222,58 +222,6 @@ async def _mint_refresh_token(user_id, session_id: str) -> str:
     ttl = settings.jwt_refresh_token_expire_days * 86400
     await register_refresh_jti(jti, session_id, ttl)
     return create_token(user_id, TokenType.REFRESH, session_id=session_id, jti=jti)
-
-
-async def _record_login_failure(db: AsyncSession, user: User) -> None:
-    """Increment the user's failed-login counter and lock if threshold crossed.
-
-    A single atomic UPDATE handles both the increment and the lockout decision
-    so concurrent failed attempts can't race past the threshold. If the user
-    has a stale (expired) lockout, the counter resets to 1 for this attempt
-    instead of incrementing, so a returning user with one typo doesn't get
-    immediately re-locked on top of old failures.
-    """
-    now = datetime.now(UTC)
-    lockout_end = now + timedelta(minutes=settings.login_lockout_minutes)
-    threshold = settings.login_max_failures
-
-    new_count = case(
-        (
-            and_(User.locked_until.is_not(None), User.locked_until < now),
-            1,
-        ),
-        else_=User.failed_login_count + 1,
-    )
-    new_lock = case(
-        (new_count >= threshold, lockout_end),
-        else_=None,
-    )
-
-    await db.execute(
-        update(User)
-        .where(User.id == user.id)
-        .values(failed_login_count=new_count, locked_until=new_lock)
-    )
-    await db.commit()
-    db.expire(user, ["failed_login_count", "locked_until"])
-
-
-def _ensure_not_locked(user: User) -> None:
-    """Raise 423 if the account is inside a failed-attempt lockout window.
-
-    Shared by the credentialed endpoints that verify a short TOTP/recovery
-    code so a stolen session can't be used to brute-force the 6-digit space.
-    """
-    now = datetime.now(UTC)
-    if user.locked_until is not None and user.locked_until > now:
-        mins = max(1, math.ceil((user.locked_until - now).total_seconds() / 60))
-        raise HTTPException(
-            status_code=status.HTTP_423_LOCKED,
-            detail=(
-                f"Account temporarily locked after repeated failed attempts. "
-                f"Try again in {mins} minute{'s' if mins != 1 else ''}."
-            ),
-        )
 
 
 async def _validate_invite_code(db: AsyncSession, code: str):
@@ -823,24 +771,12 @@ async def login(
     # Reject locked accounts before spending argon2 CPU on them. The lockout
     # state leaks that the account exists, but so does a successful login
     # attempt; rate limits + captcha are what stop anonymous enumeration.
-    now = datetime.now(UTC)
-    if (
-        user is not None
-        and user.locked_until is not None
-        and user.locked_until > now
-    ):
-        mins = max(1, math.ceil((user.locked_until - now).total_seconds() / 60))
-        raise HTTPException(
-            status_code=status.HTTP_423_LOCKED,
-            detail=(
-                f"Account temporarily locked after repeated failed attempts. "
-                f"Try again in {mins} minute{'s' if mins != 1 else ''}."
-            ),
-        )
+    if user is not None:
+        ensure_not_locked(user)
 
     if user is None or not verify_password(body.password, user.password_hash):
         if user is not None:
-            await _record_login_failure(db, user)
+            await record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
@@ -867,7 +803,7 @@ async def login(
             if not verify_code(secret, body.totp_code) and not await _check_recovery_code(
                 db, user, body.totp_code
             ):
-                await _record_login_failure(db, user)
+                await record_login_failure(db, user)
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid TOTP code",
@@ -1477,10 +1413,10 @@ async def totp_disable(
             detail="2FA is not enabled",
         )
 
-    _ensure_not_locked(user)
+    ensure_not_locked(user)
 
     if not verify_password(body.password, user.password_hash):
-        await _record_login_failure(db, user)
+        await record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid password",
@@ -1496,7 +1432,7 @@ async def totp_disable(
     if not verify_code(secret, body.totp_code) and not await _check_recovery_code(
         db, user, body.totp_code
     ):
-        await _record_login_failure(db, user)
+        await record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid TOTP code",
@@ -1529,11 +1465,11 @@ async def regenerate_recovery_codes(
             detail="2FA is not enabled",
         )
 
-    _ensure_not_locked(user)
+    ensure_not_locked(user)
 
     secret = decrypt(user.totp_secret)
     if not verify_code(secret, body.code):
-        await _record_login_failure(db, user)
+        await record_login_failure(db, user)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid TOTP code",

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -26,6 +26,7 @@ from sheaf.auth.passwords import verify_password
 from sheaf.auth.totp import verify_code
 from sheaf.crypto import decrypt
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.custom_field import CustomFieldDefinition
 from sheaf.models.export_job import ExportJob, ExportJobStatus
@@ -590,7 +591,11 @@ class ExportJobRequest(BaseModel):
     totp_code: str | None = None
 
 
-@router.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/jobs",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[rate_limit(10, 3600, "user")],
+)
 async def create_export_job(
     body: ExportJobRequest,
     request: Request,
@@ -634,6 +639,12 @@ async def create_export_job(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid TOTP code",
             )
+
+    # Lock the user row so two concurrent POSTs serialize here; the
+    # in-flight check below then can't be raced into a double-insert.
+    await db.execute(
+        select(User.id).where(User.id == user.id).with_for_update()
+    )
 
     # Per-user concurrency: refuse if there's already a non-terminal job.
     in_flight = await db.execute(

--- a/sheaf/api/v1/polls.py
+++ b/sheaf/api/v1/polls.py
@@ -217,6 +217,12 @@ async def create_poll(
     if concurrent_cap > 0:
         from sqlalchemy import func
 
+        # Lock the system row so the open-poll cap can't be raced past by
+        # simultaneous creates each passing the count check.
+        await db.execute(
+            select(System.id).where(System.id == system.id).with_for_update()
+        )
+
         now = datetime.now(UTC)
         open_count_result = await db.execute(
             select(func.count(Poll.id)).where(

--- a/sheaf/api/v1/webhooks.py
+++ b/sheaf/api/v1/webhooks.py
@@ -25,18 +25,31 @@ _SIG_HEADER = "X-Twilio-Email-Event-Webhook-Signature"
 _TS_HEADER = "X-Twilio-Email-Event-Webhook-Timestamp"
 
 
-def _verify_sendgrid_signature(timestamp: str, body: bytes, signature_b64: str) -> bool:
+def _timestamp_within_skew(timestamp: str, max_skew_seconds: int) -> bool:
+    """True if the webhook timestamp is fresh enough not to be a replay.
+
+    Rejects both stale and future-dated timestamps, and a non-numeric
+    header value.
+    """
+    try:
+        skew = abs(time.time() - float(timestamp))
+    except ValueError:
+        return False
+    return skew <= max_skew_seconds
+
+
+def _verify_sendgrid_signature(
+    public_key_b64: str, timestamp: str, body: bytes, signature_b64: str
+) -> bool:
     """Verify SendGrid's Signed Event Webhook signature.
 
     SendGrid signs `timestamp + raw_body` with ECDSA/SHA-256. The header
-    carries a base64 DER signature; the configured verification key is a
-    base64 DER SubjectPublicKeyInfo (EC P-256). The key is public — it can
-    only verify, never sign — so it lives in plain config.
+    carries a base64 DER signature; the verification key is a base64 DER
+    SubjectPublicKeyInfo (EC P-256). The key is public — it can only
+    verify, never sign — so it lives in plain config.
     """
     try:
-        public_key = load_der_public_key(
-            base64.b64decode(settings.sendgrid_webhook_public_key)
-        )
+        public_key = load_der_public_key(base64.b64decode(public_key_b64))
         signature = base64.b64decode(signature_b64)
     except Exception:
         logger.exception("Malformed SendGrid webhook key or signature")
@@ -83,15 +96,15 @@ async def sendgrid_events(
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
         # Replay window — reject stale or future-dated timestamps.
-        try:
-            skew = abs(time.time() - float(timestamp))
-        except ValueError:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN) from None
-        if skew > settings.sendgrid_webhook_max_skew_seconds:
-            logger.warning("Rejected SendGrid webhook: timestamp skew %.0fs", skew)
+        if not _timestamp_within_skew(
+            timestamp, settings.sendgrid_webhook_max_skew_seconds
+        ):
+            logger.warning("Rejected SendGrid webhook: stale or bad timestamp")
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
-        if not _verify_sendgrid_signature(timestamp, raw_body, signature):
+        if not _verify_sendgrid_signature(
+            settings.sendgrid_webhook_public_key, timestamp, raw_body, signature
+        ):
             logger.warning("Rejected SendGrid webhook: bad signature")
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     else:

--- a/sheaf/api/v1/webhooks.py
+++ b/sheaf/api/v1/webhooks.py
@@ -1,39 +1,115 @@
 """Webhook endpoints for third-party service callbacks."""
 
+import base64
 import logging
 import secrets
+import time
 
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_der_public_key
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import settings
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import rate_limit
 
 logger = logging.getLogger("sheaf.webhooks")
 
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
 
+# SendGrid Signed Event Webhook header names.
+_SIG_HEADER = "X-Twilio-Email-Event-Webhook-Signature"
+_TS_HEADER = "X-Twilio-Email-Event-Webhook-Timestamp"
 
-@router.post("/sendgrid/events")
+
+def _verify_sendgrid_signature(timestamp: str, body: bytes, signature_b64: str) -> bool:
+    """Verify SendGrid's Signed Event Webhook signature.
+
+    SendGrid signs `timestamp + raw_body` with ECDSA/SHA-256. The header
+    carries a base64 DER signature; the configured verification key is a
+    base64 DER SubjectPublicKeyInfo (EC P-256). The key is public — it can
+    only verify, never sign — so it lives in plain config.
+    """
+    try:
+        public_key = load_der_public_key(
+            base64.b64decode(settings.sendgrid_webhook_public_key)
+        )
+        signature = base64.b64decode(signature_b64)
+    except Exception:
+        logger.exception("Malformed SendGrid webhook key or signature")
+        return False
+
+    if not isinstance(public_key, ec.EllipticCurvePublicKey):
+        logger.error("SENDGRID_WEBHOOK_PUBLIC_KEY is not an EC public key")
+        return False
+
+    signed_payload = timestamp.encode() + body
+    try:
+        public_key.verify(signature, signed_payload, ec.ECDSA(hashes.SHA256()))
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+    return True
+
+
+@router.post("/sendgrid/events", dependencies=[rate_limit(300, 60)])
 async def sendgrid_events(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
     """Receive SendGrid Event Webhook callbacks for bounces and complaints.
 
-    Configure SendGrid to POST to:
-        https://<base>/v1/webhooks/sendgrid/events?token=<SENDGRID_WEBHOOK_SECRET>
+    Authentication: when `sendgrid_webhook_public_key` is configured the
+    request must carry a valid Signed Event Webhook signature with a fresh
+    timestamp (replay defence). Otherwise it falls back to the legacy
+    query-string shared-secret token — deprecated; enable signing instead.
     """
-    if not settings.sendgrid_webhook_secret:
+    if (
+        not settings.sendgrid_webhook_public_key
+        and not settings.sendgrid_webhook_secret
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
-    token = request.query_params.get("token", "")
-    if not secrets.compare_digest(token, settings.sendgrid_webhook_secret):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    # The signature covers the exact bytes SendGrid sent — read the raw
+    # body and never re-serialize parsed JSON for verification.
+    raw_body = await request.body()
+
+    if settings.sendgrid_webhook_public_key:
+        signature = request.headers.get(_SIG_HEADER, "")
+        timestamp = request.headers.get(_TS_HEADER, "")
+        if not signature or not timestamp:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+
+        # Replay window — reject stale or future-dated timestamps.
+        try:
+            skew = abs(time.time() - float(timestamp))
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN) from None
+        if skew > settings.sendgrid_webhook_max_skew_seconds:
+            logger.warning("Rejected SendGrid webhook: timestamp skew %.0fs", skew)
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+
+        if not _verify_sendgrid_signature(timestamp, raw_body, signature):
+            logger.warning("Rejected SendGrid webhook: bad signature")
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    else:
+        # Legacy shared-secret fallback. Deprecated — configure
+        # SENDGRID_WEBHOOK_PUBLIC_KEY and enable the signed webhook.
+        token = request.query_params.get("token", "")
+        if not secrets.compare_digest(token, settings.sendgrid_webhook_secret):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
 
     from sheaf.services.email_events import apply_bounce, apply_complaint
 
-    events = await request.json()
+    try:
+        events = await request.json()
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Request body is not valid JSON",
+        ) from None
     if not isinstance(events, list):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/sheaf/auth/lockout.py
+++ b/sheaf/auth/lockout.py
@@ -1,0 +1,69 @@
+"""Shared failed-attempt lockout for credentialed endpoints.
+
+`failed_login_count` / `locked_until` on the User row form a single
+lockout state consulted and incremented by every endpoint that verifies
+a short, brute-forceable credential (password at login, the 6-digit
+TOTP code, recovery codes). Keeping these helpers in one module means
+failures on one endpoint count toward locking the others, so an
+attacker can't sidestep the lockout by hopping between endpoints.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy import and_, case, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.config import settings
+from sheaf.models.user import User
+
+
+def ensure_not_locked(user: User) -> None:
+    """Raise 423 if the account is inside a failed-attempt lockout window."""
+    now = datetime.now(UTC)
+    if user.locked_until is not None and user.locked_until > now:
+        mins = max(1, math.ceil((user.locked_until - now).total_seconds() / 60))
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail=(
+                f"Account temporarily locked after repeated failed attempts. "
+                f"Try again in {mins} minute{'s' if mins != 1 else ''}."
+            ),
+        )
+
+
+async def record_login_failure(db: AsyncSession, user: User) -> None:
+    """Increment the user's failed-attempt counter and lock if threshold crossed.
+
+    A single atomic UPDATE handles both the increment and the lockout decision
+    so concurrent failed attempts can't race past the threshold. If the user
+    has a stale (expired) lockout, the counter resets to 1 for this attempt
+    instead of incrementing, so a returning user with one typo doesn't get
+    immediately re-locked on top of old failures.
+    """
+    now = datetime.now(UTC)
+    lockout_end = now + timedelta(minutes=settings.login_lockout_minutes)
+    threshold = settings.login_max_failures
+
+    new_count = case(
+        (
+            and_(User.locked_until.is_not(None), User.locked_until < now),
+            1,
+        ),
+        else_=User.failed_login_count + 1,
+    )
+    new_lock = case(
+        (new_count >= threshold, lockout_end),
+        else_=None,
+    )
+
+    await db.execute(
+        update(User)
+        .where(User.id == user.id)
+        .values(failed_login_count=new_count, locked_until=new_lock)
+    )
+    await db.commit()
+    db.expire(user, ["failed_login_count", "locked_until"])

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -163,7 +163,16 @@ class Settings(BaseSettings):
     # Shared secret for the SendGrid Event Webhook. Configure SendGrid to
     # POST to /v1/webhooks/sendgrid/events?token=<this value>.
     # When empty, the webhook endpoint returns 404.
+    # Legacy fallback only — prefer the signed-webhook key below.
     sendgrid_webhook_secret: str = ""
+    # Base64 DER ECDSA public key for SendGrid's Signed Event Webhook.
+    # Enable "Signed Event Webhook" in the SendGrid UI and paste the
+    # verification key here. When set, requests must carry a valid
+    # signature and the query-string token is ignored.
+    sendgrid_webhook_public_key: str = ""
+    # Max age (seconds) of a signed webhook request before it's rejected
+    # as a possible replay.
+    sendgrid_webhook_max_skew_seconds: int = 600
 
     # Registration
     registration_mode: str = "open"  # "open", "approval", "invite", "closed"

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -18,6 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import settings
+from sheaf.crypto import decrypt
 from sheaf.database import async_session_factory
 from sheaf.models.export_job import ExportJob, ExportJobStatus
 from sheaf.models.uploaded_file import UploadedFile
@@ -127,7 +128,7 @@ async def _build(job_id: uuid.UUID) -> None:
 
     # Email notification — best-effort, don't fail the job on send error.
     try:
-        await _send_completion_email(user_email=user.email, job_id=job.id)
+        await _send_completion_email(user_email=decrypt(user.email), job_id=job.id)
     except Exception:  # noqa: BLE001
         logger.exception("Export completion email failed for job %s", job_id)
 

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -173,10 +173,12 @@ async def _process_account_deletions(db: AsyncSession) -> dict:
     cutoff = datetime.now(UTC) - grace
 
     result = await db.execute(
-        select(User).where(
+        select(User)
+        .where(
             User.account_status == AccountStatus.PENDING_DELETION,
             User.deletion_requested_at <= cutoff,
         )
+        .with_for_update(skip_locked=True)
     )
     users = list(result.scalars().all())
 
@@ -240,10 +242,12 @@ async def _send_deletion_reminders(db: AsyncSession) -> dict:
         return {"items_processed": 0}
 
     result = await db.execute(
-        select(User).where(
+        select(User)
+        .where(
             User.account_status == AccountStatus.PENDING_DELETION,
             User.deletion_requested_at.is_not(None),
         )
+        .with_for_update(skip_locked=True)
     )
     users = list(result.scalars().all())
 
@@ -549,10 +553,12 @@ async def _finalize_pending_actions(db: AsyncSession) -> dict:
 
     now = datetime.now(UTC)
     result = await db.execute(
-        select(PendingAction).where(
+        select(PendingAction)
+        .where(
             PendingAction.status == PendingActionStatus.PENDING,
             PendingAction.finalize_after <= now,
         )
+        .with_for_update(skip_locked=True)
     )
     pending = list(result.scalars().all())
     if not pending:

--- a/tests/test_account_lockout.py
+++ b/tests/test_account_lockout.py
@@ -1,0 +1,105 @@
+"""Failed-attempt lockout coverage for the credentialed endpoints.
+
+After the lockout refactor, `failed_login_count` / `locked_until` is a
+single shared state: TOTP disable, recovery-code regeneration, and the
+account-data endpoint all consult and increment it, so a stolen session
+can't brute-force a short code by spreading attempts across endpoints.
+"""
+
+import time
+import uuid
+
+import httpx
+import pyotp
+
+# Comfortably above the default login_max_failures (10) so the lockout
+# trips regardless of small config drift.
+_ATTEMPTS = 15
+
+
+def _register(client: httpx.Client, password: str = "testpassword123") -> str:
+    email = f"lockout-{uuid.uuid4().hex[:10]}@sheaf.dev"
+    r = client.post(
+        "/v1/auth/register", json={"email": email, "password": password}
+    )
+    assert r.status_code == 201, r.text
+    client.headers["Authorization"] = f"Bearer {r.json()['access_token']}"
+    return email
+
+
+def _enrol_totp(client: httpx.Client) -> pyotp.TOTP:
+    setup = client.post("/v1/auth/totp/setup")
+    assert setup.status_code == 200, setup.text
+    totp = pyotp.TOTP(setup.json()["secret"])
+    verify = client.post("/v1/auth/totp/verify", json={"code": totp.now()})
+    assert verify.status_code == 204, verify.text
+    return totp
+
+
+def _stale_code(totp: pyotp.TOTP) -> str:
+    """A real 6-digit code for an hour-old window — well outside the
+    accepted skew, so it's a guaranteed-wrong (non-flaky) code."""
+    return totp.at(int(time.time()) - 3600)
+
+
+def test_account_data_locks_after_repeated_bad_passwords(client: httpx.Client):
+    _register(client)
+    statuses = [
+        client.post("/v1/account/data", json={"password": "wrong-password"}).status_code
+        for _ in range(_ATTEMPTS)
+    ]
+    # The wrong password is a step-up denial (403) until the lockout trips,
+    # after which the endpoint short-circuits to 423.
+    assert 423 in statuses, statuses
+    assert statuses[0] == 403, statuses
+    assert statuses[-1] == 423, statuses
+
+
+def test_lockout_is_shared_across_endpoints(client: httpx.Client):
+    """Failures on /account/data must lock /login too — the whole point of
+    the unified lockout state."""
+    password = "testpassword123"
+    email = _register(client, password)
+
+    for _ in range(_ATTEMPTS):
+        client.post("/v1/account/data", json={"password": "wrong-password"})
+
+    # Even the *correct* password is now refused at login.
+    resp = client.post(
+        "/v1/auth/login", json={"email": email, "password": password}
+    )
+    assert resp.status_code == 423, resp.text
+
+
+def test_totp_disable_locks_after_repeated_bad_codes(client: httpx.Client):
+    password = "testpassword123"
+    email = _register(client, password)
+    totp = _enrol_totp(client)
+    wrong = _stale_code(totp)
+
+    statuses = [
+        client.post(
+            "/v1/auth/totp/disable",
+            json={"email": email, "password": password, "totp_code": wrong},
+        ).status_code
+        for _ in range(_ATTEMPTS)
+    ]
+    assert 423 in statuses, statuses
+    assert statuses[0] == 400, statuses
+    assert statuses[-1] == 423, statuses
+
+
+def test_regenerate_recovery_codes_locks_after_bad_codes(client: httpx.Client):
+    _register(client)
+    totp = _enrol_totp(client)
+    wrong = _stale_code(totp)
+
+    statuses = [
+        client.post(
+            "/v1/auth/totp/regenerate-recovery-codes", json={"code": wrong}
+        ).status_code
+        for _ in range(_ATTEMPTS)
+    ]
+    assert 423 in statuses, statuses
+    assert statuses[0] == 400, statuses
+    assert statuses[-1] == 423, statuses

--- a/tests/test_webhooks_sendgrid.py
+++ b/tests/test_webhooks_sendgrid.py
@@ -1,0 +1,124 @@
+"""Unit tests for the SendGrid Signed Event Webhook verification helpers.
+
+These exercise the crypto directly (no running server): generate an
+EC P-256 key pair, sign payloads the way SendGrid does, and assert the
+verifier accepts genuine signatures and rejects everything else.
+"""
+
+import base64
+import time
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from sheaf.api.v1.webhooks import _timestamp_within_skew, _verify_sendgrid_signature
+
+
+def _new_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    """Return (private_key, base64-DER-SPKI public key) on the P-256 curve
+    SendGrid uses."""
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    public_der = private_key.public_key().public_bytes(
+        Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+    )
+    return private_key, base64.b64encode(public_der).decode()
+
+
+def _sign(private_key: ec.EllipticCurvePrivateKey, timestamp: str, body: bytes) -> str:
+    """Produce a SendGrid-style base64 DER ECDSA signature over timestamp+body."""
+    signature = private_key.sign(
+        timestamp.encode() + body, ec.ECDSA(hashes.SHA256())
+    )
+    return base64.b64encode(signature).decode()
+
+
+# --- _verify_sendgrid_signature -------------------------------------------
+
+
+def test_genuine_signature_accepted():
+    private_key, public_key_b64 = _new_keypair()
+    timestamp = "1700000000"
+    body = b'[{"event":"bounce","email":"x@example.com"}]'
+    signature = _sign(private_key, timestamp, body)
+
+    assert _verify_sendgrid_signature(public_key_b64, timestamp, body, signature)
+
+
+def test_tampered_body_rejected():
+    private_key, public_key_b64 = _new_keypair()
+    timestamp = "1700000000"
+    signature = _sign(private_key, timestamp, b'[{"event":"bounce"}]')
+
+    assert not _verify_sendgrid_signature(
+        public_key_b64, timestamp, b'[{"event":"delivered"}]', signature
+    )
+
+
+def test_tampered_timestamp_rejected():
+    """The timestamp is part of the signed payload — changing it post-sign
+    invalidates the signature even if the body is untouched."""
+    private_key, public_key_b64 = _new_keypair()
+    body = b'[{"event":"bounce"}]'
+    signature = _sign(private_key, "1700000000", body)
+
+    assert not _verify_sendgrid_signature(
+        public_key_b64, "1700009999", body, signature
+    )
+
+
+def test_signature_from_other_key_rejected():
+    """A signature made with a different private key must not verify against
+    our configured public key."""
+    attacker_key, _ = _new_keypair()
+    _, our_public_key_b64 = _new_keypair()
+    timestamp = "1700000000"
+    body = b'[{"event":"bounce"}]'
+    forged = _sign(attacker_key, timestamp, body)
+
+    assert not _verify_sendgrid_signature(
+        our_public_key_b64, timestamp, body, forged
+    )
+
+
+def test_garbage_signature_rejected():
+    _, public_key_b64 = _new_keypair()
+    assert not _verify_sendgrid_signature(
+        public_key_b64, "1700000000", b"body", "not-base64-!!!"
+    )
+    # Well-formed base64 that isn't a valid DER ECDSA signature.
+    assert not _verify_sendgrid_signature(
+        public_key_b64, "1700000000", b"body", base64.b64encode(b"junk").decode()
+    )
+
+
+def test_malformed_public_key_returns_false_not_crash():
+    private_key, _ = _new_keypair()
+    signature = _sign(private_key, "1700000000", b"body")
+    # Empty and non-key inputs must be handled gracefully.
+    assert not _verify_sendgrid_signature("", "1700000000", b"body", signature)
+    assert not _verify_sendgrid_signature(
+        base64.b64encode(b"not a key").decode(), "1700000000", b"body", signature
+    )
+
+
+# --- _timestamp_within_skew ------------------------------------------------
+
+
+def test_fresh_timestamp_within_skew():
+    assert _timestamp_within_skew(str(int(time.time())), 600)
+
+
+def test_stale_timestamp_rejected():
+    old = str(int(time.time()) - 5000)
+    assert not _timestamp_within_skew(old, 600)
+
+
+def test_future_timestamp_rejected():
+    future = str(int(time.time()) + 5000)
+    assert not _timestamp_within_skew(future, 600)
+
+
+def test_non_numeric_timestamp_rejected():
+    assert not _timestamp_within_skew("not-a-timestamp", 600)
+    assert not _timestamp_within_skew("", 600)


### PR DESCRIPTION
## Summary
- The SendGrid event webhook now verifies the Signed Event Webhook ECDSA signature with a timestamp replay window; the legacy query-string token is a fallback used only when no public key is configured.
- TOTP disable, recovery-code regeneration, and the account-data endpoint are now rate-limited and share a single failed-attempt lockout state, so a stolen session cannot brute-force a short TOTP code by spreading attempts across endpoints.
- Closed a password-reset timing oracle (email send deferred to a background task), a bug that passed a ciphertext blob as the recipient address on export-ready emails, and several check-then-act races: export/poll creation and the account-deletion / pending-action / reminder background sweeps.
- Live password-reset tokens are invalidated on password change and on successful login; delete-account recovery-code consumption now goes through the race-safe conditional-update helper.
- Added unit coverage for the webhook signature/timestamp logic and integration coverage for the shared lockout.

## Operational note
Set `SENDGRID_WEBHOOK_PUBLIC_KEY` and enable Signed Event Webhook in the SendGrid dashboard before relying on signature verification. Until then the endpoint falls back to the legacy `SENDGRID_WEBHOOK_SECRET` token.

## Test plan
- [x] `ruff check sheaf/` clean
- [x] `pytest tests/test_webhooks_sendgrid.py tests/test_account_lockout.py` passes
- [x] auth / admin / export / polls / account suites regression-free
- [ ] Confirm SendGrid signed-webhook config in the target environment