### PR TITLE
Show Re-issue activation link for mobile_push channels too

### DIFF
--- a/web/src/routes/notifications.$channelId.tsx
+++ b/web/src/routes/notifications.$channelId.tsx
@@ -250,8 +250,13 @@ export function NotificationChannelPage() {
           <span className="text-sm text-muted-foreground">
             State: <strong>{channel.destination_state.replace("_", " ")}</strong>
           </span>
+          {/* Re-issue for both web_push and mobile_push: re-imported channels
+              land in pending_registration with no link, and a token can also
+              get consumed without setup completing. Backend already accepts
+              either; the gate just needs to match. */}
           {channel.destination_state === "pending_registration" &&
-            channel.destination_type === "web_push" && (
+            (channel.destination_type === "web_push" ||
+              channel.destination_type === "mobile_push") && (
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
The Re-issue button on the channel detail page was gated on `destination_type === "web_push"`, so `mobile_push` channels in `pending_registration` had no UI path to a fresh magic link. That breaks the two cases noted in load testing:

- **Re-imported channels.** The Sheaf importer drops the activation hash / expiry deliberately (per-instance state that doesn't ride along), so an imported mobile_push channel sits in `pending_registration` with no link.
- **Consumed-but-unfinished.** If a redemption half-completes, the token is gone but the channel stays `pending_registration`.

Backend (`POST /v1/channels/{id}/reissue-activation`) already accepts any push type (`_PUSH_TYPES = {web_push, mobile_push}`); only the frontend gate needed widening. One-line condition change.

ruff / tsc / eslint clean. Frontend only.