### PR TITLE
Top-fronters quick-switch + v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-23
+
+The pre-public-beta hardening release. On top of the features that landed since v0.1.0 (front-change notifications, reminders, polls, messages, journals/notes, mobile push, PluralKit/Tupperbox/SimplyPlural import, analytics, custom fronts), this cycle moved imports onto a background job runner, did a broad security/privacy and performance pass, and added the first quick-switch building block.
+
+### Top-fronters quick-switch endpoint
+
+`GET /v1/members/top-fronters?limit=N` ranks members for a quick-pick list, so UIs (and the mobile apps) can autopopulate a start-front shortcut with the people most likely to be picked.
+
+- Recency-weighted score: per-member sum of fronting seconds with exponential decay (30-day half-life) over a 180-day window. Co-fronting counts for every participant, matching the analytics aggregator.
+- New nullable `members.quick_switch_pin`. Pinned members sort ahead of the recency ranking, ascending by pin value; everyone else follows by score.
+- Member create/edit form gains a "Pin to quick-switch" toggle; the start-front dialog shows a one-tap quick-pick chip row fed by the endpoint.
+- The pin round-trips through Sheaf export and re-import.
+
+### Imports moved onto an async job runner
+
+All five import paths (PluralKit file, PluralKit API, Tupperbox, SimplyPlural, Sheaf re-import) now run as background jobs instead of blocking the request, so a large or slow import no longer ties up a connection or times out.
+
+- New `import_jobs` table. `POST /v1/imports/file` and `/v1/imports/api` return `202` with a pollable job; `GET /v1/imports` (cursor-paginated) and `/v1/imports/{id}` expose status, per-record events, and counts. New `/imports` + `/imports/{id}` report UI.
+- Idempotency key dedupes double-submits (the double-clicked upload). Uploaded payloads are stored off-row and wiped on finalize; API credentials (PK token) are wiped once consumed.
+- File-bounds + JSON-size hardening on parse. A stale-running-job recovery sweep resets jobs orphaned by a worker crash.
+- PluralKit API preview: transient connect-retry, a busy spinner, and server-side logging of upstream API errors.
+
+### Security and privacy hardening
+
+- **SendGrid webhook**: verifies the Signed Event Webhook ECDSA signature with a timestamp replay window (`SENDGRID_WEBHOOK_PUBLIC_KEY`, optional `SENDGRID_WEBHOOK_MAX_SKEW_SECONDS`). The legacy query-string token is a fallback used only when no key is configured.
+- **Unified lockout**: failed-attempt lockout is now shared across login, TOTP disable, recovery-code regeneration, and the account-data endpoint, so attempts can't be spread across endpoints to dodge it. Per-user rate limits added to those plus the anonymous notification redeem / preview / manage endpoints.
+- **Password reset**: closed a timing oracle (the send now runs as a background task with symmetric work on the no-match branch); reset tokens are invalidated on password change and on successful login.
+- **Destructive-auth TOTP gate**: a TOTP-requiring confirmation tier can no longer be set without TOTP enrolled, TOTP can't be disabled while such a tier is active, and the verifier fails safe to a password check for legacy misconfigured rows.
+- **Races**: export-job and poll creation are row-locked; delete-account recovery-code consumption uses the race-safe conditional update; the account-deletion / pending-action / reminder background sweeps claim rows with `FOR UPDATE SKIP LOCKED`.
+- **Storage integrity**: the export-ready email now sends to the decrypted address (it was sending ciphertext); a failed upload deletes the orphaned blob; account deletion defers when storage cleanup is incomplete rather than dropping the row and orphaning blobs.
+- **Frontend**: avatar URL scheme allowlist (blocks `javascript:` / `data:` / `file:`); one-shot tokens (email verification, password reset, notification activation) stripped from the address bar after capture; cross-tab logout via BroadcastChannel; admin-reset passwords and regenerated TOTP recovery codes auto-clear from the DOM after a timeout.
+- Admin change-email normalizes the address before indexing; docker-compose binds the Postgres and Redis published ports to loopback by default (`POSTGRES_BIND_HOST` / `REDIS_BIND_HOST` to override).
+
+### Performance, correctness, and schema
+
+- **Pagination**: the journals list moved to an opaque `(created_at, id)` cursor and board messages gained an id tiebreaker, so entries sharing a timestamp can't be skipped or duplicated across a page boundary.
+- **N+1**: the board-message list and the repeated-reminder tick batch their lookups; `/admin/users` paginates in SQL and decrypts only the current page instead of the whole table.
+- **Client settings**: atomic-merge `PATCH` so independent writers (front prefs, dismissed announcements, onboarding) no longer clobber each other.
+- **Schema**: `UNIQUE(field_id, member_id)` on custom field values (with a dedup migration); indexes on `uploaded_files.user_id` and the member side of the association tables; the redundant single-column journal index dropped; server defaults added to JSONB / status columns on `pending_actions`, `safety_change_requests`, and `client_settings`; the `Group.children` ORM cascade matched to the `ON DELETE SET NULL` foreign key.
+
+### Accessibility
+
+- Form labels associated with their inputs (`htmlFor` / `id`) across ~21 settings, dialog, and route components, so screen readers and click-to-focus behave the same way they already did on the login and register pages.
+
+### Developer & ops
+
+- Alembic autogenerate now compares column types and server defaults, so schema drift isn't silently missed.
+- `run_tests.sh` fails hard if the database-backed endpoint never warms up, instead of proceeding and masking a pool-warmup bug as flake.
+- Added test coverage for login lockout, SendGrid webhook signature verification, client-settings merge, journals cursor pagination, and the top-fronters ranker.
+- README documents `SHEAF_ENCRYPTION_KEY` as a distinct backup target; the self-hosting backup section now covers encrypting the dump, off-host rotation, separating the key from the database backup, and testing restores.
+
 ### Unified `mobile_push` channels (collapse of fcm / apns_dev / apns_prod)
 
 The platform-specific mobile destination types had to be picked at channel creation, even though the owner didn't know which OS the recipient was on. Replaced with a single `mobile_push` type that binds to a Sheaf account at redemption and fans out across every `push_device_tokens` row for that account at delivery time — one channel rings every device the recipient has signed into, iOS or Android.

