### PR TITLE
Fix web build: broaden isDeleteQueued type guard

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -457,8 +457,13 @@ export interface DeleteQueued {
 
 export type DeleteResult = void | DeleteQueued;
 
-export function isDeleteQueued(r: DeleteResult): r is DeleteQueued {
-  return !!r && typeof (r as DeleteQueued).pending_action_id === "string";
+// Accepts unknown so callers whose result is a wider union (e.g. file delete
+// returns FileDeleted | DeleteQueued) can use it too, not just DeleteResult.
+export function isDeleteQueued(r: unknown): r is DeleteQueued {
+  return (
+    !!r &&
+    typeof (r as DeleteQueued).pending_action_id === "string"
+  );
 }
 
 export interface DestructiveConfirm {


### PR DESCRIPTION
## Summary

`main` is red: the web build (`tsc -b`) fails since #76 merged.

```
src/components/settings/uploaded-files-card.tsx(79,26): error TS2345:
Argument of type 'DeleteQueued | FileDeleted' is not assignable to
parameter of type 'DeleteResult'.
```

The file-delete mutation returns `FileDeleted | DeleteQueued`, but `isDeleteQueued` only accepted `DeleteResult` (`void | DeleteQueued`), so `FileDeleted` isn't assignable. Widen the guard's parameter to `unknown` - it already narrows via the `pending_action_id` check, and every existing `DeleteResult` caller still type-checks.

## Why it slipped through

The local check script runs `tsc --noEmit`, which doesn't fully resolve project references the way CI's `tsc -b` does, so it didn't surface the error. Verified this fix with `tsc -b`, `eslint`, and a full `npm run build` (all green).

## Migrations

None.