### PR TITLE
Fix API-key scope wiring: polls UI, dedicated messages scope, no key self-minting

### DIFF
--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -86,6 +86,7 @@ _VALID_SCOPES = {
     "settings:read", "settings:write", "settings:delete",
     "notifications:read", "notifications:write", "notifications:delete",
     "polls:read", "polls:write", "polls:delete",
+    "messages:read", "messages:write", "messages:delete",
     "import:write",
     "export:read",
     "admin:read", "admin:write",
@@ -1511,12 +1512,29 @@ async def regenerate_recovery_codes(
     return {"recovery_codes": codes}
 
 
+def _reject_api_key_auth(request: Request) -> None:
+    """Block API-key auth from the key-management endpoints.
+
+    An API key minting or revoking keys is privilege escalation: a leaked
+    read-only key could create a fresh write/delete key (and outlive its own
+    revocation). Key management is a session/JWT-only operation, same posture
+    as the account + async-export endpoints.
+    """
+    if getattr(request.state, "auth_method", None) == "api_key":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="API keys cannot manage API keys. Sign in with a session or JWT.",
+        )
+
+
 @router.get("/keys", response_model=list[ApiKeyRead])
 async def list_api_keys(
+    request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """List the current user's API keys (never returns plaintext key)."""
+    _reject_api_key_auth(request)
     result = await db.execute(select(ApiKey).where(ApiKey.user_id == user.id))
     return [
         ApiKeyRead(
@@ -1539,10 +1557,12 @@ async def list_api_keys(
 )
 async def create_api_key(
     body: ApiKeyCreate,
+    request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Create a new API key. The plaintext key is returned once — save it."""
+    _reject_api_key_auth(request)
     unknown = set(body.scopes) - _VALID_SCOPES
     if unknown:
         raise HTTPException(
@@ -1586,10 +1606,12 @@ async def create_api_key(
 @router.delete("/keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def revoke_api_key(
     key_id: str,
+    request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Revoke an API key. Only the owning user can revoke their own keys."""
+    _reject_api_key_auth(request)
     result = await db.execute(
         select(ApiKey).where(ApiKey.id == key_id, ApiKey.user_id == user.id)
     )

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -392,7 +392,7 @@ async def mark_seen(
     "",
     response_model=MessageRead,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_scope("members:write"))],
+    dependencies=[Depends(require_scope("messages:write"))],
 )
 async def post_message(
     body: MessageCreate,
@@ -455,7 +455,7 @@ async def post_message(
 @router.patch(
     "/{message_id}",
     response_model=MessageRead,
-    dependencies=[Depends(require_scope("members:write"))],
+    dependencies=[Depends(require_scope("messages:write"))],
 )
 async def edit_message(
     message_id: uuid.UUID,
@@ -494,7 +494,7 @@ async def edit_message(
 
 @router.delete(
     "/{message_id}",
-    dependencies=[Depends(require_scope("members:delete"))],
+    dependencies=[Depends(require_scope("messages:delete"))],
 )
 async def delete_message(
     message_id: uuid.UUID,
@@ -547,7 +547,7 @@ async def delete_message(
 
 @router.delete(
     "/{message_id}/thread",
-    dependencies=[Depends(require_scope("members:delete"))],
+    dependencies=[Depends(require_scope("messages:delete"))],
 )
 async def delete_thread(
     message_id: uuid.UUID,
@@ -627,7 +627,7 @@ async def list_revisions(
 @router.post(
     "/{message_id}/restore-revision",
     response_model=MessageRead,
-    dependencies=[Depends(require_scope("members:write"))],
+    dependencies=[Depends(require_scope("messages:write"))],
 )
 async def restore_revision(
     message_id: uuid.UUID,
@@ -653,7 +653,7 @@ async def restore_revision(
 @router.post(
     "/{message_id}/pin-revision",
     response_model=ContentRevisionRead,
-    dependencies=[Depends(require_scope("members:write"))],
+    dependencies=[Depends(require_scope("messages:write"))],
 )
 async def pin_message_revision(
     message_id: uuid.UUID,
@@ -682,7 +682,7 @@ async def pin_message_revision(
 @router.post(
     "/{message_id}/unpin-revision",
     response_model=UnpinRevisionResponse,
-    dependencies=[Depends(require_scope("members:write"))],
+    dependencies=[Depends(require_scope("messages:write"))],
 )
 async def unpin_message_revision(
     message_id: uuid.UUID,
@@ -768,7 +768,7 @@ async def get_notify_settings(
 @router.put(
     "/notify-settings/{member_id}",
     response_model=NotifyOnFrontSettings,
-    dependencies=[Depends(require_scope("members:write"))],
+    dependencies=[Depends(require_scope("messages:write"))],
 )
 async def set_notify_settings(
     member_id: uuid.UUID,

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -153,11 +153,12 @@ v1_router.include_router(
     dependencies=[Depends(require_scope("polls:read"))],
 )
 
-# Messages share the members:* scope set rather than minting new scopes —
-# the audience and authorization domain are the same as member content.
+# Messages have their own scope set: posting/deleting board messages is a
+# distinct capability from editing members, so a key shouldn't get one via
+# the other.
 v1_router.include_router(
     messages.router,
-    dependencies=[Depends(require_scope("members:read"))],
+    dependencies=[Depends(require_scope("messages:read"))],
 )
 
 # File serve catch-all MUST be last — {path:path} would shadow other routes

--- a/sheaf/auth/dependencies.py
+++ b/sheaf/auth/dependencies.py
@@ -16,19 +16,6 @@ from sheaf.request import client_ip
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
-_ALL_SCOPES = {
-    "system:read", "system:write",
-    "members:read", "members:write", "members:delete",
-    "fronts:read", "fronts:write", "fronts:delete",
-    "groups:read", "groups:write", "groups:delete",
-    "tags:read", "tags:write", "tags:delete",
-    "fields:read", "fields:write", "fields:delete",
-    "export:read",
-    "notifications:read", "notifications:write",
-    "admin:read", "admin:write",
-}
-
-
 def _hash_key(plaintext: str) -> str:
     return hashlib.sha256(plaintext.encode()).hexdigest()
 

--- a/tests/test_api_key_scope_coverage.py
+++ b/tests/test_api_key_scope_coverage.py
@@ -1,0 +1,52 @@
+"""Guards against API-key scope wiring drift.
+
+The bug this prevents: an endpoint requires a scope (via require_scope, either
+per-endpoint or at router-mount time) that isn't in the grantable set
+(_VALID_SCOPES). No API key can ever hold it, so the endpoint is permanently
+403 for key auth - which is exactly how polls/journals/messages broke.
+
+Static source scan rather than app introspection: require_scope returns a
+closure whose captured scope string isn't readily inspectable, and a grep is
+both simpler and catches the router-mount deps too.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sheaf.api.v1.auth import _VALID_SCOPES
+
+_API_DIR = Path(__file__).resolve().parent.parent / "sheaf" / "api" / "v1"
+_SCOPE_RE = re.compile(r'require_scope\(\s*"([^"]+)"\s*\)')
+
+
+def _required_scopes() -> set[str]:
+    found: set[str] = set()
+    for path in _API_DIR.glob("*.py"):
+        found |= set(_SCOPE_RE.findall(path.read_text()))
+    return found
+
+
+def test_every_required_scope_is_grantable():
+    """Each scope the API enforces must be one a key can actually be granted."""
+    required = _required_scopes()
+    assert required, "no require_scope() calls found - scan likely broken"
+    missing = required - _VALID_SCOPES
+    assert not missing, (
+        "endpoints require scopes that aren't in _VALID_SCOPES, so no API key "
+        f"can ever satisfy them: {sorted(missing)}"
+    )
+
+
+def test_polls_and_messages_scopes_present():
+    """Regression anchors for the two that were missing."""
+    for scope in (
+        "polls:read",
+        "polls:write",
+        "polls:delete",
+        "messages:read",
+        "messages:write",
+        "messages:delete",
+    ):
+        assert scope in _VALID_SCOPES, scope

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,6 +1,7 @@
 """Tests for API key creation, listing, revocation, and scope enforcement."""
 
 import os
+import uuid
 
 import httpx
 
@@ -325,3 +326,47 @@ def test_notifications_write_cannot_revoke_watch_token(auth_client: httpx.Client
     with _key_client(plaintext) as c:
         resp = c.delete(f"/v1/watch-tokens/{token_id}")
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# API keys cannot manage API keys (no self-minting / privilege escalation)
+# ---------------------------------------------------------------------------
+
+def test_api_key_cannot_create_keys(auth_client: httpx.Client):
+    """A leaked key must not be able to mint a fresh (wider-scoped) key."""
+    plaintext = _create_key(auth_client, scopes=["members:read"])["key"]
+    with _key_client(plaintext) as c:
+        resp = c.post(
+            "/v1/auth/keys",
+            json={"name": "escalated", "scopes": ["members:write", "polls:write"]},
+        )
+    assert resp.status_code == 403
+
+
+def test_api_key_cannot_list_or_revoke_keys(auth_client: httpx.Client):
+    target = _create_key(auth_client, "victim")
+    plaintext = _create_key(auth_client, scopes=["members:read"])["key"]
+    with _key_client(plaintext) as c:
+        assert c.get("/v1/auth/keys").status_code == 403
+        assert c.delete(f"/v1/auth/keys/{target['id']}").status_code == 403
+
+
+def test_api_key_can_use_polls_and_messages_scopes(auth_client: httpx.Client):
+    """The scopes that were previously ungrantable now work end to end."""
+    for scope in ("polls:write", "messages:write"):
+        # Creation with the scope succeeds (it's in _VALID_SCOPES)...
+        data = _create_key(auth_client, name=f"k-{scope}", scopes=[scope])
+        assert scope in data["scopes"]
+        # ...and a key lacking it is refused the matching write.
+        plaintext = _create_key(auth_client, scopes=["members:read"])["key"]
+        with _key_client(plaintext) as c:
+            if scope == "polls:write":
+                r = c.post("/v1/polls", json={"question": "q", "kind": "single_choice",
+                                              "results_visibility": "live",
+                                              "closes_at": "2099-01-01T00:00:00+00:00",
+                                              "options": [{"text": "a"}, {"text": "b"}]})
+            else:
+                r = c.post("/v1/messages", json={"board_kind": "system",
+                                                 "author_member_id": str(uuid.uuid4()),
+                                                 "body": "hi"})
+        assert r.status_code == 403

--- a/web/src/components/settings/api-keys-card.tsx
+++ b/web/src/components/settings/api-keys-card.tsx
@@ -33,6 +33,8 @@ const SCOPE_GROUPS: ScopeGroup[] = [
       { key: "tags", label: "Tags", hasDelete: true },
       { key: "fields", label: "Custom fields", hasDelete: true },
       { key: "journals", label: "Journals", hasDelete: true },
+      { key: "polls", label: "Polls", hasDelete: true },
+      { key: "messages", label: "Board messages", hasDelete: true },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Found while load-testing with an API key: poll creation always 403'd. The backend supports `polls:*`, but the key-creation UI never offered the scope, so a key could never be granted it. Fixed that, then swept the rest of the API-key scope system.

## Changes

- **Polls scope in the key UI.** Add `polls` to the scope picker so keys can actually be granted `polls:read/write/delete` (backend already enforced them).
- **Dedicated `messages:*` scope.** Board messages were reusing `members:*`. Posting/deleting messages is a distinct capability from editing members, so they get their own `messages:read/write/delete` (router mount + the 8 endpoints + `_VALID_SCOPES` + the UI, updated together). Least privilege: a member-management key no longer implies message access.
- **Key management is session/JWT-only.** `create` / `list` / `revoke` key endpoints now refuse API-key auth. A key minting another key is privilege escalation: a leaked read-only key could create a write/delete key and outlive its own revocation. Matches the existing account + async-export posture.
- **Remove dead `_ALL_SCOPES`** in `auth.dependencies` - unused and drifted out of sync; `_VALID_SCOPES` in `auth.py` is the real grantable set.

## Sweep result (no other gaps)

- Every `require_scope()` the API enforces (per-endpoint and at router mount) is now in `_VALID_SCOPES`. A new static test asserts this so the polls/messages class of bug can't recur.
- Admin scopes are properly enforced via `get_admin_user` / `get_admin_write_user`.
- Import/export gated at the router mount; account / async-export / webhooks correctly refuse or don't need key scopes.

## Tests

- Static guard: every required scope is grantable.
- An API key cannot create / list / revoke keys.
- `polls:write` / `messages:write` are grantable and enforced (a key lacking them is refused).
- `55 passed` across api-keys + scope-coverage + messages; ruff / tsc / eslint clean.

## Compatibility

API-key scoping only; session/JWT (the web app) bypass scopes, so UI behavior is unchanged. The `messages:*` split is a behavior change for any existing key that relied on `members:*` to reach messages (messages are new and pre-1.0, so likely none).

## Migrations

None.