### PR TITLE
Add cf-shield opt-out preference + shield-mode webhook + banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -431,6 +431,40 @@ REGISTRATION_MODE=open
 # CAPTCHA_ON_LOGIN=false
 
 # =============================================================================
+# Shield mode (Cloudflare break-glass DDoS posture)
+# =============================================================================
+# Off by default. Only relevant for operators running the cf-shield
+# break-glass script (a sheaf-infra utility that flips a Cloudflare
+# zone into under-attack mode and closes direct-origin SG ingress
+# during a DDoS incident). When enabled:
+#
+#   - Users see a "Refuse Cloudflare proxying (signs you out during
+#     mitigation)" toggle in Settings -> Account. Setting it has no
+#     immediate effect; the flag is consulted when the operator
+#     engages mitigation. Note this is NOT a bypass - opted-out users
+#     cannot reach Sheaf while mitigation is active, because the
+#     direct origin is closed.
+#   - The cf-shield script POSTs an HMAC-signed webhook to
+#     /v1/internal/shield-mode/state on the up and down edges. On the
+#     up edge, every user with the toggle on has their sessions
+#     revoked so their traffic does not unwittingly traverse the CDN.
+#   - GET /v1/shield-mode/status returns the current posture for
+#     mobile/API clients that want to honour the user's preference
+#     voluntarily.
+#
+# Leave SHIELD_MODE_ENABLED=false on instances that either never use
+# a CDN or always use a CDN (no break-glass posture, nothing to flip).
+# The user column persists either way, so flipping this on later does
+# not require a migration.
+# SHIELD_MODE_ENABLED=false
+#
+# HMAC shared secret with the cf-shield script. Required when
+# SHIELD_MODE_ENABLED=true (backend refuses to start otherwise).
+# Generate with `openssl rand -hex 32`. Must match the value the
+# script reads from SSM (cf. sheaf-infra).
+# SHIELD_MODE_WEBHOOK_SECRET=
+
+# =============================================================================
 # General
 # =============================================================================
 # Set to 0 in production behind a reverse proxy

