### PR TITLE
Trusted devices: name at create time, client_name column, immediate last_used_at

### DIFF
--- a/alembic/versions/a9d15deeee25_add_client_name_to_trusted_devices.py
+++ b/alembic/versions/a9d15deeee25_add_client_name_to_trusted_devices.py
@@ -1,0 +1,42 @@
+"""Add trusted_devices.client_name column
+
+Revision ID: a9d15deeee25
+Revises: 9706550595b1
+Create Date: 2026-05-30
+
+Friendly client identifier (e.g. "Sheaf Android", "Firefox") for
+trusted-device rows, mirroring the same field on sessions. Populated
+at mint time from X-Sheaf-Client when supplied, otherwise parsed from
+user_agent. The Settings -> Account "Trusted devices" listing reads
+this instead of guessing from user_agent each render, which lets the
+mobile app identify itself properly without the listing falling back
+to the okhttp default UA.
+
+Server-default empty string so existing rows backfill cleanly; the
+list endpoint re-parses user_agent for those.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "a9d15deeee25"
+down_revision = "9706550595b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trusted_devices",
+        sa.Column(
+            "client_name",
+            sa.String(length=64),
+            nullable=False,
+            server_default="",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("trusted_devices", "client_name")

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -872,11 +872,17 @@ async def login(
         and user.totp_enabled
         and not bypassed_via_trusted_device
     ):
+        from sheaf.auth.sessions import _parse_client_name
+
+        ua = request.headers.get("user-agent", "")
+        client_header = request.headers.get("x-sheaf-client")
         device_token, _ = await mint_trusted_device(
             db,
             user.id,
-            user_agent=request.headers.get("user-agent", ""),
+            user_agent=ua,
             ip=client_ip(request),
+            nickname=body.device_nickname,
+            client_name=_parse_client_name(ua, client_header),
         )
         await db.commit()
         response.set_cookie(
@@ -1090,11 +1096,18 @@ async def get_trusted_devices(
         from sheaf.auth.trusted_devices import _hash_token
 
         current_hash = _hash_token(trusted_cookie)
+    # Legacy rows have client_name="" (server-default backfill from the
+    # migration). For those, re-parse user_agent on the fly so the UI
+    # still shows something better than "Unknown". New rows always
+    # populate client_name at mint time and are returned as-is.
+    from sheaf.auth.sessions import _parse_client_name
+
     return [
         {
             "id": str(d.id),
             "nickname": d.nickname,
             "user_agent": d.user_agent,
+            "client_name": d.client_name or _parse_client_name(d.user_agent),
             "created_at": d.created_at,
             "created_ip": d.created_ip,
             "last_used_at": d.last_used_at,

--- a/sheaf/auth/trusted_devices.py
+++ b/sheaf/auth/trusted_devices.py
@@ -42,20 +42,35 @@ async def mint_trusted_device(
     user_agent: str,
     ip: str | None,
     nickname: str | None = None,
+    client_name: str = "",
 ) -> tuple[str, TrustedDevice]:
     """Create a new trusted-device row and return (raw_token, row).
 
     The caller sets the cookie with the raw token; the DB only ever sees
     the HMAC.
