### PR TITLE
Pre-tag fixes: nginx 1.31.0 + gate self_hosted-tier tests

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -20,7 +20,7 @@ ENV VITE_BUILD_TIME=${BUILD_TIME}
 
 RUN npm run build
 
-FROM nginx:1.27
+FROM nginx:1.31.0
 
 COPY --from=build /build/dist /usr/share/nginx/html
 

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -8,7 +8,7 @@
 
 services:
   nginx:
-    image: nginx:alpine
+    image: nginx:1.31.0-alpine
     ports:
       - "${TLS_PORT:-443}:443"
     volumes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ markers = [
     "admin_auth_password: requires server running with ADMIN_AUTH_LEVEL=password",
     "admin_auth_totp: requires server running with ADMIN_AUTH_LEVEL=totp",
     "saas: requires server running with SHEAF_MODE=saas",
+    "selfhosted: requires server running with SHEAF_MODE=selfhosted (skipped under saas)",
     "rate_limit: requires server running with RATE_LIMIT_ENABLED=true",
     "uploads_disabled: requires server running with ALLOW_IMAGE_UPLOADS=false",
     "bio_uploads_disabled: requires server running with ALLOW_BIO_IMAGES=false",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ def pytest_collection_modifyitems(items):
             item.add_marker(pytest.mark.skip("requires SHEAF_TEST_ADMIN_AUTH_LEVEL=totp"))
         if "saas" in item.keywords and _SHEAF_MODE != "saas":
             item.add_marker(pytest.mark.skip("requires SHEAF_TEST_MODE=saas"))
+        if "selfhosted" in item.keywords and _SHEAF_MODE == "saas":
+            item.add_marker(pytest.mark.skip("requires SHEAF_TEST_MODE=selfhosted"))
         if "rate_limit" in item.keywords and not _RATE_LIMIT:
             item.add_marker(pytest.mark.skip("requires SHEAF_TEST_RATE_LIMIT=true"))
         if "uploads_disabled" in item.keywords and not _UPLOADS_DISABLED:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -617,9 +617,11 @@ def test_secondary_session_mint_after_parent_revoked_fails(
     assert mint.status_code == 401, mint.text
 
 
+@pytest.mark.selfhosted
 def test_registration_defaults_to_self_hosted_tier(client: httpx.Client):
-    """Default (self-hosted) instance: new signups land on the self_hosted
-    tier (unlimited), matching the model default."""
+    """Self-hosted instance: new signups land on the self_hosted tier
+    (unlimited), matching the model default. SaaS mode is covered by
+    test_registration_defaults_to_free_tier_in_saas."""
     email = f"tier-sh-{uuid.uuid4().hex[:8]}@sheaf.dev"
     reg = client.post(
         "/v1/auth/register", json={"email": email, "password": "testpassword123"}

--- a/tests/test_revision_retention.py
+++ b/tests/test_revision_retention.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import httpx
+import pytest
 
 
 def _register(client: httpx.Client) -> str:
@@ -83,8 +84,11 @@ def _set_system_safety_via_db(user_email: str, **fields) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.selfhosted
 def test_get_retention_self_hosted_default(auth_client: httpx.Client):
-    """Default user tier in test env is self_hosted → unlimited (0/0)."""
+    """Default user tier in self-hosted mode is self_hosted → unlimited
+    (0/0). Skipped under saas, where signups default to free (see
+    test_get_retention_free_tier_caps for the free-tier values)."""
     resp = auth_client.get("/v1/retention")
     assert resp.status_code == 200
     body = resp.json()


### PR DESCRIPTION
Two small pre-v0.2.0-tag fixes.

## nginx 1.31.0
Move off the vulnerable `1.30.0` nginx release.
- `Dockerfile.web`: `nginx:1.27` -> `nginx:1.31.0` (shipped frontend image).
- `docker-compose.tls.yml`: floating `nginx:alpine` -> pinned `nginx:1.31.0-alpine` (also closes the reproducibility gap of the floating tag).
- Both base tags verified to pull.

## Gate self_hosted-tier tests
The SaaS free-tier default (#71: new signups -> `free`) makes two tests that assert `self_hosted` / unlimited behaviour fail under the `saas` test config (`run_tests.sh` config 4):
- `test_registration_defaults_to_self_hosted_tier`
- `test_get_retention_self_hosted_default`

Added a `selfhosted` marker (mirror of `saas`) that skips under `SHEAF_TEST_MODE=saas`, and applied it to both. SaaS behaviour stays covered by the free-tier registration + retention tests. Verified both skip under saas and run under selfhosted.

## Test plan
- [x] `ruff check` clean (sheaf/ + changed test files)
- [x] saas config: the two tests skip instead of fail
- [x] full `run_tests.sh` green across all 8 configs