### PR TITLE
Release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-05-30
+
+### Added
+
+- **Opt-out of CDN proxying during DDoS mitigation.** A new Privacy toggle in Settings -> Account lets users refuse Cloudflare proxying when the operator engages DDoS mitigation. When set, the user's sessions are ended the moment mitigation engages; they cannot sign back in until mitigation clears (the direct origin is closed for the duration of the incident). The toggle only renders on instances where the operator has wired the feature via `SHIELD_MODE_ENABLED` and a webhook secret. A new public `GET /v1/shield-mode/status` endpoint exposes the current posture for API and mobile clients that want to honour the preference voluntarily. While mitigation is active, a non-dismissable banner appears across every page (logged-in or not) explaining that traffic is currently routed through the CDN.
+- **Pending-delete badges across every listing.** Members, groups, tags, custom fields, fronts (current and history), journal entries, polls, board messages, watch tokens, notification channels, and uploaded images now show a "Pending delete" badge and dim styling whenever they're sitting in System Safety's grace window for deletion. Uploaded images additionally get a corner warning marker on the thumbnail; the detail modal's Delete button is disabled while a delete is already queued, with a tooltip pointing to Settings -> Safety where the queued action can be cancelled.
+
+### Changed
+
+- **Announcement banner readability.** The title and body of an announcement banner now use stronger weight contrast and a middle-dot separator so the two pieces no longer read as a single run-on sentence.
+
+### Fixed
+
+- **Notification outbox no longer grows unbounded.** Delivered notification rows are now swept on a regular schedule so the outbox table stays bounded over time; previously they accumulated indefinitely with no cleanup.
+
 ## [0.2.3] - 2026-05-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sheaf"
-version = "0.2.3"
+version = "0.2.4"
 description = "Open-source plural system tracking"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1546,7 +1546,7 @@ wheels = [
 
 [[package]]
 name = "sheaf"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
         "@tailwindcss/typography": "^0.5.19",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release v0.2.4. See `CHANGELOG.md` for the full notes; highlights:

- **Opt-out of CDN proxying during DDoS mitigation.** New Privacy toggle in Settings -> Account; sessions end on mitigation engage for opted-out users. Gated behind `SHIELD_MODE_ENABLED` + a webhook secret so dormant instances see nothing. Public status endpoint at `/v1/shield-mode/status` for mobile/API clients. Non-dismissable banner across every route while mitigation is active.
- **Pending-delete badges on every entity listing.** Members, groups, tags, custom fields, fronts, journals, polls, board messages, watch tokens, notification channels, and uploaded images. Uploaded images also get a thumbnail warning marker plus disabled Delete in the detail modal while a delete is queued.
- **Announcement banner readability fix.** Title + body now have proper weight contrast and a separator so they don't read as a run-on sentence.
- **Notification outbox cleanup sweep.** Delivered rows no longer accumulate indefinitely.

## Verification

- `ruff check sheaf/` clean
- `cd web && npx tsc --noEmit` clean
- `cd web && npm run lint` clean
- Full backend suite green on the cf-shield branch CI run prior to merge (run 26676350173).
- Version bumped in `pyproject.toml`, `uv.lock` (sheaf block), `web/package.json`, `web/package-lock.json` (both top-level and `packages.""`), and a new dated section added to `CHANGELOG.md`.

## After merge

Per the release runbook:
1. Squash-merge this PR; main moves forward by one commit.
2. Tag the squashed merge commit with `git tag -s v0.2.4 -m "v0.2.4"` and push the tag separately (`git push origin v0.2.4`).