+
+    `client_name` is the parsed/friendly client identifier (the same
+    string sessions store), supplied by the caller after consulting
+    X-Sheaf-Client and falling back to a User-Agent parse. Stored
+    verbatim on the row so the trusted-devices list can show a clean
+    label without re-parsing on every render.
+
+    `last_used_at` is seeded to the same moment as creation so the row
+    reads as "last used: just now" in the UI right after minting,
+    rather than blank until the next login.
     """
     token = secrets.token_urlsafe(32)
-    expires_at = datetime.now(UTC) + timedelta(days=TRUSTED_DEVICE_TTL_DAYS)
+    now = datetime.now(UTC)
+    expires_at = now + timedelta(days=TRUSTED_DEVICE_TTL_DAYS)
     device = TrustedDevice(
         user_id=user_id,
         token_hash=_hash_token(token),
         nickname=nickname,
         user_agent=user_agent[:500],
+        client_name=client_name[:64],
         created_ip=ip,
+        last_used_at=now,
+        last_used_ip=ip,
         expires_at=expires_at,
     )
     db.add(device)

--- a/sheaf/models/trusted_device.py
+++ b/sheaf/models/trusted_device.py
@@ -28,6 +28,16 @@ class TrustedDevice(UUIDMixin, TimestampMixin, Base):
     )
     nickname: Mapped[str | None] = mapped_column(String(128), nullable=True)
     user_agent: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+    # Friendly client identifier (e.g. "Sheaf Android", "Firefox") set at
+    # mint time from X-Sheaf-Client when supplied, otherwise parsed from
+    # user_agent via the same _parse_client_name() helper sessions use.
+    # Lets the trusted-devices list show "Sheaf Android" instead of the
+    # raw "okhttp/4.12.0" the mobile SDK sends by default. Empty string
+    # for legacy rows from before this field existed; the list endpoint
+    # falls back to re-parsing user_agent in that case.
+    client_name: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="", server_default="",
+    )
     created_ip: Mapped[str | None] = mapped_column(String(45), nullable=True)
     last_used_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True,

--- a/sheaf/schemas/user.py
+++ b/sheaf/schemas/user.py
@@ -18,6 +18,11 @@ class UserLogin(BaseModel):
     totp_code: str | None = None
     captcha: str | None = None
     remember_device: bool = False
+    # Optional friendly label for the trusted-device row when
+    # `remember_device=true`. Empty / unset = the row shows as
+    # unnamed in Settings -> Account until the user renames it
+    # there. Capped at 128 chars at write time.
+    device_nickname: str | None = None
 
 
 class TokenResponse(BaseModel):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1070,6 +1070,93 @@ def test_list_and_revoke_trusted_device(client: httpx.Client):
     assert r.status_code == 401
 
 
+def test_trusted_device_populates_client_name_and_initial_last_used(
+    client: httpx.Client,
+):
+    """Three fixes in one round-trip:
+
+    1. `client_name` is populated at mint time, from X-Sheaf-Client when
+       the request supplies it (so the mobile app shows up as 'Sheaf
+       Android' instead of okhttp/4.12.0).
+    2. `last_used_at` is set to creation time on insert, not left null
+       until the next login.
+    3. The optional `device_nickname` on the login body becomes the
+       row's nickname so users can name the device at create time
+       rather than only via the rename endpoint.
+    """
+    email = f"rd-fixes-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    token = _register_and_login(client, email, password)
+    client.headers["Authorization"] = f"Bearer {token}"
+    totp = _enrol_totp(client)
+
+    r = client.post(
+        "/v1/auth/login",
+        json={
+            "email": email,
+            "password": password,
+            "totp_code": totp.now(),
+            "remember_device": True,
+            "device_nickname": "Mara's phone",
+        },
+        headers={"X-Sheaf-Client": "Sheaf Android/1.0.0"},
+    )
+    assert r.status_code == 200, r.text
+    cookie = r.cookies.get("sheaf_trusted_device")
+    assert cookie
+
+    r = client.get(
+        "/v1/auth/trusted-devices",
+        cookies={"sheaf_trusted_device": cookie},
+    )
+    assert r.status_code == 200, r.text
+    devices = r.json()
+    assert len(devices) == 1
+    d = devices[0]
+    assert d["nickname"] == "Mara's phone"
+    assert d["client_name"] == "Sheaf Android/1.0.0"
+    # last_used_at is populated immediately, not left null until reuse.
+    assert d["last_used_at"] is not None
+
+
+def test_trusted_device_client_name_falls_back_to_user_agent_parse(
+    client: httpx.Client,
+):
+    """When X-Sheaf-Client is not supplied (older clients), client_name
+    falls back to a User-Agent parse. Firefox is the canary because it's
+    cleanly identifiable in the UA."""
+    email = f"rd-ua-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    password = "testpassword123"
+    token = _register_and_login(client, email, password)
+    client.headers["Authorization"] = f"Bearer {token}"
+    totp = _enrol_totp(client)
+
+    r = client.post(
+        "/v1/auth/login",
+        json={
+            "email": email,
+            "password": password,
+            "totp_code": totp.now(),
+            "remember_device": True,
+        },
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 "
+                "Firefox/128.0"
+            ),
+        },
+    )
+    assert r.status_code == 200, r.text
+    cookie = r.cookies.get("sheaf_trusted_device")
+
+    r = client.get(
+        "/v1/auth/trusted-devices",
+        cookies={"sheaf_trusted_device": cookie},
+    )
+    devices = r.json()
+    assert devices[0]["client_name"] == "Firefox"
+
+
 def test_change_password_revokes_other_sessions(client: httpx.Client):
     email = f"chpw-rev-{uuid.uuid4().hex[:8]}@sheaf.dev"
     password = "oldpassword123"

--- a/web/src/components/settings/trusted-devices-card.tsx
+++ b/web/src/components/settings/trusted-devices-card.tsx
@@ -110,7 +110,7 @@ export function TrustedDevicesCard() {
                     className="inline-flex items-center gap-1 font-medium hover:text-muted-foreground transition-colors"
                     onClick={() => startEdit(d)}
                   >
-                    {d.nickname || d.user_agent.slice(0, 60) || "Device"}
+                    {d.nickname || d.client_name || "Device"}
                     <Pencil className="h-3 w-3 text-muted-foreground" />
                   </button>
                 )}
@@ -120,9 +120,17 @@ export function TrustedDevicesCard() {
                   </Badge>
                 )}
               </div>
-              {d.nickname && editingId !== d.id && (
+              {/* Always show client_name + user_agent as the secondary
+                  line. When the device has a custom nickname, this is
+                  the only place the actual client/UA shows; when it
+                  doesn't, the nickname slot above already shows
+                  client_name, but the UA detail below remains useful
+                  for telling apart e.g. two Firefox profiles. */}
+              {editingId !== d.id && (
                 <p className="text-xs text-muted-foreground truncate">
-                  {d.user_agent}
+                  {d.nickname && d.client_name
+                    ? `${d.client_name} · ${d.user_agent}`
+                    : d.user_agent}
                 </p>
               )}
               <p className="text-xs text-muted-foreground">

--- a/web/src/contexts/auth-context.tsx
+++ b/web/src/contexts/auth-context.tsx
@@ -13,6 +13,7 @@ interface AuthState {
     totp_code?: string,
     captcha?: string,
     remember_device?: boolean,
+    device_nickname?: string,
   ) => Promise<void>;
   register: (
     email: string,
@@ -81,9 +82,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       totp_code?: string,
       captcha?: string,
       remember_device?: boolean,
+      device_nickname?: string,
     ) => {
       const tokens = await authApi.login(
-        email, password, totp_code, captcha, remember_device,
+        email,
+        password,
+        totp_code,
+        captcha,
+        remember_device,
+        device_nickname,
       );
       // Drop any cached query data from a prior session before fetching the
       // new user, in case a previous logout was skipped (silent token expiry).

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -54,6 +54,7 @@ export function login(
   totp_code?: string,
   captcha?: string,
   remember_device?: boolean,
+  device_nickname?: string,
 ) {
   return apiFetch<TokenResponse>("/v1/auth/login", {
     method: "POST",
@@ -64,6 +65,7 @@ export function login(
       ...(totp_code ? { totp_code } : {}),
       ...(captcha ? { captcha } : {}),
       ...(remember_device ? { remember_device } : {}),
+      ...(device_nickname ? { device_nickname } : {}),
     }),
   });
 }
@@ -188,6 +190,12 @@ export function getSessions() {
 export interface TrustedDevice {
   id: string;
   nickname: string | null;
+  /** Friendly client identifier, e.g. "Sheaf Android", "Firefox".
+   *  Populated at mint time from X-Sheaf-Client when supplied; falls
+   *  back to a User-Agent parse for legacy rows (and on the server
+   *  side, for rows that pre-date the column). Prefer this in the UI
+   *  over user_agent. */
+  client_name: string;
   user_agent: string;
   created_at: string;
   created_ip: string | null;

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -28,6 +28,7 @@ export function LoginPage() {
   const [totpCode, setTotpCode] = useState("");
   const [needs2FA, setNeeds2FA] = useState(false);
   const [rememberDevice, setRememberDevice] = useState(false);
+  const [deviceNickname, setDeviceNickname] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [config, setConfig] = useState<AuthConfig | null>(null);
@@ -59,6 +60,7 @@ export function LoginPage() {
           totpCode || undefined,
           loginCaptcha || undefined,
           rememberDevice,
+          rememberDevice ? deviceNickname.trim() || undefined : undefined,
         );
       } else {
         await register(
@@ -149,19 +151,30 @@ export function LoginPage() {
                       autoFocus
                     />
                   </div>
-                  <div className="flex items-start gap-3">
-                    <Checkbox
-                      id="login-remember"
-                      checked={rememberDevice}
-                      onCheckedChange={(v) => setRememberDevice(v === true)}
-                    />
-                    <Label
-                      htmlFor="login-remember"
-                      className="text-sm font-normal leading-snug cursor-pointer"
-                    >
-                      Trust this device for 30 days. Skip the 2FA prompt on
-                      this browser until then.
-                    </Label>
+                  <div className="space-y-2">
+                    <div className="flex items-start gap-3">
+                      <Checkbox
+                        id="login-remember"
+                        checked={rememberDevice}
+                        onCheckedChange={(v) => setRememberDevice(v === true)}
+                      />
+                      <Label
+                        htmlFor="login-remember"
+                        className="text-sm font-normal leading-snug cursor-pointer"
+                      >
+                        Trust this device for 30 days. Skip the 2FA prompt on
+                        this browser until then.
+                      </Label>
+                    </div>
+                    {rememberDevice && (
+                      <Input
+                        id="login-device-nickname"
+                        value={deviceNickname}
+                        onChange={(e) => setDeviceNickname(e.target.value)}
+                        placeholder="Device name (optional)"
+                        maxLength={128}
+                      />
+                    )}
                   </div>
                 </>
               )}


### PR DESCRIPTION
Three user-facing trusted-device fixes plus the prep for the Android app to identify itself properly.

## Bugs

1. **`last_used_at` was null until the next login.** Now stamped at mint time, so a freshly-added device reads as "Last used just now" in the Settings -> Account list instead of "Not yet used".

2. **No way to name a device at create time.** `UserLogin` now accepts an optional `device_nickname`; the login endpoint plumbs it through to `mint_trusted_device`. The web login form shows an inline text input under the "Remember this device" checkbox the moment it's checked.

3. **Android trusted-device row showed `okhttp/4.12.0`** because the app uses okhttp's default User-Agent and the trusted-devices list was rendering raw `user_agent`. Backend now mirrors the same pattern sessions use: new `client_name` column on `trusted_devices`, populated from `X-Sheaf-Client` at mint time (with the same `_parse_client_name` fallback the session create path uses). The list endpoint returns `client_name`; legacy rows (server-default backfill = `""`) get a parse-from-`user_agent` fallback in the response builder so they still surface something meaningful.

## Frontend

- Login form: nickname input slides in under the "Remember this device" checkbox when it's checked. Empty stays empty.
- Trusted-devices card: primary label is `nickname || client_name` (was `nickname || user_agent.slice(0,60)`); secondary line shows `client_name · user_agent` when a custom nickname is set, otherwise just the UA.
- `lib/auth.ts`: `login()` takes an optional sixth `device_nickname` arg; `TrustedDevice` interface picks up the new `client_name` field.
- `contexts/auth-context.tsx`: the wrapped login function relays the new arg so callers don't need to import authApi directly.

## What this PR does NOT fix

The Android app still sends `okhttp/4.12.0` as User-Agent and no `X-Sheaf-Client` header. Until it does, the backend's new `client_name` column receives the same okhttp fallback and the list will show "Unknown" for the mobile entries. The fix is a single okhttp Interceptor on the app side that sets both headers to `Sheaf Android/<versionName>`. Filed as a separate follow-up for the mobile-app side; no further backend work needed once the app ships it.

## Verification

- `ruff check sheaf/` clean
- `cd web && npx tsc --noEmit` clean
- `cd web && npm run lint` clean
- Migration `a9d15deeee25` adds the column with `server_default=""`; the existing trusted-device tests (4) all pass, plus two new ones covering all three fixes: `test_trusted_device_populates_client_name_and_initial_last_used` and `test_trusted_device_client_name_falls_back_to_user_agent_parse`.
- Full `tests/test_auth.py` + `tests/test_account_lockout.py` run: 50 passed, 1 skipped.