--- a/alembic/versions/k7l8m9n0o1p2_add_member_quick_switch_pin.py
+++ b/alembic/versions/k7l8m9n0o1p2_add_member_quick_switch_pin.py
@@ -1,0 +1,32 @@
+"""Add members.quick_switch_pin
+
+Revision ID: k7l8m9n0o1p2
+Revises: j6k7l8m9n0o1
+Create Date: 2026-05-23
+
+Nullable integer pin priority for the quick-switch / top-fronters list.
+NULL means unpinned; a value pins the member ahead of the recency-ranked
+results, ordered ascending. No index — member sets per system are small
+and the ranking happens in Python.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "k7l8m9n0o1p2"
+down_revision = "j6k7l8m9n0o1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "members",
+        sa.Column("quick_switch_pin", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("members", "quick_switch_pin")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sheaf"
-version = "0.1.0"
+version = "0.2.0"
 description = "Open-source plural system tracking"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -236,6 +236,7 @@ async def export_all(
                 "is_custom_front": m.is_custom_front,
                 "privacy": m.privacy.value,
                 "note": decrypt(m.note) if m.note else None,
+                "quick_switch_pin": m.quick_switch_pin,
                 "created_at": m.created_at.isoformat(),
             }
             for (m, name, description) in members_with_plaintext

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,6 +12,7 @@ from sheaf.config import settings
 from sheaf.crypto import blind_index, encrypt
 from sheaf.database import get_db
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
+from sheaf.models.front import Front
 from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
@@ -31,6 +33,7 @@ from sheaf.schemas.member import (
     MemberUpdate,
 )
 from sheaf.schemas.tag import TagRead
+from sheaf.services.analytics import clip_intervals, score_recent_fronters
 from sheaf.services.journals import (
     capture_revision,
     decrypt_revision_for_read,
@@ -189,6 +192,74 @@ async def create_member(
     await db.commit()
     await db.refresh(member)
     return decrypt_member_for_read(member)
+
+
+# Quick-switch ranker tunables. Window is generous relative to the
+# half-life (6 half-lives -> tail weight <2%), so the decay does the
+# real shaping and the window just bounds the query.
+_TOP_FRONTERS_HALF_LIFE_DAYS = 30.0
+_TOP_FRONTERS_WINDOW = timedelta(days=180)
+
+
+@router.get("/top-fronters", response_model=list[MemberRead])
+async def top_fronters(
+    limit: int = Query(default=8, ge=1, le=50),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Members ranked for a quick-switch list.
+
+    Pinned members (quick_switch_pin set) come first, in pin order;
+    everyone else follows by a recency-weighted fronting score
+    (exponential decay, 30-day half-life). Useful for autopopulating a
+    start-front shortcut or a member picker. Returns at most `limit`.
+    """
+    system = await _get_user_system(user, db)
+    now = datetime.now(UTC)
+    since = now - _TOP_FRONTERS_WINDOW
+
+    fronts_result = await db.execute(
+        select(Front)
+        .options(selectinload(Front.members))
+        .where(
+            Front.system_id == system.id,
+            Front.started_at < now,
+            (Front.ended_at.is_(None)) | (Front.ended_at > since),
+        )
+    )
+    rows = [
+        (f.started_at, f.ended_at, [m.id for m in f.members])
+        for f in fronts_result.scalars().all()
+    ]
+    intervals = clip_intervals(rows, since=since, until=now)
+    scores = score_recent_fronters(
+        intervals, now=now, half_life_days=_TOP_FRONTERS_HALF_LIFE_DAYS
+    )
+
+    members_result = await db.execute(
+        select(Member).where(Member.system_id == system.id)
+    )
+    members = list(members_result.scalars().all())
+
+    pinned = sorted(
+        (m for m in members if m.quick_switch_pin is not None),
+        key=lambda m: (m.quick_switch_pin, str(m.id)),
+    )
+    # Highest score first; id as a stable tiebreaker for equal scores
+    # (e.g. the long tail of members who haven't fronted in the window).
+    unpinned = sorted(
+        (m for m in members if m.quick_switch_pin is None),
+        key=lambda m: (-scores.get(m.id, 0.0), str(m.id)),
+    )
+    ordered = (pinned + unpinned)[:limit]
+
+    with_revisions = await _load_bio_revision_existence(
+        db, [m.id for m in ordered]
+    )
+    return [
+        decrypt_member_for_read(m, has_bio_revisions=m.id in with_revisions)
+        for m in ordered
+    ]
 
 
 @router.get("/{member_id}", response_model=MemberRead)

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import Boolean, Column, Enum, ForeignKey, String, Table, Text
+from sqlalchemy import Boolean, Column, Enum, ForeignKey, Integer, String, Table, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -126,6 +126,14 @@ class Member(UUIDMixin, TimestampMixin, Base):
     # wants to be notified about.
     notify_on_front_member_ids: Mapped[list] = mapped_column(
         JSONB, nullable=False, default=list, server_default="[]"
+    )
+
+    # Quick-switch pin. NULL = not pinned. A non-null integer pins this
+    # member to the top of the top-fronters / quick-switch list, ahead of
+    # the recency-ranked members, ordered by this value ascending (0 first).
+    # The user controls it; the ranker never sets it.
+    quick_switch_pin: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
     )
 
     # Relationships

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -25,6 +25,7 @@ class MemberCreate(BaseModel):
     is_custom_front: bool = False
     privacy: PrivacyLevel = PrivacyLevel.PRIVATE
     note: str | None = Field(default=None, max_length=5000)
