### PR TITLE
Surface pending_delete_at on the remaining entity listings

### DIFF
--- a/sheaf/api/v1/custom_fields.py
+++ b/sheaf/api/v1/custom_fields.py
@@ -26,6 +26,7 @@ from sheaf.services.custom_fields import (
 )
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -63,7 +64,16 @@ async def list_fields(
         .where(CustomFieldDefinition.system_id == system.id)
         .order_by(CustomFieldDefinition.order)
     )
-    return result.scalars().all()
+    fields = list(result.scalars().all())
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.FIELD_DELETE
+    )
+    out: list[CustomFieldRead] = []
+    for f in fields:
+        fr = CustomFieldRead.model_validate(f)
+        fr.pending_delete_at = pending.get(f.id)
+        out.append(fr)
+    return out
 
 
 @router.post(
@@ -101,7 +111,12 @@ async def get_field(
     field = result.scalar_one_or_none()
     if field is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Field not found")
-    return field
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.FIELD_DELETE
+    )
+    fr = CustomFieldRead.model_validate(field)
+    fr.pending_delete_at = pending.get(field.id)
+    return fr
 
 
 @router.patch(

--- a/sheaf/api/v1/files.py
+++ b/sheaf/api/v1/files.py
@@ -24,6 +24,7 @@ from sheaf.services.file_cleanup import (
 )
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -244,6 +245,13 @@ async def list_files(
         .order_by(UploadedFile.created_at.desc())
     )
     files = result.scalars().all()
+    # Images are owned by a User but image-delete pending actions are
+    # scoped by system_id (System Safety operates per-system). Look up
+    # the caller's system once and key into the resulting map by file id.
+    system = await _get_user_system(user, db)
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.IMAGE_DELETE
+    )
     return [
         {
             "id": str(f.id),
@@ -253,6 +261,9 @@ async def list_files(
             "content_type": f.content_type,
             "size_bytes": f.size_bytes,
             "created_at": f.created_at.isoformat(),
+            "pending_delete_at": (
+                pending[f.id].isoformat() if f.id in pending else None
+            ),
         }
         for f in files
     ]

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -31,6 +31,7 @@ from sheaf.services.notifications.events import (
 from sheaf.services.pagination import decode_cursor, encode_cursor
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -52,6 +53,7 @@ def _front_to_read(
     member_since: dict[str, datetime] | None = None,
     member_since_capped: list[str] | None = None,
     has_audit_history: bool = False,
+    pending_delete_at: datetime | None = None,
 ) -> FrontRead:
     """Project a Front row to its API shape.
 
@@ -82,6 +84,7 @@ def _front_to_read(
         member_since=member_since,
         member_since_capped=member_since_capped or [],
         has_audit_history=has_audit_history,
+        pending_delete_at=pending_delete_at,
     )
 
 
@@ -283,8 +286,16 @@ async def list_fronts(
         response.headers["X-Sheaf-Total-Count"] = str(total_result.scalar_one())
 
     with_audit = await _load_audit_existence(db, [f.id for f in fronts])
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.FRONT_DELETE
+    )
     return [
-        _front_to_read(f, has_audit_history=f.id in with_audit) for f in fronts
+        _front_to_read(
+            f,
+            has_audit_history=f.id in with_audit,
+            pending_delete_at=pending.get(f.id),
+        )
+        for f in fronts
     ]
 
 
@@ -303,12 +314,16 @@ async def get_current_fronts(
     fronts = list(result.scalars().all())
     member_since_map = await _build_coalesced_member_since(db, system, fronts)
     with_audit = await _load_audit_existence(db, [f.id for f in fronts])
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.FRONT_DELETE
+    )
     return [
         _front_to_read(
             f,
             member_since=member_since_map[f.id][0],
             member_since_capped=member_since_map[f.id][1],
             has_audit_history=f.id in with_audit,
+            pending_delete_at=pending.get(f.id),
         )
         for f in fronts
     ]
@@ -533,8 +548,13 @@ async def update_front(
 
     await db.commit()
     await db.refresh(front, ["members"])
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.FRONT_DELETE
+    )
     return _front_to_read(
-        front, has_audit_history=await _front_has_audit(db, front.id)
+        front,
+        has_audit_history=await _front_has_audit(db, front.id),
+        pending_delete_at=pending.get(front.id),
     )
 
 

--- a/sheaf/api/v1/groups.py
+++ b/sheaf/api/v1/groups.py
@@ -18,6 +18,7 @@ from sheaf.schemas.member import MemberDeleteConfirm, MemberRead
 from sheaf.services.members import decrypt_member_for_read
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -52,7 +53,16 @@ async def list_groups(
     result = await db.execute(
         select(Group).where(Group.system_id == system.id).order_by(Group.name)
     )
-    return result.scalars().all()
+    groups = list(result.scalars().all())
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.GROUP_DELETE
+    )
+    out: list[GroupRead] = []
+    for g in groups:
+        gr = GroupRead.model_validate(g)
+        gr.pending_delete_at = pending.get(g.id)
+        out.append(gr)
+    return out
 
 
 @router.post(
@@ -85,7 +95,13 @@ async def get_group(
     db: AsyncSession = Depends(get_db),
 ):
     system = await _get_user_system(user, db)
-    return await _get_own_group(group_id, system, db)
+    group = await _get_own_group(group_id, system, db)
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.GROUP_DELETE
+    )
+    gr = GroupRead.model_validate(group)
+    gr.pending_delete_at = pending.get(group.id)
+    return gr
 
 
 @router.patch(

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -50,6 +50,7 @@ from sheaf.services.journals import (
 from sheaf.services.pagination import decode_cursor, encode_cursor
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -136,13 +137,15 @@ async def list_journals(
         if has_more and page
         else None
     )
-    return JournalListResponse(
-        items=[
-            JournalEntryRead.model_validate(decrypt_entry_for_read(r))
-            for r in page
-        ],
-        next_cursor=next_cursor,
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.JOURNAL_DELETE
     )
+    items: list[JournalEntryRead] = []
+    for r in page:
+        item = JournalEntryRead.model_validate(decrypt_entry_for_read(r))
+        item.pending_delete_at = pending.get(r.id)
+        items.append(item)
+    return JournalListResponse(items=items, next_cursor=next_cursor)
 
 
 @router.post(
@@ -188,8 +191,12 @@ async def get_entry(
     count = await revision_count_for(
         ContentRevisionTarget.JOURNAL_ENTRY, entry.id, db
     )
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.JOURNAL_DELETE
+    )
     payload = JournalEntryReadWithCount.model_validate(decrypt_entry_for_read(entry))
     payload.revision_count = count
+    payload.pending_delete_at = pending.get(entry.id)
     return payload
 
 

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -68,6 +68,7 @@ from sheaf.services.messages import (
 )
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -99,7 +100,32 @@ async def _get_owned_message(
     return msg
 
 
-async def _to_read(msg: Message, db: AsyncSession) -> MessageRead:
+async def _message_pending_map(
+    db: AsyncSession, system_id: uuid.UUID
+) -> dict[uuid.UUID, datetime]:
+    """Union MESSAGE_DELETE + MESSAGE_THREAD_DELETE pending actions by
+    target_id. Either type marks a message row for delete in the grace
+    window, so the badge surfaces both."""
+    direct = await pending_finalize_after_by_target(
+        db, system_id, PendingActionType.MESSAGE_DELETE
+    )
+    thread = await pending_finalize_after_by_target(
+        db, system_id, PendingActionType.MESSAGE_THREAD_DELETE
+    )
+    # Earliest finalize wins if a row appears in both (unlikely; defensive).
+    out = dict(direct)
+    for k, v in thread.items():
+        if k not in out or v < out[k]:
+            out[k] = v
+    return out
+
+
+async def _to_read(
+    msg: Message,
+    db: AsyncSession,
+    *,
+    pending_delete_at: datetime | None = None,
+) -> MessageRead:
     parent_preview, parent_author, _ = await fetch_parent_preview(
         db, msg.parent_message_id
     )
@@ -116,11 +142,15 @@ async def _to_read(msg: Message, db: AsyncSession) -> MessageRead:
         body=decrypt_body(msg.body),
         created_at=msg.created_at,
         updated_at=msg.updated_at,
+        pending_delete_at=pending_delete_at,
     )
 
 
 async def _render_messages(
-    msgs: list[Message], db: AsyncSession
+    msgs: list[Message],
+    db: AsyncSession,
+    *,
+    pending_delete_at_by_id: dict[uuid.UUID, datetime] | None = None,
 ) -> list[MessageRead]:
     """Render a page of messages without the per-row N+1 that looping
     _to_read incurs. Parent messages and member names are each batched
@@ -157,6 +187,11 @@ async def _render_messages(
             if parent is not None and parent.deleted_at is None:
                 parent_preview = preview_for(decrypt_body(parent.body))
                 parent_author = _name(parent.author_member_id)
+        pending_at = (
+            pending_delete_at_by_id.get(msg.id)
+            if pending_delete_at_by_id
+            else None
+        )
         rendered.append(MessageRead(
             id=msg.id,
             system_id=msg.system_id,
@@ -170,6 +205,7 @@ async def _render_messages(
             body=decrypt_body(msg.body),
             created_at=msg.created_at,
             updated_at=msg.updated_at,
+            pending_delete_at=pending_at,
         ))
     return rendered
 
@@ -275,7 +311,10 @@ async def get_board(
         limit=capped_limit,
         before=before,
     )
-    rendered = await _render_messages(msgs, db)
+    pending_map = await _message_pending_map(db, system.id)
+    rendered = await _render_messages(
+        msgs, db, pending_delete_at_by_id=pending_map
+    )
 
     caller_last_seen: datetime | None = None
     if caller_member_id is not None:

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -59,6 +59,7 @@ from sheaf.services.notifications.resolution import (
 )
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -166,7 +167,11 @@ async def _load_owned_channel(
     return channel
 
 
-def _channel_to_read(channel: NotificationChannel) -> ChannelRead:
+def _channel_to_read(
+    channel: NotificationChannel,
+    *,
+    pending_delete_at: datetime | None = None,
+) -> ChannelRead:
     return ChannelRead(
         id=channel.id,
         watch_token_id=channel.watch_token_id,
@@ -202,6 +207,7 @@ def _channel_to_read(channel: NotificationChannel) -> ChannelRead:
         last_delivered_at=channel.last_delivered_at,
         created_at=channel.created_at,
         updated_at=channel.updated_at,
+        pending_delete_at=pending_delete_at,
     )
 
 
@@ -433,7 +439,14 @@ async def list_channels(
         )
         .order_by(NotificationChannel.created_at.desc())
     )
-    return [_channel_to_read(c) for c in result.scalars().all()]
+    channels = list(result.scalars().all())
+    pending = await pending_finalize_after_by_target(
+        db, token.system_id, PendingActionType.CHANNEL_DELETE
+    )
+    return [
+        _channel_to_read(c, pending_delete_at=pending.get(c.id))
+        for c in channels
+    ]
 
 
 @router.get("/channels", response_model=list[ChannelRead])
@@ -468,7 +481,14 @@ async def list_all_channels(
         )
         .order_by(NotificationChannel.created_at.desc())
     )
-    return [_channel_to_read(c) for c in result.scalars().all()]
+    channels = list(result.scalars().all())
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.CHANNEL_DELETE
+    )
+    return [
+        _channel_to_read(c, pending_delete_at=pending.get(c.id))
+        for c in channels
+    ]
 
 
 @router.get("/channels/{channel_id}", response_model=ChannelRead)
@@ -478,7 +498,15 @@ async def get_channel(
     db: AsyncSession = Depends(get_db),
 ) -> ChannelRead:
     channel = await _load_owned_channel(db, user, channel_id)
-    return _channel_to_read(channel)
+    # Resolve via the parent token's system; channel rows don't carry
+    # system_id directly.
+    token = await db.get(WatchToken, channel.watch_token_id)
+    pending: dict = {}
+    if token is not None:
+        pending = await pending_finalize_after_by_target(
+            db, token.system_id, PendingActionType.CHANNEL_DELETE
+        )
+    return _channel_to_read(channel, pending_delete_at=pending.get(channel.id))
 
 
 @router.patch(

--- a/sheaf/api/v1/polls.py
+++ b/sheaf/api/v1/polls.py
@@ -50,6 +50,7 @@ from sheaf.services.polls import (
 )
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -106,7 +107,12 @@ async def _get_owned_poll(
     return poll
 
 
-def _to_read(poll: Poll, *, now: datetime | None = None) -> PollRead:
+def _to_read(
+    poll: Poll,
+    *,
+    now: datetime | None = None,
+    pending_delete_at: datetime | None = None,
+) -> PollRead:
     now = now or datetime.now(UTC)
     visible = is_results_visible(poll, now=now)
     options = [
@@ -157,6 +163,7 @@ def _to_read(poll: Poll, *, now: datetime | None = None) -> PollRead:
         votes=votes,
         created_at=poll.created_at,
         updated_at=poll.updated_at,
+        pending_delete_at=pending_delete_at,
     )
 
 
@@ -179,7 +186,13 @@ async def list_polls(
         .order_by(Poll.created_at.desc())
     )
     now = datetime.now(UTC)
-    return [_to_read(p, now=now) for p in result.scalars().all()]
+    polls = list(result.scalars().all())
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.POLL_DELETE
+    )
+    return [
+        _to_read(p, now=now, pending_delete_at=pending.get(p.id)) for p in polls
+    ]
 
 
 @router.post(
@@ -274,7 +287,10 @@ async def get_poll(
 ):
     system = await _get_user_system(user, db)
     poll = await _get_owned_poll(poll_id, system, db)
-    return _to_read(poll)
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.POLL_DELETE
+    )
+    return _to_read(poll, pending_delete_at=pending.get(poll.id))
 
 
 @router.delete(

--- a/sheaf/api/v1/reminders.py
+++ b/sheaf/api/v1/reminders.py
@@ -8,6 +8,7 @@ permitted to manage reminders that ride those destinations.
 """
 
 import uuid
+from datetime import datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
@@ -39,6 +40,7 @@ from sheaf.services.reminders import (
 )
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -208,7 +210,9 @@ def _validate_trigger_config(
             ) from exc
 
 
-def _to_read(reminder: Reminder) -> ReminderRead:
+def _to_read(
+    reminder: Reminder, *, pending_delete_at: datetime | None = None
+) -> ReminderRead:
     decrypted = decrypt_for_read(reminder)
     return ReminderRead(
         id=reminder.id,
@@ -236,6 +240,7 @@ def _to_read(reminder: Reminder) -> ReminderRead:
         next_fire_at=decrypted["next_fire_at"],
         created_at=reminder.created_at,
         updated_at=reminder.updated_at,
+        pending_delete_at=pending_delete_at,
     )
 
 
@@ -257,7 +262,13 @@ async def list_reminders(
         .where(Reminder.system_id == system.id)
         .order_by(Reminder.created_at.desc())
     )
-    return [_to_read(r) for r in result.scalars().all()]
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.REMINDER_DELETE
+    )
+    return [
+        _to_read(r, pending_delete_at=pending.get(r.id))
+        for r in result.scalars().all()
+    ]
 
 
 @router.post(
@@ -326,7 +337,10 @@ async def get_reminder(
 ):
     system = await _get_user_system(user, db)
     reminder = await _get_owned_reminder(reminder_id, system, db)
-    return _to_read(reminder)
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.REMINDER_DELETE
+    )
+    return _to_read(reminder, pending_delete_at=pending.get(reminder.id))
 
 
 @router.patch(

--- a/sheaf/api/v1/tags.py
+++ b/sheaf/api/v1/tags.py
@@ -18,6 +18,7 @@ from sheaf.schemas.tag import TagCreate, TagMemberUpdate, TagRead, TagUpdate
 from sheaf.services.members import decrypt_member_for_read
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -42,7 +43,16 @@ async def list_tags(
     result = await db.execute(
         select(Tag).where(Tag.system_id == system.id).order_by(Tag.name)
     )
-    return result.scalars().all()
+    tags = list(result.scalars().all())
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.TAG_DELETE
+    )
+    out: list[TagRead] = []
+    for t in tags:
+        tr = TagRead.model_validate(t)
+        tr.pending_delete_at = pending.get(t.id)
+        out.append(tr)
+    return out
 
 
 @router.post(
@@ -77,7 +87,12 @@ async def get_tag(
     tag = result.scalar_one_or_none()
     if tag is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tag not found")
-    return tag
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.TAG_DELETE
+    )
+    tr = TagRead.model_validate(tag)
+    tr.pending_delete_at = pending.get(tag.id)
+    return tr
 
 
 @router.patch(

--- a/sheaf/api/v1/watch_tokens.py
+++ b/sheaf/api/v1/watch_tokens.py
@@ -24,6 +24,7 @@ from sheaf.schemas.notifications import (
 )
 from sheaf.services.system_safety import (
     is_safeguarded,
+    pending_finalize_after_by_target,
     queue_pending_action,
     verify_destructive_auth,
 )
@@ -42,7 +43,10 @@ async def _get_user_system(user: User, db: AsyncSession) -> System:
 
 
 async def _watch_token_to_read(
-    db: AsyncSession, token: WatchToken
+    db: AsyncSession,
+    token: WatchToken,
+    *,
+    pending_delete_at: datetime | None = None,
 ) -> WatchTokenRead:
     count_result = await db.execute(
         select(func.count())
@@ -57,6 +61,7 @@ async def _watch_token_to_read(
         created_at=token.created_at,
         updated_at=token.updated_at,
         channel_count=count_result.scalar_one(),
+        pending_delete_at=pending_delete_at,
     )
 
 
@@ -105,7 +110,13 @@ async def list_watch_tokens(
         .order_by(WatchToken.created_at.desc())
     )
     tokens = list(result.scalars().all())
-    return [await _watch_token_to_read(db, t) for t in tokens]
+    pending = await pending_finalize_after_by_target(
+        db, system.id, PendingActionType.WATCH_TOKEN_REVOKE
+    )
+    return [
+        await _watch_token_to_read(db, t, pending_delete_at=pending.get(t.id))
+        for t in tokens
+    ]
 
 
 async def _load_owned_token(
@@ -135,7 +146,12 @@ async def get_watch_token(
     db: AsyncSession = Depends(get_db),
 ) -> WatchTokenRead:
     token = await _load_owned_token(db, user, token_id)
-    return await _watch_token_to_read(db, token)
+    pending = await pending_finalize_after_by_target(
+        db, token.system_id, PendingActionType.WATCH_TOKEN_REVOKE
+    )
+    return await _watch_token_to_read(
+        db, token, pending_delete_at=pending.get(token.id)
+    )
 
 
 @router.patch(
@@ -154,7 +170,12 @@ async def update_watch_token(
         token.label = body.label
     await db.commit()
     await db.refresh(token)
-    return await _watch_token_to_read(db, token)
+    pending = await pending_finalize_after_by_target(
+        db, token.system_id, PendingActionType.WATCH_TOKEN_REVOKE
+    )
+    return await _watch_token_to_read(
+        db, token, pending_delete_at=pending.get(token.id)
+    )
 
 
 @router.delete(

--- a/sheaf/schemas/custom_field.py
+++ b/sheaf/schemas/custom_field.py
@@ -40,6 +40,8 @@ class CustomFieldRead(BaseModel):
     privacy: PrivacyLevel
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if queued for delete; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/schemas/front.py
+++ b/sheaf/schemas/front.py
@@ -77,5 +77,7 @@ class FrontRead(BaseModel):
     # Lets the UI grey out the history button on entries that have never
     # been edited, without making the recipient pay for a per-row fetch.
     has_audit_history: bool = False
+    # finalize_after timestamp if queued for delete; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}

--- a/sheaf/schemas/group.py
+++ b/sheaf/schemas/group.py
@@ -34,6 +34,8 @@ class GroupRead(BaseModel):
     parent_id: uuid.UUID | None
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if queued for delete; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/schemas/journal.py
+++ b/sheaf/schemas/journal.py
@@ -72,6 +72,8 @@ class JournalEntryRead(BaseModel):
     author_member_names: list[str]
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if queued for delete; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/schemas/message.py
+++ b/sheaf/schemas/message.py
@@ -49,6 +49,10 @@ class MessageRead(BaseModel):
     body: str
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if this message (or its thread) is queued
+    # for delete in System Safety's grace window; null otherwise. Unioned
+    # across MESSAGE_DELETE and MESSAGE_THREAD_DELETE pending actions.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/schemas/notifications.py
+++ b/sheaf/schemas/notifications.py
@@ -37,6 +37,9 @@ class WatchTokenRead(BaseModel):
     created_at: datetime
     updated_at: datetime
     channel_count: int = 0
+    # finalize_after timestamp if this token is queued for revoke in
+    # System Safety's grace window; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 
@@ -187,6 +190,8 @@ class ChannelRead(BaseModel):
     last_delivered_at: datetime | None
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if queued for delete; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/schemas/poll.py
+++ b/sheaf/schemas/poll.py
@@ -84,6 +84,8 @@ class PollRead(BaseModel):
 
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if queued for delete; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/schemas/reminder.py
+++ b/sheaf/schemas/reminder.py
@@ -137,5 +137,7 @@ class ReminderRead(BaseModel):
 
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if queued for delete; null otherwise.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}

--- a/sheaf/schemas/tag.py
+++ b/sheaf/schemas/tag.py
@@ -28,6 +28,10 @@ class TagRead(BaseModel):
     color: str | None
     created_at: datetime
     updated_at: datetime
+    # finalize_after timestamp if this tag is queued for delete in System
+    # Safety's grace window; null otherwise. Drives the pending-delete
+    # badge + dim styling in list views.
+    pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/web/src/components/journal-entry-card.tsx
+++ b/web/src/components/journal-entry-card.tsx
@@ -1,6 +1,8 @@
 import { Link } from "react-router";
 import { Card, CardContent } from "@/components/ui/card";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import { formatDateTime } from "@/lib/date-format";
+import { cn } from "@/lib/utils";
 import type { DateFormat, JournalEntry, Member } from "@/types/api";
 
 const SNIPPET_CHARS = 180;
@@ -33,7 +35,12 @@ export function JournalEntryCard({
 
   return (
     <Link to={`/journals/${entry.id}`} className="block">
-      <Card className="cursor-pointer transition-colors hover:bg-accent/50">
+      <Card
+        className={cn(
+          "cursor-pointer transition-colors hover:bg-accent/50",
+          entry.pending_delete_at && "opacity-60",
+        )}
+      >
         <CardContent className="space-y-1 p-4">
           <div className="flex flex-wrap items-baseline justify-between gap-2">
             <p className="font-medium truncate">{titleDisplay}</p>
@@ -56,6 +63,7 @@ export function JournalEntryCard({
           <p className="text-sm text-muted-foreground line-clamp-2">
             {snippet(entry.body) || "(empty)"}
           </p>
+          <PendingDeleteBadge finalizeAt={entry.pending_delete_at} />
         </CardContent>
       </Card>
     </Link>

--- a/web/src/components/notifications/watch-token-card.tsx
+++ b/web/src/components/notifications/watch-token-card.tsx
@@ -5,8 +5,10 @@ import { Pause, Play, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import {
   useChannels,
   useRevokeWatchToken,
@@ -63,7 +65,11 @@ export function WatchTokenCard({
   const isRevoked = token.revoked_at !== null;
 
   return (
-    <Card className={isRevoked ? "opacity-60" : ""}>
+    <Card
+      className={cn(
+        (isRevoked || token.pending_delete_at) && "opacity-60",
+      )}
+    >
       <CardContent className="space-y-4 p-5">
         <div className="flex items-center justify-between">
           <div>
@@ -75,6 +81,10 @@ export function WatchTokenCard({
               {(channels?.length ?? token.channel_count) === 1 ? "" : "s"}
               {isRevoked ? " · revoked" : ""}
             </p>
+            <PendingDeleteBadge
+              finalizeAt={token.pending_delete_at}
+              className="mt-1"
+            />
           </div>
           {!isRevoked && (
             <div className="flex gap-2">
@@ -175,7 +185,12 @@ function ChannelRow({ channel }: { channel: NotificationChannel }) {
     channel.destination_state === "disabled";
 
   return (
-    <div className="flex items-center justify-between rounded-md border bg-background px-3 py-2 hover:bg-accent/40 transition-colors">
+    <div
+      className={cn(
+        "flex items-center justify-between rounded-md border bg-background px-3 py-2 hover:bg-accent/40 transition-colors",
+        channel.pending_delete_at && "opacity-60",
+      )}
+    >
       <Link
         to={`/notifications/${channel.id}`}
         className="flex items-center gap-3 min-w-0 flex-1"
@@ -189,6 +204,10 @@ function ChannelRow({ channel }: { channel: NotificationChannel }) {
           <p className="text-xs text-muted-foreground">
             {destinationLabel(channel.destination_type)}
           </p>
+          <PendingDeleteBadge
+            finalizeAt={channel.pending_delete_at}
+            className="mt-1"
+          />
         </div>
       </Link>
       <div className="flex items-center gap-2 ml-2">

--- a/web/src/components/pending-action-row.tsx
+++ b/web/src/components/pending-action-row.tsx
@@ -12,6 +12,10 @@ const actionLabels: Record<PendingActionType, string> = {
   revision_unpin: "Unpin revision",
   watch_token_revoke: "Revoke watcher",
   channel_delete: "Delete notification channel",
+  reminder_delete: "Delete reminder",
+  poll_delete: "Delete poll",
+  message_delete: "Delete message",
+  message_thread_delete: "Delete message thread",
 };
 
 function timeRemaining(finalizeAfter: string): string {

--- a/web/src/components/settings/custom-fields-card.tsx
+++ b/web/src/components/settings/custom-fields-card.tsx
@@ -14,6 +14,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
+import { cn } from "@/lib/utils";
 import type { FieldType } from "@/types/api";
 
 export function CustomFieldsCard() {
@@ -116,11 +118,18 @@ export function CustomFieldsCard() {
             ) : (
               <div
                 key={f.id}
-                className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                className={cn(
+                  "flex items-center justify-between rounded-md border px-3 py-2 text-sm",
+                  f.pending_delete_at && "opacity-60",
+                )}
               >
                 <span className="cursor-pointer" onClick={() => startEdit(f)}>
                   {f.name}
                   <span className="ml-2 text-xs text-muted-foreground">{f.field_type}</span>
+                  <PendingDeleteBadge
+                    finalizeAt={f.pending_delete_at}
+                    className="ml-2"
+                  />
                 </span>
                 <Button
                   variant="ghost"

--- a/web/src/components/settings/tags-manager-card.tsx
+++ b/web/src/components/settings/tags-manager-card.tsx
@@ -9,6 +9,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
+import { cn } from "@/lib/utils";
+import { Clock } from "lucide-react";
+import { Link } from "react-router";
 
 export function TagsManagerCard() {
   const { data: tags } = useTags();
@@ -105,15 +108,32 @@ export function TagsManagerCard() {
               <Badge
                 key={t.id}
                 variant="outline"
-                className="cursor-pointer gap-1.5"
+                className={cn(
+                  "cursor-pointer gap-1.5",
+                  t.pending_delete_at && "opacity-60",
+                )}
                 onClick={() => startEdit(t)}
                 onContextMenu={(e) => {
                   e.preventDefault();
                   setDeletingTag({ id: t.id, name: t.name });
                 }}
+                title={
+                  t.pending_delete_at
+                    ? `Pending delete - finalises ${new Date(t.pending_delete_at).toLocaleString()}. Click to cancel in Safety.`
+                    : undefined
+                }
               >
                 <ColorDot color={t.color} />
                 {t.name}
+                {t.pending_delete_at && (
+                  <Link
+                    to="/settings/safety"
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label="Pending delete - manage in Safety"
+                  >
+                    <Clock className="ml-1 h-3 w-3 text-amber-600 dark:text-amber-400" />
+                  </Link>
+                )}
               </Badge>
             ),
           )}

--- a/web/src/components/settings/uploaded-files-card.tsx
+++ b/web/src/components/settings/uploaded-files-card.tsx
@@ -21,7 +21,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
-import { formatBytes } from "@/lib/utils";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
+import { cn, formatBytes } from "@/lib/utils";
+import { AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 
 /** In-app link for a reference target, or null if it isn't deep-linkable.
@@ -112,7 +114,15 @@ export function UploadedFilesCard() {
                   key={f.id}
                   type="button"
                   onClick={() => setSelected(f)}
-                  className="group relative aspect-square rounded-md border overflow-hidden text-left focus:outline-none focus:ring-2 focus:ring-ring"
+                  className={cn(
+                    "group relative aspect-square rounded-md border overflow-hidden text-left focus:outline-none focus:ring-2 focus:ring-ring",
+                    f.pending_delete_at && "opacity-60",
+                  )}
+                  title={
+                    f.pending_delete_at
+                      ? `Pending delete - finalises ${new Date(f.pending_delete_at).toLocaleString()}. Open to manage.`
+                      : undefined
+                  }
                 >
                   <img
                     src={f.url}
@@ -120,6 +130,14 @@ export function UploadedFilesCard() {
                     className="h-full w-full object-cover"
                   />
                   <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors" />
+                  {f.pending_delete_at && (
+                    <span
+                      className="absolute top-1 right-1 rounded-full bg-amber-500/90 p-0.5 text-white shadow"
+                      aria-label="Pending delete"
+                    >
+                      <AlertTriangle className="h-3 w-3" />
+                    </span>
+                  )}
                   <span className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[10px] px-1 py-0.5 truncate">
                     {f.purpose} · {formatBytes(f.size_bytes)}
                   </span>
@@ -194,6 +212,8 @@ function FileDetailDialog({
               className="max-h-48 w-auto rounded-md border mx-auto"
             />
 
+            <PendingDeleteBadge finalizeAt={file.pending_delete_at} />
+
             <div className="space-y-3">
               {isLoading && (
                 <p className="text-sm text-muted-foreground">
@@ -257,7 +277,16 @@ function FileDetailDialog({
             Close
           </Button>
           {file && (
-            <Button variant="destructive" onClick={() => onRequestDelete(file)}>
+            <Button
+              variant="destructive"
+              onClick={() => onRequestDelete(file)}
+              disabled={!!file.pending_delete_at}
+              title={
+                file.pending_delete_at
+                  ? "Already queued for deletion. Cancel from Settings -> Safety."
+                  : undefined
+              }
+            >
               Delete
             </Button>
           )}

--- a/web/src/lib/files.ts
+++ b/web/src/lib/files.ts
@@ -43,6 +43,10 @@ export interface UploadedFileInfo {
   content_type: string;
   size_bytes: number;
   created_at: string;
+  /** Pending-delete grace timestamp from System Safety; null when not
+   *  queued. Drives the warning marker on the thumbnail + full badge in
+   *  the file detail modal. */
+  pending_delete_at: string | null;
 }
 
 export function listFiles() {

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -31,8 +31,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { formatDateTime, timeAgo } from "@/lib/utils";
+import { cn, formatDateTime, timeAgo } from "@/lib/utils";
 import { getMySystem } from "@/lib/systems";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import type { Front } from "@/types/api";
 
 const HISTORY_PAGE_SIZES = [25, 50, 100] as const;
@@ -221,7 +222,10 @@ export function FrontsPage() {
               {current.map((front) => (
                 <div
                   key={front.id}
-                  className="rounded-md border p-3 space-y-2"
+                  className={cn(
+                    "rounded-md border p-3 space-y-2",
+                    front.pending_delete_at && "opacity-60",
+                  )}
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
@@ -237,6 +241,10 @@ export function FrontsPage() {
                           &ldquo;{front.custom_status}&rdquo;
                         </p>
                       )}
+                      <PendingDeleteBadge
+                        finalizeAt={front.pending_delete_at}
+                        className="mt-2"
+                      />
                     </div>
                     <div className="flex items-center gap-1 shrink-0">
                       <Button
@@ -349,7 +357,13 @@ export function FrontsPage() {
       ) : history && history.length > 0 ? (
         <div className="space-y-2">
           {history.map((front) => (
-            <div key={front.id} className="rounded-md border p-3 space-y-2">
+            <div
+              key={front.id}
+              className={cn(
+                "rounded-md border p-3 space-y-2",
+                front.pending_delete_at && "opacity-60",
+              )}
+            >
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
@@ -360,6 +374,10 @@ export function FrontsPage() {
                       &ldquo;{front.custom_status}&rdquo;
                     </p>
                   )}
+                  <PendingDeleteBadge
+                    finalizeAt={front.pending_delete_at}
+                    className="mt-2"
+                  />
                 </div>
                 <div className="flex items-center gap-3 text-sm text-muted-foreground shrink-0">
                   <span>

--- a/web/src/routes/groups.tsx
+++ b/web/src/routes/groups.tsx
@@ -13,8 +13,10 @@ import { PageHeader } from "@/components/page-header";
 import { ColorDot } from "@/components/color-dot";
 import { MemberSelect } from "@/components/member-select";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -131,12 +133,21 @@ export function GroupsPage() {
           {groups.map((g) => (
             <Card
               key={g.id}
-              className="cursor-pointer transition-colors hover:bg-accent/50"
+              className={cn(
+                "cursor-pointer transition-colors hover:bg-accent/50",
+                g.pending_delete_at && "opacity-60",
+              )}
               onClick={() => openEdit(g)}
             >
               <CardContent className="flex items-center gap-3 p-4">
                 <ColorDot color={g.color} className="h-4 w-4" />
-                <p className="font-medium">{g.name}</p>
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium">{g.name}</p>
+                  <PendingDeleteBadge
+                    finalizeAt={g.pending_delete_at}
+                    className="mt-1"
+                  />
+                </div>
               </CardContent>
             </Card>
           ))}

--- a/web/src/routes/messages.tsx
+++ b/web/src/routes/messages.tsx
@@ -38,6 +38,8 @@ import {
 } from "@/components/ui/dialog";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { PageHeader } from "@/components/page-header";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
@@ -548,9 +550,11 @@ function MessageRow({
 
   return (
     <div
-      className={`rounded-md border p-3 ${
-        isUnread ? "border-primary/60 bg-primary/5" : ""
-      }`}
+      className={cn(
+        "rounded-md border p-3",
+        isUnread && "border-primary/60 bg-primary/5",
+        msg.pending_delete_at && "opacity-60",
+      )}
     >
       {msg.parent_message_id && (
         <div className="mb-1 flex items-start gap-1 text-xs text-muted-foreground">
@@ -585,6 +589,10 @@ function MessageRow({
         </span>
       </div>
       <p className="mt-1 whitespace-pre-wrap text-sm">{msg.body}</p>
+      <PendingDeleteBadge
+        finalizeAt={msg.pending_delete_at}
+        className="mt-2"
+      />
       <div className="mt-2 flex gap-1">
         <Button size="sm" variant="ghost" onClick={onReply}>
           Reply

--- a/web/src/routes/polls.tsx
+++ b/web/src/routes/polls.tsx
@@ -13,6 +13,8 @@ import {
 } from "@/lib/polls";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { PageHeader } from "@/components/page-header";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -196,7 +198,12 @@ function PollSummaryCard({
   onDelete: () => void;
 }) {
   return (
-    <div className="rounded-md border p-4">
+    <div
+      className={cn(
+        "rounded-md border p-4",
+        poll.pending_delete_at && "opacity-60",
+      )}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <Link
@@ -228,6 +235,10 @@ function PollSummaryCard({
               {poll.total_votes} {poll.total_votes === 1 ? "vote" : "votes"}
             </span>
           </div>
+          <PendingDeleteBadge
+            finalizeAt={poll.pending_delete_at}
+            className="mt-2"
+          />
         </div>
         <Button
           size="icon"

--- a/web/src/routes/reminders.tsx
+++ b/web/src/routes/reminders.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/lib/reminders";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { PageHeader } from "@/components/page-header";
+import { PendingDeleteBadge } from "@/components/pending-delete-badge";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -225,7 +227,12 @@ function ReminderRow({
     ? new Date(reminder.next_fire_at).toLocaleString()
     : null;
   return (
-    <div className="rounded-md border p-4">
+    <div
+      className={cn(
+        "rounded-md border p-4",
+        reminder.pending_delete_at && "opacity-60",
+      )}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
@@ -247,6 +254,10 @@ function ReminderRow({
             via {channelName}
             {nextFire && ` · next ${nextFire}`}
           </p>
+          <PendingDeleteBadge
+            finalizeAt={reminder.pending_delete_at}
+            className="mt-2"
+          />
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <Button

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -163,6 +163,10 @@ export interface Front {
   // True iff at least one audit row exists for this front. Lets the UI
   // grey out the history button on entries that have never been edited.
   has_audit_history: boolean;
+  /** finalize_after timestamp if this front is in System Safety's
+   *  pending-delete grace queue; null otherwise. Drives the "Pending
+   *  delete" badge + dim styling in list views. */
+  pending_delete_at: string | null;
 }
 
 export interface FrontCreate {
@@ -205,6 +209,8 @@ export interface Reminder {
   next_fire_at: string | null;
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. */
+  pending_delete_at: string | null;
 }
 
 export interface ReminderCreate {
@@ -284,6 +290,8 @@ export interface Group {
   parent_id: string | null;
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. */
+  pending_delete_at: string | null;
 }
 
 export interface GroupCreate {
@@ -307,6 +315,8 @@ export interface Tag {
   color: string | null;
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. */
+  pending_delete_at: string | null;
 }
 
 export interface TagCreate {
@@ -331,6 +341,8 @@ export interface CustomField {
   privacy: PrivacyLevel;
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. */
+  pending_delete_at: string | null;
 }
 
 export interface CustomFieldCreate {
@@ -369,7 +381,11 @@ export type PendingActionType =
   | "image_delete"
   | "revision_unpin"
   | "watch_token_revoke"
-  | "channel_delete";
+  | "channel_delete"
+  | "reminder_delete"
+  | "poll_delete"
+  | "message_delete"
+  | "message_thread_delete";
 
 export type PendingActionStatus =
   | "pending"
@@ -493,6 +509,8 @@ export interface JournalEntry {
   author_member_names: string[];
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. */
+  pending_delete_at: string | null;
 }
 
 export interface JournalEntryWithCount extends JournalEntry {
@@ -606,6 +624,9 @@ export interface WatchToken {
   created_at: string;
   updated_at: string;
   channel_count: number;
+  /** Pending-revoke grace timestamp from System Safety; null when not
+   *  queued. Drives the "Pending delete" badge in the watchers list. */
+  pending_delete_at: string | null;
 }
 
 export interface WatchTokenCreate {
@@ -659,6 +680,8 @@ export interface NotificationChannel {
   last_delivered_at: string | null;
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. */
+  pending_delete_at: string | null;
 }
 
 export interface ChannelCreate {
@@ -789,6 +812,9 @@ export interface Message {
   body: string;
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. Unioned
+   *  across single-message and thread deletes. */
+  pending_delete_at: string | null;
 }
 
 export interface MessageCreate {
@@ -881,6 +907,8 @@ export interface Poll {
   votes: PollVote[] | null;
   created_at: string;
   updated_at: string;
+  /** Pending-delete grace timestamp; null when not queued. */
+  pending_delete_at: string | null;
 }
 
 export interface PollOptionCreate {


### PR DESCRIPTION
Extends the per-entity pending-delete surfacing started in #85 (which
covered members only) to the remaining entity types whose listings
could hide a queued System Safety delete from the user.

## Backend

Each list/GET endpoint now resolves the relevant pending action type
once per request via `pending_finalize_after_by_target` and threads
`pending_delete_at` into the read schema:

- Groups (`GROUP_DELETE`)
- Tags (`TAG_DELETE`)
- Custom fields (`FIELD_DELETE`)
- Reminders (`REMINDER_DELETE`)
- Fronts, current + history (`FRONT_DELETE`)
- Journal entries (`JOURNAL_DELETE`)
- Polls (`POLL_DELETE`)
- Board messages (`MESSAGE_DELETE` unioned with `MESSAGE_THREAD_DELETE`,
  since either type marks the same row for deletion)
- Watch tokens (`WATCH_TOKEN_REVOKE`)
- Notification channels (`CHANNEL_DELETE`)
- Uploaded images (`IMAGE_DELETE`)

## Frontend

`PendingDeleteBadge` + `opacity-60` dim integrated into the matching
list rows:

- Groups grid
- Fronts (current + history)
- Journal entry cards
- Poll summary card
- Reminder row
- Message row (badge below body)
- Watch-token card and channel row
- Settings: custom-fields list, tags list

Tags get a compact inline clock-icon link to `/settings/safety` rather
than a nested badge, since the existing chip layout does not fit a
sub-badge cleanly.

Uploaded images get an amber `AlertTriangle` marker in the thumbnail
corner plus a full badge in the detail modal. The modal's Delete
button is disabled while a delete is already queued, with a tooltip
pointing at Settings -> Safety, since requeuing would just produce a
duplicate pending action row.

`PendingActionType` (TS) and the `actionLabels` map on
`pending-action-row.tsx` pick up the four newer action variants
(`reminder_delete`, `poll_delete`, `message_delete`,
`message_thread_delete`) so the union stays exhaustive.

## Verification

- `ruff check sheaf/` clean
- `cd web && npx tsc --noEmit` clean
- `cd web && npm run lint` clean
- `pytest tests/test_groups_tags.py tests/test_fronts.py
  tests/test_polls_api.py tests/test_journals.py
  tests/test_reminders_api.py tests/test_messages.py
  tests/test_notifications_api.py tests/test_notifications_safety.py
  tests/test_files.py tests/test_system_safety.py` -> all green
  (149 tests across the touched endpoints + safety suite)
