### PR TITLE
Fix message read-state get-or-create race (500s on the messages page)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-24
+
+### Fixed
+
+- **Messages page 500s under concurrency.** Opening a board fires several endpoints in parallel (board list, board contents, mark-seen, unread badge), each of which calls `get_or_create_read_state`. The plain select-then-insert raced: per-member boards hit the unique index (500), and the system board (`board_member_id` NULL) silently accumulated duplicate rows because Postgres treats NULLs as distinct in a unique index, later breaking `scalar_one_or_none`. Now uses `INSERT ... ON CONFLICT DO NOTHING` then selects the winner, and the `ix_message_read_state_lookup` unique index is rebuilt with `NULLS NOT DISTINCT` (PG15+) so the system board is covered too. A migration dedupes existing read-state rows first, keeping the most-recently-seen row per member/board.
+
 ## [0.2.0] - 2026-05-23
 
 The pre-public-beta hardening release. On top of the features that landed since v0.1.0 (front-change notifications, reminders, polls, messages, journals/notes, mobile push, PluralKit/Tupperbox/SimplyPlural import, analytics, custom fronts), this cycle moved imports onto a background job runner, did a broad security/privacy and performance pass, and added the first quick-switch building block.

--- a/alembic/versions/l8m9n0o1p2q3_message_read_state_nulls_not_distinct.py
+++ b/alembic/versions/l8m9n0o1p2q3_message_read_state_nulls_not_distinct.py
@@ -1,0 +1,57 @@
+"""Dedupe message_read_state and make its unique index NULLS NOT DISTINCT
+
+Revision ID: l8m9n0o1p2q3
+Revises: k7l8m9n0o1p2
+Create Date: 2026-05-24
+
+The system board stores board_member_id = NULL. Postgres treats NULLs as
+distinct in a unique index, so the get-or-create read-state race could
+insert duplicate system-board rows (and the per-member board raced into
+unique-violation 500s). Collapse the existing duplicates, keeping the
+most-recently-seen row per (member, board_kind, board_member_id), then
+recreate the unique index with NULLS NOT DISTINCT (PG15+) so the system
+board is covered too and INSERT ... ON CONFLICT can dedupe it.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "l8m9n0o1p2q3"
+down_revision = "k7l8m9n0o1p2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Keep the row with the latest last_seen_at per logical key (NULLs
+    # grouped via IS NOT DISTINCT FROM); id breaks ties deterministically.
+    op.execute(
+        """
+        DELETE FROM message_read_state a
+        USING message_read_state b
+        WHERE a.member_id = b.member_id
+          AND a.board_kind = b.board_kind
+          AND a.board_member_id IS NOT DISTINCT FROM b.board_member_id
+          AND (
+                a.last_seen_at < b.last_seen_at
+                OR (a.last_seen_at = b.last_seen_at AND a.id < b.id)
+              )
+        """
+    )
+    op.drop_index("ix_message_read_state_lookup", table_name="message_read_state")
+    op.execute(
+        "CREATE UNIQUE INDEX ix_message_read_state_lookup "
+        "ON message_read_state (member_id, board_kind, board_member_id) "
+        "NULLS NOT DISTINCT"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_message_read_state_lookup", table_name="message_read_state")
+    op.create_index(
+        "ix_message_read_state_lookup",
+        "message_read_state",
+        ["member_id", "board_kind", "board_member_id"],
+        unique=True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sheaf"
-version = "0.2.0"
+version = "0.2.1"
 description = "Open-source plural system tracking"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/sheaf/models/message.py
+++ b/sheaf/models/message.py
@@ -150,5 +150,11 @@ class MessageReadState(UUIDMixin, Base):
             "board_kind",
             "board_member_id",
             unique=True,
+            # board_member_id is NULL for the system board. Without this,
+            # Postgres treats those NULLs as distinct and the unique index
+            # fails to dedupe system-board read-state rows, letting the
+            # get-or-create race create duplicates. NULLS NOT DISTINCT
+            # (PG15+) closes that gap.
+            postgresql_nulls_not_distinct=True,
         ),
     )

--- a/sheaf/services/messages.py
+++ b/sheaf/services/messages.py
@@ -14,6 +14,7 @@ import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import and_, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import decrypt, encrypt
@@ -109,6 +110,30 @@ async def get_or_create_read_state(
     board_kind: str,
     board_member_id: uuid.UUID | None,
 ) -> MessageReadState:
+    # Concurrency-safe get-or-create. The messages page fires several
+    # board-touching requests in parallel (get_board, mark-seen, unread),
+    # so a plain select-then-insert races: two callers both miss the select
+    # and both insert. For a per-member board that trips the unique index
+    # (500); for the system board, where board_member_id is NULL, the
+    # NULLS-NOT-DISTINCT index now still catches it. INSERT ... ON CONFLICT
+    # DO NOTHING collapses the race into a no-op, then we read the winner.
+    insert_stmt = (
+        pg_insert(MessageReadState)
+        .values(
+            id=uuid.uuid4(),
+            member_id=member_id,
+            board_kind=board_kind,
+            board_member_id=board_member_id,
+            # Default to "now" so a freshly-created member doesn't
+            # see every historical message as unread.
+            last_seen_at=datetime.now(UTC),
+        )
+        .on_conflict_do_nothing(
+            index_elements=["member_id", "board_kind", "board_member_id"]
+        )
+    )
+    await db.execute(insert_stmt)
+
     result = await db.execute(
         select(MessageReadState).where(
             MessageReadState.member_id == member_id,
@@ -120,20 +145,7 @@ async def get_or_create_read_state(
             ),
         )
     )
-    state = result.scalar_one_or_none()
-    if state is None:
-        state = MessageReadState(
-            id=uuid.uuid4(),
-            member_id=member_id,
-            board_kind=board_kind,
-            board_member_id=board_member_id,
-            # Default to "now" so a freshly-created member doesn't
-            # see every historical message as unread.
-            last_seen_at=datetime.now(UTC),
-        )
-        db.add(state)
-        await db.flush()
-    return state
+    return result.scalar_one()
 
 
 async def mark_seen(

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -39,6 +39,48 @@ def _post(
 # --- System board ----------------------------------------------------------
 
 
+def test_read_state_get_or_create_is_race_safe(auth_client: httpx.Client):
+    """Opening the messages page fires several board-touching requests in
+    parallel, all funnelling through get_or_create_read_state. The old
+    select-then-insert raced: per-member boards 500'd on the unique index
+    and the system board (NULL board_member_id) accumulated duplicate rows
+    that later broke scalar_one_or_none. Hammer both board kinds
+    concurrently and assert no 5xx, then confirm follow-up reads still
+    resolve to a single row."""
+    import concurrent.futures
+
+    member_id = _create_member(auth_client, "Racer")
+    auth_header = auth_client.headers["Authorization"]
+    base_url = str(auth_client.base_url)
+
+    def hit(path: str) -> int:
+        with httpx.Client(
+            base_url=base_url, headers={"Authorization": auth_header}
+        ) as c:
+            return c.get(path).status_code
+
+    system = f"/v1/messages?board_kind=system&caller_member_id={member_id}"
+    wall = (
+        f"/v1/messages?board_kind=member&board_member_id={member_id}"
+        f"&caller_member_id={member_id}"
+    )
+    paths = [system, wall] * 8
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
+        statuses = list(ex.map(hit, paths))
+
+    assert all(s == 200 for s in statuses), statuses
+    # No duplicate rows left behind: subsequent reads still succeed
+    # (a MultipleResultsFound would surface here as a 500).
+    assert auth_client.get(system).status_code == 200
+    assert (
+        auth_client.get(
+            f"/v1/messages/unread?caller_member_id={member_id}"
+        ).status_code
+        == 200
+    )
+
+
 def test_post_to_system_board(auth_client: httpx.Client):
     alice = _create_member(auth_client, "Alice")
     body = _post(auth_client, author_member_id=alice, body="hello system")

--- a/uv.lock
+++ b/uv.lock
@@ -1546,7 +1546,7 @@ wheels = [
 
 [[package]]
 name = "sheaf"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Problem
Opening the Messages page on prod 500s intermittently. Two symptoms, same root cause:
- `GET /v1/messages/boards` (and `/messages`) -> `UniqueViolationError` on `ix_message_read_state_lookup`.
- `GET /v1/messages` -> `MultipleResultsFound` in `get_or_create_read_state`.

The page fires several board endpoints in parallel (board list, board contents, `mark-seen`, unread badge), each calling `get_or_create_read_state`, which was a plain select-then-insert with no race protection:
- **per-member board** (`board_member_id` NOT NULL): concurrent callers both insert -> unique violation -> 500.
- **system board** (`board_member_id` NULL): Postgres treats NULLs as distinct in a unique index, so the race silently inserts duplicate rows -> later `scalar_one_or_none()` -> 500.

(Surfaced right after importing a system onto prod, but the importer doesn't touch read-state - the import just gave boards to open. It reproduces for any user opening Messages under real concurrency.)

## Fix
- `get_or_create_read_state`: `INSERT ... ON CONFLICT DO NOTHING` then select the winner - concurrent callers collapse to one row.
- Recreate `ix_message_read_state_lookup` with **`NULLS NOT DISTINCT`** (PG15+) so the system board is unique too and ON CONFLICT can dedupe it.
- Migration dedupes existing rows first (keeps the most-recently-seen per member/board, NULLs grouped), then rebuilds the index.

## Test plan
- [x] `ruff` clean
- [x] `tests/test_messages.py` (24) pass, incl. a new test that hammers both board kinds with parallel requests (fails on old code)
- [x] migration applies on the existing test DB (dedupe + reindex)

## Notes
- Requires PostgreSQL 15+ (`NULLS NOT DISTINCT`). Prod is PG16.
- The migration mutates data (dedupe) - keeps the row with the latest `last_seen_at` per member/board, so "seen" progress is preserved.
- Candidate for a v0.2.1 patch.