+    quick_switch_pin: int | None = Field(default=None, ge=0)
 
     @field_validator("avatar_url", mode="before")
     @classmethod
@@ -50,6 +51,8 @@ class MemberUpdate(BaseModel):
     is_custom_front: bool | None = None
     privacy: PrivacyLevel | None = None
     note: str | None = Field(default=None, max_length=5000)
+    # Explicit null clears the pin (unpins); omitted leaves it untouched.
+    quick_switch_pin: int | None = Field(default=None, ge=0)
 
     @field_validator("avatar_url", mode="before")
     @classmethod
@@ -95,6 +98,7 @@ class MemberRead(BaseModel):
     is_custom_front: bool
     privacy: PrivacyLevel
     note: str | None
+    quick_switch_pin: int | None = None
     created_at: datetime
     updated_at: datetime
     # True iff at least one ContentRevision exists for this member's bio.

--- a/sheaf/services/analytics.py
+++ b/sheaf/services/analytics.py
@@ -27,6 +27,7 @@ Key semantics:
 
 from __future__ import annotations
 
+import math
 import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -175,6 +176,38 @@ def _bucket_into_hours(
         cursor = slice_end
 
     return buckets
+
+
+def score_recent_fronters(
+    intervals: Iterable[FrontInterval],
+    *,
+    now: datetime,
+    half_life_days: float = 30.0,
+) -> dict[uuid.UUID, float]:
+    """Recency-weighted fronting score per member, for quick-switch ranking.
+
+    Each (window-clipped) front contributes
+    ``duration_seconds * 0.5 ** (age_days / half_life_days)`` to every
+    member who was fronting, where age is measured from the front's end
+    (which is `now` for an ongoing front) back to `now`. So long and
+    recent fronts score highest, and old activity decays smoothly rather
+    than dropping off a window edge. Co-fronting counts for everyone, the
+    same as `aggregate`.
+
+    Returns member_id -> score. Members with no fronting time in the
+    supplied intervals are simply absent (caller treats them as 0).
+    """
+    decay_per_day = math.log(2) / half_life_days
+    scores: dict[uuid.UUID, float] = {}
+    for interval in intervals:
+        duration = (interval.end - interval.start).total_seconds()
+        if duration <= 0:
+            continue
+        age_days = max(0.0, (now - interval.end).total_seconds() / 86400.0)
+        weight = duration * math.exp(-decay_per_day * age_days)
+        for member_id in interval.member_ids:
+            scores[member_id] = scores.get(member_id, 0.0) + weight
+    return scores
 
 
 def clip_intervals(

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -79,6 +79,7 @@ def decrypt_member_for_read(
         "is_custom_front": member.is_custom_front,
         "privacy": member.privacy,
         "note": member_note_plaintext(member),
+        "quick_switch_pin": member.quick_switch_pin,
         "created_at": member.created_at,
         "updated_at": member.updated_at,
         "has_bio_revisions": has_bio_revisions,

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -164,6 +164,7 @@ async def run_import(
             emoji=_trunc(m_data.get("emoji"), 8),
             is_custom_front=bool(m_data.get("is_custom_front", False)),
             privacy=_privacy(m_data.get("privacy")),
+            quick_switch_pin=_coerce_pin(m_data.get("quick_switch_pin")),
         )
         db.add(member)
         old_id_to_member[old_id] = member
@@ -331,6 +332,14 @@ def _trunc(val: str | None, max_len: int) -> str | None:
     if not val:
         return None
     return val[:max_len]
+
+
+def _coerce_pin(val: object) -> int | None:
+    """Quick-switch pin from import data: a non-negative int, else None.
+    Guards against bools (bool is an int subclass) and junk values."""
+    if isinstance(val, bool) or not isinstance(val, int):
+        return None
+    return val if val >= 0 else None
 
 
 def _parse_iso(val: str | None) -> datetime | None:

--- a/tests/test_top_fronters.py
+++ b/tests/test_top_fronters.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta
 import httpx
 
 from sheaf.services.analytics import FrontInterval, score_recent_fronters
+from sheaf.services.sheaf_import import _coerce_pin
 
 # --- scorer unit tests -----------------------------------------------------
 
@@ -110,6 +111,23 @@ def test_limit_caps_result_count(auth_client: httpx.Client):
     for i in range(3):
         _member(auth_client, f"M{i}-{uuid.uuid4().hex[:6]}")
     assert len(_ids(auth_client, limit=2)) == 2
+
+
+def test_coerce_pin_guards_junk():
+    assert _coerce_pin(3) == 3
+    assert _coerce_pin(0) == 0
+    assert _coerce_pin(-1) is None
+    assert _coerce_pin(None) is None
+    assert _coerce_pin(True) is None  # bool is an int subclass; reject it
+    assert _coerce_pin("5") is None
+
+
+def test_export_includes_quick_switch_pin(auth_client: httpx.Client):
+    m = _member(auth_client, f"Pinned-{uuid.uuid4().hex[:6]}")
+    auth_client.patch(f"/v1/members/{m['id']}", json={"quick_switch_pin": 2})
+    export = auth_client.get("/v1/export").json()
+    by_id = {x["id"]: x for x in export["members"]}
+    assert by_id[m["id"]]["quick_switch_pin"] == 2
 
 
 def test_pin_set_and_clear_via_member_patch(auth_client: httpx.Client):

--- a/tests/test_top_fronters.py
+++ b/tests/test_top_fronters.py
@@ -1,0 +1,127 @@
+"""Top-fronters quick-switch ranking.
+
+Unit tests for the recency scorer (pure, no server) plus integration
+tests for the endpoint's ordering, pinning, and limit behaviour.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import httpx
+
+from sheaf.services.analytics import FrontInterval, score_recent_fronters
+
+# --- scorer unit tests -----------------------------------------------------
+
+_NOW = datetime(2026, 5, 1, tzinfo=UTC)
+
+
+def _iv(start: datetime, end: datetime, members: list[uuid.UUID]) -> FrontInterval:
+    return FrontInterval(start=start, end=end, member_ids=members)
+
+
+def test_scorer_recent_beats_old_for_equal_duration():
+    a, b = uuid.uuid4(), uuid.uuid4()
+    hour = timedelta(hours=1)
+    scores = score_recent_fronters(
+        [
+            _iv(_NOW - timedelta(days=1) - hour, _NOW - timedelta(days=1), [a]),
+            _iv(_NOW - timedelta(days=60) - hour, _NOW - timedelta(days=60), [b]),
+        ],
+        now=_NOW,
+        half_life_days=30.0,
+    )
+    assert scores[a] > scores[b]
+    # 60 days is two half-lives, so b's weight is ~1/4 of a near-now front.
+    assert scores[b] < scores[a] / 3
+
+
+def test_scorer_cofront_counts_for_every_participant():
+    a, b = uuid.uuid4(), uuid.uuid4()
+    scores = score_recent_fronters(
+        [_iv(_NOW - timedelta(hours=2), _NOW - timedelta(hours=1), [a, b])],
+        now=_NOW,
+    )
+    assert scores[a] == scores[b] > 0
+
+
+def test_scorer_skips_zero_duration_and_empty_membership():
+    a = uuid.uuid4()
+    scores = score_recent_fronters(
+        [
+            _iv(_NOW, _NOW, [a]),  # zero duration
+            _iv(_NOW - timedelta(hours=1), _NOW, []),  # nobody fronting
+        ],
+        now=_NOW,
+    )
+    assert scores == {}
+
+
+# --- endpoint integration --------------------------------------------------
+
+
+def _member(client: httpx.Client, name: str, **extra) -> dict:
+    r = client.post("/v1/members", json={"name": name, **extra})
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _ids(client: httpx.Client, **params) -> list[str]:
+    r = client.get("/v1/members/top-fronters", params=params)
+    assert r.status_code == 200, r.text
+    return [m["id"] for m in r.json()]
+
+
+def test_member_create_pin_defaults_null(auth_client: httpx.Client):
+    m = _member(auth_client, f"Default-{uuid.uuid4().hex[:6]}")
+    assert m["quick_switch_pin"] is None
+
+
+def test_ranks_fronted_above_never_fronted(auth_client: httpx.Client):
+    a = _member(auth_client, f"A-{uuid.uuid4().hex[:6]}")
+    b = _member(auth_client, f"B-{uuid.uuid4().hex[:6]}")
+    auth_client.post("/v1/fronts", json={"member_ids": [a["id"]]})
+
+    ids = _ids(auth_client)
+    assert ids.index(a["id"]) < ids.index(b["id"])
+
+
+def test_pinned_member_comes_first_despite_no_fronting(auth_client: httpx.Client):
+    a = _member(auth_client, f"Fronter-{uuid.uuid4().hex[:6]}")
+    b = _member(auth_client, f"Pinned-{uuid.uuid4().hex[:6]}")
+    auth_client.post("/v1/fronts", json={"member_ids": [a["id"]]})
+    auth_client.patch(f"/v1/members/{b['id']}", json={"quick_switch_pin": 0})
+
+    assert _ids(auth_client)[0] == b["id"]
+
+
+def test_pins_order_by_priority_ascending(auth_client: httpx.Client):
+    a = _member(auth_client, f"Five-{uuid.uuid4().hex[:6]}")
+    b = _member(auth_client, f"One-{uuid.uuid4().hex[:6]}")
+    auth_client.patch(f"/v1/members/{a['id']}", json={"quick_switch_pin": 5})
+    auth_client.patch(f"/v1/members/{b['id']}", json={"quick_switch_pin": 1})
+
+    ids = _ids(auth_client)
+    assert ids[0] == b["id"]
+    assert ids[1] == a["id"]
+
+
+def test_limit_caps_result_count(auth_client: httpx.Client):
+    for i in range(3):
+        _member(auth_client, f"M{i}-{uuid.uuid4().hex[:6]}")
+    assert len(_ids(auth_client, limit=2)) == 2
+
+
+def test_pin_set_and_clear_via_member_patch(auth_client: httpx.Client):
+    m = _member(auth_client, f"Pinnable-{uuid.uuid4().hex[:6]}")
+    set_resp = auth_client.patch(
+        f"/v1/members/{m['id']}", json={"quick_switch_pin": 3}
+    )
+    assert set_resp.status_code == 200
+    assert set_resp.json()["quick_switch_pin"] == 3
+
+    clear_resp = auth_client.patch(
+        f"/v1/members/{m['id']}", json={"quick_switch_pin": None}
+    )
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["quick_switch_pin"] is None

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/start-front-dialog.tsx
+++ b/web/src/components/start-front-dialog.tsx
@@ -3,7 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useCreateFront } from "@/hooks/use-fronts";
 import { ApiError } from "@/lib/api-client";
+import { getTopFronters } from "@/lib/members";
 import { getMySystem } from "@/lib/systems";
+import { cn } from "@/lib/utils";
+import { ColorDot } from "@/components/color-dot";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -16,6 +19,54 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MemberSelect } from "@/components/member-select";
+
+/** One-tap chips for the members most likely to be picked — pinned
+ *  members and recent fronters, from /v1/members/top-fronters. */
+function QuickPick({
+  open,
+  selected,
+  onToggle,
+}: {
+  open: boolean;
+  selected: string[];
+  onToggle: (id: string) => void;
+}) {
+  const { data: top } = useQuery({
+    queryKey: ["members", "top-fronters"],
+    queryFn: () => getTopFronters(8),
+    enabled: open,
+    staleTime: 60_000,
+  });
+  if (!top || top.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {top.map((m) => {
+        const on = selected.includes(m.id);
+        return (
+          <button
+            key={m.id}
+            type="button"
+            aria-pressed={on}
+            onClick={() => onToggle(m.id)}
+            className={cn(
+              "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors",
+              on
+                ? "border-primary bg-primary/10"
+                : "bg-background hover:bg-muted",
+            )}
+          >
+            {m.emoji ? (
+              <span aria-hidden>{m.emoji}</span>
+            ) : (
+              <ColorDot color={m.color} />
+            )}
+            <span>{m.display_name || m.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 export function StartFrontDialog({
   open,
@@ -112,6 +163,17 @@ export function StartFrontDialog({
         <p className="text-sm text-muted-foreground">
           Select who is fronting. Pick multiple for co-fronting.
         </p>
+        <QuickPick
+          open={open}
+          selected={selectedMembers}
+          onToggle={(id) =>
+            setSelectedMembers(
+              selectedMembers.includes(id)
+                ? selectedMembers.filter((x) => x !== id)
+                : [...selectedMembers, id],
+            )
+          }
+        />
         <MemberSelect
           selected={selectedMembers}
           onChange={setSelectedMembers}

--- a/web/src/lib/members.ts
+++ b/web/src/lib/members.ts
@@ -18,6 +18,12 @@ export function getMember(id: string) {
   return apiFetch<Member>(`/v1/members/${id}`);
 }
 
+/** Members ranked for a quick-switch list: pinned first, then by a
+ *  recency-weighted fronting score. */
+export function getTopFronters(limit = 8) {
+  return apiFetch<Member[]>(`/v1/members/top-fronters?limit=${limit}`);
+}
+
 export function createMember(data: MemberCreate) {
   return apiFetch<Member>("/v1/members", {
     method: "POST",

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -75,6 +75,10 @@ function MemberForm({
     initial?.is_custom_front ?? false,
   );
   const [privacy, setPrivacy] = useState<PrivacyLevel>(initial?.privacy ?? "private");
+  // Preserve an existing numeric pin priority when toggling stays on; a
+  // freshly-pinned member gets priority 0.
+  const initialPin = initial?.quick_switch_pin ?? null;
+  const [pinned, setPinned] = useState(initialPin != null);
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -91,6 +95,7 @@ function MemberForm({
       emoji: emoji.trim() || null,
       is_custom_front: isCustomFront,
       privacy,
+      quick_switch_pin: pinned ? (initialPin ?? 0) : null,
     });
   }
 
@@ -229,6 +234,21 @@ function MemberForm({
             than a system member. Custom fronts can still front and be in
             groups, but don&apos;t count toward member statistics and are
             listed separately from members.
+          </p>
+        </div>
+      </label>
+      <label className="flex items-start gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={pinned}
+          onChange={(e) => setPinned(e.target.checked)}
+          className="h-4 w-4 mt-0.5 rounded border-input"
+        />
+        <div>
+          <span className="text-sm font-medium">Pin to quick-switch</span>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Keeps this member at the top of the start-front quick-pick
+            list, ahead of the recently-fronted suggestions.
           </p>
         </div>
       </label>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -90,6 +90,10 @@ export interface Member {
   /** Lightweight scratchpad note; deliberately overwrite-only and not
    *  protected by System Safety. ~5kb plaintext cap. */
   note: string | null;
+  /** Quick-switch pin priority. null = unpinned. A number pins the member
+   *  to the top of the top-fronters list ahead of the recency ranking,
+   *  ordered ascending. */
+  quick_switch_pin: number | null;
   created_at: string;
   updated_at: string;
   /** True iff at least one ContentRevision exists for this member's
@@ -113,6 +117,7 @@ export interface MemberCreate {
   is_custom_front?: boolean;
   privacy?: PrivacyLevel;
   note?: string | null;
+  quick_switch_pin?: number | null;
 }
 
 export interface MemberUpdate {
@@ -128,6 +133,8 @@ export interface MemberUpdate {
   is_custom_front?: boolean;
   privacy?: PrivacyLevel;
   note?: string | null;
+  /** Set a number to pin, or null to clear the pin. */
+  quick_switch_pin?: number | null;
 }
 
 export interface Front {


### PR DESCRIPTION
## Summary

Adds the top-fronters quick-switch feature and stamps the **v0.2.0** release. Merging this cuts 0.2.0 (tag `main` at the merge commit afterwards).

### Top-fronters quick-switch
- `GET /v1/members/top-fronters?limit=N`: pinned members first (by the new nullable `members.quick_switch_pin`, ascending), then by a recency-weighted fronting score (exponential decay, 30-day half-life, 180-day window). Co-fronting counts for every participant.
- Scorer lives alongside the analytics aggregator (unit-tested); endpoint has integration coverage for ordering, pinning, pin order, and limit.
- Member create/edit form gains a "Pin to quick-switch" toggle (preserves an API-set numeric priority); start-front dialog shows a one-tap quick-pick chip row.
- Pin round-trips through Sheaf export + re-import.

### Release stamp
- Bump `pyproject.toml` (the stray `0.2.1` was a typo) and `web/package.json` to `0.2.0`.
- `[0.2.0]` changelog section covering the whole cycle since v0.1.0: async import job runner, the security/privacy + performance/schema hardening passes, accessibility label associations, dev/ops hardening, and this feature.

## Test plan
- [x] `ruff check sheaf/` clean
- [x] `tsc --noEmit` + `eslint` clean
- [x] pytest: top-fronters (unit + integration) + export/import/sp-gap suites green; migration applies on a fresh DB
- [ ] Eyeball on localdev: start-front quick-pick chips; member-form pin toggle

## Post-merge
- Tag `main` at the merge commit as `v0.2.0`.

## Migration
Adds `members.quick_switch_pin` (nullable int). No data backfill.