### PR TITLE
Sheaf re-import completeness + S3 SigV4 fix (v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-05-24
+
+### Fixed
+
+- **Sheaf import completeness** The importer only consumed system / members / fronts / groups / tags / custom fields, so journals (and their edit history), board messages, polls, reminders, and the notification config (watch tokens + channels + filter rules) silently vanished on re-import even though the export had always carried them. The importer now round-trips all of them, remapping cross-references (revision targets, poll option/vote refs, channel group/member rules, reminder channel + scope members) onto the freshly minted IDs. The import screen gains per-section selectors (journals, messages, polls, reminders, notifications), and the preview shows a count for each.
+  - Restored references: journal/revision authorship re-points at the importing user, the poll audit-log actor is nulled (old-instance account UUIDs are meaningless on the target), notification channels land in `pending_registration` so nothing dispatches to external recipients until the owner re-activates, and `delete_confirmation` is intentionally not restored (it would otherwise lock destructive actions on an account without the matching TOTP enrolment). Reminders attach to a channel, so they ride the notifications toggle.
+- **Export download failed on KMS-encrypted buckets.** S3 only serves a presigned `GET` for an SSE-KMS-encrypted object (including objects covered by a bucket-default KMS policy) when the URL is signed with SigV4; the boto3 clients weren't pinning a signature version and could fall back to SigV2, so the download 403'd with "requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4". Both the export-artefact and image storage clients now pin `s3v4` (harmless for non-KMS buckets and MinIO).
+
 ## [0.2.1] - 2026-05-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sheaf"
-version = "0.2.1"
+version = "0.2.2"
 description = "Open-source plural system tracking"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/sheaf/api/v1/sheaf_import.py
+++ b/sheaf/api/v1/sheaf_import.py
@@ -37,11 +37,10 @@ async def _parse_upload(file: UploadFile) -> dict:
 
     # Accept both legacy v1 exports and current v2 exports. v2 added new
     # top-level keys (reminders, watch_tokens, polls, journals, revisions,
-    # uploaded_files) over time; the importer only consumes the original
-    # set (system / members / fronts / groups / tags / custom_fields) and
-    # silently ignores extras, so accepting v2 is forward-compatible
-    # without requiring per-field handlers for the not-yet-importable
-    # surfaces. New format versions should be added here as they ship.
+    # uploaded_files) over time; the importer now round-trips all of them
+    # except image bytes (which the sync export omits anyway). A v1 file
+    # simply lacks those keys and the importer skips them. New format
+    # versions should be added here as they ship.
     if not isinstance(parsed, dict) or parsed.get("version") not in {"1", "2"}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -69,4 +68,9 @@ async def preview_import(
         "group_count": p.group_count,
         "tag_count": p.tag_count,
         "custom_field_count": p.custom_field_count,
+        "journal_count": p.journal_count,
+        "message_count": p.message_count,
+        "poll_count": p.poll_count,
+        "reminder_count": p.reminder_count,
+        "channel_count": p.channel_count,
     }

--- a/sheaf/schemas/sheaf_import.py
+++ b/sheaf/schemas/sheaf_import.py
@@ -27,3 +27,10 @@ class SheafImportOptions(BaseModel):
     groups: bool = True
     tags: bool = True
     custom_fields: bool = True
+    journals: bool = True
+    messages: bool = True
+    polls: bool = True
+    reminders: bool = True
+    # Watch tokens + their channels + filter rules. Reminders reference a
+    # channel, so importing reminders without notifications drops them.
+    notifications: bool = True

--- a/sheaf/services/export_storage.py
+++ b/sheaf/services/export_storage.py
@@ -56,8 +56,17 @@ def _client(endpoint: str):
     filesystem deployments don't need it.
     """
     import boto3
+    from botocore.config import Config
 
-    kwargs: dict = {"region_name": settings.s3_region}
+    kwargs: dict = {
+        "region_name": settings.s3_region,
+        # SSE-KMS (including a bucket-default KMS encryption policy)
+        # requires SigV4. Presigned GETs fall back to SigV2 otherwise and
+        # S3 rejects them with "requests specifying Server Side Encryption
+        # with AWS KMS managed keys require AWS Signature Version 4". Pin
+        # it so both API calls and presigned URLs are SigV4.
+        "config": Config(signature_version="s3v4"),
+    }
     if settings.s3_access_key and settings.s3_secret_key:
         kwargs["aws_access_key_id"] = settings.s3_access_key
         kwargs["aws_secret_access_key"] = settings.s3_secret_key

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -1,15 +1,20 @@
 """Sheaf data import service.
 
 Imports data from Sheaf's own export format. Versions "1" and "2" are
-accepted; "2" added top-level keys over time (reminders, watch_tokens,
-polls, journals, revisions, uploaded_files) which this importer
-deliberately does not consume — those carry runtime state or live
-deliverability info that doesn't round-trip into a fresh instance
-without re-registration. The fields here are silently ignored when
-present.
+accepted. The importer round-trips the full export: system profile +
+preferences, members, fronts, groups, tags, custom fields (+ values),
+journals, content revisions, messages, polls, reminders, and the
+notification config (watch tokens + channels + rules). Per-instance
+runtime state that can't survive a move to a fresh instance is omitted
+by the exporter (push subscriptions, activation hashes, webhook
+secrets, last-fired/last-delivered timestamps, pending queues) and so
+isn't consumed here either.
 
 Generates new UUIDs for all imported entities and maps old IDs to new
-ones for cross-references inside the file.
+ones for cross-references inside the file. References to user accounts
+(journal/revision authorship) are re-pointed at the importing user;
+historical audit actors are dropped, since the original account UUIDs
+are meaningless on the target instance.
 """
 
 import logging
@@ -19,12 +24,38 @@ from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
+from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
 from sheaf.models.front import Front
 from sheaf.models.group import Group
+from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member, front_members, group_members, member_tags
-from sheaf.models.system import PrivacyLevel, System
+from sheaf.models.message import Message
+from sheaf.models.notification_channel import (
+    CofrontRedaction,
+    DestinationType,
+    NotificationChannel,
+    PayloadSensitivity,
+)
+from sheaf.models.notification_channel_group_rule import (
+    GroupRuleAction,
+    IncludePrivate,
+    NotificationChannelGroupRule,
+)
+from sheaf.models.notification_channel_member_rule import NotificationChannelMemberRule
+from sheaf.models.poll import (
+    Poll,
+    PollKind,
+    PollOption,
+    PollResultsVisibility,
+    PollVote,
+    PollVoteAction,
+    PollVoteEvent,
+)
+from sheaf.models.reminder import Reminder, reminder_scope_members
+from sheaf.models.system import DateFormat, PrivacyLevel, System
 from sheaf.models.tag import Tag
+from sheaf.models.watch_token import WatchToken
 from sheaf.services.custom_fields import encrypt_field_value
 
 logger = logging.getLogger("sheaf.import.sheaf")
@@ -46,6 +77,45 @@ def _field_type(val: str | None) -> FieldType:
     return FieldType.TEXT
 
 
+_VALID_DATE_FORMAT = {e.value for e in DateFormat}
+_VALID_DESTINATION_TYPE = {e.value for e in DestinationType}
+_VALID_COFRONT_REDACTION = {e.value for e in CofrontRedaction}
+_VALID_PAYLOAD_SENSITIVITY = {e.value for e in PayloadSensitivity}
+_VALID_INCLUDE_PRIVATE = {e.value for e in IncludePrivate}
+# Group and member rules share the same include/exclude vocabulary.
+_VALID_RULE_ACTION = {GroupRuleAction.INCLUDE.value, GroupRuleAction.EXCLUDE.value}
+
+_SAFETY_APPLIES_KEYS = (
+    "applies_to_members",
+    "applies_to_groups",
+    "applies_to_tags",
+    "applies_to_fields",
+    "applies_to_fronts",
+    "applies_to_journals",
+    "applies_to_images",
+    "applies_to_revisions",
+    "applies_to_notifications",
+    "applies_to_reminders",
+    "applies_to_polls",
+    "applies_to_messages",
+)
+
+
+def _date_format(val: object) -> DateFormat | None:
+    if isinstance(val, str) and val in _VALID_DATE_FORMAT:
+        return DateFormat(val)
+    return None
+
+
+def _coerce_int(val: object, *, default: int, minimum: int | None = None) -> int:
+    """Import-data int coercion: reject bools/junk, clamp below a floor."""
+    if isinstance(val, bool) or not isinstance(val, int):
+        return default
+    if minimum is not None and val < minimum:
+        return default
+    return val
+
+
 class SheafPreviewSummary:
     def __init__(self):
         self.system_name: str | None = None
@@ -55,6 +125,11 @@ class SheafPreviewSummary:
         self.group_count: int = 0
         self.tag_count: int = 0
         self.custom_field_count: int = 0
+        self.journal_count: int = 0
+        self.message_count: int = 0
+        self.poll_count: int = 0
+        self.reminder_count: int = 0
+        self.channel_count: int = 0
 
 
 class SheafImportResult:
@@ -64,6 +139,12 @@ class SheafImportResult:
         self.groups_imported: int = 0
         self.tags_imported: int = 0
         self.custom_fields_imported: int = 0
+        self.journals_imported: int = 0
+        self.revisions_imported: int = 0
+        self.messages_imported: int = 0
+        self.polls_imported: int = 0
+        self.reminders_imported: int = 0
+        self.channels_imported: int = 0
         self.warnings: list[str] = []
 
 
@@ -86,6 +167,13 @@ def preview(data: dict) -> SheafPreviewSummary:
     summary.group_count = len(data.get("groups", []))
     summary.tag_count = len(data.get("tags", []))
     summary.custom_field_count = len(data.get("custom_fields", []))
+    summary.journal_count = len(data.get("journals", []))
+    summary.message_count = len(data.get("messages", []))
+    summary.poll_count = len(data.get("polls", []))
+    summary.reminder_count = len(data.get("reminders", []))
+    summary.channel_count = sum(
+        len(t.get("channels", [])) for t in data.get("watch_tokens", [])
+    )
 
     return summary
 
@@ -101,10 +189,21 @@ async def run_import(
     groups: bool = True,
     tags: bool = True,
     custom_fields: bool = True,
+    journals: bool = True,
+    messages: bool = True,
+    polls: bool = True,
+    reminders: bool = True,
+    notifications: bool = True,
 ) -> SheafImportResult:
     """Import Sheaf export data into the user's system."""
     result = SheafImportResult()
     warnings: list[str] = []
+    # Old-export-id -> new-object maps, hoisted to function scope so later
+    # sections can resolve cross-references regardless of which earlier
+    # sections the user opted into.
+    old_gid_to_group: dict[str, Group] = {}
+    old_journal_to_entry: dict[str, JournalEntry] = {}
+    old_channel_to_new: dict[str, NotificationChannel] = {}
 
     # --- System profile ---
     if system_profile:
@@ -125,6 +224,51 @@ async def run_import(
             if "note" in sys_data:
                 note_val = sys_data["note"]
                 system.note = encrypt(note_val) if note_val else None
+            if sys_data.get("avatar_url") is not None:
+                system.avatar_url = _trunc(sys_data["avatar_url"], 500)
+            if "replace_fronts_default" in sys_data:
+                system.replace_fronts_default = bool(
+                    sys_data["replace_fronts_default"]
+                )
+            df = _date_format(sys_data.get("date_format"))
+            if df is not None:
+                system.date_format = df
+
+            # System Safety toggles + grace period + auto-pin. delete_confirmation
+            # is deliberately NOT restored: importing a TOTP-requiring tier onto
+            # an account without TOTP enrolled would lock destructive actions.
+            safety = sys_data.get("safety") or {}
+            if isinstance(safety, dict):
+                if "grace_period_days" in safety:
+                    system.safety_grace_period_days = _coerce_int(
+                        safety["grace_period_days"], default=0, minimum=0
+                    )
+                for key in _SAFETY_APPLIES_KEYS:
+                    if key in safety:
+                        setattr(
+                            system,
+                            f"safety_{key}",
+                            bool(safety[key]),
+                        )
+                if "auto_pin_first_revision" in safety:
+                    system.auto_pin_first_revision = bool(
+                        safety["auto_pin_first_revision"]
+                    )
+
+            # Revision-retention caps.
+            retention = sys_data.get("retention") or {}
+            if isinstance(retention, dict):
+                for key in (
+                    "journal_max_revisions",
+                    "journal_max_revision_days",
+                    "pinned_revision_max_per_target",
+                ):
+                    if key in retention and retention[key] is not None:
+                        setattr(
+                            system,
+                            key,
+                            _coerce_int(retention[key], default=0, minimum=0),
+                        )
 
     # --- Members ---
     export_members = data.get("members", [])
@@ -244,7 +388,6 @@ async def run_import(
     # --- Groups ---
     if groups:
         export_groups = data.get("groups", [])
-        old_gid_to_group: dict[str, Group] = {}
 
         # First pass: create groups without parent links
         for g_data in export_groups:
@@ -324,6 +467,436 @@ async def run_import(
                 )
             result.fronts_imported += 1
 
+    # --- Journals ---
+    if journals:
+        for j_data in data.get("journals", []):
+            old_jid = j_data.get("id", "")
+            old_member_id = j_data.get("member_id")
+            member = None
+            if old_member_id:
+                # System-wide entries have member_id=None; a per-member entry
+                # whose member wasn't imported has nowhere to live, so drop it.
+                member = old_id_to_member.get(old_member_id)
+                if member is None:
+                    continue
+            title = j_data.get("title")
+            entry = JournalEntry(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                member_id=member.id if member else None,
+                title=encrypt(title) if title else None,
+                body=encrypt(j_data.get("body") or ""),
+                visibility=j_data.get("visibility") or "system",
+                # The original authoring account is meaningless on this
+                # instance; attribute the fallback author to the importing user.
+                author_user_id=system.user_id,
+                author_member_ids=[
+                    str(o.id)
+                    for o in _resolve_ids(
+                        j_data.get("author_member_ids"), old_id_to_member
+                    )
+                ],
+                author_member_names=_str_list(j_data.get("author_member_names")),
+                image_keys=_str_list(j_data.get("image_keys")),
+            )
+            created = _parse_iso(j_data.get("created_at"))
+            if created:
+                entry.created_at = created
+            updated = _parse_iso(j_data.get("updated_at"))
+            if updated:
+                entry.updated_at = updated
+            db.add(entry)
+            old_journal_to_entry[old_jid] = entry
+            result.journals_imported += 1
+
+        await db.flush()
+
+    # --- Content revisions (member-bio + journal-entry edit history) ---
+    # Always attempted: each revision resolves its polymorphic target through
+    # the member / journal maps, so bio revisions follow their member and
+    # journal revisions only land if the journals section ran. Message-target
+    # revisions aren't exported, so they never appear here.
+    for r_data in data.get("revisions", []):
+        target_type = r_data.get("target_type")
+        old_target = r_data.get("target_id")
+        if target_type == ContentRevisionTarget.MEMBER_BIO.value:
+            target = old_id_to_member.get(old_target)
+        elif target_type == ContentRevisionTarget.JOURNAL_ENTRY.value:
+            target = old_journal_to_entry.get(old_target)
+        else:
+            target = None
+        if target is None:
+            continue
+        title = r_data.get("title")
+        revision = ContentRevision(
+            id=uuid.uuid4(),
+            target_type=target_type,
+            target_id=target.id,
+            user_id=system.user_id,
+            editor_member_ids=[
+                str(o.id)
+                for o in _resolve_ids(
+                    r_data.get("editor_member_ids"), old_id_to_member
+                )
+            ],
+            editor_member_names=_str_list(r_data.get("editor_member_names")),
+            title=encrypt(title) if title else None,
+            body=encrypt(r_data.get("body") or ""),
+            image_keys=_str_list(r_data.get("image_keys")),
+            pinned_at=_parse_iso(r_data.get("pinned_at")),
+        )
+        created = _parse_iso(r_data.get("created_at"))
+        if created:
+            revision.created_at = created
+        db.add(revision)
+        result.revisions_imported += 1
+
+    # --- Messages (board posts + replies) ---
+    if messages:
+        old_msg_to_new: dict[str, Message] = {}
+        # First pass: create posts without reply links. A member-wall post
+        # whose board member wasn't imported is dropped along with the wall.
+        for msg_data in data.get("messages", []):
+            old_mid = msg_data.get("id", "")
+            board_kind = msg_data.get("board_kind") or "system"
+            board_member = None
+            if board_kind == "member":
+                old_board = msg_data.get("board_member_id")
+                board_member = old_id_to_member.get(old_board) if old_board else None
+                if board_member is None:
+                    continue
+            old_author = msg_data.get("author_member_id")
+            author = old_id_to_member.get(old_author) if old_author else None
+            message = Message(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                board_kind=board_kind,
+                board_member_id=board_member.id if board_member else None,
+                author_member_id=author.id if author else None,
+                body=encrypt(msg_data.get("body") or ""),
+            )
+            created = _parse_iso(msg_data.get("created_at"))
+            if created:
+                message.created_at = created
+            updated = _parse_iso(msg_data.get("updated_at"))
+            if updated:
+                message.updated_at = updated
+            db.add(message)
+            old_msg_to_new[old_mid] = message
+            result.messages_imported += 1
+
+        await db.flush()
+
+        # Second pass: wire reply pointers now every post exists. A parent that
+        # didn't import (deleted, or on a dropped wall) leaves the reply
+        # parentless, which the UI renders as "[deleted]".
+        for msg_data in data.get("messages", []):
+            old_parent = msg_data.get("parent_message_id")
+            if not old_parent:
+                continue
+            child = old_msg_to_new.get(msg_data.get("id", ""))
+            parent = old_msg_to_new.get(old_parent)
+            if child is not None and parent is not None:
+                child.parent_message_id = parent.id
+
+    # --- Polls (config + current votes + audit log) ---
+    if polls:
+        for p_data in data.get("polls", []):
+            closes_at = _parse_iso(p_data.get("closes_at"))
+            if not closes_at:
+                warnings.append(
+                    f"Skipped poll with invalid closes_at: {p_data.get('id', '?')}"
+                )
+                continue
+            description = p_data.get("description")
+            poll = Poll(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                question=encrypt(p_data.get("question") or ""),
+                description=encrypt(description) if description else None,
+                kind=p_data.get("kind") or PollKind.SINGLE_CHOICE.value,
+                results_visibility=(
+                    p_data.get("results_visibility")
+                    or PollResultsVisibility.LIVE.value
+                ),
+                closes_at=closes_at,
+                retention_days=_coerce_int(
+                    p_data.get("retention_days"), default=30, minimum=0
+                ),
+                include_custom_fronts=bool(
+                    p_data.get("include_custom_fronts", False)
+                ),
+            )
+            created = _parse_iso(p_data.get("created_at"))
+            if created:
+                poll.created_at = created
+            db.add(poll)
+
+            # Options first; vote/event option references resolve through this.
+            old_option_to_new: dict[str, PollOption] = {}
+            for o_data in p_data.get("options", []):
+                option = PollOption(
+                    id=uuid.uuid4(),
+                    poll_id=poll.id,
+                    text=encrypt(o_data.get("text") or ""),
+                    position=_coerce_int(
+                        o_data.get("position"), default=0, minimum=0
+                    ),
+                )
+                db.add(option)
+                old_option_to_new[o_data.get("id", "")] = option
+
+            # Current votes (one per member; option refs must resolve).
+            for v_data in p_data.get("votes", []):
+                voter = old_id_to_member.get(v_data.get("voted_as_member_id"))
+                if voter is None:
+                    continue
+                option_ids = [
+                    o.id
+                    for o in _resolve_ids(
+                        v_data.get("option_ids"), old_option_to_new
+                    )
+                ]
+                if not option_ids:
+                    continue
+                vote = PollVote(
+                    id=uuid.uuid4(),
+                    poll_id=poll.id,
+                    voted_as_member_id=voter.id,
+                    option_ids=option_ids,
+                )
+                vcreated = _parse_iso(v_data.get("created_at"))
+                if vcreated:
+                    vote.created_at = vcreated
+                vupdated = _parse_iso(v_data.get("updated_at"))
+                if vupdated:
+                    vote.updated_at = vupdated
+                db.add(vote)
+
+            # Append-only audit log.
+            for e_data in p_data.get("events", []):
+                old_voter = e_data.get("voted_as_member_id")
+                voter = old_id_to_member.get(old_voter) if old_voter else None
+                event = PollVoteEvent(
+                    id=uuid.uuid4(),
+                    poll_id=poll.id,
+                    voted_as_member_id=voter.id if voter else None,
+                    action=e_data.get("action") or PollVoteAction.CAST.value,
+                    option_ids=[
+                        o.id
+                        for o in _resolve_ids(
+                            e_data.get("option_ids"), old_option_to_new
+                        )
+                    ],
+                    fronting_member_ids=[
+                        o.id
+                        for o in _resolve_ids(
+                            e_data.get("fronting_member_ids"), old_id_to_member
+                        )
+                    ],
+                    # The acting account is meaningless on the target instance;
+                    # the member attribution above is the durable part.
+                    actor_user_id=None,
+                )
+                ecreated = _parse_iso(e_data.get("created_at"))
+                if ecreated:
+                    event.created_at = ecreated
+                db.add(event)
+
+            result.polls_imported += 1
+
+        await db.flush()
+
+    # --- Notification config (watch tokens + channels + rules) ---
+    # Per-instance recipient state (activation hashes, push subscriptions,
+    # webhook secrets, delivery bookkeeping) is omitted by the exporter and
+    # not reconstructed here; channels land in their default
+    # pending_registration state so the owner re-activates / re-enters the
+    # secret on the new instance.
+    if notifications:
+        for t_data in data.get("watch_tokens", []):
+            token = WatchToken(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                label=_trunc(t_data.get("label"), 120),
+                revoked_at=_parse_iso(t_data.get("revoked_at")),
+            )
+            tcreated = _parse_iso(t_data.get("created_at"))
+            if tcreated:
+                token.created_at = tcreated
+            db.add(token)
+
+            for c_data in t_data.get("channels", []):
+                dest_type = c_data.get("destination_type")
+                if dest_type not in _VALID_DESTINATION_TYPE:
+                    warnings.append(
+                        f"Skipped channel with unknown destination type: "
+                        f"{dest_type!r}"
+                    )
+                    continue
+                config = c_data.get("destination_config")
+                channel = NotificationChannel(
+                    id=uuid.uuid4(),
+                    watch_token_id=token.id,
+                    name=(c_data.get("name") or "channel")[:120],
+                    destination_type=dest_type,
+                    destination_config=config if isinstance(config, dict) else {},
+                    event_type=c_data.get("event_type") or "front_change",
+                    base_all_members=bool(c_data.get("base_all_members", False)),
+                    base_include_private=bool(
+                        c_data.get("base_include_private", False)
+                    ),
+                    trigger_on_start=bool(c_data.get("trigger_on_start", True)),
+                    trigger_on_stop=bool(c_data.get("trigger_on_stop", False)),
+                    trigger_on_cofront_change=bool(
+                        c_data.get("trigger_on_cofront_change", False)
+                    ),
+                    cofront_redaction=(
+                        c_data["cofront_redaction"]
+                        if c_data.get("cofront_redaction")
+                        in _VALID_COFRONT_REDACTION
+                        else CofrontRedaction.COUNT.value
+                    ),
+                    payload_sensitivity=(
+                        c_data["payload_sensitivity"]
+                        if c_data.get("payload_sensitivity")
+                        in _VALID_PAYLOAD_SENSITIVITY
+                        else PayloadSensitivity.FULL.value
+                    ),
+                    debounce_seconds=_coerce_int(
+                        c_data.get("debounce_seconds"), default=30, minimum=0
+                    ),
+                    aggregation_window_seconds=_coerce_int(
+                        c_data.get("aggregation_window_seconds"),
+                        default=0,
+                        minimum=0,
+                    ),
+                    quiet_hours=(
+                        c_data["quiet_hours"]
+                        if isinstance(c_data.get("quiet_hours"), dict)
+                        else None
+                    ),
+                )
+                ccreated = _parse_iso(c_data.get("created_at"))
+                if ccreated:
+                    channel.created_at = ccreated
+                db.add(channel)
+                old_channel_to_new[c_data.get("id", "")] = channel
+
+                # Group rules resolve against imported groups.
+                for gr in c_data.get("group_rules", []):
+                    group = old_gid_to_group.get(gr.get("group_id"))
+                    if group is None:
+                        continue
+                    rule = gr.get("rule")
+                    if rule not in _VALID_RULE_ACTION:
+                        continue
+                    inc = gr.get("include_private")
+                    db.add(
+                        NotificationChannelGroupRule(
+                            channel_id=channel.id,
+                            group_id=group.id,
+                            rule=rule,
+                            include_private=(
+                                inc
+                                if inc in _VALID_INCLUDE_PRIVATE
+                                else IncludePrivate.INHERIT.value
+                            ),
+                        )
+                    )
+
+                # Member rules resolve against imported members.
+                for mr in c_data.get("member_rules", []):
+                    member = old_id_to_member.get(mr.get("member_id"))
+                    if member is None:
+                        continue
+                    rule = mr.get("rule")
+                    if rule not in _VALID_RULE_ACTION:
+                        continue
+                    db.add(
+                        NotificationChannelMemberRule(
+                            channel_id=channel.id,
+                            member_id=member.id,
+                            rule=rule,
+                        )
+                    )
+
+                result.channels_imported += 1
+
+        await db.flush()
+
+    # --- Reminders ---
+    if reminders:
+        for rm_data in data.get("reminders", []):
+            channel = old_channel_to_new.get(rm_data.get("channel_id"))
+            if channel is None:
+                # channel_id is a NOT NULL FK; a reminder can't outlive its
+                # channel. If notifications weren't imported, every reminder
+                # lands here.
+                warnings.append(
+                    f"Skipped reminder '{rm_data.get('name', '?')}' - its "
+                    "notification channel was not imported"
+                )
+                continue
+            old_tm = rm_data.get("trigger_member_id")
+            trigger_member = old_id_to_member.get(old_tm) if old_tm else None
+            if old_tm and trigger_member is None:
+                warnings.append(
+                    f"Reminder '{rm_data.get('name', '?')}' trigger member "
+                    "was not imported; kept without a member trigger"
+                )
+            body = rm_data.get("body")
+            reminder = Reminder(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                channel_id=channel.id,
+                name=(rm_data.get("name") or "reminder")[:120],
+                title=encrypt(rm_data.get("title") or ""),
+                body=encrypt(body) if body else None,
+                enabled=bool(rm_data.get("enabled", True)),
+                trigger_type=rm_data.get("trigger_type") or "repeated",
+                trigger_member_id=trigger_member.id if trigger_member else None,
+                trigger_event=_trunc(rm_data.get("trigger_event"), 16),
+                delay_seconds=(
+                    _coerce_int(rm_data.get("delay_seconds"), default=0, minimum=0)
+                    if rm_data.get("delay_seconds") is not None
+                    else None
+                ),
+                schedule_kind=_trunc(rm_data.get("schedule_kind"), 16),
+                schedule_time=_trunc(rm_data.get("schedule_time"), 5),
+                schedule_dow_mask=(
+                    _coerce_int(
+                        rm_data.get("schedule_dow_mask"), default=0, minimum=0
+                    )
+                    if rm_data.get("schedule_dow_mask") is not None
+                    else None
+                ),
+                schedule_dom=(
+                    _coerce_int(rm_data.get("schedule_dom"), default=0, minimum=0)
+                    if rm_data.get("schedule_dom") is not None
+                    else None
+                ),
+                schedule_tz=_trunc(rm_data.get("schedule_tz"), 64),
+                cron_expression=_trunc(rm_data.get("cron_expression"), 120),
+                scope=rm_data.get("scope") or "system",
+                digest_when_absent=bool(rm_data.get("digest_when_absent", True)),
+            )
+            rcreated = _parse_iso(rm_data.get("created_at"))
+            if rcreated:
+                reminder.created_at = rcreated
+            db.add(reminder)
+            await db.flush()
+
+            for old_smid in rm_data.get("scope_member_ids", []):
+                scope_member = old_id_to_member.get(old_smid)
+                if scope_member:
+                    await db.execute(
+                        reminder_scope_members.insert().values(
+                            reminder_id=reminder.id, member_id=scope_member.id
+                        )
+                    )
+            result.reminders_imported += 1
+
     result.warnings = warnings
     return result
 
@@ -349,3 +922,22 @@ def _parse_iso(val: str | None) -> datetime | None:
         return datetime.fromisoformat(val)
     except (ValueError, TypeError):
         return None
+
+
+def _str_list(val: object) -> list:
+    """Pass through a JSONB list verbatim, or [] for missing/malformed data."""
+    return val if isinstance(val, list) else []
+
+
+def _resolve_ids(old_ids: object, mapping: dict) -> list:
+    """Map a list of old export IDs to the new ORM objects that imported,
+    dropping any that didn't (filtered out, or never present). Order is
+    preserved. Callers take .id off each object as str (JSONB) or UUID (ARRAY)."""
+    if not isinstance(old_ids, list):
+        return []
+    out = []
+    for oid in old_ids:
+        obj = mapping.get(oid)
+        if obj is not None:
+            out.append(obj)
+    return out

--- a/sheaf/services/sheaf_import_runner.py
+++ b/sheaf/services/sheaf_import_runner.py
@@ -70,6 +70,11 @@ async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
         groups=options.groups,
         tags=options.tags,
         custom_fields=options.custom_fields,
+        journals=options.journals,
+        messages=options.messages,
+        polls=options.polls,
+        reminders=options.reminders,
+        notifications=options.notifications,
     )
 
     update_counts(
@@ -79,6 +84,12 @@ async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
         groups_imported=result.groups_imported,
         tags_imported=result.tags_imported,
         custom_fields_imported=result.custom_fields_imported,
+        journals_imported=result.journals_imported,
+        revisions_imported=result.revisions_imported,
+        messages_imported=result.messages_imported,
+        polls_imported=result.polls_imported,
+        reminders_imported=result.reminders_imported,
+        channels_imported=result.channels_imported,
     )
     for warning in result.warnings:
         append_event(job, level="warning", stage="import", message=warning)
@@ -91,7 +102,13 @@ async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
             f"{result.fronts_imported} fronts, "
             f"{result.groups_imported} groups, "
             f"{result.tags_imported} tags, "
-            f"{result.custom_fields_imported} custom fields"
+            f"{result.custom_fields_imported} custom fields, "
+            f"{result.journals_imported} journals, "
+            f"{result.revisions_imported} revisions, "
+            f"{result.messages_imported} messages, "
+            f"{result.polls_imported} polls, "
+            f"{result.reminders_imported} reminders, "
+            f"{result.channels_imported} notification channels"
         ),
     )
 

