### PR TITLE
Add cleanup_notification_outbox sweep

### DIFF
--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -307,6 +307,12 @@ class Settings(BaseSettings):
     # around the same time' queries line up.
     import_job_retention_days: int = 30
 
+    # How long terminal notification_outbox rows are kept for audit before
+    # the cleanup sweep deletes them. Both delivered and dropped rows
+    # (filtered out, revoked, permanent failure) stamp delivered_at, so a
+    # single age cutoff covers everything in a done state.
+    notification_outbox_retention_days: int = 30
+
     # A job stuck in `running` longer than this is presumed orphaned by
     # a crashed worker; the recovery sweep resets it to `pending` for a
     # retry. Generous — a large PluralKit API import paginating switch

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -662,6 +662,32 @@ async def _purge_expired_polls(db: AsyncSession) -> dict:
     return {"items_processed": purged}
 
 
+async def _cleanup_notification_outbox(db: AsyncSession) -> dict:
+    """Drop terminal notification_outbox rows past the retention window.
+
+    Every dispatched notification leaves a row behind, and so do the dropped
+    ones - the dispatcher stamps `delivered_at` as the universal sentinel
+    for "this row is done" (whether actually delivered, filtered out by the
+    resolver, revoked, or permanently failed). Without this sweep the outbox
+    grows unbounded; a busy system or a load test can leave thousands of
+    rows. Only terminal rows (`delivered_at IS NOT NULL`) are eligible;
+    anything still awaiting dispatch or in retry backoff is left alone.
+    """
+    from sheaf.models.notification_outbox import NotificationOutboxRow
+
+    cutoff = datetime.now(UTC) - timedelta(
+        days=settings.notification_outbox_retention_days
+    )
+    result = await db.execute(
+        delete(NotificationOutboxRow).where(
+            NotificationOutboxRow.delivered_at.is_not(None),
+            NotificationOutboxRow.delivered_at < cutoff,
+        )
+    )
+    await db.commit()
+    return {"items_processed": result.rowcount or 0}
+
+
 async def _cleanup_import_jobs(db: AsyncSession) -> dict:
     """Drop ImportJob rows past the retention window.
 
@@ -897,6 +923,13 @@ def _register_all_jobs() -> None:
         name="cleanup_import_jobs",
         description="Delete ImportJob rows past their retention window",
         func=_cleanup_import_jobs,
+        interval_seconds=lambda: 86400,  # daily
+    )
+
+    register_job(
+        name="cleanup_notification_outbox",
+        description="Delete terminal notification_outbox rows past retention",
+        func=_cleanup_notification_outbox,
         interval_seconds=lambda: 86400,  # daily
     )
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -112,8 +112,20 @@ def test_list_jobs_contains_known_jobs(admin_client: httpx.Client):
         "process_account_deletions",
         "cleanup_job_logs",
         "cleanup_orphaned_files",
+        "cleanup_notification_outbox",
     }
     assert expected.issubset(names)
+
+
+def test_trigger_cleanup_notification_outbox(admin_client: httpx.Client):
+    """The outbox sweep is wired and runnable; with no terminal rows it's a
+    no-op that still reports success + an items_processed count."""
+    resp = admin_client.post("/v1/admin/jobs/cleanup_notification_outbox/run")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["job_name"] == "cleanup_notification_outbox"
+    assert data["status"] == "success"
+    assert "items_processed" in data
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Found during the data-bloat sweep: the `notification_outbox` table grows unbounded. Every dispatched row leaves `delivered_at` set, and the dropped path (filtered out by the resolver, revoked channel, permanent failure) sets `delivered_at` too — the dispatcher uses it as the universal "this row is done" sentinel. Across all 17 scheduled jobs, nothing was deleting them. A busy week or a load test can leave tens of thousands of rows that no UI surfaces.

New daily `cleanup_notification_outbox` job deletes terminal rows past `settings.notification_outbox_retention_days` (default 30). Anything still awaiting dispatch or in retry backoff is left alone (`delivered_at IS NULL`). One age cutoff covers both delivered + dropped because of the shared sentinel.

## Tests

- `cleanup_notification_outbox` shows up in the registered-jobs list.
- The admin trigger endpoint runs it cleanly + returns `items_processed`.

## Notes

- `email_verification` looked like a similar accumulator but the table is forward-compat scaffolding (`Not used by v1 code` per its docstring) - no rows yet, no sweep needed.
- No migration. Pure backend.