### PR TITLE
Isolate test stack from developer .env

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,14 @@ services:
       dockerfile: Dockerfile.backend
     ports: !override
       - "8001:8000"
+    # Clear the env_file inherited from the base compose so the test
+    # stack does not pick up whatever the developer has in their .env
+    # (e.g. SHIELD_MODE_ENABLED, FCM credentials, captcha keys). The
+    # CI test stack has no .env at all, so any reliance on inheritance
+    # creates a silent localdev-vs-CI divergence. Test config lives
+    # only in this file's `environment:` block + the run_tests.sh
+    # exports.
+    env_file: !override []
     environment:
       DATABASE_URL: postgresql+asyncpg://sheaf:sheaftest@db:5432/sheaf
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
The test stack composes from `docker-compose.yml` + `docker-compose.test.yml`. The base file has `env_file: .env` (with `required: false`) so any variable in a developer's `.env` flows through to the test container, unless the override file's `environment:` block explicitly clobbers it. That's been the case since the test stack was built, but it only bit recently when `SHIELD_MODE_ENABLED` was added to `.env` for cf-shield smoketesting and silently flipped the feature on inside the test container. CI saw default-off, localdev saw enabled, and the dormant-path shield-mode tests failed locally while staying green on CI.

Fix is one line: clear the inherited `env_file` via `env_file: !override []` on the app service in `docker-compose.test.yml`. The test stack now only sees what the override file's `environment:` block declares plus the per-config exports `run_tests.sh` sets, reproducibly, regardless of what the developer has in `.env`. CI behaviour unchanged (CI never had a `.env` to begin with, so this is a no-op there).

#90 added a runtime skip for the same symptom; that's now defensive code that just never triggers, which is fine. Decided against ripping it out in this PR because it's harmless and protects against the same class of bug recurring with a different env var.

## Verification

- Test stack rebuilt with the change: `GET /v1/shield-mode/status` reports `feature_enabled=false` despite `.env` containing `SHIELD_MODE_ENABLED=true`. Without the fix, same probe returned `feature_enabled=true`.
- `tests/test_shield_mode.py` (8 tests) passes without invoking #90's runtime-skip path, on a stack where `.env` would have flipped the feature on.
- Broader regression sweep: `tests/test_auth.py` + `test_system_safety.py` + `test_account_lockout.py` + `test_account_export_completeness.py` + `test_files.py` + `test_shield_mode.py` = 105 passed, 1 skipped.
