### PR TITLE
Medium fixes: a11y, perf, schema, security, and infra hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ python -c "import secrets; print(secrets.token_urlsafe(32))"
 python -c "import secrets; print(secrets.token_hex(32))"
 ```
 
-> **Important:** If you let Sheaf auto-generate the encryption key, it's saved to `data/encryption.key` inside the Docker volume. **Back this up. If you lose it, all sensiive user data (emails, TOTP secrets, and all member information) is unrecoverable.**
+> **Important:** Sheaf encrypts sensitive data at rest (emails, TOTP secrets, and all member information). The key is `SHEAF_ENCRYPTION_KEY` — either set it in `.env` (recommended) or let Sheaf auto-generate one on first start, saved to `data/encryption.key` inside the Docker volume. **Either way, this key is a third backup target alongside your database and uploaded files: back it up somewhere safe. If you lose it, all encrypted data is unrecoverable.**
 
 ## Web UI
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -22,13 +22,20 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
     )
     with context.begin_transaction():
         context.run_migrations()
 
 
 def do_run_migrations(connection) -> None:
-    context.configure(connection=connection, target_metadata=target_metadata)
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+    )
     with context.begin_transaction():
         context.run_migrations()
 

--- a/alembic/versions/j6k7l8m9n0o1_medium_fixes_schema.py
+++ b/alembic/versions/j6k7l8m9n0o1_medium_fixes_schema.py
@@ -1,0 +1,122 @@
+"""Schema hardening: indexes, a uniqueness constraint, server defaults
+
+Revision ID: j6k7l8m9n0o1
+Revises: i5j6k7l8m9n0
+Create Date: 2026-05-18
+
+A batch of small schema corrections:
+
+- custom_field_values gains a UNIQUE(field_id, member_id) constraint
+  (deduplicating any existing rows first) plus an index on member_id.
+- uploaded_files.user_id is indexed — the cleanup job and per-user
+  listings were full-scanning.
+- The composite-PK association tables get an index on their second
+  column so member-direction lookups don't heap-scan.
+- The redundant single-column index on journal_entries.system_id is
+  dropped; the (system_id, created_at) composite already covers it.
+- pending_actions / safety_change_requests / client_settings get
+  server defaults on their JSONB / status columns so raw-SQL inserts
+  don't fail.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "j6k7l8m9n0o1"
+down_revision = "i5j6k7l8m9n0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- custom_field_values: dedupe, then enforce one value per pair ----
+    # Keep one arbitrary survivor per (field_id, member_id); duplicates
+    # here are a bug, so which one survives doesn't matter.
+    op.execute(
+        """
+        DELETE FROM custom_field_values
+        WHERE ctid NOT IN (
+            SELECT MAX(ctid) FROM custom_field_values
+            GROUP BY field_id, member_id
+        )
+        """
+    )
+    op.create_unique_constraint(
+        "uq_custom_field_values_field_member",
+        "custom_field_values",
+        ["field_id", "member_id"],
+    )
+    op.create_index(
+        "ix_custom_field_values_member_id",
+        "custom_field_values",
+        ["member_id"],
+    )
+
+    # --- uploaded_files.user_id index -----------------------------------
+    op.create_index("ix_uploaded_files_user_id", "uploaded_files", ["user_id"])
+
+    # --- association tables: reverse-direction (member_id) indexes ------
+    for table in (
+        "front_members",
+        "group_members",
+        "member_tags",
+        "reminder_scope_members",
+    ):
+        op.create_index(f"ix_{table}_member_id", table, ["member_id"])
+
+    # --- drop the redundant journal_entries.system_id index -------------
+    op.drop_index("ix_journal_entries_system_id", table_name="journal_entries")
+
+    # --- server defaults so raw-SQL inserts don't fail ------------------
+    op.alter_column(
+        "pending_actions",
+        "fronting_member_ids",
+        server_default=sa.text("'[]'::jsonb"),
+    )
+    op.alter_column(
+        "pending_actions",
+        "fronting_member_names",
+        server_default=sa.text("'[]'::jsonb"),
+    )
+    op.alter_column(
+        "pending_actions", "status", server_default=sa.text("'pending'")
+    )
+    op.alter_column(
+        "safety_change_requests", "status", server_default=sa.text("'pending'")
+    )
+    op.alter_column(
+        "client_settings", "settings", server_default=sa.text("'{}'::jsonb")
+    )
+
+
+def downgrade() -> None:
+    op.alter_column("client_settings", "settings", server_default=None)
+    op.alter_column("safety_change_requests", "status", server_default=None)
+    op.alter_column("pending_actions", "status", server_default=None)
+    op.alter_column("pending_actions", "fronting_member_names", server_default=None)
+    op.alter_column("pending_actions", "fronting_member_ids", server_default=None)
+
+    op.create_index(
+        "ix_journal_entries_system_id", "journal_entries", ["system_id"]
+    )
+
+    for table in (
+        "front_members",
+        "group_members",
+        "member_tags",
+        "reminder_scope_members",
+    ):
+        op.drop_index(f"ix_{table}_member_id", table_name=table)
+
+    op.drop_index("ix_uploaded_files_user_id", table_name="uploaded_files")
+
+    op.drop_index(
+        "ix_custom_field_values_member_id", table_name="custom_field_values"
+    )
+    op.drop_constraint(
+        "uq_custom_field_values_field_member",
+        "custom_field_values",
+        type_="unique",
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,11 @@ services:
   db:
     image: postgres:16-alpine
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      # Bound to loopback by default — the app talks to Postgres over the
+      # compose network, so the published port is only for local tooling.
+      # Set POSTGRES_BIND_HOST=0.0.0.0 only if you deliberately want it
+      # reachable off-host.
+      - "${POSTGRES_BIND_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:
@@ -45,7 +49,8 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      # Loopback by default — see the note on the db service above.
+      - "${REDIS_BIND_HOST:-127.0.0.1}:${REDIS_PORT:-6379}:6379"
     volumes:
       - redisdata:/data
     healthcheck:

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -943,6 +943,28 @@ docker compose exec db pg_dump -U sheaf sheaf > sheaf-backup.sql
 docker compose exec -T db psql -U sheaf sheaf < sheaf-backup.sql
 ```
 
+### Handling backups responsibly
+
+Sheaf stores GDPR Article 9 special-category data, so the dump itself is
+sensitive — treat the backup file with the same care as the live database.
+
+- **Encrypt the dump at rest.** Pipe `pg_dump` through `age` or `gpg`
+  before it lands on disk, e.g.
+  `docker compose exec db pg_dump -U sheaf sheaf | age -r <your-key> > sheaf-backup.sql.age`.
+  An unencrypted `.sql` file on a laptop or in object storage is a breach
+  waiting to happen.
+- **Keep a copy off-host**, and rotate it — a backup on the same machine
+  doesn't survive a disk failure or a ransomware event. Rotate old copies
+  out so a single leaked snapshot has a bounded lifetime.
+- **Back up the encryption key separately from the database.** If both
+  live in the same archive, that archive is a single-file total
+  compromise. The key (item 3 above) belongs in a different store than
+  the dump.
+- **Test your restore.** A backup you have never restored is a guess.
+  Periodically restore into a throwaway database and confirm the app
+  starts and decrypts data. The encryption key and the database must be
+  from a consistent point in time, or login (blind-index lookup) breaks.
+
 ---
 
 ## MinIO (local S3-compatible storage)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -48,8 +48,11 @@ wait_for_app() {
                 fi
                 sleep 1
             done
-            echo "App ready (docs up, DB check timed out — proceeding anyway)."
-            return 0
+            echo "ERROR: /v1/docs is up but the DB-backed endpoint never"
+            echo "       returned 401. The DB pool failed to warm up;"
+            echo "       proceeding would mask that as test flake."
+            $COMPOSE logs app | tail -30
+            exit 1
         fi
         sleep 2
     done

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -194,8 +194,6 @@ async def list_users(
     db: AsyncSession = Depends(get_db),
 ):
     """List all users with member counts. Requires admin:read scope or is_admin."""