--- a/alembic/versions/9706550595b1_add_users_disable_cdn_during_ddos_column.py
+++ b/alembic/versions/9706550595b1_add_users_disable_cdn_during_ddos_column.py
@@ -1,0 +1,38 @@
+"""Add users.disable_cdn_during_ddos column
+
+Revision ID: 9706550595b1
+Revises: l8m9n0o1p2q3
+Create Date: 2026-05-29
+
+Per-user opt-out flag for cf-shield mass-invalidation. When the operator
+engages cf-shield, users with this flag set have their sessions revoked
+so their traffic does not unwittingly traverse the Cloudflare CDN. The
+column is created unconditionally even on selfhost; instances that do
+not run cf-shield (settings.shield_mode_enabled=false) simply never
+read it.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "9706550595b1"
+down_revision = "l8m9n0o1p2q3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "disable_cdn_during_ddos",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "disable_cdn_during_ddos")

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -12,6 +12,12 @@ set -euo pipefail
 COMPOSE="docker compose -p sheaf-test -f docker-compose.yml -f docker-compose.test.yml"
 TEST_URL="http://localhost:8001"
 TEST_DB_URL="postgresql+asyncpg://sheaf:sheaftest@localhost:5433/sheaf"
+# Most tests drive Redis transitively (sessions, rate limits) via HTTP and
+# never touch it from the host. The shield-mode unit tests do though — they
+# call get_redis() directly to exercise the state machine and the mass-
+# invalidate pass. Expose the test stack's host-mapped Redis URL the same
+# way SHEAF_TEST_DB_URL is exposed so those tests work in CI.
+TEST_REDIS_URL="redis://localhost:6380/0"
 BUILD_FLAG="--build"
 FAILED=()
 
@@ -86,6 +92,7 @@ run_config() {
 
     if SHEAF_TEST_URL="$TEST_URL" \
        SHEAF_TEST_DB_URL="$TEST_DB_URL" \
+       SHEAF_TEST_REDIS_URL="$TEST_REDIS_URL" \
        SHEAF_TEST_ADMIN_AUTH_LEVEL="$admin_auth_level" \
        SHEAF_TEST_MODE="$sheaf_mode" \
        uv run --extra dev pytest "${pytest_args[@]}"; then

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -229,6 +229,7 @@ async def get_account_data(
             ),
             "email_soft_bounce_count": user.email_soft_bounce_count,
             "email_revalidation_required": user.email_revalidation_required,
+            "disable_cdn_during_ddos": user.disable_cdn_during_ddos,
         },
         "sessions": [
             {

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -1293,6 +1293,7 @@ async def get_me(user: User = Depends(get_current_user_allow_unverified)):
         newsletter_opt_in=user.newsletter_opt_in,
         email_delivery_status=user.email_delivery_status.value,
         email_revalidation_required=user.email_revalidation_required,
+        disable_cdn_during_ddos=user.disable_cdn_during_ddos,
         uploads_allowed=(
             user.is_admin or settings.allow_image_uploads or user.can_upload_images
         ),
@@ -1313,6 +1314,17 @@ async def update_me(
     if body.newsletter_opt_in is not None and body.newsletter_opt_in != user.newsletter_opt_in:
         user.newsletter_opt_in = body.newsletter_opt_in
         user.newsletter_opted_in_at = datetime.now(UTC) if body.newsletter_opt_in else None
+
+    if (
+        body.disable_cdn_during_ddos is not None
+        and body.disable_cdn_during_ddos != user.disable_cdn_during_ddos
+    ):
+        # Persist regardless of settings.shield_mode_enabled — the user
+        # may set the preference on a selfhost instance now and migrate
+        # to a SaaS deployment later, or vice versa. The flag is only
+        # acted on when the cf-shield script flips state, so it's a
+        # no-op on instances where the feature isn't wired.
+        user.disable_cdn_during_ddos = body.disable_cdn_during_ddos
 
     await db.commit()
     await db.refresh(user)
@@ -1338,6 +1350,7 @@ async def update_me(
         newsletter_opt_in=user.newsletter_opt_in,
         email_delivery_status=user.email_delivery_status.value,
         email_revalidation_required=user.email_revalidation_required,
+        disable_cdn_during_ddos=user.disable_cdn_during_ddos,
         uploads_allowed=(
             user.is_admin or settings.allow_image_uploads or user.can_upload_images
         ),

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -24,6 +24,7 @@ from sheaf.api.v1 import (
     reminders,
     retention,
     sheaf_import,
+    shield_mode,
     sp_import,
     system_safety,
     systems,
@@ -39,6 +40,12 @@ v1_router = APIRouter(prefix="/v1")
 
 # Public (no auth): build provenance for verifiability tooling.
 v1_router.include_router(version.router)
+
+# Shield mode: unauthenticated GET /status (clients poll voluntarily)
+# and HMAC-authenticated POST /internal/...state from the cf-shield
+# script. Both routes are dormant when settings.shield_mode_enabled is
+# false; the module guards itself.
+v1_router.include_router(shield_mode.router)
 
 # Auth, admin, announcements: no scope enforcement
 v1_router.include_router(auth.router)

--- a/sheaf/api/v1/shield_mode.py
+++ b/sheaf/api/v1/shield_mode.py
@@ -1,0 +1,112 @@
+"""Shield-mode endpoints.
+
+Two public-facing routes plus one internal webhook:
+
+  - `GET /v1/shield-mode/status`: unauthenticated, lightweight. Returns
+    the current `active` flag and (if known) the timestamp of the last
+    transition, plus a `feature_enabled` flag that the frontend uses to
+    decide whether to render the Privacy/Security toggle at all. Always
+    safe to call; cheap to poll from mobile clients that want to honor
+    their user's opt-out preference voluntarily.
+
+  - `POST /v1/internal/shield-mode/state`: HMAC-authenticated webhook
+    from the operator's cf-shield script. Body `{"active": bool}`. Only
+    accepted when `settings.shield_mode_enabled=true`; otherwise 404 so
+    the URL doesn't even appear to exist.
+
+The webhook is intentionally not behind `require_scope` - it isn't a
+user-facing action. Authentication is the HMAC signature alone, which
+the script computes from the raw body using a shared secret kept in
+SSM.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.config import settings
+from sheaf.database import get_db
+from sheaf.services.shield_mode import (
+    SIGNATURE_HEADER,
+    apply_transition,
+    get_state,
+    verify_signature,
+)
+
+logger = logging.getLogger("sheaf.shield_mode.api")
+
+router = APIRouter(tags=["shield mode"])
+
+
+class ShieldModeStatus(BaseModel):
+    """Public status payload.
+
+    `feature_enabled` mirrors the operator-side config and lets the
+    frontend hide the user-facing toggle on instances that aren't wired
+    to a cf-shield setup. `active` is always truthful regardless: it
+    reflects whatever Redis says, defaulting to false.
+    """
+
+    feature_enabled: bool
+    active: bool
+    since: str | None = None
+
+
+class ShieldModeTransitionRequest(BaseModel):
+    active: bool
+
+
+@router.get("/shield-mode/status", response_model=ShieldModeStatus)
+async def shield_mode_status() -> ShieldModeStatus:
+    if not settings.shield_mode_enabled:
+        # Truthful: feature is dormant, so by definition no shield is up.
+        return ShieldModeStatus(feature_enabled=False, active=False, since=None)
+    state = await get_state()
+    return ShieldModeStatus(
+        feature_enabled=True,
+        active=state.active,
+        since=state.since.isoformat() if state.since else None,
+    )
+
+
+@router.post(
+    "/internal/shield-mode/state",
+    response_model=ShieldModeStatus,
+)
+async def shield_mode_transition(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> ShieldModeStatus:
+    if not settings.shield_mode_enabled:
+        # Don't leak that the route exists at all when the feature is
+        # off. The script knows what configuration it expects.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    body = await request.body()
+    sig = request.headers.get(SIGNATURE_HEADER)
+    if not verify_signature(body, sig):
+        # Generic 401 - don't distinguish "missing header" from
+        # "wrong digest" so a probe can't fingerprint the secret.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid signature",
+        )
+
+    try:
+        parsed = ShieldModeTransitionRequest.model_validate_json(body)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Malformed body: {exc}",
+        ) from exc
+
+    new_state = await apply_transition(active=parsed.active, db=db)
+    return ShieldModeStatus(
+        feature_enabled=True,
+        active=new_state.active,
+        since=new_state.since.isoformat() if new_state.since else None,
+    )

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -460,6 +460,20 @@ class Settings(BaseSettings):
     s3_export_endpoint: str = ""
     s3_export_presign_endpoint: str = ""
 
+    # Shield mode (Cloudflare break-glass DDoS posture).
+    # When enabled, the operator's cf-shield script POSTs to
+    # /v1/internal/shield-mode/state to flip Sheaf's view of shield
+    # state. Users with disable_cdn_during_ddos=true get their sessions
+    # invalidated on the up edge so they don't unwittingly traverse the
+    # CDN. Default off so selfhosters without a Cloudflare break-glass
+    # setup never see the toggle in their UI and never have to think
+    # about the webhook.
+    shield_mode_enabled: bool = False
+    # HMAC shared secret with the cf-shield script. Required when
+    # shield_mode_enabled is true; ignored otherwise. Used to verify
+    # the webhook signature on /v1/internal/shield-mode/state.
+    shield_mode_webhook_secret: str = ""
+
     # Server
     sheaf_port: int = 8000
     sheaf_host: str = "0.0.0.0"
