### PR TITLE
Default new SaaS signups to the free tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All five import paths (PluralKit file, PluralKit API, Tupperbox, SimplyPlural, S
 
 ### Security and privacy hardening
 
+- **SaaS signup tier**: new registrations in SaaS mode now default to the `free` tier instead of inheriting the model's `self_hosted` default, so member-count and storage-quota limits actually apply to new accounts. Self-hosted instances are unaffected (signups stay `self_hosted`).
 - **SendGrid webhook**: verifies the Signed Event Webhook ECDSA signature with a timestamp replay window (`SENDGRID_WEBHOOK_PUBLIC_KEY`, optional `SENDGRID_WEBHOOK_MAX_SKEW_SECONDS`). The legacy query-string token is a fallback used only when no key is configured.
 - **Unified lockout**: failed-attempt lockout is now shared across login, TOTP disable, recovery-code regeneration, and the account-data endpoint, so attempts can't be spread across endpoints to dodge it. Per-user rate limits added to those plus the anonymous notification redeem / preview / manage endpoints.
 - **Password reset**: closed a timing oracle (the send now runs as a background task with symmetric work on the no-match branch); reset tokens are invalidated on password change and on successful login.

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -52,14 +52,14 @@ from sheaf.auth.trusted_devices import (
     revoke_trusted_device,
     verify_trusted_device,
 )
-from sheaf.config import settings
+from sheaf.config import SheafMode, settings
 from sheaf.crypto import blind_index, decrypt, encrypt, hash_mail_token
 from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.api_key import ApiKey
 from sheaf.models.system import DeleteConfirmation, System
 from sheaf.models.trusted_device import TrustedDevice
-from sheaf.models.user import AccountStatus, User
+from sheaf.models.user import AccountStatus, User, UserTier
 from sheaf.request import client_ip
 from sheaf.schemas.user import (
     SecondarySessionRequest,
@@ -321,6 +321,16 @@ async def register(
         account_status = AccountStatus.ACTIVE
     email_verified = settings.email_verification != "required"
 
+    # The model default is SELF_HOSTED (the right default for a self-hosted
+    # instance). In SaaS mode new signups must start on FREE so tier limits
+    # (member count, storage quota, etc.) actually apply; admins bump
+    # individuals up out of band.
+    signup_tier = (
+        UserTier.FREE
+        if settings.sheaf_mode == SheafMode.SAAS
+        else UserTier.SELF_HOSTED
+    )
+
     user = User(
         email=encrypt(body.email),
         email_hash=email_hash,
@@ -328,6 +338,7 @@ async def register(
         account_status=account_status,
         email_verified=email_verified,
         signup_ip=client_ip(request),
+        tier=signup_tier,
         newsletter_opt_in=body.newsletter_opt_in,
         newsletter_opted_in_at=datetime.now(UTC) if body.newsletter_opt_in else None,
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,7 @@ import uuid
 
 import httpx
 import pyotp
+import pytest
 
 
 def test_register(client: httpx.Client):
@@ -614,6 +615,38 @@ def test_secondary_session_mint_after_parent_revoked_fails(
         json={"client_name": "Sheaf watchOS/1.0"},
     )
     assert mint.status_code == 401, mint.text
+
+
+def test_registration_defaults_to_self_hosted_tier(client: httpx.Client):
+    """Default (self-hosted) instance: new signups land on the self_hosted
+    tier (unlimited), matching the model default."""
+    email = f"tier-sh-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    reg = client.post(
+        "/v1/auth/register", json={"email": email, "password": "testpassword123"}
+    )
+    assert reg.status_code == 201, reg.text
+    me = client.get(
+        "/v1/auth/me",
+        headers={"Authorization": f"Bearer {reg.json()['access_token']}"},
+    )
+    assert me.json()["tier"] == "self_hosted"
+
+
+@pytest.mark.saas
+def test_registration_defaults_to_free_tier_in_saas(client: httpx.Client):
+    """SaaS instance: new signups must start on the free tier so tier limits
+    (member count, storage quota) actually apply. Admins bump individuals up
+    out of band."""
+    email = f"tier-saas-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    reg = client.post(
+        "/v1/auth/register", json={"email": email, "password": "testpassword123"}
+    )
+    assert reg.status_code == 201, reg.text
+    me = client.get(
+        "/v1/auth/me",
+        headers={"Authorization": f"Bearer {reg.json()['access_token']}"},
+    )
+    assert me.json()["tier"] == "free"
 
 
 def _register_and_login(client: httpx.Client, email: str, password: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -1546,7 +1546,7 @@ wheels = [
 
 [[package]]
 name = "sheaf"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Pre-launch fix found during the smoketest pass. `User.tier` defaults to `self_hosted` at the model level (right for a self-hosted instance), but registration never overrode it, so in **SaaS mode** new signups silently got `self_hosted` - unlimited members and storage, no tier limits. Registration now selects the tier from the run mode: `free` in SaaS, `self_hosted` otherwise. Admins still bump individuals up out of band.

Belongs in v0.2.0 (landed just after #70 merged).

## Test plan
- [x] `ruff check sheaf/` clean
- [x] self-hosted mode: registration -> `self_hosted` (default test stack)
- [x] saas mode: registration -> `free` (verified against a saas-mode test stack; new `@pytest.mark.saas` test)