### PR TITLE
More responsive modals + cap member picker height

### DIFF
--- a/web/src/components/member-select.tsx
+++ b/web/src/components/member-select.tsx
@@ -120,7 +120,10 @@ export function MemberSelect({
           autoFocus
         />
       )}
-      <div className="flex flex-wrap gap-2">
+      {/* Cap the picker height with its own scroll so a large roster doesn't
+          push the surrounding controls (e.g. the Start button in the switch
+          modal) below the fold. */}
+      <div className="flex flex-wrap gap-2 max-h-[40vh] overflow-y-auto pr-1">
         {filtered.map((m) => (
           <Badge
             key={m.id}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -71,8 +71,12 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         onInteractOutside={(e) => e.preventDefault()}
+        // Responsive default width: comfortable on large monitors (2xl at
+        // lg+) without running long on phones. Modals needing a specific
+        // width still override via className - tailwind-merge wins on the
+        // matching breakpoint variant.
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg lg:max-w-2xl",
           className
         )}
         {...props}


### PR DESCRIPTION
Two UX findings from load-testing on a large system / large monitors.

## Member picker no longer dominates the modal

`MemberSelect`'s chip list had no height cap, so a roster of hundreds (the load-test profile) pushed the surrounding controls way below the fold. In the switch modal you had to scroll past every member to reach the Start button.

Now the chip list caps at `max-h-[40vh]` with its own internal scroll. The custom-status field, the "End all current fronts" toggle, and the Start button stay visible no matter the member count. Applies everywhere the picker is used (tag / group editors too).

## Dialogs are no longer 512px on a 2560 monitor

Default `DialogContent` was `sm:max-w-lg` (512px), cramped on a 1920+ display. Default now scales to `max-w-2xl` (672px) at `lg+` (>= 1024px viewport):

```
sm:max-w-lg lg:max-w-2xl
```

Modals that already opted into a different width via `className` still win - tailwind-merge resolves the matching breakpoint variant. So `sm:max-w-2xl` content modals are unchanged.

## Worth eyeballing

The 40vh picker cap and 2xl default width are reasonable defaults but subjective. Easy to tweak both numbers if they feel off:
- `40vh` in `member-select.tsx` -> `45vh` / `50vh` for a taller picker.
- `lg:max-w-2xl` in `dialog.tsx` -> `xl` (576px) for less aggressive, `3xl` (768px) for wider on huge monitors.

ruff / tsc / eslint clean. Frontend only, no backend changes or migrations.