-    # Email is encrypted — search must happen after decryption, so we fetch
-    # all rows (or all for the unfiltered case), decrypt, filter, then paginate.
     member_count_sq = (
         select(System.user_id, func.count(Member.id).label("member_count"))
         .outerjoin(Member, Member.system_id == System.id)
@@ -223,18 +221,37 @@ async def list_users(
         .order_by(User.created_at.desc())
     )
 
-    rows = await db.execute(query)
-    all_users = []
-    for user, member_count, storage_used_bytes in rows:
+    offset = max(0, (page - 1) * limit)
+
+    def _decrypt_email(user: User) -> str:
         try:
-            email = decrypt(user.email)
+            return decrypt(user.email)
         except Exception:
-            email = "<encrypted>"
+            return "<encrypted>"
 
-        if search and search.lower() not in email.lower():
-            continue
+    if search:
+        # Email is encrypted with no substring index, so a search has to
+        # decrypt and filter in Python. Admin-only and lower-frequency, so
+        # the full scan is acceptable here.
+        rows = await db.execute(query)
+        needle = search.lower()
+        matched = []
+        for user, member_count, storage in rows:
+            email = _decrypt_email(user)
+            if needle in email.lower():
+                matched.append((user, member_count, storage, email))
+        page_rows = matched[offset : offset + limit]
+    else:
+        # Unfiltered list: paginate in SQL so only the current page is
+        # loaded and decrypted, not the entire users table.
+        rows = await db.execute(query.offset(offset).limit(limit))
+        page_rows = [
+            (user, member_count, storage, _decrypt_email(user))
+            for user, member_count, storage in rows
+        ]
 
-        all_users.append(AdminUserRead(
+    return [
+        AdminUserRead(
             id=str(user.id),
             email=email,
             tier=user.tier,
@@ -249,10 +266,9 @@ async def list_users(
             can_upload_images=user.can_upload_images,
             created_at=user.created_at,
             last_login_at=user.last_login_at,
-        ))
-
-    offset = (page - 1) * limit
-    return all_users[offset : offset + limit]
+        )
+        for user, member_count, storage_used_bytes, email in page_rows
+    ]
 
 
 @router.patch("/users/{user_id}", response_model=AdminUserRead)

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -57,7 +57,7 @@ from sheaf.crypto import blind_index, decrypt, encrypt, hash_mail_token
 from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.api_key import ApiKey
-from sheaf.models.system import System
+from sheaf.models.system import DeleteConfirmation, System
 from sheaf.models.trusted_device import TrustedDevice
 from sheaf.models.user import AccountStatus, User
 from sheaf.request import client_ip
@@ -1436,6 +1436,23 @@ async def totp_disable(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid TOTP code",
+        )
+
+    # If System Safety requires TOTP for destructive actions, disabling it
+    # here would silently weaken that gate (verify_destructive_auth would
+    # fall back to password-only). Block until the tier is lowered.
+    sys_row = await db.execute(select(System).where(System.user_id == user.id))
+    system = sys_row.scalar_one_or_none()
+    if system is not None and system.delete_confirmation in (
+        DeleteConfirmation.TOTP,
+        DeleteConfirmation.BOTH,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "System Safety requires TOTP for destructive actions. "
+                "Lower that confirmation setting before disabling 2FA."
+            ),
         )
 
     user.totp_enabled = False

--- a/sheaf/api/v1/client_settings.py
+++ b/sheaf/api/v1/client_settings.py
@@ -2,7 +2,8 @@ import json
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user, require_scope
@@ -102,6 +103,56 @@ async def put_client_settings(
 
     await db.commit()
     await db.refresh(row)
+    return {"client_id": row.client_id, "settings": row.settings}
+
+
+@router.patch(
+    "/{client_id}",
+    dependencies=[Depends(require_scope("settings:write"))],
+)
+async def patch_client_settings(
+    client_id: str,
+    body: ClientSettingsBody,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Merge the given keys into the stored settings for a client.
+
+    Unlike PUT (which replaces the whole blob), this does an atomic
+    top-level key merge in a single statement, so independent callers
+    each writing their own key can't clobber one another.
+    """
+    if len(client_id) > 64:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="client_id must be 64 characters or fewer",
+        )
+
+    payload_size = len(json.dumps(body.settings, separators=(",", ":")).encode())
+    if payload_size > MAX_SETTINGS_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Settings patch exceeds {MAX_SETTINGS_BYTES // 1024}KB limit",
+        )
+
+    insert_stmt = pg_insert(ClientSettings).values(
+        user_id=user.id, client_id=client_id, settings=body.settings
+    )
+    # On conflict, merge: existing JSONB || incoming JSONB (incoming wins
+    # per top-level key). The whole thing is one atomic UPDATE.
+    stmt = insert_stmt.on_conflict_do_update(
+        constraint="uq_client_settings_user_client",
+        set_={
+            "settings": ClientSettings.settings.op("||")(
+                insert_stmt.excluded.settings
+            ),
+            "updated_at": func.now(),
+        },
+    ).returning(ClientSettings.client_id, ClientSettings.settings)
+
+    result = await db.execute(stmt)
+    await db.commit()
+    row = result.one()
     return {"client_id": row.client_id, "settings": row.settings}
 
 

--- a/sheaf/api/v1/files.py
+++ b/sheaf/api/v1/files.py
@@ -1,3 +1,4 @@
+import logging
 import time
 import uuid
 
@@ -24,6 +25,8 @@ from sheaf.services.system_safety import (
     verify_destructive_auth,
 )
 from sheaf.storage import get_storage
+
+logger = logging.getLogger("sheaf.files")
 
 router = APIRouter(prefix="/files", tags=["files"])
 
@@ -161,37 +164,45 @@ async def upload_file(
     storage = get_storage()
     await storage.put(key, data, actual_mime)
 
-    # Serialize per-user quota accounting. Without this lock, two concurrent
-    # uploads can both pass the quota check above and both insert, landing
-    # the user over their limit. SELECT FOR UPDATE on the user row forces
-    # the second uploader to wait until the first's transaction commits,
-    # then recount with the new row visible.
-    if quota > 0:
-        await db.execute(
-            select(User.id).where(User.id == user.id).with_for_update()
-        )
-        used = await db.scalar(
-            select(func.coalesce(func.sum(UploadedFile.size_bytes), 0))
-            .where(UploadedFile.user_id == user.id)
-        )
-        if (used + file_size) > quota:
-            await storage.delete(key)
-            await db.rollback()
-            quota_mb = quota // (1024 * 1024)
-            raise HTTPException(
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                detail=f"Storage quota exceeded. Limit: {quota_mb}MB",
+    # The blob now exists in storage. Anything that raises before the
+    # UploadedFile row is committed would orphan it, so everything from
+    # here on is guarded: on any failure, best-effort delete the blob.
+    try:
+        # Serialize per-user quota accounting. Without this lock, two
+        # concurrent uploads can both pass the quota check above and both
+        # insert, landing the user over their limit. SELECT FOR UPDATE on
+        # the user row forces the second uploader to wait until the first's
+        # transaction commits, then recount with the new row visible.
+        if quota > 0:
+            await db.execute(
+                select(User.id).where(User.id == user.id).with_for_update()
             )
+            used = await db.scalar(
+                select(func.coalesce(func.sum(UploadedFile.size_bytes), 0))
+                .where(UploadedFile.user_id == user.id)
+            )
+            if (used + file_size) > quota:
+                quota_mb = quota // (1024 * 1024)
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=f"Storage quota exceeded. Limit: {quota_mb}MB",
+                )
 
-    # Track upload
-    db.add(UploadedFile(
-        user_id=user.id,
-        key=key,
-        purpose=purpose,
-        content_type=actual_mime,
-        size_bytes=file_size,
-    ))
-    await db.commit()
+        db.add(UploadedFile(
+            user_id=user.id,
+            key=key,
+            purpose=purpose,
+            content_type=actual_mime,
+            size_bytes=file_size,
+        ))
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        try:
+            await storage.delete(key)
+        except Exception:
+            logger.warning("Failed to clean up orphaned upload blob %s", key)
+        raise
 
     return {"url": resolve_avatar_url(key), "key": key, "size": file_size}
 

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -8,11 +8,10 @@ history shared with member bios.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.api.v1.members import _get_user_system
@@ -48,6 +47,7 @@ from sheaf.services.journals import (
     unpin_revision_immediate,
     update_journal_entry,
 )
+from sheaf.services.pagination import decode_cursor, encode_cursor
 from sheaf.services.system_safety import (
     is_safeguarded,
     queue_pending_action,
@@ -86,7 +86,7 @@ def _label_for(entry: JournalEntry) -> str:
 async def list_journals(
     member_id: uuid.UUID | None = Query(default=None),
     system_only: bool = Query(default=False),
-    before: datetime | None = Query(default=None),
+    cursor: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -97,6 +97,9 @@ async def list_journals(
       - system_only=true → only entries with member_id IS NULL
       - member_id=<uuid> → only that member's entries
       - neither → all entries owned by the user's system
+
+    Pagination uses an opaque (created_at, id) cursor so entries sharing
+    a created_at can't be skipped or duplicated across page boundaries.
     """
     system = await _get_user_system(user, db)
     stmt = select(JournalEntry).where(JournalEntry.system_id == system.id)
@@ -105,17 +108,38 @@ async def list_journals(
     elif member_id is not None:
         await _verify_member_in_system(member_id, system.id, db)
         stmt = stmt.where(JournalEntry.member_id == member_id)
-    if before is not None:
-        stmt = stmt.where(JournalEntry.created_at < before)
+    if cursor is not None:
+        try:
+            cursor_created, cursor_id = decode_cursor(cursor)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid cursor",
+            ) from None
+        # Row comparison: (created_at, id) strictly before the cursor pair.
+        stmt = stmt.where(
+            tuple_(JournalEntry.created_at, JournalEntry.id)
+            < tuple_(cursor_created, cursor_id)
+        )
     # Fetch one extra to determine if a next cursor exists.
-    stmt = stmt.order_by(JournalEntry.created_at.desc()).limit(limit + 1)
+    stmt = stmt.order_by(
+        JournalEntry.created_at.desc(), JournalEntry.id.desc()
+    ).limit(limit + 1)
     result = await db.execute(stmt)
     rows = list(result.scalars().all())
-    next_cursor = rows[limit].created_at if len(rows) > limit else None
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    # Cursor is the last returned row; the next page asks for rows strictly
+    # past it, so the boundary row is neither skipped nor repeated.
+    next_cursor = (
+        encode_cursor(page[-1].created_at, page[-1].id)
+        if has_more and page
+        else None
+    )
     return JournalListResponse(
         items=[
             JournalEntryRead.model_validate(decrypt_entry_for_read(r))
-            for r in rows[:limit]
+            for r in page
         ],
         next_cursor=next_cursor,
     )

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -54,11 +54,13 @@ from sheaf.services.messages import (
     author_display_name,
     board_summaries,
     decrypt_body,
+    display_name,
     encrypt_body,
     fetch_parent_preview,
     front_start_prompt,
     list_messages,
     member_belongs_to_system,
+    preview_for,
     restore_message_revision,
 )
 from sheaf.services.messages import (
@@ -115,6 +117,61 @@ async def _to_read(msg: Message, db: AsyncSession) -> MessageRead:
         created_at=msg.created_at,
         updated_at=msg.updated_at,
     )
+
+
+async def _render_messages(
+    msgs: list[Message], db: AsyncSession
+) -> list[MessageRead]:
+    """Render a page of messages without the per-row N+1 that looping
+    _to_read incurs. Parent messages and member names are each batched
+    into a single query."""
+    if not msgs:
+        return []
+
+    parent_ids = {m.parent_message_id for m in msgs if m.parent_message_id}
+    parents: dict[uuid.UUID, Message] = {}
+    if parent_ids:
+        rows = await db.execute(select(Message).where(Message.id.in_(parent_ids)))
+        parents = {p.id: p for p in rows.scalars()}
+
+    # Members needed: authors of the page plus authors of any parent.
+    member_ids = {m.author_member_id for m in msgs if m.author_member_id}
+    for parent in parents.values():
+        if parent.author_member_id:
+            member_ids.add(parent.author_member_id)
+    members: dict[uuid.UUID, Member] = {}
+    if member_ids:
+        rows = await db.execute(select(Member).where(Member.id.in_(member_ids)))
+        members = {mem.id: mem for mem in rows.scalars()}
+
+    def _name(member_id: uuid.UUID | None) -> str | None:
+        member = members.get(member_id) if member_id else None
+        return display_name(member) if member is not None else None
+
+    rendered: list[MessageRead] = []
+    for msg in msgs:
+        parent_preview: str | None = None
+        parent_author: str | None = None
+        if msg.parent_message_id is not None:
+            parent = parents.get(msg.parent_message_id)
+            if parent is not None and parent.deleted_at is None:
+                parent_preview = preview_for(decrypt_body(parent.body))
+                parent_author = _name(parent.author_member_id)
+        rendered.append(MessageRead(
+            id=msg.id,
+            system_id=msg.system_id,
+            board_kind=msg.board_kind,
+            board_member_id=msg.board_member_id,
+            author_member_id=msg.author_member_id,
+            author_member_name=_name(msg.author_member_id),
+            parent_message_id=msg.parent_message_id,
+            parent_preview=parent_preview,
+            parent_author_member_name=parent_author,
+            body=decrypt_body(msg.body),
+            created_at=msg.created_at,
+            updated_at=msg.updated_at,
+        ))
+    return rendered
 
 
 def _normalise_board(
@@ -218,7 +275,7 @@ async def get_board(
         limit=capped_limit,
         before=before,
     )
-    rendered = [await _to_read(m, db) for m in msgs]
+    rendered = await _render_messages(msgs, db)
 
     caller_last_seen: datetime | None = None
     if caller_member_id is not None:

--- a/sheaf/api/v1/notifications_public.py
+++ b/sheaf/api/v1/notifications_public.py
@@ -25,6 +25,7 @@ from sheaf.auth.dependencies import get_current_user_optional
 from sheaf.auth.sessions import get_session_user_id
 from sheaf.config import settings
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.notification_channel import (
     DestinationState,
     DestinationType,
@@ -51,7 +52,11 @@ from sheaf.services.notifications.activation import (
 router = APIRouter(prefix="/notifications", tags=["notifications-public"])
 
 
-@router.get("/redeem-preview", response_model=RedeemPreview)
+@router.get(
+    "/redeem-preview",
+    response_model=RedeemPreview,
+    dependencies=[rate_limit(30, 60)],
+)
 async def preview_activation(
     code: str,
     db: AsyncSession = Depends(get_db),
@@ -114,7 +119,11 @@ async def preview_activation(
     )
 
 
-@router.post("/redeem", response_model=RedeemResponse)
+@router.post(
+    "/redeem",
+    response_model=RedeemResponse,
+    dependencies=[rate_limit(30, 60)],
+)
 async def redeem_activation(
     body: RedeemRequest,
     db: AsyncSession = Depends(get_db),
@@ -274,7 +283,11 @@ async def _channel_by_management_token(
     return channel
 
 
-@router.get("/manage/{mgmt_token}", response_model=ManageChannelView)
+@router.get(
+    "/manage/{mgmt_token}",
+    response_model=ManageChannelView,
+    dependencies=[rate_limit(30, 60)],
+)
 async def view_managed(
     mgmt_token: str,
     session_id: str | None = Cookie(default=None, alias="sheaf_session"),
@@ -308,6 +321,7 @@ async def view_managed(
 @router.post(
     "/manage/{mgmt_token}/unsubscribe",
     status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[rate_limit(30, 60)],
 )
 async def unsubscribe(
     mgmt_token: str,

--- a/sheaf/api/v1/system_safety.py
+++ b/sheaf/api/v1/system_safety.py
@@ -23,7 +23,7 @@ from sheaf.models.safety_change_request import (
     SafetyChangeRequest,
     SafetyChangeStatus,
 )
-from sheaf.models.system import System
+from sheaf.models.system import DeleteConfirmation, System
 from sheaf.models.user import User
 from sheaf.schemas.system_safety import (
     PendingActionRead,
@@ -139,6 +139,20 @@ async def update_system_safety(
         for k, v in external_updates.items()
         if k in _EXTERNAL_TO_INTERNAL
     }
+    # Don't let the auth tier be raised to a TOTP-requiring level unless the
+    # user actually has TOTP enrolled — otherwise the gate would be a no-op
+    # and silently wave destructive actions through. Mirrors the dedicated
+    # /v1/systems delete-confirmation endpoint.
+    new_tier = internal_updates.get("delete_confirmation")
+    if (
+        new_tier in (DeleteConfirmation.TOTP, DeleteConfirmation.BOTH)
+        and not user.totp_enabled
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot require TOTP confirmation without 2FA enabled",
+        )
+
     split = split_safety_changes(system, internal_updates)
 
     # Re-auth gate applies to any loosening change. For tightening-only changes

--- a/sheaf/models/client_settings.py
+++ b/sheaf/models/client_settings.py
@@ -20,4 +20,6 @@ class ClientSettings(UUIDMixin, TimestampMixin, Base):
         index=True,
     )
     client_id: Mapped[str] = mapped_column(String(64), nullable=False)
-    settings: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    settings: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default="{}"
+    )

--- a/sheaf/models/custom_field.py
+++ b/sheaf/models/custom_field.py
@@ -1,7 +1,7 @@
 import enum
 import uuid
 
-from sqlalchemy import Enum, ForeignKey, Integer, String
+from sqlalchemy import Enum, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -50,6 +50,13 @@ class CustomFieldDefinition(UUIDMixin, TimestampMixin, Base):
 
 class CustomFieldValue(UUIDMixin, Base):
     __tablename__ = "custom_field_values"
+    # One value per (field, member). The constraint also indexes field_id
+    # (leftmost column); member_id gets its own index below.
+    __table_args__ = (
+        UniqueConstraint(
+            "field_id", "member_id", name="uq_custom_field_values_field_member"
+        ),
+    )
 
     field_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -60,6 +67,7 @@ class CustomFieldValue(UUIDMixin, Base):
         UUID(as_uuid=True),
         ForeignKey("members.id", ondelete="CASCADE"),
         nullable=False,
+        index=True,
     )
 
     value: Mapped[dict | None] = mapped_column(JSONB, nullable=True)

--- a/sheaf/models/group.py
+++ b/sheaf/models/group.py
@@ -34,9 +34,11 @@ class Group(UUIDMixin, TimestampMixin, Base):
     members: Mapped[list["Member"]] = relationship(
         secondary=group_members, back_populates="groups"
     )
-    children: Mapped[list["Group"]] = relationship(
-        back_populates="parent", cascade="all, delete-orphan"
-    )
+    # No delete-orphan / delete cascade: the DB FK is ON DELETE SET NULL,
+    # so deleting a parent group un-nests its children rather than
+    # destroying them. The ORM cascade must match that, or an ORM-issued
+    # delete and a raw-SQL delete would behave differently.
+    children: Mapped[list["Group"]] = relationship(back_populates="parent")
     parent: Mapped["Group | None"] = relationship(
         back_populates="children", remote_side="Group.id"
     )

--- a/sheaf/models/journal_entry.py
+++ b/sheaf/models/journal_entry.py
@@ -16,11 +16,12 @@ class JournalEntry(UUIDMixin, TimestampMixin, Base):
 
     __tablename__ = "journal_entries"
 
+    # No standalone index — the (system_id, created_at) composite below
+    # already serves system_id-only lookups via its leftmost column.
     system_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("systems.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
     member_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -15,9 +15,12 @@ front_members = Table(
         "front_id", UUID(as_uuid=True),
         ForeignKey("fronts.id", ondelete="CASCADE"), primary_key=True,
     ),
+    # Indexed: the composite PK only serves front_id-leading lookups, so
+    # "which fronts is member X in?" would otherwise heap-scan.
     Column(
         "member_id", UUID(as_uuid=True),
         ForeignKey("members.id", ondelete="CASCADE"), primary_key=True,
+        index=True,
     ),
 )
 
@@ -32,6 +35,7 @@ group_members = Table(
     Column(
         "member_id", UUID(as_uuid=True),
         ForeignKey("members.id", ondelete="CASCADE"), primary_key=True,
+        index=True,
     ),
 )
 
@@ -46,6 +50,7 @@ member_tags = Table(
     Column(
         "member_id", UUID(as_uuid=True),
         ForeignKey("members.id", ondelete="CASCADE"), primary_key=True,
+        index=True,
     ),
 )
 

--- a/sheaf/models/pending_action.py
+++ b/sheaf/models/pending_action.py
@@ -60,11 +60,18 @@ class PendingAction(UUIDMixin, Base):
 
     # Snapshot of who was fronting when the action was requested.
     # Frozen — members may be deleted or front composition may change before finalization.
-    fronting_member_ids: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
-    fronting_member_names: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    fronting_member_ids: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
+    fronting_member_names: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
 
     status: Mapped[str] = mapped_column(
-        String(16), nullable=False, default=PendingActionStatus.PENDING
+        String(16),
+        nullable=False,
+        default=PendingActionStatus.PENDING,
+        server_default=PendingActionStatus.PENDING.value,
     )
     cancelled_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/sheaf/models/reminder.py
+++ b/sheaf/models/reminder.py
@@ -51,6 +51,7 @@ reminder_scope_members = Table(
         UUID(as_uuid=True),
         ForeignKey("members.id", ondelete="CASCADE"),
         primary_key=True,
+        index=True,
     ),
 )
 

--- a/sheaf/models/safety_change_request.py
+++ b/sheaf/models/safety_change_request.py
@@ -45,7 +45,10 @@ class SafetyChangeRequest(UUIDMixin, Base):
     changes: Mapped[dict] = mapped_column(JSONB, nullable=False)
 
     status: Mapped[str] = mapped_column(
-        String(16), nullable=False, default=SafetyChangeStatus.PENDING
+        String(16),
+        nullable=False,
+        default=SafetyChangeStatus.PENDING,
+        server_default=SafetyChangeStatus.PENDING.value,
     )
     cancelled_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/sheaf/models/uploaded_file.py
+++ b/sheaf/models/uploaded_file.py
@@ -12,7 +12,10 @@ class UploadedFile(UUIDMixin, Base):
     __tablename__ = "uploaded_files"
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     key: Mapped[str] = mapped_column(String(500), unique=True, nullable=False)
     purpose: Mapped[str] = mapped_column(String(20), nullable=False)

--- a/sheaf/schemas/journal.py
+++ b/sheaf/schemas/journal.py
@@ -86,7 +86,8 @@ class JournalEntryReadWithCount(JournalEntryRead):
 
 class JournalListResponse(BaseModel):
     items: list[JournalEntryRead]
-    next_cursor: datetime | None = None
+    # Opaque (created_at, id) cursor — pass back as ?cursor= for the next page.
+    next_cursor: str | None = None
 
 
 class ContentRevisionRead(BaseModel):

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -190,18 +190,31 @@ async def _process_account_deletions(db: AsyncSession) -> dict:
     detail_lines: list[str] = []
 
     for user in users:
-        # Delete storage files before cascade removes the DB rows
+        # Delete storage files before cascade removes the DB rows.
         file_result = await db.execute(
             select(UploadedFile).where(UploadedFile.user_id == user.id)
         )
         files = list(file_result.scalars().all())
         file_keys = []
+        all_blobs_deleted = True
         for f in files:
             try:
                 await storage.delete(f.key)
                 file_keys.append(f.key)
             except Exception:
+                all_blobs_deleted = False
                 logger.warning("Failed to delete file %s for user %s", f.key, user.id)
+
+        # Don't drop the user row while blobs survive: the CASCADE would
+        # erase the UploadedFile records too, orphaning the storage objects
+        # with nothing left to locate them by. Leave the account
+        # PENDING_DELETION and retry on the next sweep.
+        if not all_blobs_deleted:
+            logger.warning(
+                "Deferring deletion of account %s: storage cleanup incomplete",
+                user.id,
+            )
+            continue
 
         # Delete Redis sessions
         try:

--- a/sheaf/services/messages.py
+++ b/sheaf/services/messages.py
@@ -355,7 +355,9 @@ async def list_messages(
             Message.deleted_at.is_(None),
             _board_match_clause(board_kind, board_member_id),
         )
-        .order_by(Message.created_at.desc())
+        # id is the deterministic tiebreaker for rows sharing a created_at,
+        # so ordering stays stable across pages.
+        .order_by(Message.created_at.desc(), Message.id.desc())
         .limit(limit)
     )
     if before is not None:

--- a/sheaf/services/messages.py
+++ b/sheaf/services/messages.py
@@ -252,7 +252,7 @@ async def board_summaries(
             BoardSummary(
                 board_kind=BoardKind.MEMBER.value,
                 board_member_id=member.id,
-                member_name=_display_name(member),
+                member_name=display_name(member),
                 last_message_at=msgs[0].created_at if msgs else None,
                 last_message_preview=(
                     preview_for(decrypt_body(msgs[0].body)) if msgs else None
@@ -271,7 +271,7 @@ async def board_summaries(
     return summaries + member_summaries
 
 
-def _display_name(member: Member) -> str:
+def display_name(member: Member) -> str:
     if member.display_name:
         return member.display_name
     return decrypt(member.name) if member.name else "(unnamed)"
@@ -382,7 +382,7 @@ async def fetch_parent_preview(
     if parent.author_member_id is not None:
         author = await db.get(Member, parent.author_member_id)
         if author is not None:
-            author_name = _display_name(author)
+            author_name = display_name(author)
     return preview_for(body_pt), author_name, parent_id
 
 
@@ -392,7 +392,7 @@ async def author_display_name(
     if author_member_id is None:
         return None
     author = await db.get(Member, author_member_id)
-    return _display_name(author) if author is not None else None
+    return display_name(author) if author is not None else None
 
 
 # ---------------------------------------------------------------------------

--- a/sheaf/services/reminders.py
+++ b/sheaf/services/reminders.py
@@ -251,9 +251,11 @@ async def tick_repeated_reminders(db: AsyncSession) -> int:
     # usually a single small set.
     system_ids = {r.system_id for r in reminders}
     fronting_by_system = await _currently_fronting_by_system(db, system_ids)
+    # Batch the channel lookups too — one query instead of one per reminder.
+    channels_by_id = await _load_channels(db, {r.channel_id for r in reminders})
 
     for reminder in reminders:
-        if not _channel_is_active(await _load_channel(db, reminder.channel_id)):
+        if not _channel_is_active(channels_by_id.get(reminder.channel_id)):
             continue
 
         # Anchor scheduling against last_fired_at (or created_at if never
@@ -520,6 +522,19 @@ async def _load_channel(
             select(NotificationChannel).where(NotificationChannel.id == channel_id)
         )
     ).scalar_one_or_none()
+
+
+async def _load_channels(
+    db: AsyncSession, channel_ids: set[uuid.UUID]
+) -> dict[uuid.UUID, NotificationChannel]:
+    """Batch-load channels by id — avoids a per-reminder query in the
+    repeated-reminder tick."""
+    if not channel_ids:
+        return {}
+    rows = await db.execute(
+        select(NotificationChannel).where(NotificationChannel.id.in_(channel_ids))
+    )
+    return {c.id: c for c in rows.scalars()}
 
 
 def _channel_is_active(channel: NotificationChannel | None) -> bool:

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -132,8 +132,19 @@ def verify_destructive_auth(
     loosening changes.
     """
     level = system.delete_confirmation
+    needs_password = level in (DeleteConfirmation.PASSWORD, DeleteConfirmation.BOTH)
+    needs_totp = level in (DeleteConfirmation.TOTP, DeleteConfirmation.BOTH)
 
-    if level in (DeleteConfirmation.PASSWORD, DeleteConfirmation.BOTH):
+    # Misconfiguration fail-safe: the tier requires TOTP but the user has no
+    # TOTP enrolled. Both settings endpoints and the TOTP-disable path now
+    # prevent reaching this state, so it only happens with legacy data —
+    # fall back to a password check rather than silently waving the action
+    # through (which, for a TOTP-only tier, would be no gate at all).
+    if needs_totp and not user.totp_enabled:
+        needs_password = True
+        needs_totp = False
+
+    if needs_password:
         if not password:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -151,11 +162,7 @@ def verify_destructive_auth(
                 detail="Incorrect password",
             )
 
-    if level in (DeleteConfirmation.TOTP, DeleteConfirmation.BOTH):
-        if not user.totp_enabled:
-            # TOTP gate requested but not configured — skip silently, as
-            # elsewhere in the codebase (members.py:154).
-            return
+    if needs_totp:
         if not totp_code:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/tests/test_account_lockout.py
+++ b/tests/test_account_lockout.py
@@ -6,11 +6,54 @@ account-data endpoint all consult and increment it, so a stolen session
 can't brute-force a short code by spreading attempts across endpoints.
 """
 
+import asyncio
+import os
 import time
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pyotp
+
+
+def _login(client: httpx.Client, email: str, password: str) -> int:
+    return client.post(
+        "/v1/auth/login", json={"email": email, "password": password}
+    ).status_code
+
+
+async def _db_lockout_op(email: str, *, read: bool, count: int = 0):
+    """Read or set a user's failed-attempt state directly in the DB.
+
+    Used to exercise the lockout reset path without waiting out a real
+    15-minute lockout window.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from sheaf.config import settings
+    from sheaf.crypto import blind_index
+    from sheaf.models.user import User
+
+    db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+    engine = create_async_engine(db_url)
+    session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with session() as db:
+            result = await db.execute(
+                select(User).where(User.email_hash == blind_index(email))
+            )
+            user = result.scalar_one()
+            if read:
+                return user.failed_login_count
+            # Simulate an expired lockout: counter at the cap, window past.
+            user.failed_login_count = count
+            user.locked_until = datetime.now(UTC) - timedelta(minutes=1)
+            await db.commit()
+            return None
+    finally:
+        await engine.dispose()
 
 # Comfortably above the default login_max_failures (10) so the lockout
 # trips regardless of small config drift.
@@ -69,6 +112,50 @@ def test_lockout_is_shared_across_endpoints(client: httpx.Client):
         "/v1/auth/login", json={"email": email, "password": password}
     )
     assert resp.status_code == 423, resp.text
+
+
+def test_login_locks_after_repeated_failures(client: httpx.Client):
+    email = _register(client)
+    statuses = [
+        _login(client, email, "wrong-password") for _ in range(_ATTEMPTS)
+    ]
+    assert 423 in statuses, statuses
+    assert statuses[0] == 401, statuses
+
+
+def test_correct_password_rejected_during_lockout(client: httpx.Client):
+    password = "testpassword123"
+    email = _register(client, password)
+    for _ in range(_ATTEMPTS):
+        _login(client, email, "wrong-password")
+    # The lockout window rejects even the genuine password.
+    assert _login(client, email, password) == 423
+
+
+def test_successful_login_clears_failure_counter(client: httpx.Client):
+    """Five failures, a success, then five more must not lock — the success
+    reset the counter, so the second batch starts from zero rather than
+    accumulating past the threshold."""
+    password = "testpassword123"
+    email = _register(client, password)
+    for _ in range(5):
+        assert _login(client, email, "wrong-password") == 401
+    assert _login(client, email, password) == 200  # clears the counter
+    for _ in range(5):
+        assert _login(client, email, "wrong-password") == 401
+    # Still unlocked — the genuine password works.
+    assert _login(client, email, password) == 200
+
+
+def test_expired_lockout_resets_counter_to_one(client: httpx.Client):
+    """A stale (expired) lockout doesn't carry its old count forward: the
+    next failure starts a fresh count of 1, not threshold+1."""
+    email = _register(client)
+    asyncio.run(_db_lockout_op(email, read=False, count=10))
+    # The expired window lets the attempt through to a normal 401...
+    assert _login(client, email, "wrong-password") == 401
+    # ...and the counter restarted at 1 rather than incrementing to 11.
+    assert asyncio.run(_db_lockout_op(email, read=True)) == 1
 
 
 def test_totp_disable_locks_after_repeated_bad_codes(client: httpx.Client):

--- a/tests/test_client_settings.py
+++ b/tests/test_client_settings.py
@@ -1,0 +1,66 @@
+"""Tests for the client-settings endpoints, focused on the PATCH merge.
+
+PATCH does an atomic top-level key merge so independent callers each
+writing their own key can't clobber one another the way concurrent
+full-blob PUTs would.
+"""
+
+import httpx
+
+
+def test_put_then_get_roundtrips(auth_client: httpx.Client):
+    resp = auth_client.put(
+        "/v1/settings/client/web",
+        json={"settings": {"theme": "dark", "fronts": {"view": "paged"}}},
+    )
+    assert resp.status_code == 200, resp.text
+    got = auth_client.get("/v1/settings/client/web").json()
+    assert got["settings"] == {"theme": "dark", "fronts": {"view": "paged"}}
+
+
+def test_patch_merges_into_existing(auth_client: httpx.Client):
+    auth_client.put(
+        "/v1/settings/client/web",
+        json={"settings": {"theme": "dark", "onboarding_complete": False}},
+    )
+    resp = auth_client.patch(
+        "/v1/settings/client/web",
+        json={"settings": {"onboarding_complete": True, "new_key": 1}},
+    )
+    assert resp.status_code == 200, resp.text
+    merged = resp.json()["settings"]
+    # theme survives; the patched keys win / are added.
+    assert merged == {"theme": "dark", "onboarding_complete": True, "new_key": 1}
+
+
+def test_patch_creates_when_absent(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        "/v1/settings/client/fresh-client",
+        json={"settings": {"hello": "world"}},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["settings"] == {"hello": "world"}
+
+
+def test_patch_independent_keys_do_not_clobber(auth_client: httpx.Client):
+    """The race-fix property: two callers each patching their own key both
+    survive, where two full-blob PUTs would have lost one write."""
+    auth_client.patch(
+        "/v1/settings/client/web",
+        json={"settings": {"fronts": {"view": "paged"}}},
+    )
+    auth_client.patch(
+        "/v1/settings/client/web",
+        json={"settings": {"dismissed_announcements": ["a1"]}},
+    )
+    final = auth_client.get("/v1/settings/client/web").json()["settings"]
+    assert final["fronts"] == {"view": "paged"}
+    assert final["dismissed_announcements"] == ["a1"]
+
+
+def test_patch_oversize_rejected(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        "/v1/settings/client/web",
+        json={"settings": {"blob": "x" * (17 * 1024)}},
+    )
+    assert resp.status_code == 413, resp.text

--- a/tests/test_journals.py
+++ b/tests/test_journals.py
@@ -97,6 +97,37 @@ def test_list_filters_by_member(auth_client: httpx.Client):
     assert a_only["items"][0]["body"] == "for-a"
 
 
+def test_list_cursor_pagination_partitions(auth_client: httpx.Client):
+    """The opaque (created_at, id) cursor walks every entry exactly once
+    with no skips or duplicates across page boundaries."""
+    created = []
+    for i in range(5):
+        r = auth_client.post("/v1/journals", json={"body": f"entry-{i}"})
+        assert r.status_code == 201, r.text
+        created.append(r.json()["id"])
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(10):  # generous loop bound
+        params: dict[str, str] = {"limit": "2"}
+        if cursor:
+            params["cursor"] = cursor
+        page = auth_client.get("/v1/journals", params=params).json()
+        seen.extend(item["id"] for item in page["items"])
+        cursor = page["next_cursor"]
+        if cursor is None:
+            break
+
+    # Every created entry shows up exactly once.
+    assert sorted(seen) == sorted(created), seen
+    assert len(seen) == len(set(seen)), "page boundary produced a duplicate"
+
+
+def test_list_rejects_bad_cursor(auth_client: httpx.Client):
+    resp = auth_client.get("/v1/journals", params={"cursor": "not-a-cursor"})
+    assert resp.status_code == 422, resp.text
+
+
 def test_visibility_only_system_v1(auth_client: httpx.Client):
     resp = auth_client.post(
         "/v1/journals",

--- a/web/src/components/announcement-banners.tsx
+++ b/web/src/components/announcement-banners.tsx
@@ -6,6 +6,7 @@ import {
   type Announcement,
 } from "@/lib/announcements";
 import { apiFetch } from "@/lib/api-client";
+import { patchWebSettings } from "@/lib/client-settings";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -64,12 +65,7 @@ export function AnnouncementBanners() {
   async function handleDontShowAgain(id: string) {
     const updated = [...permanentlyDismissed, id];
     try {
-      await apiFetch(`/v1/settings/client/web`, {
-        method: "PUT",
-        body: JSON.stringify({
-          settings: { ...settings, dismissed_announcements: updated },
-        }),
-      });
+      await patchWebSettings({ dismissed_announcements: updated });
       qc.invalidateQueries({ queryKey: ["client-settings", "web"] });
     } catch {
       // Fall back to session dismiss

--- a/web/src/components/avatar-upload.tsx
+++ b/web/src/components/avatar-upload.tsx
@@ -61,11 +61,18 @@ export function AvatarUpload({
     // stopPropagation the parent form saves with stale state before our
     // onUpload takes effect.
     e.stopPropagation();
-    if (urlValue.trim()) {
-      onUpload(urlValue.trim());
-      setUrlValue("");
-      setShowUrlInput(false);
+    const trimmed = urlValue.trim();
+    if (!trimmed) return;
+    // Allowlist the scheme so a javascript:/data:/file: URL can't ride in
+    // as an avatar src. http and https are both fine for an image URL.
+    if (!/^https?:\/\//i.test(trimmed)) {
+      setError("Image URL must start with http:// or https://");
+      return;
     }
+    setError("");
+    onUpload(trimmed);
+    setUrlValue("");
+    setShowUrlInput(false);
   }
 
   return (

--- a/web/src/components/destructive-confirm-dialog.tsx
+++ b/web/src/components/destructive-confirm-dialog.tsx
@@ -77,8 +77,9 @@ export function DestructiveConfirmDialog({
           <div className="space-y-3">
             {needsPassword && (
               <div className="space-y-1">
-                <Label className="text-sm">Password</Label>
+                <Label htmlFor="destructive-confirm-password" className="text-sm">Password</Label>
                 <Input
+                  id="destructive-confirm-password"
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
@@ -88,8 +89,9 @@ export function DestructiveConfirmDialog({
             )}
             {needsTotp && (
               <div className="space-y-1">
-                <Label className="text-sm">TOTP code</Label>
+                <Label htmlFor="destructive-confirm-totp" className="text-sm">TOTP code</Label>
                 <Input
+                  id="destructive-confirm-totp"
                   value={totpCode}
                   onChange={(e) => setTotpCode(e.target.value)}
                   placeholder="6-digit code"

--- a/web/src/components/journal-entry-editor.tsx
+++ b/web/src/components/journal-entry-editor.tsx
@@ -46,8 +46,9 @@ export function JournalEntryEditor({
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
       <div className="space-y-1">
-        <Label className="text-sm">Title (optional)</Label>
+        <Label htmlFor="journal-entry-title" className="text-sm">Title (optional)</Label>
         <Input
+          id="journal-entry-title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Untitled — will use date in lists"

--- a/web/src/components/notifications/delivery-card.tsx
+++ b/web/src/components/notifications/delivery-card.tsx
@@ -69,14 +69,14 @@ export function DeliveryCard({
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="space-y-2">
-          <Label>Payload sensitivity</Label>
+          <Label htmlFor="delivery-payload-sensitivity">Payload sensitivity</Label>
           <Select
             value={channel.payload_sensitivity}
             onValueChange={(v) =>
               onChange({ payload_sensitivity: v as PayloadSensitivity })
             }
           >
-            <SelectTrigger>
+            <SelectTrigger id="delivery-payload-sensitivity">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -95,8 +95,9 @@ export function DeliveryCard({
 
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label>Debounce (seconds)</Label>
+            <Label htmlFor="delivery-debounce">Debounce (seconds)</Label>
             <Input
+              id="delivery-debounce"
               type="number"
               min={debounceFloor}
               max={86400}
@@ -130,8 +131,9 @@ export function DeliveryCard({
           </div>
 
           <div className="space-y-2">
-            <Label>Aggregation window (seconds)</Label>
+            <Label htmlFor="delivery-aggregation">Aggregation window (seconds)</Label>
             <Input
+              id="delivery-aggregation"
               type="number"
               min={0}
               max={86400}
@@ -166,8 +168,9 @@ export function DeliveryCard({
           {quietEnabled && (
             <div className="ml-6 grid gap-2 sm:grid-cols-2">
               <div className="space-y-1">
-                <Label className="text-xs">Start</Label>
+                <Label htmlFor="quiet-hours-start" className="text-xs">Start</Label>
                 <Input
+                  id="quiet-hours-start"
                   type="time"
                   value={qh.start}
                   onChange={(e) =>
@@ -176,8 +179,9 @@ export function DeliveryCard({
                 />
               </div>
               <div className="space-y-1">
-                <Label className="text-xs">End</Label>
+                <Label htmlFor="quiet-hours-end" className="text-xs">End</Label>
                 <Input
+                  id="quiet-hours-end"
                   type="time"
                   value={qh.end}
                   onChange={(e) =>
@@ -186,14 +190,14 @@ export function DeliveryCard({
                 />
               </div>
               <div className="col-span-2 space-y-1">
-                <Label className="text-xs">Timezone</Label>
+                <Label htmlFor="quiet-hours-tz" className="text-xs">Timezone</Label>
                 <Select
                   value={qh.tz}
                   onValueChange={(v) =>
                     onChange({ quiet_hours: { ...qh, tz: v } })
                   }
                 >
-                  <SelectTrigger>
+                  <SelectTrigger id="quiet-hours-tz">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent className="max-h-72">

--- a/web/src/components/notifications/layer-cards.tsx
+++ b/web/src/components/notifications/layer-cards.tsx
@@ -179,9 +179,9 @@ export function L2Card({
 
         {availableGroups.length > 0 && (
           <div className="space-y-1">
-            <Label className="text-xs text-muted-foreground">Add group</Label>
+            <Label htmlFor="layer-add-group" className="text-xs text-muted-foreground">Add group</Label>
             <Select onValueChange={add} value="">
-              <SelectTrigger>
+              <SelectTrigger id="layer-add-group">
                 <SelectValue placeholder="Choose a group..." />
               </SelectTrigger>
               <SelectContent>
@@ -278,9 +278,9 @@ export function L3Card({
 
         {availableMembers.length > 0 && (
           <div className="space-y-1">
-            <Label className="text-xs text-muted-foreground">Add member</Label>
+            <Label htmlFor="layer-add-member" className="text-xs text-muted-foreground">Add member</Label>
             <Select onValueChange={add} value="">
-              <SelectTrigger>
+              <SelectTrigger id="layer-add-member">
                 <SelectValue placeholder="Choose a member..." />
               </SelectTrigger>
               <SelectContent>

--- a/web/src/components/notifications/new-channel-dialog.tsx
+++ b/web/src/components/notifications/new-channel-dialog.tsx
@@ -119,8 +119,9 @@ export function NewChannelDialog({
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label>Name</Label>
+            <Label htmlFor="new-channel-name">Name</Label>
             <Input
+              id="new-channel-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Mara's phone"
@@ -128,9 +129,9 @@ export function NewChannelDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label>Destination</Label>
+            <Label htmlFor="new-channel-destination">Destination</Label>
             <Select value={type} onValueChange={(v) => setType(v as DestinationType)}>
-              <SelectTrigger>
+              <SelectTrigger id="new-channel-destination">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -146,8 +147,9 @@ export function NewChannelDialog({
           {type === "webhook" && (
             <>
               <div className="space-y-2">
-                <Label>URL</Label>
+                <Label htmlFor="webhook-url">URL</Label>
                 <Input
+                  id="webhook-url"
                   type="url"
                   value={webhookUrl}
                   onChange={(e) => setWebhookUrl(e.target.value)}
@@ -156,14 +158,14 @@ export function NewChannelDialog({
                 />
               </div>
               <div className="space-y-2">
-                <Label>Payload format</Label>
+                <Label htmlFor="webhook-format">Payload format</Label>
                 <Select
                   value={webhookFormat}
                   onValueChange={(v) =>
                     setWebhookFormat(v as typeof webhookFormat)
                   }
                 >
-                  <SelectTrigger>
+                  <SelectTrigger id="webhook-format">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -188,8 +190,9 @@ export function NewChannelDialog({
               </div>
               {(webhookFormat === "json" || webhookFormat === "plaintext") && (
                 <div className="space-y-2">
-                  <Label>Secret (optional)</Label>
+                  <Label htmlFor="webhook-secret">Secret (optional)</Label>
                   <Input
+                    id="webhook-secret"
                     type="password"
                     value={webhookSecret}
                     onChange={(e) => setWebhookSecret(e.target.value)}
@@ -203,8 +206,9 @@ export function NewChannelDialog({
           {type === "ntfy" && (
             <>
               <div className="space-y-2">
-                <Label>Server URL</Label>
+                <Label htmlFor="ntfy-server">Server URL</Label>
                 <Input
+                  id="ntfy-server"
                   type="url"
                   value={ntfyServer}
                   onChange={(e) => setNtfyServer(e.target.value)}
@@ -212,8 +216,9 @@ export function NewChannelDialog({
                 />
               </div>
               <div className="space-y-2">
-                <Label>Topic</Label>
+                <Label htmlFor="ntfy-topic">Topic</Label>
                 <Input
+                  id="ntfy-topic"
                   value={ntfyTopic}
                   onChange={(e) => setNtfyTopic(e.target.value)}
                   required
@@ -225,8 +230,9 @@ export function NewChannelDialog({
           {type === "pushover" && (
             <>
               <div className="space-y-2">
-                <Label>User key</Label>
+                <Label htmlFor="pushover-user-key">User key</Label>
                 <Input
+                  id="pushover-user-key"
                   value={pushoverUserKey}
                   onChange={(e) => setPushoverUserKey(e.target.value)}
                   placeholder="From your Pushover dashboard"
@@ -274,8 +280,9 @@ export function NewChannelDialog({
                       — you'll hit your own account's 10k/month free pool
                       instead.
                     </p>
-                    <Label className="text-xs">App token (optional)</Label>
+                    <Label htmlFor="pushover-app-token" className="text-xs">App token (optional)</Label>
                     <Input
+                      id="pushover-app-token"
                       value={pushoverAppToken}
                       onChange={(e) => setPushoverAppToken(e.target.value)}
                       placeholder="a-30-char-pushover-app-token"

--- a/web/src/components/notifications/triggers-card.tsx
+++ b/web/src/components/notifications/triggers-card.tsx
@@ -44,7 +44,10 @@ export function TriggersCard({
           />
           {channel.trigger_on_cofront_change && (
             <div className="ml-6 space-y-1">
-              <Label className="text-xs text-muted-foreground">
+              <Label
+                htmlFor="cofront-redaction-select"
+                className="text-xs text-muted-foreground"
+              >
                 Co-fronter redaction
               </Label>
               <Select
@@ -54,7 +57,7 @@ export function TriggersCard({
                 }
                 disabled={cofrontDisabled}
               >
-                <SelectTrigger className="h-8 w-56">
+                <SelectTrigger id="cofront-redaction-select" className="h-8 w-56">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/web/src/components/onboarding-prompt.tsx
+++ b/web/src/components/onboarding-prompt.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Shield, KeyRound, Upload } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { apiFetch } from "@/lib/api-client";
+import { patchWebSettings } from "@/lib/client-settings";
 
 function useWebSettings() {
   return useQuery({
@@ -44,12 +45,7 @@ export function OnboardingPrompt() {
   async function markComplete() {
     setDismissing(true);
     try {
-      await apiFetch("/v1/settings/client/web", {
-        method: "PUT",
-        body: JSON.stringify({
-          settings: { ...settings, onboarding_complete: true },
-        }),
-      });
+      await patchWebSettings({ onboarding_complete: true });
       qc.invalidateQueries({ queryKey: ["client-settings", "web"] });
     } finally {
       setDismissing(false);

--- a/web/src/components/revision-retention-card.tsx
+++ b/web/src/components/revision-retention-card.tsx
@@ -124,8 +124,9 @@ function RetentionForm({ settings }: { settings: RetentionSettings }) {
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-1">
-              <Label className="text-sm">Revisions per item</Label>
+              <Label htmlFor="revision-max-count" className="text-sm">Revisions per item</Label>
               <Input
+                id="revision-max-count"
                 type="number"
                 min={0}
                 value={draft.max_revisions}
@@ -140,8 +141,9 @@ function RetentionForm({ settings }: { settings: RetentionSettings }) {
               </p>
             </div>
             <div className="space-y-1">
-              <Label className="text-sm">Revision age (days)</Label>
+              <Label htmlFor="revision-max-days" className="text-sm">Revision age (days)</Label>
               <Input
+                id="revision-max-days"
                 type="number"
                 min={0}
                 value={draft.max_revision_days}
@@ -164,8 +166,9 @@ function RetentionForm({ settings }: { settings: RetentionSettings }) {
               </p>
               {(authTier === "password" || authTier === "both") && (
                 <div className="space-y-1">
-                  <Label className="text-sm">Password</Label>
+                  <Label htmlFor="revision-retention-password" className="text-sm">Password</Label>
                   <Input
+                    id="revision-retention-password"
                     type="password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -176,8 +179,9 @@ function RetentionForm({ settings }: { settings: RetentionSettings }) {
               {(authTier === "totp" || authTier === "both") &&
                 user?.totp_enabled && (
                   <div className="space-y-1">
-                    <Label className="text-sm">TOTP code</Label>
+                    <Label htmlFor="revision-retention-totp" className="text-sm">TOTP code</Label>
                     <Input
+                      id="revision-retention-totp"
                       value={totpCode}
                       onChange={(e) => setTotpCode(e.target.value)}
                       placeholder="6-digit code"

--- a/web/src/components/settings/api-keys-card.tsx
+++ b/web/src/components/settings/api-keys-card.tsx
@@ -218,8 +218,9 @@ export function ApiKeysCard() {
         {showForm && (
           <form onSubmit={handleCreate} className="space-y-4 rounded-md border p-4">
             <div className="space-y-1">
-              <Label className="text-sm">Key name</Label>
+              <Label htmlFor="api-key-name" className="text-sm">Key name</Label>
               <Input
+                id="api-key-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="e.g. Mobile app, Scripts"

--- a/web/src/components/settings/custom-fields-card.tsx
+++ b/web/src/components/settings/custom-fields-card.tsx
@@ -63,8 +63,9 @@ export function CustomFieldsCard() {
       <CardContent className="space-y-4">
         <form onSubmit={handleCreate} className="flex items-end gap-2">
           <div className="flex-1 space-y-1">
-            <Label className="text-xs">Field name</Label>
+            <Label htmlFor="new-custom-field-name" className="text-xs">Field name</Label>
             <Input
+              id="new-custom-field-name"
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               placeholder="e.g. Species, Role"

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -90,8 +90,9 @@ function StepUpDialog({
         </DialogHeader>
         <div className="space-y-3">
           <div className="space-y-1">
-            <Label className="text-sm">Password</Label>
+            <Label htmlFor="data-export-password" className="text-sm">Password</Label>
             <Input
+              id="data-export-password"
               type="password"
               autoComplete="current-password"
               value={password}
@@ -100,8 +101,9 @@ function StepUpDialog({
           </div>
           {totpEnabled && (
             <div className="space-y-1">
-              <Label className="text-sm">TOTP code</Label>
+              <Label htmlFor="data-export-totp" className="text-sm">TOTP code</Label>
               <Input
+                id="data-export-totp"
                 value={totp}
                 onChange={(e) => setTotp(e.target.value)}
                 placeholder="6-digit code"

--- a/web/src/components/settings/system-profile-card.tsx
+++ b/web/src/components/settings/system-profile-card.tsx
@@ -89,12 +89,13 @@ function SystemSettingsForm({
             onRemove={() => setAvatarUrl(null)}
           />
           <div className="space-y-2">
-            <Label>Name</Label>
-            <Input value={name} onChange={(e) => setName(e.target.value)} required />
+            <Label htmlFor="system-name">Name</Label>
+            <Input id="system-name" value={name} onChange={(e) => setName(e.target.value)} required />
           </div>
           <div className="space-y-2">
-            <Label>Description</Label>
+            <Label htmlFor="system-description">Description</Label>
             <Input
+              id="system-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Optional"
@@ -118,8 +119,9 @@ function SystemSettingsForm({
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label>Tag</Label>
+              <Label htmlFor="system-tag">Tag</Label>
               <Input
+                id="system-tag"
                 value={tag}
                 onChange={(e) => setTag(e.target.value)}
                 placeholder="Short ID"
@@ -127,9 +129,10 @@ function SystemSettingsForm({
               />
             </div>
             <div className="space-y-2">
-              <Label>Color</Label>
+              <Label htmlFor="system-color">Color</Label>
               <div className="flex items-center gap-2">
                 <Input
+                  id="system-color"
                   type="color"
                   value={color || "#000000"}
                   onChange={(e) => setColor(e.target.value)}
@@ -144,9 +147,9 @@ function SystemSettingsForm({
             </div>
           </div>
           <div className="space-y-2">
-            <Label>Privacy</Label>
+            <Label htmlFor="system-privacy">Privacy</Label>
             <Select value={privacy} onValueChange={(v) => setPrivacy(v as PrivacyLevel)}>
-              <SelectTrigger>
+              <SelectTrigger id="system-privacy">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -157,9 +160,9 @@ function SystemSettingsForm({
             </Select>
           </div>
           <div className="space-y-2">
-            <Label>Date format</Label>
+            <Label htmlFor="system-date-format">Date format</Label>
             <Select value={dateFormat} onValueChange={(v) => setDateFormat(v as DateFormat)}>
-              <SelectTrigger>
+              <SelectTrigger id="system-date-format">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/web/src/components/settings/tags-manager-card.tsx
+++ b/web/src/components/settings/tags-manager-card.tsx
@@ -59,8 +59,9 @@ export function TagsManagerCard() {
       <CardContent className="space-y-4">
         <form onSubmit={handleCreate} className="flex items-end gap-2">
           <div className="flex-1 space-y-1">
-            <Label className="text-xs">New tag</Label>
+            <Label htmlFor="new-tag-name" className="text-xs">New tag</Label>
             <Input
+              id="new-tag-name"
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               placeholder="Tag name"

--- a/web/src/components/system-safety-card.tsx
+++ b/web/src/components/system-safety-card.tsx
@@ -192,8 +192,9 @@ function SafetyForm({ settings }: { settings: SystemSafetySettings }) {
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="space-y-1">
-          <Label className="text-sm">Grace period (days)</Label>
+          <Label htmlFor="safety-grace-period" className="text-sm">Grace period (days)</Label>
           <Input
+            id="safety-grace-period"
             type="number"
             min={0}
             max={365}
@@ -207,12 +208,12 @@ function SafetyForm({ settings }: { settings: SystemSafetySettings }) {
           </p>
         </div>
         <div className="space-y-1">
-          <Label className="text-sm">Auth tier</Label>
+          <Label htmlFor="safety-auth-tier" className="text-sm">Auth tier</Label>
           <Select
             value={draft.auth_tier}
             onValueChange={(v) => setField("auth_tier", v as DeleteConfirmation)}
           >
-            <SelectTrigger>
+            <SelectTrigger id="safety-auth-tier">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -280,8 +281,9 @@ function SafetyForm({ settings }: { settings: SystemSafetySettings }) {
           </p>
           {(settings.auth_tier === "password" || settings.auth_tier === "both") && (
             <div className="space-y-1">
-              <Label className="text-sm">Password</Label>
+              <Label htmlFor="safety-reauth-password" className="text-sm">Password</Label>
               <Input
+                id="safety-reauth-password"
                 type="password"
                 name="current-password"
                 autoComplete="current-password"
@@ -294,8 +296,9 @@ function SafetyForm({ settings }: { settings: SystemSafetySettings }) {
           {(settings.auth_tier === "totp" || settings.auth_tier === "both") &&
             user?.totp_enabled && (
               <div className="space-y-1">
-                <Label className="text-sm">TOTP code</Label>
+                <Label htmlFor="safety-reauth-totp" className="text-sm">TOTP code</Label>
                 <Input
+                  id="safety-reauth-totp"
                   value={totpCode}
                   onChange={(e) => setTotpCode(e.target.value)}
                   placeholder="6-digit code"

--- a/web/src/components/totp-setup.tsx
+++ b/web/src/components/totp-setup.tsx
@@ -100,9 +100,10 @@ export function TOTPSetup() {
           </code>
         </details>
         <form onSubmit={handleVerify} className="space-y-2">
-          <Label>Verification code</Label>
+          <Label htmlFor="totp-setup-verify">Verification code</Label>
           <div className="flex gap-2">
             <Input
+              id="totp-setup-verify"
               value={code}
               onChange={(e) => setCode(e.target.value)}
               placeholder="000000"
@@ -268,8 +269,9 @@ function TOTPDisable() {
           Enter a current TOTP code to generate new recovery codes. This will invalidate your existing codes.
         </p>
         <div className="space-y-1">
-          <Label className="text-sm">TOTP code</Label>
+          <Label htmlFor="totp-regen-code" className="text-sm">TOTP code</Label>
           <Input
+            id="totp-regen-code"
             value={totpCode}
             onChange={(e) => setTotpCode(e.target.value)}
             placeholder="000000"
@@ -300,8 +302,9 @@ function TOTPDisable() {
         Enter your password and a current TOTP code to disable 2FA.
       </p>
       <div className="space-y-1">
-        <Label className="text-sm">Password</Label>
+        <Label htmlFor="totp-disable-password" className="text-sm">Password</Label>
         <Input
+          id="totp-disable-password"
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
@@ -309,8 +312,9 @@ function TOTPDisable() {
         />
       </div>
       <div className="space-y-1">
-        <Label className="text-sm">TOTP code</Label>
+        <Label htmlFor="totp-disable-code" className="text-sm">TOTP code</Label>
         <Input
+          id="totp-disable-code"
           value={totpCode}
           onChange={(e) => setTotpCode(e.target.value)}
           placeholder="000000"

--- a/web/src/components/totp-setup.tsx
+++ b/web/src/components/totp-setup.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { useAuth } from "@/hooks/use-auth";
 import {
@@ -35,6 +35,19 @@ export function TOTPSetup() {
       setLoading(false);
     }
   }
+
+  // Don't leave the recovery codes rendered indefinitely if the user
+  // walks away mid-setup. Five minutes is plenty to save them; after that
+  // we drop back to idle (codes can be regenerated if missed).
+  useEffect(() => {
+    if (step !== "recovery") return;
+    const timer = setTimeout(() => {
+      setStep("idle");
+      setSetup(null);
+      setCode("");
+    }, 300_000);
+    return () => clearTimeout(timer);
+  }, [step]);
 
   async function handleVerify(e: FormEvent) {
     e.preventDefault();
@@ -155,6 +168,17 @@ function TOTPDisable() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [newCodes, setNewCodes] = useState<string[]>([]);
+
+  // Mirror the setup flow: don't leave regenerated recovery codes on
+  // screen forever if the user steps away.
+  useEffect(() => {
+    if (action !== "show-codes") return;
+    const timer = setTimeout(() => {
+      setAction("idle");
+      setNewCodes([]);
+    }, 300_000);
+    return () => clearTimeout(timer);
+  }, [action]);
 
   async function handleDisable(e: FormEvent) {
     e.preventDefault();

--- a/web/src/contexts/auth-context.tsx
+++ b/web/src/contexts/auth-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useEffect, useState } from "react";
+import { createContext, useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { User } from "@/types/api";
 import { bootstrapAuth, setAccessToken } from "@/lib/api-client";
@@ -31,6 +31,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const queryClient = useQueryClient();
+  const authChannelRef = useRef<BroadcastChannel | null>(null);
+
+  // Cross-tab logout: when any tab logs out, the others drop their
+  // in-memory token + user state immediately, instead of carrying a dead
+  // session until their next 401.
+  useEffect(() => {
+    if (typeof BroadcastChannel === "undefined") return;
+    const channel = new BroadcastChannel("sheaf-auth");
+    authChannelRef.current = channel;
+    channel.onmessage = (e) => {
+      if (e.data?.type === "logout") {
+        setAccessToken(null);
+        setUser(null);
+        queryClient.clear();
+      }
+    };
+    return () => {
+      channel.close();
+      authChannelRef.current = null;
+    };
+  }, [queryClient]);
 
   // Try silent refresh on mount using HttpOnly cookie. Routes through the
   // shared single-flight in api-client so StrictMode's double-fire (and any
@@ -111,6 +132,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setAccessToken(null);
       setUser(null);
       queryClient.clear();
+      authChannelRef.current?.postMessage({ type: "logout" });
     }
   }, [queryClient]);
 

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -14,3 +14,18 @@ export function deleteClientSettings(clientId: string): Promise<void> {
     method: "DELETE",
   });
 }
+
+/**
+ * Merge a partial object into the "web" client settings. The server does
+ * an atomic top-level key merge, so independent callers each writing
+ * their own key (front prefs, dismissed announcements, onboarding state)
+ * can't clobber one another the way concurrent full-blob PUTs would.
+ */
+export function patchWebSettings(
+  partial: Record<string, unknown>,
+): Promise<ClientSettingsEntry> {
+  return apiFetch("/v1/settings/client/web", {
+    method: "PATCH",
+    body: JSON.stringify({ settings: partial }),
+  });
+}

--- a/web/src/lib/journals.ts
+++ b/web/src/lib/journals.ts
@@ -14,7 +14,7 @@ import { apiFetch } from "./api-client";
 export interface ListJournalsParams {
   member_id?: string | null;
   system_only?: boolean;
-  before?: string | null;
+  cursor?: string | null;
   limit?: number;
 }
 
@@ -22,7 +22,7 @@ export function listJournals(params: ListJournalsParams = {}) {
   const qs = new URLSearchParams();
   if (params.system_only) qs.set("system_only", "true");
   if (params.member_id) qs.set("member_id", params.member_id);
-  if (params.before) qs.set("before", params.before);
+  if (params.cursor) qs.set("cursor", params.cursor);
   if (params.limit) qs.set("limit", String(params.limit));
   const suffix = qs.toString() ? `?${qs.toString()}` : "";
   return apiFetch<JournalListResponse>(`/v1/journals${suffix}`);

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -91,10 +91,12 @@ export async function markBoardSeen(
   member_id: string,
   board_kind: BoardKind,
   board_member_id: string | null,
+  signal?: AbortSignal,
 ): Promise<void> {
   await apiFetch<void>("/v1/messages/mark-seen", {
     method: "POST",
     body: JSON.stringify({ member_id, board_kind, board_member_id }),
+    signal,
   });
 }
 

--- a/web/src/routes/admin/announcements.tsx
+++ b/web/src/routes/admin/announcements.tsx
@@ -220,17 +220,18 @@ function EditAnnouncementForm({
     <div className="border-b px-4 py-3 last:border-0 space-y-3">
       <div className="flex flex-wrap items-end gap-3">
         <div className="space-y-1 flex-1 min-w-48">
-          <Label className="text-xs">Title</Label>
+          <Label htmlFor="edit-title" className="text-xs">Title</Label>
           <Input
+            id="edit-title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             maxLength={200}
           />
         </div>
         <div className="space-y-1 w-32">
-          <Label className="text-xs">Severity</Label>
+          <Label htmlFor="edit-severity" className="text-xs">Severity</Label>
           <Select value={severity} onValueChange={setSeverity}>
-            <SelectTrigger>
+            <SelectTrigger id="edit-severity">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -242,8 +243,9 @@ function EditAnnouncementForm({
         </div>
       </div>
       <div className="space-y-1">
-        <Label className="text-xs">Body</Label>
+        <Label htmlFor="edit-body" className="text-xs">Body</Label>
         <Input
+          id="edit-body"
           value={body}
           onChange={(e) => setBody(e.target.value)}
           maxLength={2000}

--- a/web/src/routes/admin/users.tsx
+++ b/web/src/routes/admin/users.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
@@ -83,6 +83,14 @@ function UserActions({ user }: { user: AdminUser }) {
     emailChange.isPending ||
     disableTotp.isPending ||
     verifyEmail.isPending;
+
+  // The generated password is shown once for the admin to hand off. Don't
+  // leave it sitting in the DOM indefinitely if the row stays expanded.
+  useEffect(() => {
+    if (!generatedPassword) return;
+    const timer = setTimeout(() => setGeneratedPassword(null), 120_000);
+    return () => clearTimeout(timer);
+  }, [generatedPassword]);
 
   function copyPassword() {
     if (generatedPassword) {

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "react-router";
 import { apiFetch } from "@/lib/api-client";
+import { patchWebSettings } from "@/lib/client-settings";
 import { ChevronDown, ChevronRight, History, Infinity as InfinityIcon, ListOrdered, Pencil } from "lucide-react";
 import {
   useCurrentFronts,
@@ -101,16 +102,10 @@ export function FrontsPage() {
   })();
 
   async function persistFrontsPrefs(next: FrontsViewPrefs) {
-    // PUT merges client-side: read the existing blob, splice in our key,
-    // write back. Same shape as the announcement-banners dismissal flow.
-    const current = clientSettings ?? {};
+    // Atomic server-side merge of just our key — won't clobber a
+    // concurrent write of some other client-settings key.
     try {
-      await apiFetch("/v1/settings/client/web", {
-        method: "PUT",
-        body: JSON.stringify({
-          settings: { ...current, fronts: { ...savedFrontsPrefs, ...next } },
-        }),
-      });
+      await patchWebSettings({ fronts: { ...savedFrontsPrefs, ...next } });
       qc.invalidateQueries({ queryKey: ["client-settings", "web"] });
     } catch {
       // Persistence failure is non-fatal — URL state still works.

--- a/web/src/routes/groups.tsx
+++ b/web/src/routes/groups.tsx
@@ -155,13 +155,14 @@ export function GroupsPage() {
           </DialogHeader>
           <form onSubmit={handleCreate} className="space-y-4">
             <div className="space-y-2">
-              <Label>Name</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} required />
+              <Label htmlFor="group-create-name">Name</Label>
+              <Input id="group-create-name" value={name} onChange={(e) => setName(e.target.value)} required />
             </div>
             <div className="space-y-2">
-              <Label>Color</Label>
+              <Label htmlFor="group-create-color">Color</Label>
               <div className="flex items-center gap-2">
                 <Input
+                  id="group-create-color"
                   type="color"
                   value={color}
                   onChange={(e) => setColor(e.target.value)}
@@ -191,13 +192,14 @@ export function GroupsPage() {
           </DialogHeader>
           <form onSubmit={handleUpdate} className="space-y-4">
             <div className="space-y-2">
-              <Label>Name</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} required />
+              <Label htmlFor="group-edit-name">Name</Label>
+              <Input id="group-edit-name" value={name} onChange={(e) => setName(e.target.value)} required />
             </div>
             <div className="space-y-2">
-              <Label>Color</Label>
+              <Label htmlFor="group-edit-color">Color</Label>
               <div className="flex items-center gap-2">
                 <Input
+                  id="group-edit-color"
                   type="color"
                   value={color}
                   onChange={(e) => setColor(e.target.value)}

--- a/web/src/routes/journals.$id.tsx
+++ b/web/src/routes/journals.$id.tsx
@@ -283,8 +283,9 @@ function DeleteEntryDialog({
           </p>
           {needsPassword && (
             <div className="space-y-1">
-              <Label className="text-sm">Password</Label>
+              <Label htmlFor="journal-delete-password" className="text-sm">Password</Label>
               <Input
+                id="journal-delete-password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -294,8 +295,9 @@ function DeleteEntryDialog({
           )}
           {needsTotp && (
             <div className="space-y-1">
-              <Label className="text-sm">TOTP code</Label>
+              <Label htmlFor="journal-delete-totp" className="text-sm">TOTP code</Label>
               <Input
+                id="journal-delete-totp"
                 value={totpCode}
                 onChange={(e) => setTotpCode(e.target.value)}
                 placeholder="6-digit code"

--- a/web/src/routes/journals.tsx
+++ b/web/src/routes/journals.tsx
@@ -155,7 +155,7 @@ function JournalList({
   const query = useInfiniteQuery<JournalListResponse>({
     queryKey: ["journals", params],
     queryFn: ({ pageParam }) =>
-      listJournals({ ...params, before: pageParam as string | undefined }),
+      listJournals({ ...params, cursor: pageParam as string | undefined }),
     initialPageParam: undefined,
     getNextPageParam: (last) => last.next_cursor ?? undefined,
   });

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -103,21 +103,23 @@ function MemberForm({
         onRemove={() => setAvatarUrl(null)}
       />
       <div className="space-y-2">
-        <Label>Name</Label>
-        <Input value={name} onChange={(e) => setName(e.target.value)} required />
+        <Label htmlFor="member-name">Name</Label>
+        <Input id="member-name" value={name} onChange={(e) => setName(e.target.value)} required />
       </div>
       <div className="grid grid-cols-[1fr_auto] gap-3">
         <div className="space-y-2">
-          <Label>Display name</Label>
+          <Label htmlFor="member-display-name">Display name</Label>
           <Input
+            id="member-display-name"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             placeholder="Optional, shown instead of name if set"
           />
         </div>
         <div className="space-y-2">
-          <Label>Emoji</Label>
+          <Label htmlFor="member-emoji">Emoji</Label>
           <Input
+            id="member-emoji"
             value={emoji}
             onChange={(e) => setEmoji(e.target.value)}
             placeholder=""
@@ -127,8 +129,9 @@ function MemberForm({
         </div>
       </div>
       <div className="space-y-2">
-        <Label>Pronouns</Label>
+        <Label htmlFor="member-pronouns">Pronouns</Label>
         <Input
+          id="member-pronouns"
           value={pronouns}
           onChange={(e) => setPronouns(e.target.value)}
           placeholder="e.g. she/her"
@@ -136,9 +139,10 @@ function MemberForm({
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label>Color</Label>
+          <Label htmlFor="member-color">Color</Label>
           <div className="flex items-center gap-2">
             <Input
+              id="member-color"
               type="color"
               value={color}
               onChange={(e) => setColor(e.target.value)}
@@ -184,8 +188,9 @@ function MemberForm({
         </p>
       </div>
       <div className="space-y-2">
-        <Label>PluralKit ID</Label>
+        <Label htmlFor="member-pluralkit-id">PluralKit ID</Label>
         <Input
+          id="member-pluralkit-id"
           value={pluralkitId}
           onChange={(e) => setPluralkitId(e.target.value)}
           placeholder="Optional, e.g. wyyetr"
@@ -198,9 +203,9 @@ function MemberForm({
         </p>
       </div>
       <div className="space-y-2">
-        <Label>Privacy</Label>
+        <Label htmlFor="member-privacy">Privacy</Label>
         <Select value={privacy} onValueChange={(v) => setPrivacy(v as PrivacyLevel)}>
-          <SelectTrigger>
+          <SelectTrigger id="member-privacy">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -271,8 +276,9 @@ function MemberFieldValues({ memberId }: { memberId: string }) {
       <p className="text-sm font-medium text-muted-foreground">Custom fields</p>
       {fields.map((f) => (
         <div key={f.id} className="space-y-1">
-          <Label className="text-xs">{f.name}</Label>
+          <Label htmlFor={`custom-field-${f.id}`} className="text-xs">{f.name}</Label>
           <Input
+            id={`custom-field-${f.id}`}
             value={overrides[f.id] ?? serverValues[f.id] ?? ""}
             onChange={(e) => {
               setOverrides((prev) => ({ ...prev, [f.id]: e.target.value }));
@@ -342,8 +348,9 @@ function DeleteMemberDialog({
           <div className="space-y-3">
             {needsPassword && (
               <div className="space-y-1">
-                <Label className="text-sm">Password</Label>
+                <Label htmlFor="member-delete-password" className="text-sm">Password</Label>
                 <Input
+                  id="member-delete-password"
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
@@ -353,8 +360,9 @@ function DeleteMemberDialog({
             )}
             {needsTotp && (
               <div className="space-y-1">
-                <Label className="text-sm">TOTP code</Label>
+                <Label htmlFor="member-delete-totp" className="text-sm">TOTP code</Label>
                 <Input
+                  id="member-delete-totp"
                   value={totpCode}
                   onChange={(e) => setTotpCode(e.target.value)}
                   placeholder="6-digit code"

--- a/web/src/routes/messages.tsx
+++ b/web/src/routes/messages.tsx
@@ -236,17 +236,24 @@ function BoardView({
   });
 
   // Mark this board as seen for the caller-member after the page renders
-  // — the act of looking IS the act of reading.
+  // — the act of looking IS the act of reading. The AbortController cancels
+  // the in-flight request on unmount, which also collapses StrictMode's
+  // double-invoke into a single effective POST.
   useEffect(() => {
     if (!callerMemberId) return;
-    markBoardSeen(callerMemberId, boardKind, boardMemberId)
+    const controller = new AbortController();
+    markBoardSeen(callerMemberId, boardKind, boardMemberId, controller.signal)
       .then(() => {
+        if (controller.signal.aborted) return;
         qc.invalidateQueries({ queryKey: ["messages", "boards"] });
         qc.invalidateQueries({ queryKey: ["messages", "unread"] });
       })
-      .catch(() => {
-        // Non-fatal — marking-seen is best-effort.
+      .catch((err) => {
+        // Best-effort, but a real failure shouldn't vanish silently.
+        if (controller.signal.aborted) return;
+        console.error("Failed to mark board as seen", err);
       });
+    return () => controller.abort();
   }, [boardKind, boardMemberId, callerMemberId, qc]);
 
   const memberById = useMemo(

--- a/web/src/routes/notifications.redeem.tsx
+++ b/web/src/routes/notifications.redeem.tsx
@@ -107,6 +107,9 @@ export function NotificationsRedeemPage() {
       setPhase({ kind: "error", message: "Missing activation code." });
       return;
     }
+    // Strip the activation code from the address bar so it doesn't linger
+    // in browser history or leak through the Referer header.
+    window.history.replaceState(null, "", window.location.pathname);
     let cancelled = false;
     previewActivation(code)
       .then((preview) => {

--- a/web/src/routes/notifications.tsx
+++ b/web/src/routes/notifications.tsx
@@ -139,8 +139,9 @@ export function NotificationsPage() {
           </DialogHeader>
           <form onSubmit={handleCreate} className="space-y-4">
             <div className="space-y-2">
-              <Label>Label (optional)</Label>
+              <Label htmlFor="new-watcher-label">Label (optional)</Label>
               <Input
+                id="new-watcher-label"
                 value={label}
                 onChange={(e) => setLabel(e.target.value)}
                 placeholder="e.g. Mara, my therapist, Discord bot"

--- a/web/src/routes/polls.tsx
+++ b/web/src/routes/polls.tsx
@@ -337,12 +337,12 @@ function CreatePollDialog({
 
           <div className="grid grid-cols-2 gap-3">
             <div className="grid gap-2">
-              <Label>Kind</Label>
+              <Label htmlFor="poll-kind">Kind</Label>
               <Select
                 value={kind}
                 onValueChange={(v) => setKind(v as PollKind)}
               >
-                <SelectTrigger>
+                <SelectTrigger id="poll-kind">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -352,14 +352,14 @@ function CreatePollDialog({
               </Select>
             </div>
             <div className="grid gap-2">
-              <Label>Results visibility</Label>
+              <Label htmlFor="poll-visibility">Results visibility</Label>
               <Select
                 value={visibility}
                 onValueChange={(v) =>
                   setVisibility(v as PollResultsVisibility)
                 }
               >
-                <SelectTrigger>
+                <SelectTrigger id="poll-visibility">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/web/src/routes/reminders.tsx
+++ b/web/src/routes/reminders.tsx
@@ -495,12 +495,12 @@ function ReminderDialog({
               />
             </div>
             <div className="space-y-1.5">
-              <Label>Trigger type</Label>
+              <Label htmlFor="reminder-trigger-type">Trigger type</Label>
               <Select
                 value={triggerType}
                 onValueChange={(v) => setTriggerType(v as ReminderTriggerType)}
               >
-                <SelectTrigger>
+                <SelectTrigger id="reminder-trigger-type">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -592,14 +592,14 @@ function AutomatedSection(props: {
     <div className="space-y-3 rounded-md border p-3 bg-muted/20">
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1.5">
-          <Label>When</Label>
+          <Label htmlFor="reminder-when-member">When</Label>
           <Select
             value={props.triggerMemberId || "_any"}
             onValueChange={(v) =>
               props.setTriggerMemberId(v === "_any" ? "" : v)
             }
           >
-            <SelectTrigger>
+            <SelectTrigger id="reminder-when-member">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -613,14 +613,14 @@ function AutomatedSection(props: {
           </Select>
         </div>
         <div className="space-y-1.5">
-          <Label>Event</Label>
+          <Label htmlFor="reminder-when-event">Event</Label>
           <Select
             value={props.triggerEvent}
             onValueChange={(v) =>
               props.setTriggerEvent(v as ReminderTriggerEvent)
             }
           >
-            <SelectTrigger>
+            <SelectTrigger id="reminder-when-event">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -715,14 +715,14 @@ function RepeatedSection(props: {
         <div className="space-y-3">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label>Frequency</Label>
+              <Label htmlFor="reminder-frequency">Frequency</Label>
               <Select
                 value={props.scheduleKind}
                 onValueChange={(v) =>
                   props.setScheduleKind(v as ReminderScheduleKind)
                 }
               >
-                <SelectTrigger>
+                <SelectTrigger id="reminder-frequency">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -733,8 +733,9 @@ function RepeatedSection(props: {
               </Select>
             </div>
             <div className="space-y-1.5">
-              <Label>Time of day</Label>
+              <Label htmlFor="reminder-time-of-day">Time of day</Label>
               <Input
+                id="reminder-time-of-day"
                 type="time"
                 value={props.scheduleTime}
                 onChange={(e) => props.setScheduleTime(e.target.value)}
@@ -774,8 +775,9 @@ function RepeatedSection(props: {
 
           {props.scheduleKind === "monthly" && (
             <div className="space-y-1.5">
-              <Label>Day of month</Label>
+              <Label htmlFor="reminder-day-of-month">Day of month</Label>
               <Input
+                id="reminder-day-of-month"
                 type="number"
                 min={1}
                 max={31}
@@ -792,9 +794,9 @@ function RepeatedSection(props: {
       )}
 
       <div className="space-y-1.5">
-        <Label>Timezone</Label>
+        <Label htmlFor="reminder-timezone">Timezone</Label>
         <Select value={props.tz} onValueChange={props.setTz}>
-          <SelectTrigger>
+          <SelectTrigger id="reminder-timezone">
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="max-h-72">
@@ -808,12 +810,12 @@ function RepeatedSection(props: {
       </div>
 
       <div className="border-t pt-3 space-y-2">
-        <Label>Only fire when…</Label>
+        <Label htmlFor="reminder-scope">Only fire when…</Label>
         <Select
           value={props.scope}
           onValueChange={(v) => props.setScope(v as "system" | "member")}
         >
-          <SelectTrigger>
+          <SelectTrigger id="reminder-scope">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/web/src/routes/reset-password.tsx
+++ b/web/src/routes/reset-password.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 import { useSearchParams, Link } from "react-router";
 import { useTheme } from "@/hooks/use-theme";
 import { Button } from "@/components/ui/button";
@@ -27,6 +27,15 @@ export function ResetPasswordPage() {
   const [submitting, setSubmitting] = useState(false);
 
   const effectiveToken = urlToken || manualToken.trim();
+
+  // Strip the token from the address bar so it doesn't linger in browser
+  // history or leak through the Referer header. urlToken is already
+  // captured above, so the form still submits with it.
+  useEffect(() => {
+    if (urlToken) {
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+  }, [urlToken]);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();

--- a/web/src/routes/verify-email.tsx
+++ b/web/src/routes/verify-email.tsx
@@ -16,6 +16,10 @@ export function VerifyEmailPage() {
     if (!token || calledRef.current) return;
     calledRef.current = true;
 
+    // Strip the token from the address bar so it doesn't linger in
+    // browser history or leak through the Referer header.
+    window.history.replaceState(null, "", window.location.pathname);
+
     apiFetch<{ verified: boolean }>(`/v1/auth/verify-email?token=${encodeURIComponent(token)}`)
       .then(() => setState("success"))
       .catch((err) => {


### PR DESCRIPTION
## Summary

A broad cleanup batch covering the medium-priority review items. Eight focused commits, each reviewable on its own.

**Frontend hardening**
- Block non-http(s) schemes on the avatar URL form (no more `javascript:`/`data:` rides).
- `markBoardSeen` uses an AbortController, collapsing StrictMode's double-invoke and no longer swallowing real failures.
- Atomic-merge PATCH for client settings; the three call sites (front prefs, dismissed announcements, onboarding) now route through it so concurrent writes don't clobber.
- Auto-clear the admin-reset password and regenerated TOTP recovery codes from the DOM after a timeout.
- Strip one-shot tokens (email verification, password reset, notification activation) from the address bar after capture.
- Cross-tab logout via BroadcastChannel.

**Backend hardening**
- `/admin/users` paginates the unfiltered list in SQL (was loading and decrypting every row).
- Per-IP rate limit on the anonymous notification redeem / preview / manage endpoints.
- Closed the destructive-auth TOTP foot-gun: settings refuse a TOTP-requiring tier without TOTP enrolled, disabling TOTP is blocked while such a tier is set, and the verifier fails safe to a password check.
- File-upload guard: a failure between the storage put and the row commit deletes the orphaned blob.
- Account deletion is deferred when storage cleanup is incomplete, so the user row is not dropped while blobs survive.

**Pagination and N+1**
- Journals list paginates on an opaque `(created_at, id)` cursor (fixed an off-by-one boundary-row skip in the previous bare-timestamp cursor). New tests cover partition + reject-bad-cursor.
- Board-message list renders a page in two batched queries instead of per-row parent + author lookups.
- Repeated-reminder tick batch-loads notification channels.
- `id` tiebreaker added to message ordering.

**Schema**
- `UNIQUE(field_id, member_id)` on `custom_field_values` with a dedup migration; `member_id` indexed.
- `uploaded_files.user_id` indexed.
- Reverse-direction `member_id` indexes on the composite-PK association tables.
- Redundant `system_id` index dropped from `journal_entries`.
- Server defaults added to JSONB / status columns on `pending_actions`, `safety_change_requests`, `client_settings`.
- `Group.children` ORM cascade matches the DB `ON DELETE SET NULL` so ORM and raw-SQL deletes behave the same.

**Infra and docs**
- Alembic autogenerate now compares column types and server defaults.
- docker-compose binds Postgres / Redis published ports to loopback by default; override via `POSTGRES_BIND_HOST` / `REDIS_BIND_HOST`.
- `run_tests.sh` fails hard if the DB-backed endpoint never warms up, instead of masking it as flake.
- README names `SHEAF_ENCRYPTION_KEY` as a distinct backup target (and fixes a typo).
- `SELFHOSTING.md` backup section now covers encrypting the dump, off-host rotation, key separation, and testing restores.

**Tests**
- Login-lockout coverage: lock after N failures, correct password rejected mid-window, success clears the counter, expired lockout resets to one.
- New client-settings PATCH tests cover the atomic merge.
- New journals pagination tests cover the opaque cursor.

**Accessibility**
- `<Label htmlFor>` associations added across 21 files for real form labels (Input / Select / Textarea). Cosmetic Labels heading custom multi-control groups left as-is.

## Test plan
- [x] `ruff check sheaf/` clean
- [x] `tsc --noEmit` + `eslint` clean
- [x] Full default-config pytest suite passes (745+ tests including new lockout / journals-cursor / client-settings coverage)
- [x] Alembic upgrade applies on a fresh DB

## Operational note
The migration in this PR includes a dedup pass on `custom_field_values` (keeps one arbitrary row per `(field_id, member_id)`). Public beta and existing data should be sparse, but worth knowing before the first production-like run.

## Deferred / blocked (logged to follow-ups)
- `/fronts/current` coalesce-walk N+1 (low N for /current; matters more on the history endpoint).
- Password-reset / verify-email E2E tests (blocked on an email-capture test backend, which is its own task).
- Conftest engine sharing for `pytest -n auto`.
- Notification management-token Referrer-Policy header.
- Reconciling `_security_txt_body` PGP advertisement with `SECURITY.md` (verification step, separate session).