### PR TITLE
Dedupe custom field definitions on re-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Re-import no longer duplicates custom field definitions.** Restoring a Sheaf export into a system that already had those fields stacked a second copy of every definition ("Pronouns", "Pronouns", ...). The importer now dedupes definitions by (name, type) against the target system and within the file, reusing the existing one; members and their values are still added (member dedup is a separate, larger piece of work). Field values guard the `UNIQUE(field_id, member_id)` constraint so a shared definition can't trip it mid-import.
+
 ## [0.2.2] - 2026-05-24
 
 ### Fixed

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -15,12 +15,18 @@ ones for cross-references inside the file. References to user accounts
 (journal/revision authorship) are re-pointed at the importing user;
 historical audit actors are dropped, since the original account UUIDs
 are meaningless on the target instance.
+
+Re-import is additive, with one exception: custom field *definitions*
+are deduped by (name, type) against the target system, so restoring a
+backup into a populated system doesn't leave a second copy of every
+field. Members and their data are still added rather than merged.
 """
 
 import logging
 import uuid
 from datetime import datetime
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
@@ -349,24 +355,50 @@ async def run_import(
     # --- Custom fields ---
     old_field_to_def: dict[str, CustomFieldDefinition] = {}
     if custom_fields:
+        # Re-import is additive, but duplicating field *definitions* just
+        # litters the field list with a second "Pronouns" etc. Dedupe by
+        # (name, type) against what the system already has, and within the
+        # file itself, reusing the existing definition rather than minting a
+        # twin. Members aren't deduped, so their values still attach to the
+        # fresh member rows under the shared definition. The system's own
+        # config (privacy/order/options) on a reused field is left untouched.
+        existing_fields = await db.execute(
+            select(CustomFieldDefinition).where(
+                CustomFieldDefinition.system_id == system.id
+            )
+        )
+        field_by_key: dict[tuple[str, str], CustomFieldDefinition] = {
+            (fd.name, fd.field_type.value): fd
+            for fd in existing_fields.scalars().all()
+        }
         for fd_data in data.get("custom_fields", []):
             old_fid = fd_data.get("id", "")
-            field_def = CustomFieldDefinition(
-                id=uuid.uuid4(),
-                system_id=system.id,
-                name=(fd_data.get("name") or "field")[:100],
-                field_type=_field_type(fd_data.get("field_type")),
-                options=fd_data.get("options"),
-                order=fd_data.get("order", 0),
-                privacy=_privacy(fd_data.get("privacy")),
-            )
-            db.add(field_def)
+            name = (fd_data.get("name") or "field")[:100]
+            ftype = _field_type(fd_data.get("field_type"))
+            key = (name, ftype.value)
+            field_def = field_by_key.get(key)
+            if field_def is None:
+                field_def = CustomFieldDefinition(
+                    id=uuid.uuid4(),
+                    system_id=system.id,
+                    name=name,
+                    field_type=ftype,
+                    options=fd_data.get("options"),
+                    order=fd_data.get("order", 0),
+                    privacy=_privacy(fd_data.get("privacy")),
+                )
+                db.add(field_def)
+                field_by_key[key] = field_def
+                result.custom_fields_imported += 1
             old_field_to_def[old_fid] = field_def
-            result.custom_fields_imported += 1
 
         await db.flush()
 
-        # Import field values
+        # Import field values. A reused definition can be referenced by more
+        # than one export field (a file with duplicate defs, or future deduped
+        # members), so guard (field, member) uniqueness ourselves to avoid
+        # tripping the UNIQUE(field_id, member_id) constraint mid-import.
+        seen_values: set[tuple[uuid.UUID, uuid.UUID]] = set()
         for fd_data in data.get("custom_fields", []):
             old_fid = fd_data.get("id", "")
             field_def = old_field_to_def.get(old_fid)
@@ -377,6 +409,10 @@ async def run_import(
                 member = old_id_to_member.get(old_mid)
                 if not member:
                     continue
+                vkey = (field_def.id, member.id)
+                if vkey in seen_values:
+                    continue
+                seen_values.add(vkey)
                 cfv = CustomFieldValue(
                     id=uuid.uuid4(),
                     field_id=field_def.id,

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -341,6 +341,50 @@ def test_sheaf_runner_section_toggles_respected(auth_client: httpx.Client):
     assert counts.get("revisions_imported", 0) == 1, counts
 
 
+_FIELDS_EXPORT = {
+    "version": "2",
+    "system": {"name": "Fields System"},
+    "members": [{"id": "m1", "name": "Ada"}],
+    "fronts": [],
+    "groups": [],
+    "tags": [],
+    "custom_fields": [
+        {
+            "id": "f1",
+            "name": "Pronouns",
+            "field_type": "text",
+            "options": None,
+            "order": 0,
+            "privacy": "private",
+            "values": [{"member_id": "m1", "value": "she/her"}],
+        }
+    ],
+}
+
+
+def test_sheaf_runner_dedupes_custom_field_definitions(auth_client: httpx.Client):
+    """Restoring a backup into a system that already has the field reuses the
+    existing definition instead of stacking a second "Pronouns" column."""
+    j1 = _post_file(auth_client, payload=json.dumps(_FIELDS_EXPORT).encode())
+    drive_import_runner()
+    f1 = wait_for_terminal(auth_client, j1["id"])
+    assert f1["status"] == "complete", f1
+    assert f1["counts"]["custom_fields_imported"] == 1, f1["counts"]
+
+    # Second import of the same file: the field already exists, so nothing new
+    # is created.
+    j2 = _post_file(auth_client, payload=json.dumps(_FIELDS_EXPORT).encode())
+    drive_import_runner()
+    f2 = wait_for_terminal(auth_client, j2["id"])
+    assert f2["status"] == "complete", f2
+    assert f2["counts"].get("custom_fields_imported", 0) == 0, f2["counts"]
+
+    # Exactly one definition named Pronouns survives.
+    fields = auth_client.get("/v1/fields").json()
+    pronouns = [f for f in fields if f["name"] == "Pronouns"]
+    assert len(pronouns) == 1, fields
+
+
 def test_sheaf_runner_fails_on_invalid_json(auth_client: httpx.Client):
     job = _post_file(auth_client, payload=b"not json")
     drive_import_runner()

--- a/uv.lock
+++ b/uv.lock
@@ -1546,7 +1546,7 @@ wheels = [
 
 [[package]]
 name = "sheaf"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Restoring a Sheaf export into a system that already had its custom fields stacked a second copy of every definition ("Pronouns", "Pronouns", ...), because the importer created definitions unconditionally. This dedupes them. Follow-up to the import-completeness work merged in #74; sequenced as unreleased (not folded into v0.2.2).

## Change

- Custom field definitions are deduped by `(name, type)` against the target system and within the file itself, reusing the existing definition rather than minting a twin. The system's own config (privacy / order / options) on a reused field is left untouched.
- Members are still added rather than merged (member dedup is separate, larger work), so their values attach to the fresh member rows under the shared definition.
- Field-value inserts guard `(field_id, member_id)` uniqueness in-run, so a reused definition (a file with duplicate defs, or future deduped members) can't trip the `UNIQUE(field_id, member_id)` constraint mid-import.

## Also

- Syncs `uv.lock` to `0.2.2` (the v0.2.2 bump updated pyproject but not the lockfile; only the version field moves, no dependency resolutions change). Same lockfile-drift class as the `package-lock.json` fix in v0.2.2.

## Tests

- New runner test: importing the same export twice creates the field once, the second run reports zero new fields, and exactly one definition survives.
- `11 passed` across the import runner + preview suite; ruff clean.

## Not in scope

Member deduplication (re-import stays additive for members).