--- a/sheaf/storage/s3.py
+++ b/sheaf/storage/s3.py
@@ -2,6 +2,7 @@ import asyncio
 from functools import partial
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from sheaf.config import settings
@@ -13,7 +14,13 @@ class S3Storage(StorageBackend):
         # When access/secret are unset, fall through to boto3's default
         # credential chain (IAM instance profile, IRSA, ~/.aws/credentials,
         # AWS_ACCESS_KEY_ID env, etc.). Passing empty strings would block it.
-        kwargs: dict = {"region_name": settings.s3_region}
+        # signature_version is pinned to SigV4 because SSE-KMS (incl. a
+        # bucket-default KMS policy) rejects SigV2-signed presigned GETs with
+        # "requires AWS Signature Version 4". Harmless for non-KMS / MinIO.
+        kwargs: dict = {
+            "region_name": settings.s3_region,
+            "config": Config(signature_version="s3v4"),
+        }
         if settings.s3_access_key and settings.s3_secret_key:
             kwargs["aws_access_key_id"] = settings.s3_access_key
             kwargs["aws_secret_access_key"] = settings.s3_secret_key

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -74,6 +74,273 @@ def test_sheaf_runner_roundtrip_from_export(auth_client: httpx.Client):
     assert final["counts"]["members_imported"] >= 1, final["counts"]
 
 