@@ -583,6 +597,15 @@ def _validate_settings() -> None:
             "REGISTRATION_MODE=approval with EMAIL_BACKEND=none — "
             "users won't receive notification when approved. Consider configuring email."
         )
+
+    if settings.shield_mode_enabled and not settings.shield_mode_webhook_secret:
+        logger.critical(
+            "SHIELD_MODE_ENABLED=true but SHIELD_MODE_WEBHOOK_SECRET is not set. "
+            "The cf-shield script needs a shared HMAC secret to authenticate the "
+            "state-flip webhook. Generate one with `openssl rand -hex 32` and set "
+            "it in both the backend env and the operator's SSM parameter."
+        )
+        sys.exit(1)
 
     if settings.sheaf_mode == SheafMode.SAAS and problems:
         logger.critical("REFUSING TO START IN SAAS MODE WITH INSECURE DEFAULTS:")

--- a/sheaf/models/user.py
+++ b/sheaf/models/user.py
@@ -142,6 +142,21 @@ class User(UUIDMixin, TimestampMixin, Base):
         Boolean, default=False, nullable=False, server_default="false"
     )
 
+    # Shield-mode opt-out. When the operator engages cf-shield (Cloudflare
+    # under-attack + revoked direct-origin SG ingress), every login on the
+    # SaaS necessarily routes through the CDN. Users who explicitly do not
+    # want their traffic proxied by Cloudflare set this flag; on the up
+    # edge their sessions are invalidated so they cannot unwittingly
+    # traverse the CDN. They are bounced to login (also CDN-fronted) and
+    # will not be able to authenticate again until shield mode clears.
+    # The flag has no effect on instances that don't have a Cloudflare
+    # break-glass setup (settings.shield_mode_enabled=false), but the
+    # column always exists so selfhosters don't need a conditional
+    # migration.
+    disable_cdn_during_ddos: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+
     # Relationships
     system: Mapped["System"] = relationship(back_populates="user", uselist=False)
     api_keys: Mapped[list["ApiKey"]] = relationship(

--- a/sheaf/schemas/user.py
+++ b/sheaf/schemas/user.py
@@ -62,6 +62,12 @@ class UserRead(BaseModel):
     newsletter_opt_in: bool = False
     email_delivery_status: str = "ok"
     email_revalidation_required: bool = False
+    # When the operator engages cf-shield (Cloudflare under-attack mode),
+    # users with this flag set have their sessions invalidated so their
+    # traffic does not unwittingly traverse the CDN. Always present in
+    # the response; the frontend hides the toggle unless the instance
+    # reports shield_mode feature_enabled=true via /v1/shield-mode/status.
+    disable_cdn_during_ddos: bool = False
     # Effective permission — True if global uploads are on, the user is an
     # admin, or the user is individually allowlisted.
     uploads_allowed: bool = True
@@ -77,6 +83,7 @@ class UserRead(BaseModel):
 
 class UserUpdate(BaseModel):
     newsletter_opt_in: bool | None = None
+    disable_cdn_during_ddos: bool | None = None
 
 
 class TOTPSetupResponse(BaseModel):

--- a/sheaf/services/shield_mode.py
+++ b/sheaf/services/shield_mode.py
@@ -1,0 +1,179 @@
+"""Shield-mode state machine + opt-out enforcement.
+
+When the operator runs `cf-shield up`, the script POSTs to
+`POST /v1/internal/shield-mode/state` with an HMAC-signed body. The
+endpoint forwards the parsed `active` flag here, which:
+
+  - Persists `{active, since}` in Redis so other backend code (e.g.
+    the status endpoint, the login flow, future banners) can read it
+    without round-tripping Cloudflare.
+  - On the up edge specifically, runs the mass-invalidate pass: every
+    user with `User.disable_cdn_during_ddos=true` has all of their
+    sessions deleted via the existing `delete_all_user_sessions`
+    primitive. They cannot reach the API afterwards without re-auth,
+    and the re-auth itself is gated by shield mode (CDN + UAM
+    challenge), so the opt-out is effectively enforced for the
+    duration of the incident.
+
+Redis is acceptable transient storage here. If the key is lost
+mid-shield, the worst case is opted-out users could log back in
+through the CDN challenge until either the backend restarts (no
+shield-state knowledge) or the script re-sends `up`. The CF side is
+the source of truth; the script can be re-run safely.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.sessions import delete_all_user_sessions, get_redis
+from sheaf.config import settings
+from sheaf.models.user import User
+
+logger = logging.getLogger("sheaf.shield_mode")
+
+_STATE_KEY = "sheaf:shield_mode:state"
+
+# Signature header convention mirrors webhook auth elsewhere in the
+# codebase (X-Sheaf-Signature on the notification-channel webhook). The
+# script computes `hex(hmac_sha256(secret, body))` and the receiver
+# rejects on mismatch with constant-time compare.
+SIGNATURE_HEADER = "X-Sheaf-Signature"
+
+
+@dataclass(frozen=True)
+class ShieldState:
+    active: bool
+    # ISO-8601 timestamp of the most recent transition. None if we have
+    # no record (Redis was flushed, or shield has never been engaged).
+    since: datetime | None
+
+
+async def get_state() -> ShieldState:
+    """Read the current shield state from Redis. Default off if unset."""
+    r = await get_redis()
+    raw = await r.get(_STATE_KEY)
+    if not raw:
+        return ShieldState(active=False, since=None)
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        # Corrupted state - treat as off rather than crashing the
+        # status endpoint. The next `up` from the script will overwrite.
+        logger.warning("shield_mode: failed to parse state %r, treating as off", raw)
+        return ShieldState(active=False, since=None)
+    since_raw = parsed.get("since")
+    since = datetime.fromisoformat(since_raw) if since_raw else None
+    return ShieldState(active=bool(parsed.get("active", False)), since=since)
+
+
+async def _write_state(state: ShieldState) -> None:
+    r = await get_redis()
+    payload = json.dumps(
+        {
+            "active": state.active,
+            "since": state.since.isoformat() if state.since else None,
+        }
+    )
+    # No TTL - we want this to persist across container restarts. The
+    # cf-shield script owns the lifecycle; if Redis loses the key, the
+    # next operator action re-syncs.
+    await r.set(_STATE_KEY, payload)
+
+
+async def apply_transition(*, active: bool, db: AsyncSession) -> ShieldState:
+    """Set shield to `active` and run the side-effects of any transition.
+
+    Idempotent: re-posting `up` while already up is a no-op (no second
+    invalidation pass, no `since` rewrite). Returns the resulting state.
+    """
+    current = await get_state()
+    now = datetime.now(UTC)
+
+    if active == current.active:
+        # No transition - leave `since` alone so the timestamp reflects
+        # the original engagement, not the most recent ping.
+        return current
+
+    new_state = ShieldState(active=active, since=now)
+    await _write_state(new_state)
+
+    if active:
+        # Up edge: run the mass-invalidate pass. Anything that fails
+        # here is logged but does not roll back the state flip - the
+        # operator-side reality is that CF is already in under-attack
+        # mode, so the state is correct even if we couldn't kick a
+        # particular user.
+        revoked = await _invalidate_opted_out_users(db)
+        logger.warning(
+            "shield_mode: engaged at %s, invalidated %d opted-out user(s)",
+            now.isoformat(),
+            revoked,
+        )
+    else:
+        logger.warning("shield_mode: disengaged at %s", now.isoformat())
+
+    return new_state
+
+
+async def _invalidate_opted_out_users(db: AsyncSession) -> int:
+    """Delete sessions for every user with disable_cdn_during_ddos=true.
+
+    Returns the count of users whose sessions were touched (not the
+    count of sessions; one user may have multiple). The existing
+    `delete_all_user_sessions` returns the per-user session count which
+    we sum and log for visibility.
+    """
+    result = await db.execute(
+        select(User.id).where(User.disable_cdn_during_ddos.is_(True))
+    )
+    user_ids: list[uuid.UUID] = [row[0] for row in result]
+
+    if not user_ids:
+        return 0
+
+    total_sessions = 0
+    for user_id in user_ids:
+        try:
+            total_sessions += await delete_all_user_sessions(user_id)
+        except Exception:
+            # Don't let one user's stuck Redis pipeline starve the rest.
+            logger.exception(
+                "shield_mode: failed to invalidate sessions for user %s", user_id
+            )
+
+    logger.info(
+        "shield_mode: revoked %d session(s) across %d opted-out user(s)",
+        total_sessions,
+        len(user_ids),
+    )
+    return len(user_ids)
+
+
+def verify_signature(body: bytes, header_value: str | None) -> bool:
+    """Constant-time HMAC verification of the webhook body.
+
+    `body` is the raw request body bytes (FastAPI exposes this via
+    `await request.body()`). `header_value` is the X-Sheaf-Signature
+    header (hex digest). Returns False on any structural problem -
+    missing secret, missing header, wrong length - so callers can 401
+    uniformly.
+    """
+    secret = settings.shield_mode_webhook_secret
+    if not secret:
+        return False
+    if not header_value:
+        return False
+    expected = hmac.new(
+        secret.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, header_value.strip())

--- a/tests/test_shield_mode.py
+++ b/tests/test_shield_mode.py
@@ -1,0 +1,299 @@
+"""Tests for shield-mode (cf-shield opt-out + webhook).
+
+Two layers:
+
+1. HTTP integration against the test stack — covers the dormant path
+   (settings.shield_mode_enabled=false) since that's how the test
+   container is configured. Verifies the status endpoint, the user
+   PATCH for the opt-out flag, and that the internal webhook is 404
+   when the feature is off.
+
+2. Unit-style tests against the service module — directly exercise
+   HMAC verification, state transitions, and the mass-invalidate pass
+   without depending on the FastAPI process having shield mode wired.
+   Monkey-patch `settings.shield_mode_webhook_secret` for HMAC tests
+   so we don't have to spin up a second container config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import os
+import uuid
+
+import httpx
+import pytest
+
+
+def _register(client: httpx.Client) -> tuple[str, str, str]:
+    """Register a fresh user; return (email, password, access_token)."""
+    email = f"shield-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    resp = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert resp.status_code == 201
+    return email, password, resp.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level: feature dormant on the test stack
+# ---------------------------------------------------------------------------
+
+
+def test_status_endpoint_reports_feature_disabled(client: httpx.Client) -> None:
+    """When shield_mode_enabled is false the status endpoint says so
+    and reports active=false. No auth required."""
+    resp = client.get("/v1/shield-mode/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["feature_enabled"] is False
+    assert body["active"] is False
+    assert body["since"] is None
+
+
+def test_internal_webhook_404_when_feature_disabled(client: httpx.Client) -> None:
+    """The internal webhook must not even appear to exist when the
+    feature is off; a probe gets a flat 404 rather than a hint."""
+    resp = client.post(
+        "/v1/internal/shield-mode/state",
+        json={"active": True},
+        headers={"X-Sheaf-Signature": "deadbeef"},
+    )
+    assert resp.status_code == 404
+
+
+def test_user_can_set_opt_out_flag(client: httpx.Client) -> None:
+    """The opt-out preference persists regardless of feature_enabled.
+    Selfhosters can flip it now and have it honored if they later
+    migrate to an instance that runs cf-shield."""
+    email, _, token = _register(client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    initial = client.get("/v1/auth/me", headers=auth).json()
+    assert initial["disable_cdn_during_ddos"] is False
+
+    patched = client.patch(
+        "/v1/auth/me",
+        headers=auth,
+        json={"disable_cdn_during_ddos": True},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["disable_cdn_during_ddos"] is True
+
+    # Round-trip via a fresh GET to confirm persistence.
+    refreshed = client.get("/v1/auth/me", headers=auth).json()
+    assert refreshed["disable_cdn_during_ddos"] is True
+
+
+def test_account_export_includes_opt_out_field(client: httpx.Client) -> None:
+    """Article-15 account dump surfaces the new preference too. POST
+    /v1/account/data is the right endpoint (it requires a password
+    confirm; we hand it the registration password)."""
+    email, password, token = _register(client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    client.patch(
+        "/v1/auth/me",
+        headers=auth,
+        json={"disable_cdn_during_ddos": True},
+    )
+
+    resp = client.post(
+        "/v1/account/data",
+        headers=auth,
+        json={"password": password},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["account"]["disable_cdn_during_ddos"] is True
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: service module exercised directly
+# ---------------------------------------------------------------------------
+
+
+def test_verify_signature_constant_time_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sheaf.config import settings
+    from sheaf.services.shield_mode import verify_signature
+
+    monkeypatch.setattr(settings, "shield_mode_webhook_secret", "topsecret")
+    body = b'{"active": true}'
+    good = hmac.new(b"topsecret", body, hashlib.sha256).hexdigest()
+    bad = "00" * 32
+
+    assert verify_signature(body, good) is True
+    assert verify_signature(body, bad) is False
+    assert verify_signature(body, None) is False
+    assert verify_signature(body, "") is False
+
+
+def test_verify_signature_refuses_when_secret_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty secret should never accept a signature, even an empty one.
+    Prevents a foot-gun where a misconfigured deploy would silently
+    accept anything."""
+    from sheaf.config import settings
+    from sheaf.services.shield_mode import verify_signature
+
+    monkeypatch.setattr(settings, "shield_mode_webhook_secret", "")
+    body = b"{}"
+    assert verify_signature(body, "") is False
+    assert verify_signature(body, hmac.new(b"", body, hashlib.sha256).hexdigest()) is False
+
+
+def _async_db_session():
+    """Build an AsyncSession bound to the test DB. Yields a session;
+    caller closes it. Mirrors the pattern in test_system_safety.py."""
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from sheaf.config import settings
+
+    db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+    engine = create_async_engine(db_url)
+    session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    return engine, session
+
+
+def _reset_redis_singleton() -> None:
+    """`sheaf.auth.sessions` caches the Redis client in a module global
+    bound to whatever event loop first touched it. asyncio.run() makes
+    a fresh loop per call, so the cached client points at a closed
+    loop on the second call. Reset before each test that builds its
+    own loop."""
+    import sheaf.auth.sessions as sessions_mod
+
+    sessions_mod._redis = None
+
+
+def test_apply_transition_clears_redis_state_after_down() -> None:
+    """A down transition writes active=false. A subsequent up writes
+    active=true with a fresh `since`. Re-applying the same state is a
+    no-op (since does not get rewritten)."""
+    from sheaf.services.shield_mode import (
+        ShieldState,
+        _write_state,
+        apply_transition,
+        get_state,
+    )
+
+    _reset_redis_singleton()
+
+    async def _run() -> None:
+        engine, session = _async_db_session()
+        try:
+            # Clear any leftover state from a previous test.
+            await _write_state(ShieldState(active=False, since=None))
+            async with session() as db:
+                up = await apply_transition(active=True, db=db)
+                assert up.active is True
+                first_since = up.since
+                assert first_since is not None
+
+                # Re-apply up: idempotent.
+                still_up = await apply_transition(active=True, db=db)
+                assert still_up.active is True
+                assert still_up.since == first_since
+
+                # Down clears.
+                down = await apply_transition(active=False, db=db)
+                assert down.active is False
+
+                # Confirm get_state reads what was written.
+                read = await get_state()
+                assert read.active is False
+        finally:
+            # Leave Redis in a clean state for the next test.
+            await _write_state(ShieldState(active=False, since=None))
+            await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_mass_invalidate_only_touches_opted_out_users() -> None:
+    """An up transition deletes sessions for users with the flag set
+    and leaves everyone else's sessions alone."""
+    from sqlalchemy import select
+
+    from sheaf.auth.sessions import (
+        create_session,
+        get_session_info,
+    )
+    from sheaf.crypto import blind_index
+    from sheaf.models.user import User
+    from sheaf.services.shield_mode import (
+        ShieldState,
+        _write_state,
+        apply_transition,
+    )
+
+    _reset_redis_singleton()
+
+    # Two fresh users — one opted out, one not. Register via HTTP so
+    # everything (encryption keys, blind index) goes through the
+    # normal flow.
+    with httpx.Client(base_url=os.environ["SHEAF_TEST_URL"]) as client:
+        opted_email = f"shield-opt-{uuid.uuid4().hex[:8]}@sheaf.dev"
+        stay_email = f"shield-stay-{uuid.uuid4().hex[:8]}@sheaf.dev"
+        client.post(
+            "/v1/auth/register",
+            json={"email": opted_email, "password": "testpassword123"},
+        )
+        client.post(
+            "/v1/auth/register",
+            json={"email": stay_email, "password": "testpassword123"},
+        )
+
+    async def _run() -> str:
+        engine, session = _async_db_session()
+        try:
+            await _write_state(ShieldState(active=False, since=None))
+
+            # Mint a session for each user directly so we have something
+            # to invalidate without going through login.
+            async with session() as db:
+                opted = (
+                    await db.execute(
+                        select(User).where(User.email_hash == blind_index(opted_email))
+                    )
+                ).scalar_one()
+                stay = (
+                    await db.execute(
+                        select(User).where(User.email_hash == blind_index(stay_email))
+                    )
+                ).scalar_one()
+                opted.disable_cdn_during_ddos = True
+                await db.commit()
+                opted_sid = await create_session(
+                    opted.id, user_agent="pytest", ip="127.0.0.1"
+                )
+                stay_sid = await create_session(
+                    stay.id, user_agent="pytest", ip="127.0.0.1"
+                )
+
+                await apply_transition(active=True, db=db)
+
+            # Opted-out session should be gone, the other intact.
+            opted_present = await get_session_info(opted_sid) is not None
+            stay_present = await get_session_info(stay_sid) is not None
+            return (
+                f"opted_sid={opted_sid} present={opted_present}, "
+                f"stay_sid={stay_sid} present={stay_present}"
+            )
+        finally:
+            await _write_state(ShieldState(active=False, since=None))
+            await engine.dispose()
+
+    summary = asyncio.run(_run())
+    assert "opted_sid=" in summary
+    # Parse: opted should be gone, stay should remain. Format above.
+    parts = dict(p.split(" present=") for p in summary.split(", "))
+    opted_present = parts[next(k for k in parts if k.startswith("opted_sid="))]
+    stay_present = parts[next(k for k in parts if k.startswith("stay_sid="))]
+    assert opted_present == "False", f"opted-out session should be revoked: {summary}"
+    assert stay_present == "True", f"non-opted-out session should remain: {summary}"

--- a/tests/test_shield_mode.py
+++ b/tests/test_shield_mode.py
@@ -171,7 +171,26 @@ def _reset_redis_singleton() -> None:
     sessions_mod._redis = None
 
 
-def test_apply_transition_clears_redis_state_after_down() -> None:
+def _patch_redis_url_for_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point `settings.redis_url` at the test stack's host-mapped port.
+
+    The default redis_url is `redis://redis:6379/0`, which only resolves
+    from inside the docker-compose network. Tests that exercise the
+    Redis client directly (rather than going through the HTTP app) need
+    the host-port-mapped URL instead. run_tests.sh exports this as
+    SHEAF_TEST_REDIS_URL; when invoked manually, the default falls back
+    to the compose convention (localhost:6380)."""
+    from sheaf.config import settings
+
+    test_redis_url = (
+        os.environ.get("SHEAF_TEST_REDIS_URL") or "redis://localhost:6380/0"
+    )
+    monkeypatch.setattr(settings, "redis_url", test_redis_url)
+
+
+def test_apply_transition_clears_redis_state_after_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A down transition writes active=false. A subsequent up writes
     active=true with a fresh `since`. Re-applying the same state is a
     no-op (since does not get rewritten)."""
@@ -182,6 +201,7 @@ def test_apply_transition_clears_redis_state_after_down() -> None:
         get_state,
     )
 
+    _patch_redis_url_for_host(monkeypatch)
     _reset_redis_singleton()
 
     async def _run() -> None:
@@ -215,7 +235,9 @@ def test_apply_transition_clears_redis_state_after_down() -> None:
     asyncio.run(_run())
 
 
-def test_mass_invalidate_only_touches_opted_out_users() -> None:
+def test_mass_invalidate_only_touches_opted_out_users(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """An up transition deletes sessions for users with the flag set
     and leaves everyone else's sessions alone."""
     from sqlalchemy import select
@@ -232,6 +254,7 @@ def test_mass_invalidate_only_touches_opted_out_users() -> None:
         apply_transition,
     )
 
+    _patch_redis_url_for_host(monkeypatch)
     _reset_redis_singleton()
 
     # Two fresh users — one opted out, one not. Register via HTTP so

--- a/web/src/components/announcement-banners.tsx
+++ b/web/src/components/announcement-banners.tsx
@@ -146,9 +146,14 @@ function AnnouncementBanner({
     >
       <Icon className={cn("mt-0.5 h-4 w-4 shrink-0", config.iconColor)} />
       <div className={cn("flex-1 min-w-0", config.text)}>
-        <span className="font-medium">{announcement.title}</span>
+        <span className="font-semibold">{announcement.title}</span>
         {announcement.body && (
-          <span className="ml-1.5">{announcement.body}</span>
+          <>
+            <span className="mx-2 opacity-50" aria-hidden="true">
+              ·
+            </span>
+            <span className="opacity-90">{announcement.body}</span>
+          </>
         )}
       </div>
       {announcement.dismissible && (

--- a/web/src/components/settings/privacy-card.tsx
+++ b/web/src/components/settings/privacy-card.tsx
@@ -1,0 +1,84 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/hooks/use-auth";
+import { updateMe } from "@/lib/auth";
+import { getShieldModeStatus } from "@/lib/shield-mode";
+
+/** Privacy/security toggles that don't fit the Account card. Currently
+ *  one knob: refuse Cloudflare proxying during cf-shield mitigation
+ *  (sign-out, not bypass - origin is closed during the event so the
+ *  user cannot reach Sheaf at all until mitigation lifts). The card
+ *  only renders
+ *  when the instance reports `feature_enabled` on /v1/shield-mode/status
+ *  - selfhosters without a Cloudflare break-glass setup never see it.
+ *
+ *  When more privacy preferences land (e.g. analytics opt-out, future
+ *  client-side telemetry toggles), they slot in here. */
+export function PrivacyCard() {
+  const { user, refreshUser } = useAuth();
+  const { data: shieldStatus } = useQuery({
+    queryKey: ["shield-mode-status"],
+    queryFn: getShieldModeStatus,
+    // Refetch on focus is enough; this is a low-traffic status read.
+    refetchOnWindowFocus: true,
+    staleTime: 30_000,
+  });
+
+  const cdnToggle = useMutation({
+    mutationFn: (disable_cdn_during_ddos: boolean) =>
+      updateMe({ disable_cdn_during_ddos }),
+    onSuccess: async () => {
+      await refreshUser();
+      toast.success("Preference saved");
+    },
+    onError: () => toast.error("Failed to save preference"),
+  });
+
+  if (!shieldStatus?.feature_enabled) {
+    // Dormant feature - don't render the card at all rather than show
+    // a toggle that does nothing visible to the user.
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Privacy</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="disable-cdn-during-ddos"
+            checked={user?.disable_cdn_during_ddos ?? false}
+            onCheckedChange={(v) => cdnToggle.mutate(v === true)}
+            disabled={cdnToggle.isPending}
+          />
+          <div>
+            <Label
+              htmlFor="disable-cdn-during-ddos"
+              className="text-sm font-medium cursor-pointer"
+            >
+              Refuse Cloudflare proxying (signs you out during
+              mitigation)
+            </Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              When the operator engages DDoS mitigation, traffic is
+              temporarily routed through Cloudflare and the direct
+              origin is closed. Enabling this means your sessions are
+              ended the moment mitigation is engaged, and you cannot
+              sign back in until mitigation clears. Sheaf is
+              effectively unreachable to you for the duration. Choose
+              this if you would rather wait out the incident than have
+              your traffic proxied through Cloudflare. Has no effect
+              outside an active mitigation window.
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/shield-mode-banner.tsx
+++ b/web/src/components/shield-mode-banner.tsx
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { severityConfig } from "@/components/banner-severity";
+import { getShieldModeStatus } from "@/lib/shield-mode";
+import { cn } from "@/lib/utils";
+
+/** Top-of-app banner shown while the operator has cf-shield engaged.
+ *
+ *  Only logged-in users with their session still alive ever see this:
+ *  by definition, anyone with `disable_cdn_during_ddos=true` has just
+ *  been bounced to login when the operator flipped state, so the
+ *  audience for the banner is the people for whom the CDN is doing
+ *  its job. The banner is purely informational - it tells them why
+ *  responses might feel a bit different (challenge interstitials,
+ *  slower TLS handshakes through the CF edge) and that things are
+ *  expected to return to normal once mitigation lifts.
+ *
+ *  Renders null when feature is dormant or shield is inactive, so it
+ *  is safe to drop into the layout unconditionally. */
+export function ShieldModeBanner() {
+  const { data } = useQuery({
+    queryKey: ["shield-mode-status"],
+    queryFn: getShieldModeStatus,
+    // Poll while a session is live so the banner clears within a
+    // minute of the operator running `cf-shield down`. Backend cost is
+    // a single Redis GET per call.
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  if (!data?.feature_enabled || !data.active) return null;
+
+  const config = severityConfig.warning;
+  const Icon = config.icon;
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 border-b px-4 py-2 text-sm",
+        config.bg,
+        config.border,
+      )}
+    >
+      <Icon className={cn("h-4 w-4 shrink-0", config.iconColor)} />
+      <span className={cn("flex-1 min-w-0", config.text)}>
+        DDoS mitigation is active. Traffic is currently routed via
+        Cloudflare. Sheaf is otherwise operating normally.
+      </span>
+    </div>
+  );
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -38,7 +38,10 @@ export function register(
   });
 }
 
-export function updateMe(update: { newsletter_opt_in?: boolean }) {
+export function updateMe(update: {
+  newsletter_opt_in?: boolean;
+  disable_cdn_during_ddos?: boolean;
+}) {
   return apiFetch<User>("/v1/auth/me", {
     method: "PATCH",
     body: JSON.stringify(update),

--- a/web/src/lib/shield-mode.ts
+++ b/web/src/lib/shield-mode.ts
@@ -1,0 +1,13 @@
+import { apiFetch } from "@/lib/api-client";
+import type { ShieldModeStatus } from "@/types/api";
+
+/** Fetch the instance's shield-mode posture.
+ *
+ *  Unauthenticated; safe to call from any context. `feature_enabled`
+ *  reflects the operator-side config and tells the UI whether to
+ *  render the Privacy/Security toggle. `active` is true only while
+ *  cf-shield is engaged.
+ */
+export function getShieldModeStatus() {
+  return apiFetch<ShieldModeStatus>("/v1/shield-mode/status");
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "@/contexts/auth-context";
+import { ShieldModeBanner } from "@/components/shield-mode-banner";
 import { Toaster } from "@/components/ui/sonner";
 import { router } from "@/routes";
 import "./index.css";
@@ -20,6 +21,12 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
+        {/* Pinned above everything (including the login/register pages
+            and the authed app header) so a DDoS-mitigation banner is
+            visible regardless of route. Non-dismissable: it renders
+            null when the feature is off or shield is inactive, so the
+            unconditional mount is safe. */}
+        <ShieldModeBanner />
         <RouterProvider router={router} />
         <Toaster />
       </AuthProvider>

--- a/web/src/routes/settings/account.tsx
+++ b/web/src/routes/settings/account.tsx
@@ -1,12 +1,14 @@
 import { AccountInfoCard } from "@/components/settings/account-info-card";
 import { ApiKeysCard } from "@/components/settings/api-keys-card";
 import { ActiveSessionsCard } from "@/components/settings/active-sessions-card";
+import { PrivacyCard } from "@/components/settings/privacy-card";
 import { TrustedDevicesCard } from "@/components/settings/trusted-devices-card";
 
 export function SettingsAccountPage() {
   return (
     <>
       <AccountInfoCard />
+      <PrivacyCard />
       <ApiKeysCard />
       <ActiveSessionsCard />
       <TrustedDevicesCard />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -23,9 +23,23 @@ export interface User {
   newsletter_opt_in: boolean;
   email_delivery_status: "ok" | "soft_bouncing" | "hard_bounced" | "complained";
   email_revalidation_required: boolean;
+  /** When the operator engages cf-shield, sessions for users with this
+   *  flag set are invalidated so their traffic does not unwittingly
+   *  traverse the Cloudflare CDN. Persisted regardless of whether the
+   *  instance has shield_mode_enabled - the UI hides the toggle when
+   *  the feature is dormant. */
+  disable_cdn_during_ddos: boolean;
   uploads_allowed: boolean;
   bio_uploads_allowed: boolean;
   external_images_allowed: boolean;
+}
+
+/** Public payload from GET /v1/shield-mode/status. `feature_enabled`
+ *  drives whether the Privacy/Security toggle is rendered at all. */
+export interface ShieldModeStatus {
+  feature_enabled: boolean;
+  active: boolean;
+  since: string | null;
 }
 
 export interface ApiKey {


### PR DESCRIPTION
Backend + frontend of the cf-shield opt-out feature. Operator-side script + secrets-provisioning work is deployed separately and is not required for this change to land - the backend tolerates the script being unaware of the new endpoint, in which case shield mode just never goes active from the backend's perspective.

## Concept

cf-shield is the operator-side break-glass that flips the SaaS deployment from grey-cloud to Cloudflare-proxied under-attack mode +revokes the direct-origin SG ingress during a DDoS. Some users do not want their traffic proxied through Cloudflare under any circumstances.

This PR gives those users a preference (`disable_cdn_during_ddos`) that the operator's script can act on: when cf-shield engages, the script POSTs an HMAC-signed webhook to the backend, which iterates opted-out users and revokes all of their sessions. They cannot sign back in until mitigation clears - the direct origin is closed, so they effectively wait out the incident. Truthful trade-off; the UI copy makes that explicit.

Self-hosters and CDN-always operators never see the toggle. The whole feature is gated behind `SHIELD_MODE_ENABLED`; the user column exists unconditionally so no migration is needed if an instance flips the setting on later.

## Backend

- `SHIELD_MODE_ENABLED` (bool, default false) and   `SHIELD_MODE_WEBHOOK_SECRET` (string) added to `sheaf/config.py`  with a startup validator that exits 1 if the flag is true but the  secret is empty.
- `User.disable_cdn_during_ddos` column added by migration  `9706550595b1` (server_default false).
- `sheaf/services/shield_mode.py` holds the Redis state machine  (`sheaf:shield_mode:state`), HMAC verification, and the mass-invalidation pass that calls the existing `delete_all_user_sessions` primitive for every opted-out user.
- `sheaf/api/v1/shield_mode.py` exposes `GET /v1/shield-mode/status` (unauthenticated, always-truthful `{feature_enabled, active, since}`) and `POST /v1/internal/shield-mode/state` (HMAC-authenticated body `{active: bool}`, 404 when the feature flag is off so probes can't fingerprint the route).
- `PATCH /v1/auth/me` accepts the new field; `GET /v1/auth/me` and the Article-15 dump in `account.py` surface it.

## Frontend

- `web/src/types/api.ts` extended with `disable_cdn_during_ddos` on  `User` and a new `ShieldModeStatus` interface.
- `web/src/lib/auth.ts` `updateMe()` accepts the new field.
- `web/src/lib/shield-mode.ts` (new) wraps the status endpoint.
- `web/src/components/settings/privacy-card.tsx` (new) renders the toggle when `feature_enabled` is true, with explanatory copy that is blunt about the trade-off (signed out + cannot sign back in until mitigation clears). Slotted into Settings > Account between the existing Account info and API keys cards.
- `web/src/components/shield-mode-banner.tsx` (new) mounts in `main.tsx` above the router output so it shows on every route, authed and public, with no dismiss UI. Renders null when the feature is dormant or shield is inactive.
- `web/src/components/announcement-banners.tsx`: title/body got a stronger weight contrast + a middle-dot separator so the two pieces no longer read as a single run-on sentence.

## Tests

`tests/test_shield_mode.py` (8 tests, all passing):

- Dormant HTTP path: status endpoint reports `feature_enabled=false`, webhook 404s, user can still PATCH the opt-out flag, Article-15 dump surfaces it.
- HMAC: good signature accepted, bad/missing/empty rejected, empty-secret refuses even a matching signature.
- State machine: idempotent up/up + down, `since` preserved on re-apply, fresh value on flip.
- Mass invalidate: only opted-out users' sessions are revoked; an opted-in user's session remains intact.

## Verification

- `ruff check sheaf/` clean
- `cd web && npx tsc --noEmit` clean
- `cd web && npm run lint` clean
- `pytest tests/test_shield_mode.py` 8/8 pass
- Full backend smoke (`test_auth.py + test_system_safety.py +
  test_account_export_completeness.py + test_shield_mode.py`):
  80 pass + 1 skip, no regressions

## Not in this PR

- Operator-side script changes (the cf-shield script's webhook call, the new shared-secret SSM parameter, the operator playbook update) are handled separately 
- API auto-logout for opted-out users (a future enhancement; would add a per-request middleware that 401s opted-out users while shield is active). Filed but not in scope here.
