### PR TITLE
Enforce member cap on imports + warn before exceeding it

### DIFF
--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -3,12 +3,11 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user, require_scope
-from sheaf.config import settings
 from sheaf.crypto import blind_index, encrypt
 from sheaf.database import get_db
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
@@ -17,7 +16,7 @@ from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
-from sheaf.models.user import User, UserTier
+from sheaf.models.user import User
 from sheaf.schemas.journal import (
     ContentRevisionRead,
     PinRevisionRequest,
@@ -42,6 +41,7 @@ from sheaf.services.journals import (
     restore_member_bio_revision,
     unpin_revision_immediate,
 )
+from sheaf.services.member_limits import count_members, get_member_limit
 from sheaf.services.members import decrypt_member_for_read, member_plaintext
 from sheaf.services.system_safety import (
     is_safeguarded,
@@ -131,20 +131,6 @@ async def list_members(
     return decoded
 
 
-_MEMBER_LIMIT_MAP = {
-    UserTier.FREE: lambda: settings.member_limit_free,
-    UserTier.PLUS: lambda: settings.member_limit_plus,
-    UserTier.SELF_HOSTED: lambda: settings.member_limit_selfhosted,
-}
-
-
-def _get_member_limit(user: User) -> int:
-    """Return the member limit for a user. 0 means unlimited."""
-    if user.member_limit is not None:
-        return user.member_limit
-    return _MEMBER_LIMIT_MAP.get(user.tier, lambda: 0)()
-
-
 @router.post(
     "",
     response_model=MemberRead,
@@ -158,12 +144,9 @@ async def create_member(
 ):
     system = await _get_user_system(user, db)
 
-    limit = _get_member_limit(user)
+    limit = get_member_limit(user)
     if limit > 0:
-        result = await db.execute(
-            select(func.count()).where(Member.system_id == system.id)
-        )
-        count = result.scalar_one()
+        count = await count_members(db, system.id)
         if count >= limit:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -199,6 +182,26 @@ async def create_member(
 # real shaping and the window just bounds the query.
 _TOP_FRONTERS_HALF_LIFE_DAYS = 30.0
 _TOP_FRONTERS_WINDOW = timedelta(days=180)
+
+
+@router.get("/limit")
+async def member_limit(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Effective member cap and current usage for the account.
+
+    `limit` of 0 means unlimited (and `remaining` is null). Used by the
+    import flows to warn before an import would blow the cap.
+    """
+    system = await _get_user_system(user, db)
+    limit = get_member_limit(user)
+    current = await count_members(db, system.id)
+    return {
+        "limit": limit,
+        "current": current,
+        "remaining": max(limit - current, 0) if limit > 0 else None,
+    }
 
 
 @router.get("/top-fronters", response_model=list[MemberRead])

--- a/sheaf/services/member_limits.py
+++ b/sheaf/services/member_limits.py
@@ -1,0 +1,78 @@
+"""Member-count limits (per tier, with per-user override).
+
+Single source of truth for "how many members may this account have" and the
+"would this import blow the cap" check. The normal create path
+(`POST /v1/members`) and every importer share these so the limit can't be
+enforced in one place and silently bypassed in another.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.config import settings
+from sheaf.models.member import Member
+from sheaf.models.system import System
+from sheaf.models.user import User, UserTier
+from sheaf.services.import_parsing import ImportPayloadError
+
+_MEMBER_LIMIT_MAP = {
+    UserTier.FREE: lambda: settings.member_limit_free,
+    UserTier.PLUS: lambda: settings.member_limit_plus,
+    UserTier.SELF_HOSTED: lambda: settings.member_limit_selfhosted,
+}
+
+
+def get_member_limit(user: User) -> int:
+    """Effective member limit for a user. 0 means unlimited.
+
+    A per-user override (`user.member_limit`) wins over the tier default,
+    so support can lift an individual account without changing its tier.
+    """
+    if user.member_limit is not None:
+        return user.member_limit
+    return _MEMBER_LIMIT_MAP.get(user.tier, lambda: 0)()
+
+
+async def count_members(db: AsyncSession, system_id: uuid.UUID) -> int:
+    """Current member count for a system."""
+    result = await db.scalar(
+        select(func.count()).select_from(Member).where(Member.system_id == system_id)
+    )
+    return result or 0
+
+
+async def enforce_import_member_cap(
+    db: AsyncSession,
+    system: System,
+    incoming: int,
+) -> None:
+    """Raise ImportPayloadError if adding `incoming` new members would push the
+    system past its member cap.
+
+    No-op when the account is unlimited (limit 0) or the import adds nothing.
+    Raising ImportPayloadError gets it surfaced to the user as a clean job
+    failure (a classified, expected failure) rather than an unhandled error.
+    Imports are additive, so `incoming` is counted on top of the existing
+    members.
+    """
+    if incoming <= 0:
+        return
+    user = await db.get(User, system.user_id)
+    if user is None:
+        return
+    limit = get_member_limit(user)
+    if limit <= 0:
+        return
+    current = await count_members(db, system.id)
+    if current + incoming > limit:
+        over = current + incoming - limit
+        raise ImportPayloadError(
+            f"This import would add {incoming} members, but your account is "
+            f"limited to {limit} ({current} already in use) — {over} over the "
+            "cap. Deselect at least that many members and try again, or upgrade "
+            "for a higher limit."
+        )

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -37,6 +37,7 @@ from sheaf.services.import_runner import (
     update_counts,
 )
 from sheaf.services.import_storage import get_payload
+from sheaf.services.member_limits import enforce_import_member_cap
 from sheaf.services.pk_api import PKApiError, fetch_export
 from sheaf.services.pk_import import (
     apply_system_profile,
@@ -84,6 +85,9 @@ async def _process_pk_export(
     if options.member_ids is not None:
         wanted = set(options.member_ids)
         pk_members = [m for m in pk_members if m.get("id") in wanted]
+
+    # Hard-fail before writing anything if this would blow the member cap.
+    await enforce_import_member_cap(db, system, len(pk_members))
 
     hid_to_member: dict[str, Member] = {}
     for pk_m in pk_members:

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -63,6 +63,7 @@ from sheaf.models.system import DateFormat, PrivacyLevel, System
 from sheaf.models.tag import Tag
 from sheaf.models.watch_token import WatchToken
 from sheaf.services.custom_fields import encrypt_field_value
+from sheaf.services.member_limits import enforce_import_member_cap
 
 logger = logging.getLogger("sheaf.import.sheaf")
 
@@ -281,6 +282,9 @@ async def run_import(
     if member_ids is not None:
         selected = set(member_ids)
         export_members = [m for m in export_members if m.get("id") in selected]
+
+    # Hard-fail before writing anything if this would blow the member cap.
+    await enforce_import_member_cap(db, system, len(export_members))
 
     # Map old export ID → new Member
     old_id_to_member: dict[str, Member] = {}

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -32,6 +32,7 @@ from sheaf.schemas.sp_import import (
     SPPreviewSummary,
 )
 from sheaf.services.custom_fields import encrypt_field_value
+from sheaf.services.member_limits import enforce_import_member_cap
 
 logger = logging.getLogger("sheaf.import")
 
@@ -120,6 +121,13 @@ async def run_import(
     if options.member_ids is not None:
         selected = set(options.member_ids)
         sp_members = [m for m in sp_members if m.get("_id") in selected]
+
+    # Custom fronts also become Member rows and count toward the cap, so fold
+    # them into the headroom check. Hard-fail before writing anything.
+    incoming = len(sp_members)
+    if options.custom_fronts:
+        incoming += len(_get_collection(data, "frontStatuses"))
+    await enforce_import_member_cap(db, system, incoming)
 
     # Map SP member _id → new Sheaf Member for cross-referencing
     sp_id_to_member: dict[str, Member] = {}

--- a/sheaf/services/tb_import.py
+++ b/sheaf/services/tb_import.py
@@ -43,6 +43,7 @@ from sheaf.schemas.tb_import import (
     TBPreviewMember,
     TBPreviewSummary,
 )
+from sheaf.services.member_limits import enforce_import_member_cap
 
 logger = logging.getLogger("sheaf.import.tb")
 
@@ -94,6 +95,9 @@ async def run_import(
     if options.member_ids is not None:
         wanted = set(options.member_ids)
         tuppers = [t for t in tuppers if _tupper_id(t) in wanted]
+
+    # Hard-fail before writing anything if this would blow the member cap.
+    await enforce_import_member_cap(db, system, len(tuppers))
 
     id_to_member: dict[str, Member] = {}
     for tupper in tuppers:

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -401,3 +401,43 @@ def test_sheaf_runner_fails_on_non_object_root(auth_client: httpx.Client):
 
     assert final["status"] == "failed", final
     assert any("must be a JSON object" in e["message"] for e in final["events"])
+
+
+def test_member_limit_endpoint(auth_client: httpx.Client):
+    """The cap endpoint the import flows read for their warning. Shape is
+    config-independent: self-hosted is unlimited (limit 0, remaining null),
+    SaaS free tier has a numeric cap."""
+    data = auth_client.get("/v1/members/limit").json()
+    assert set(data) == {"limit", "current", "remaining"}
+    assert data["current"] == 0
+    if data["limit"] == 0:
+        assert data["remaining"] is None
+    else:
+        assert data["remaining"] == data["limit"]
+
+
+def test_sheaf_runner_hard_fails_over_member_cap(admin_client: httpx.Client):
+    """An import that would push the account past its member cap fails up
+    front rather than silently overshooting. Uses a per-user override so the
+    check fires regardless of the server's tier config."""
+    me = admin_client.get("/v1/auth/me").json()
+    patched = admin_client.patch(
+        f"/v1/admin/users/{me['id']}", json={"member_limit": 1}
+    )
+    assert patched.status_code == 200, patched.text
+
+    # _SHEAF_EXPORT has two members; cap is 1.
+    job = _post_file(admin_client, payload=json.dumps(_SHEAF_EXPORT).encode())
+    drive_import_runner()
+    final = wait_for_terminal(admin_client, job["id"])
+
+    assert final["status"] == "failed", final
+    blob = (
+        (final.get("last_error") or "")
+        + " "
+        + " ".join(e["message"] for e in final["events"])
+    ).lower()
+    assert "member" in blob and "limit" in blob, final
+
+    # Nothing was written: the account still has zero members.
+    assert admin_client.get("/v1/members/limit").json()["current"] == 0

--- a/web/src/lib/members.ts
+++ b/web/src/lib/members.ts
@@ -24,6 +24,20 @@ export function getTopFronters(limit = 8) {
   return apiFetch<Member[]>(`/v1/members/top-fronters?limit=${limit}`);
 }
 
+export interface MemberLimitStatus {
+  /** 0 means unlimited. */
+  limit: number;
+  current: number;
+  /** null when unlimited. */
+  remaining: number | null;
+}
+
+/** Effective member cap + current usage, for warning before an import would
+ *  exceed it. */
+export function getMemberLimit() {
+  return apiFetch<MemberLimitStatus>("/v1/members/limit");
+}
+
 export function createMember(data: MemberCreate) {
   return apiFetch<Member>("/v1/members", {
     method: "POST",

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -1,6 +1,8 @@
 import { type ChangeEvent, useState } from "react";
 import { Link, useNavigate } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import { Loader2Icon } from "lucide-react";
+import { getMemberLimit } from "@/lib/members";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -154,6 +156,10 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
   const [importPolls, setImportPolls] = useState(true);
   const [importNotifications, setImportNotifications] = useState(true);
   const [importReminders, setImportReminders] = useState(true);
+
+  const importIncoming = allMembers
+    ? (preview?.member_count ?? 0)
+    : selectedMembers.size;
 
   async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -336,9 +342,7 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
-              <Button onClick={handleImport} className="w-full">
-                Import
-              </Button>
+              <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
         </div>
@@ -368,6 +372,11 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
   const [customFields, setCustomFields] = useState(true);
   const [groups, setGroups] = useState(true);
   const [frontHistory, setFrontHistory] = useState(false);
+
+  // Custom fronts also become members and count toward the cap.
+  const importIncoming =
+    (allMembers ? (preview?.member_count ?? 0) : selectedMembers.size) +
+    (customFronts ? (preview?.custom_front_count ?? 0) : 0);
 
   async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -506,9 +515,7 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
-              <Button onClick={handleImport} className="w-full">
-                Import
-              </Button>
+              <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
         </div>
@@ -545,6 +552,10 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
   const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set());
   const [groups, setGroups] = useState(true);
   const [frontHistory, setFrontHistory] = useState(false);
+
+  const importIncoming = allMembers
+    ? (preview?.member_count ?? 0)
+    : selectedMembers.size;
 
   async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -812,9 +823,7 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
-              <Button onClick={handleImport} className="w-full">
-                Import
-              </Button>
+              <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
         </div>
@@ -840,6 +849,10 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
   const [allMembers, setAllMembers] = useState(true);
   const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set());
   const [groups, setGroups] = useState(true);
+
+  const importIncoming = allMembers
+    ? (preview?.member_count ?? 0)
+    : selectedMembers.size;
 
   async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -949,9 +962,7 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
-              <Button onClick={handleImport} className="w-full">
-                Import
-              </Button>
+              <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
         </div>
@@ -1031,6 +1042,37 @@ function MemberSelector({
           {selectedMembers.size} of {totalCount} selected
         </p>
       )}
+    </div>
+  );
+}
+
+function ImportSubmit({
+  incoming,
+  onImport,
+}: {
+  incoming: number;
+  onImport: () => void;
+}) {
+  const { data } = useQuery({
+    queryKey: ["members", "limit"],
+    queryFn: getMemberLimit,
+  });
+  const remaining = data?.remaining ?? null;
+  // remaining null == unlimited. Block + warn only when we know it won't fit.
+  const over = remaining !== null && incoming > remaining;
+  return (
+    <div className="space-y-2">
+      {over && remaining !== null && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          This would import {incoming.toLocaleString()} members, but only{" "}
+          {remaining.toLocaleString()} fit under your account&apos;s member
+          limit. Deselect at least {(incoming - remaining).toLocaleString()} more
+          (or upgrade); the import will be rejected otherwise.
+        </div>
+      )}
+      <Button onClick={onImport} className="w-full" disabled={over}>
+        Import
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Imports bypassed the per-account member cap entirely. Every importer added members directly via `db.add`, so a large import sailed past the limit (free tier = 512) and the account only hit the wall on the next manual "Add member" (403). This enforces the cap on every import path (hard-fail up front) and warns in the UI before it would happen.

Per the agreed behaviour: over-cap imports hard-fail the whole job rather than partially filling.

## Backend

- New `member_limits` service as the single source of truth: `get_member_limit` (tier default, per-user `member_limit` override wins, 0 = unlimited), `count_members`, and `enforce_import_member_cap` which raises `ImportPayloadError` (a classified, clean job failure) when an import would overflow. The normal `POST /v1/members` create path now uses the same helper, so enforcement can't drift between places.
- All four importers (Sheaf, PluralKit, SimplyPlural, Tupperbox) call the check after applying the member selector, before writing anything. SimplyPlural counts custom fronts too, since they become `Member` rows and count toward the cap (matching the create path).
- New `GET /v1/members/limit` returning `{limit, current, remaining}` (remaining null when unlimited).

## Frontend

- Each import flow fetches the limit, shows a warning, and disables the Import button when the current selection would exceed the remaining headroom. Deselecting members (or using the existing member selector) clears it. The backend hard-fail is the backstop if the warning is ignored or the API is hit directly.

## Tests

- An import over an overridden cap hard-fails and writes nothing.
- The limit endpoint shape holds across tier configs (self-hosted unlimited / SaaS numeric cap).

## Migrations

None. Reuses the existing `user.member_limit` column, the `member_limit_*` config, and a member `COUNT(*)`.