+# A fuller export touching every section the importer now round-trips, with
+# the cross-references (revisions -> bio/journal, votes -> options, rules ->
+# group/member, reminder -> channel) the importer has to remap.
+_TS = "2026-01-02T03:04:05+00:00"
+_FULL_EXPORT = {
+    "version": "2",
+    "system": {
+        "name": "Full System",
+        "description": "everything",
+        "safety": {"grace_period_days": 3, "applies_to_journals": True},
+        "retention": {"journal_max_revisions": 7},
+    },
+    "members": [
+        {"id": "m1", "name": "Ada"},
+        {"id": "m2", "name": "Bea"},
+    ],
+    "fronts": [],
+    "groups": [
+        {"id": "g1", "name": "Inner", "member_ids": ["m1"]},
+    ],
+    "tags": [],
+    "custom_fields": [],
+    "journals": [
+        {
+            "id": "j1",
+            "member_id": "m1",
+            "title": "Ada's entry",
+            "body": "dear diary",
+            "visibility": "system",
+            "author_member_ids": ["m1"],
+            "author_member_names": ["Ada"],
+            "image_keys": [],
+            "created_at": _TS,
+            "updated_at": _TS,
+        },
+        {
+            "id": "j2",
+            "member_id": None,
+            "title": "System note",
+            "body": "house meeting",
+            "visibility": "system",
+            "author_member_ids": [],
+            "author_member_names": [],
+            "image_keys": [],
+            "created_at": _TS,
+            "updated_at": _TS,
+        },
+    ],
+    "revisions": [
+        {
+            "id": "rev1",
+            "target_type": "member_bio",
+            "target_id": "m1",
+            "editor_member_ids": ["m1"],
+            "editor_member_names": ["Ada"],
+            "title": None,
+            "body": "old bio",
+            "image_keys": [],
+            "pinned_at": None,
+            "created_at": _TS,
+        },
+        {
+            "id": "rev2",
+            "target_type": "journal_entry",
+            "target_id": "j1",
+            "editor_member_ids": [],
+            "editor_member_names": [],
+            "title": "Ada's entry",
+            "body": "older draft",
+            "image_keys": [],
+            "pinned_at": _TS,
+            "created_at": _TS,
+        },
+    ],
+    "messages": [
+        {
+            "id": "msg1",
+            "board_kind": "system",
+            "board_member_id": None,
+            "author_member_id": "m1",
+            "parent_message_id": None,
+            "body": "hello board",
+            "created_at": _TS,
+            "updated_at": _TS,
+        },
+        {
+            "id": "msg2",
+            "board_kind": "member",
+            "board_member_id": "m2",
+            "author_member_id": "m1",
+            "parent_message_id": None,
+            "body": "hi Bea",
+            "created_at": _TS,
+            "updated_at": _TS,
+        },
+        {
+            "id": "msg3",
+            "board_kind": "system",
+            "board_member_id": None,
+            "author_member_id": "m2",
+            "parent_message_id": "msg1",
+            "body": "replying",
+            "created_at": _TS,
+            "updated_at": _TS,
+        },
+    ],
+    "polls": [
+        {
+            "id": "p1",
+            "question": "lunch?",
+            "description": None,
+            "kind": "single_choice",
+            "results_visibility": "live",
+            "closes_at": _TS,
+            "retention_days": 30,
+            "include_custom_fronts": False,
+            "created_at": _TS,
+            "options": [
+                {"id": "o1", "text": "pizza", "position": 0},
+                {"id": "o2", "text": "sushi", "position": 1},
+            ],
+            "votes": [
+                {
+                    "voted_as_member_id": "m1",
+                    "option_ids": ["o1"],
+                    "created_at": _TS,
+                    "updated_at": _TS,
+                },
+            ],
+            "events": [
+                {
+                    "id": "ev1",
+                    "voted_as_member_id": "m1",
+                    "action": "cast",
+                    "option_ids": ["o1"],
+                    "fronting_member_ids": ["m1"],
+                    "actor_user_id": str(uuid.uuid4()),
+                    "created_at": _TS,
+                },
+            ],
+        },
+    ],
+    "watch_tokens": [
+        {
+            "id": "w1",
+            "label": "Mara",
+            "revoked_at": None,
+            "created_at": _TS,
+            "channels": [
+                {
+                    "id": "c1",
+                    "watch_token_id": "w1",
+                    "name": "Mara webhook",
+                    "destination_type": "webhook",
+                    "destination_config": {"url": "https://example.com/hook"},
+                    "event_type": "front_change",
+                    "base_all_members": False,
+                    "base_include_private": False,
+                    "trigger_on_start": True,
+                    "trigger_on_stop": False,
+                    "trigger_on_cofront_change": False,
+                    "cofront_redaction": "count",
+                    "payload_sensitivity": "minimal",
+                    "debounce_seconds": 30,
+                    "aggregation_window_seconds": 0,
+                    "quiet_hours": None,
+                    "group_rules": [
+                        {"group_id": "g1", "rule": "include", "include_private": "inherit"},
+                    ],
+                    "member_rules": [
+                        {"member_id": "m2", "rule": "include"},
+                    ],
+                    "created_at": _TS,
+                },
+            ],
+        },
+    ],
+    "uploaded_files": [],
+    "reminders": [
+        {
+            "id": "r1",
+            "channel_id": "c1",
+            "name": "wake up",
+            "title": "Good morning",
+            "body": "rise and shine",
+            "enabled": True,
+            "trigger_type": "automated",
+            "trigger_member_id": "m2",
+            "trigger_event": "start",
+            "delay_seconds": 60,
+            "schedule_kind": None,
+            "schedule_time": None,
+            "schedule_dow_mask": None,
+            "schedule_dom": None,
+            "schedule_tz": None,
+            "cron_expression": None,
+            "scope": "system",
+            "scope_member_ids": ["m1"],
+            "digest_when_absent": True,
+            "created_at": _TS,
+        },
+    ],
+}
+
+
+def test_sheaf_runner_imports_all_sections(auth_client: httpx.Client):
+    """Every section the exporter emits round-trips back in, with the
+    cross-references remapped to the freshly minted IDs."""
+    job = _post_file(auth_client, payload=json.dumps(_FULL_EXPORT).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    counts = final["counts"]
+    assert counts["members_imported"] == 2, counts
+    assert counts["groups_imported"] == 1, counts
+    assert counts["journals_imported"] == 2, counts
+    assert counts["revisions_imported"] == 2, counts
+    assert counts["messages_imported"] == 3, counts
+    assert counts["polls_imported"] == 1, counts
+    assert counts["channels_imported"] == 1, counts
+    assert counts["reminders_imported"] == 1, counts
+
+
+def test_sheaf_runner_section_toggles_respected(auth_client: httpx.Client):
+    """Deselecting journals / messages / polls / notifications / reminders
+    skips exactly those sections. Reminders ride on notifications, so with
+    notifications off the reminder is dropped too."""
+    resp = auth_client.post(
+        "/v1/imports/file",
+        files={"file": ("sheaf.json", json.dumps(_FULL_EXPORT).encode(), "application/json")},
+        data={
+            "source": "sheaf_file",
+            "idempotency_key": str(uuid.uuid4()),
+            "options": json.dumps(
+                {
+                    "journals": False,
+                    "messages": False,
+                    "polls": False,
+                    "notifications": False,
+                    "reminders": True,
+                }
+            ),
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    job = resp.json()
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    counts = final["counts"]
+    # Members + groups still come across.
+    assert counts["members_imported"] == 2, counts
+    assert counts["groups_imported"] == 1, counts
+    # The deselected sections are absent (zeroed counts are filtered out of
+    # the JSONB, so the keys are simply missing).
+    assert counts.get("journals_imported", 0) == 0, counts
+    assert counts.get("messages_imported", 0) == 0, counts
+    assert counts.get("polls_imported", 0) == 0, counts
+    assert counts.get("channels_imported", 0) == 0, counts
+    assert counts.get("reminders_imported", 0) == 0, counts
+    # Member-bio revisions still land (they follow members, not journals);
+    # the journal-entry revision is dropped with journals off.
+    assert counts.get("revisions_imported", 0) == 1, counts
+
+
 def test_sheaf_runner_fails_on_invalid_json(auth_client: httpx.Client):
     job = _post_file(auth_client, payload=b"not json")
     drive_import_runner()

--- a/tests/test_sheaf_import.py
+++ b/tests/test_sheaf_import.py
@@ -1,10 +1,11 @@
 """Integration tests for the Sheaf-to-Sheaf import *preview* endpoint.
 
 Covers the version-check gate (v1 + v2 accepted, anything else
-rejected) and forward-compat with v2-only top-level keys (reminders /
-polls / etc. silently ignored). The actual re-import now runs through
-the async job runner — covered end-to-end, including a real
-export-then-reimport round-trip, in test_imports_sheaf_runner.py.
+rejected) and the per-section counts the preview surfaces (members,
+journals, messages, polls, reminders, channels). The actual re-import
+now runs through the async job runner — covered end-to-end, including a
+real export-then-reimport round-trip and per-section toggles, in
+test_imports_sheaf_runner.py.
 """
 
 from __future__ import annotations
@@ -60,8 +61,8 @@ def test_preview_accepts_v1(auth_client: httpx.Client):
 
 def test_preview_accepts_v2_with_extra_keys(auth_client: httpx.Client):
     """A current-format export carries reminders / polls / watch_tokens /
-    journals / revisions / uploaded_files. Those aren't re-importable
-    yet but their presence must not gate the preview."""
+    journals / revisions / uploaded_files. The preview surfaces a count for
+    each so the user can see what's about to come across."""
     resp = _upload(
         auth_client,
         "/v1/import/sheaf/preview",
@@ -74,9 +75,10 @@ def test_preview_accepts_v2_with_extra_keys(auth_client: httpx.Client):
             "tags": [],
             "custom_fields": [],
             "reminders": [{"id": "r1", "name": "drift-by"}],
-            "watch_tokens": [{"id": "w1"}],
+            "watch_tokens": [{"id": "w1", "channels": [{"id": "c1"}, {"id": "c2"}]}],
             "polls": [{"id": "p1"}],
             "journals": [{"id": "j1"}],
+            "messages": [{"id": "msg1"}],
             "revisions": [],
             "uploaded_files": [],
         },
@@ -84,3 +86,9 @@ def test_preview_accepts_v2_with_extra_keys(auth_client: httpx.Client):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["member_count"] == 1
+    assert body["journal_count"] == 1
+    assert body["message_count"] == 1
+    assert body["poll_count"] == 1
+    assert body["reminder_count"] == 1
+    # channel_count sums channels across all watch tokens.
+    assert body["channel_count"] == 2

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
         "@tailwindcss/typography": "^0.5.19",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/sheaf-import.ts
+++ b/web/src/lib/sheaf-import.ts
@@ -19,6 +19,11 @@ export interface SheafPreviewSummary {
   group_count: number;
   tag_count: number;
   custom_field_count: number;
+  journal_count: number;
+  message_count: number;
+  poll_count: number;
+  reminder_count: number;
+  channel_count: number;
 }
 
 export async function previewSheafImport(file: File): Promise<SheafPreviewSummary> {

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -149,6 +149,11 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
   const [importGroups, setImportGroups] = useState(true);
   const [importTags, setImportTags] = useState(true);
   const [importFields, setImportFields] = useState(true);
+  const [importJournals, setImportJournals] = useState(true);
+  const [importMessages, setImportMessages] = useState(true);
+  const [importPolls, setImportPolls] = useState(true);
+  const [importNotifications, setImportNotifications] = useState(true);
+  const [importReminders, setImportReminders] = useState(true);
 
   async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -180,6 +185,13 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
           groups: importGroups,
           tags: importTags,
           custom_fields: importFields,
+          journals: importJournals,
+          messages: importMessages,
+          polls: importPolls,
+          notifications: importNotifications,
+          // Reminders need a channel; without notifications there's nothing
+          // for them to attach to.
+          reminders: importReminders && importNotifications,
         },
       });
       navigate(`/imports/${job.id}`);
@@ -243,6 +255,11 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
               <div>Groups: <strong>{preview.group_count}</strong></div>
               <div>Tags: <strong>{preview.tag_count}</strong></div>
               <div>Custom fields: <strong>{preview.custom_field_count}</strong></div>
+              <div>Journals: <strong>{preview.journal_count}</strong></div>
+              <div>Messages: <strong>{preview.message_count}</strong></div>
+              <div>Polls: <strong>{preview.poll_count}</strong></div>
+              <div>Reminders: <strong>{preview.reminder_count}</strong></div>
+              <div>Notification channels: <strong>{preview.channel_count}</strong></div>
             </CardContent>
           </Card>
 
@@ -252,7 +269,7 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
             </CardHeader>
             <CardContent className="space-y-4">
               <Checkbox
-                label="System profile (name, description, color, tag)"
+                label="System profile (name, description, color, tag, safety + retention settings)"
                 checked={systemProfile}
                 onChange={setSystemProfile}
               />
@@ -276,6 +293,39 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
                 checked={importFields}
                 onChange={setImportFields}
               />
+              <Checkbox
+                label={`Journals (${preview.journal_count.toLocaleString()} entries, with edit history)`}
+                checked={importJournals}
+                onChange={setImportJournals}
+              />
+              <Checkbox
+                label={`Messages (${preview.message_count.toLocaleString()} board posts)`}
+                checked={importMessages}
+                onChange={setImportMessages}
+              />
+              <Checkbox
+                label={`Polls (${preview.poll_count.toLocaleString()}, with votes + audit log)`}
+                checked={importPolls}
+                onChange={setImportPolls}
+              />
+              <Checkbox
+                label={`Notification setup (${preview.channel_count.toLocaleString()} channels — recipients re-activate on this instance)`}
+                checked={importNotifications}
+                onChange={setImportNotifications}
+              />
+              <div>
+                <Checkbox
+                  label={`Reminders (${preview.reminder_count.toLocaleString()})`}
+                  checked={importReminders && importNotifications}
+                  onChange={setImportReminders}
+                />
+                {!importNotifications && (
+                  <p className="ml-6 text-xs text-muted-foreground">
+                    Reminders attach to a notification channel, so they need
+                    Notification setup enabled to come across.
+                  </p>
+                )}
+              </div>
 
               <MemberSelector
                 members={preview.members}


### PR DESCRIPTION
## Summary

The Sheaf-to-Sheaf re-import was only consuming system / members / fronts / groups / tags / custom fields, so journals (and their edit history), board messages, polls, reminders, and the notification config silently vanished on re-import even though the export had always carried them. This makes the importer round-trip the full export, adds per-section selectors, and fixes the KMS export-download bug found while testing. Tagged v0.2.2.

## Import completeness

- New importer sections for journals, content revisions (member-bio + journal-entry history), messages, polls (options/votes/audit log), notification config (watch tokens + channels + group/member rules), and reminders. All cross-references are remapped onto the freshly minted IDs (revision targets, poll option/vote refs, channel rules, reminder channel + scope members).
- Per-section import selectors (journals, messages, polls, reminders, notifications) added to the options schema, runner, preview counts, and the import UI. Reminders attach to a channel, so they ride the notifications toggle.
- Restored-reference decisions:
  - Journal/revision authorship re-points at the importing user; the poll audit-log actor is nulled (old-instance account UUIDs are meaningless here).
  - Notification channels land in `pending_registration` so nothing dispatches to external recipients until the owner re-activates. Webhook secrets and recipient subscriptions are not carried by the export and are not reconstructed.
  - `delete_confirmation` is intentionally not restored (it would otherwise lock destructive actions on an account without the matching TOTP enrolment). Safety toggles, grace period, and retention caps are restored.

## S3 SigV4 fix

- Export download was failing with "requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4". S3 only serves a presigned GET for an SSE-KMS object (incl. a bucket-default KMS policy) when the URL is SigV4-signed; the boto3 clients were not pinning a signature version and could fall back to SigV2. Both the export-artefact and image storage clients now pin `s3v4` (harmless for non-KMS buckets and MinIO).
- Note: this can only be verified against the KMS-encrypted export bucket; MinIO will not reproduce it.

## Release

- Bumped to v0.2.2 (pyproject + web package.json), changelog entry added, and corrected the web lockfile version which had drifted from package.json since v0.2.0.

## Tests

- Full hand-crafted-export round-trip exercising every section and its cross-references, plus a section-toggle test (proving deselection works, and that member-bio revisions survive `journals=off` while journal revisions do not).
- `46 passed` across the import suite; ruff / tsc / eslint clean.

## Migrations

None. The importer writes into existing tables.