### PR TITLE
Web: palette catalog, dark/system/light mode, sync toggle

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark" style="color-scheme: dark">
+<html lang="en" class="dark" style="color-scheme: dark" data-palette="classic">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -29,11 +29,26 @@
     />
     <meta name="twitter:image" content="/og-image.png" />
     <script>
-      // Apply saved theme before first paint to avoid flash
+      // Apply saved theme + palette before first paint to avoid flash.
+      // Default mode = dark, default palette = classic; matches the
+      // look the app shipped with before the picker existed.
+      // Backend-synced values are applied later (after auth + fetch);
+      // this script only resolves localStorage so the very first paint
+      // never flashes the wrong colours on browsers that have a local
+      // pick.
       (function() {
-        var t = localStorage.getItem("sheaf_theme") || "dark";
-        document.documentElement.classList.toggle("dark", t === "dark");
-        document.documentElement.style.colorScheme = t;
+        var mode = localStorage.getItem("sheaf_theme") || "dark";
+        var palette = localStorage.getItem("sheaf_palette") || "classic";
+        var dark;
+        if (mode === "system") {
+          dark = window.matchMedia
+            && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        } else {
+          dark = mode === "dark";
+        }
+        document.documentElement.classList.toggle("dark", dark);
+        document.documentElement.style.colorScheme = dark ? "dark" : "light";
+        document.documentElement.setAttribute("data-palette", palette);
       })();
     </script>
   </head>

--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -1,11 +1,11 @@
 import { NavLink } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
-import { useTheme } from "@/hooks/use-theme";
 import { useCurrentFronts } from "@/hooks/use-fronts";
 import { getUnread } from "@/lib/messages";
 import { Button } from "@/components/ui/button";
 import { Logo } from "@/components/logo";
+import { ThemeModeToggle } from "@/components/theme-mode-toggle";
 import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
@@ -14,8 +14,6 @@ import {
   FolderOpen,
   Settings,
   LogOut,
-  Sun,
-  Moon,
   Shield,
   BookOpen,
   Bell,
@@ -64,7 +62,6 @@ export function AppSidebar({
   onMobileClose?: () => void;
 }) {
   const { user, logout } = useAuth();
-  const { theme, toggleTheme } = useTheme();
 
   // Pick the first fronting member as the perspective for unread counts.
   // If no one is fronting, skip the query - badge stays hidden.
@@ -116,19 +113,7 @@ export function AppSidebar({
         {isCollapsed && <Logo className="h-7 w-7 rounded-md" />}
         {!isCollapsed && (
           <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-sidebar-foreground/70"
-              onClick={toggleTheme}
-              aria-label="Toggle theme"
-            >
-              {theme === "dark" ? (
-                <Sun className="h-4 w-4" />
-              ) : (
-                <Moon className="h-4 w-4" />
-              )}
-            </Button>
+            <ThemeModeToggle className="text-sidebar-foreground/70" />
             {/* Mobile-only close button */}
             {onMobileClose && (
               <Button

--- a/web/src/components/bio-editor.tsx
+++ b/web/src/components/bio-editor.tsx
@@ -32,9 +32,9 @@ import { type AuthConfig, getAuthConfig } from "@/lib/auth";
 const HLJS_LINK_ID = "hljs-theme-stylesheet";
 
 function useHljsTheme() {
-  const { theme } = useTheme();
+  const { effectiveMode } = useTheme();
   useEffect(() => {
-    const href = theme === "dark" ? hljsDarkUrl : hljsLightUrl;
+    const href = effectiveMode === "dark" ? hljsDarkUrl : hljsLightUrl;
     let link = document.getElementById(
       HLJS_LINK_ID,
     ) as HTMLLinkElement | null;
@@ -47,7 +47,7 @@ function useHljsTheme() {
     if (link.href !== new URL(href, document.baseURI).href) {
       link.href = href;
     }
-  }, [theme]);
+  }, [effectiveMode]);
 }
 
 function isHostedImage(src: string, cdnBase: string | null) {

--- a/web/src/components/logo.tsx
+++ b/web/src/components/logo.tsx
@@ -2,7 +2,7 @@ import { useTheme } from "@/hooks/use-theme";
 import { cn } from "@/lib/utils";
 
 export function Logo({ className }: { className?: string }) {
-  const { theme } = useTheme();
-  const src = theme === "dark" ? "/logo-dark.svg" : "/logo-light.svg";
+  const { effectiveMode } = useTheme();
+  const src = effectiveMode === "dark" ? "/logo-dark.svg" : "/logo-light.svg";
   return <img src={src} alt="Sheaf" className={cn("select-none", className)} />;
 }

--- a/web/src/components/settings/appearance-card.tsx
+++ b/web/src/components/settings/appearance-card.tsx
@@ -1,0 +1,191 @@
+import { Check, Monitor, Moon, Sun } from "lucide-react";
+
+import { useTheme, type ThemeMode } from "@/hooks/use-theme";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { PALETTES, type PaletteId } from "@/lib/palettes";
+import { cn } from "@/lib/utils";
+
+/**
+ * Single source of truth for picking the theme: palette grid + mode
+ * radio + sync-across-devices toggle. The sync toggle decides where
+ * the picks get persisted (backend client_settings/web if on,
+ * localStorage if off); the picker is otherwise the same in either
+ * mode so users don't have to learn two flows.
+ *
+ * Each palette card shows a three-colour swatch sampled from the
+ * palette's actual primary / secondary / accent values, rendered in
+ * the mode the user currently has applied (so they're previewing
+ * "what does this look like right now" rather than a fixed light or
+ * dark sample).
+ */
+export function AppearanceCard() {
+  const { mode, effectiveMode, palette, synced, setMode, setPalette, setSynced } =
+    useTheme();
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Appearance</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <PaletteGrid
+          selected={palette}
+          previewMode={effectiveMode}
+          onSelect={setPalette}
+        />
+        <ModeRadio mode={mode} onChange={setMode} />
+        <SyncToggle synced={synced} onChange={setSynced} />
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Palette grid
+// ---------------------------------------------------------------------------
+
+function PaletteGrid({
+  selected,
+  previewMode,
+  onSelect,
+}: {
+  selected: PaletteId;
+  previewMode: "light" | "dark";
+  onSelect: (id: PaletteId) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">Palette</Label>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {PALETTES.map((p) => {
+          const swatch = p.swatch[previewMode];
+          const isSelected = p.id === selected;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => onSelect(p.id)}
+              className={cn(
+                "relative flex flex-col items-stretch gap-2 rounded-md border p-3 text-left transition-colors hover:bg-accent/40",
+                isSelected && "border-primary ring-2 ring-primary/30",
+              )}
+              aria-pressed={isSelected}
+            >
+              <div className="flex h-6 overflow-hidden rounded">
+                <span
+                  className="flex-1"
+                  style={{ backgroundColor: swatch[0] }}
+                  aria-hidden="true"
+                />
+                <span
+                  className="flex-1"
+                  style={{ backgroundColor: swatch[1] }}
+                  aria-hidden="true"
+                />
+                <span
+                  className="flex-1"
+                  style={{ backgroundColor: swatch[2] }}
+                  aria-hidden="true"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">{p.displayName}</span>
+                {isSelected && (
+                  <Check
+                    className="h-3.5 w-3.5 text-primary"
+                    aria-label="Selected"
+                  />
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mode radio (dark / system / light)
+// ---------------------------------------------------------------------------
+
+const MODE_OPTIONS: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+  { value: "system", label: "System", icon: Monitor },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "light", label: "Light", icon: Sun },
+];
+
+function ModeRadio({
+  mode,
+  onChange,
+}: {
+  mode: ThemeMode;
+  onChange: (mode: ThemeMode) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">Theme mode</Label>
+      <div className="grid grid-cols-3 gap-2" role="radiogroup">
+        {MODE_OPTIONS.map((opt) => {
+          const Icon = opt.icon;
+          const isSelected = opt.value === mode;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => onChange(opt.value)}
+              className={cn(
+                "flex flex-col items-center gap-1 rounded-md border px-3 py-2 text-xs font-medium transition-colors hover:bg-accent/40",
+                isSelected && "border-primary ring-2 ring-primary/30",
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              <span>{opt.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        System follows your operating system's dark / light preference.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sync toggle
+// ---------------------------------------------------------------------------
+
+function SyncToggle({
+  synced,
+  onChange,
+}: {
+  synced: boolean;
+  onChange: (synced: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start gap-3 border-t pt-4">
+      <Checkbox
+        id="theme-sync"
+        checked={synced}
+        onCheckedChange={(v) => onChange(v === true)}
+      />
+      <div className="space-y-0.5">
+        <Label
+          htmlFor="theme-sync"
+          className="text-sm font-medium cursor-pointer"
+        >
+          Sync these settings across my devices
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {synced
+            ? "Your palette and mode follow your account. Changes here apply to every browser logged into this account."
+            : "This browser keeps its own palette and mode. Other browsers logged into this account use their own picks (or your last synced choice)."}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/theme-mode-toggle.tsx
+++ b/web/src/components/theme-mode-toggle.tsx
@@ -1,0 +1,58 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+
+import { useTheme, type ThemeMode } from "@/hooks/use-theme";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Tri-state mode toggle used in the sidebar header and the
+ * pre-login pages. Cycles dark -> system -> light -> dark.
+ *
+ * Distinct from the Appearance settings card, which is the canonical
+ * place to set both mode and palette. This is the inline quick-access
+ * version: it changes mode only, never palette. When the user reaches
+ * the system position, the icon switches to `Monitor` and the
+ * tooltip explains that the OS-following state is active.
+ *
+ * Cycle order chosen so the most common transition (dark -> light or
+ * vice versa, with a single click) lands on the system state in
+ * between rather than past it: someone who clicks once from dark
+ * ends up on system (which often appears as dark anyway depending on
+ * OS), and a second click lands on light. Avoids the "wait, why is
+ * it still dark" confusion.
+ */
+
+const ICON: Record<ThemeMode, typeof Sun> = {
+  dark: Moon,
+  system: Monitor,
+  light: Sun,
+};
+
+const NEXT: Record<ThemeMode, ThemeMode> = {
+  dark: "system",
+  system: "light",
+  light: "dark",
+};
+
+const LABEL: Record<ThemeMode, string> = {
+  dark: "Theme: dark (click for system)",
+  system: "Theme: system (click for light)",
+  light: "Theme: light (click for dark)",
+};
+
+export function ThemeModeToggle({ className }: { className?: string }) {
+  const { mode, setMode } = useTheme();
+  const Icon = ICON[mode];
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setMode(NEXT[mode])}
+      title={LABEL[mode]}
+      aria-label={LABEL[mode]}
+      className={cn("h-8 w-8", className)}
+    >
+      <Icon className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -9,11 +9,11 @@ import { useTheme } from "@/hooks/use-theme"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme } = useTheme()
+  const { effectiveMode } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={effectiveMode}
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,

--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,37 +1,336 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-type Theme = "dark" | "light";
+import { apiFetch, getAccessToken } from "@/lib/api-client";
+import { patchWebSettings } from "@/lib/client-settings";
+import {
+  DEFAULT_PALETTE,
+  paletteFromId,
+  type PaletteId,
+} from "@/lib/palettes";
 
-const themeListeners = new Set<() => void>();
+/**
+ * Theme system. Two user preferences:
+ *
+ *   - `mode`: "system" | "light" | "dark" — when "system" the
+ *     effective light/dark follows the OS via `prefers-color-scheme`.
+ *   - `palette`: one of the shipped palette ids — selects which colour
+ *     catalog (see `index.css`) gets applied via `data-palette` on
+ *     `<html>`.
+ *
+ * Plus a `synced` toggle that decides storage tier:
+ *
+ *   - on: values live in `client_settings/web.theme` and follow the
+ *     account across browsers.
+ *   - off: values live in localStorage on this browser only. The
+ *     backend value (if any) stays untouched and represents what
+ *     other browsers logged into this account will use.
+ *
+ * Resolution order on load: localStorage > backend > app defaults.
+ * Whichever tier the active values came from determines the displayed
+ * `synced` state — flipping the picker doesn't surprise the user
+ * about where their choice ends up.
+ *
+ * Pre-paint script (`index.html`) reads localStorage synchronously
+ * and sets the `data-palette` attribute + `.dark` class before React
+ * mounts, so the first paint never flashes the wrong palette. The
+ * backend value is fetched after mount; if localStorage is empty and
+ * the backend has a different value, a one-time visual switch happens
+ * after the initial paint. Acceptable for the rare case (fresh browser
+ * on an already-synced account).
+ */
 
-function getTheme(): Theme {
-  return (localStorage.getItem("sheaf_theme") as Theme) || "dark";
+// ---------------------------------------------------------------------------
+// Mode (light / dark / system)
+// ---------------------------------------------------------------------------
+
+export type ThemeMode = "system" | "light" | "dark";
+const MODE_KEY = "sheaf_theme";
+const PALETTE_KEY = "sheaf_palette";
+
+// Lazy media query so we don't construct it during SSR / tests where
+// `matchMedia` is missing. Memoised after first call.
+let _prefersDark: MediaQueryList | null = null;
+function prefersDarkMQ(): MediaQueryList | null {
+  if (typeof window === "undefined" || !window.matchMedia) return null;
+  if (_prefersDark === null) {
+    _prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+  }
+  return _prefersDark;
 }
 
-function subscribeTheme(cb: () => void) {
-  themeListeners.add(cb);
-  return () => themeListeners.delete(cb);
+function resolveEffective(mode: ThemeMode): "light" | "dark" {
+  if (mode === "dark") return "dark";
+  if (mode === "light") return "light";
+  return prefersDarkMQ()?.matches ? "dark" : "light";
 }
 
-function applyTheme(theme: Theme) {
-  document.documentElement.classList.toggle("dark", theme === "dark");
-  document.documentElement.style.colorScheme = theme;
-  localStorage.setItem("sheaf_theme", theme);
-  themeListeners.forEach((cb) => cb());
+function applyMode(effective: "light" | "dark"): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("dark", effective === "dark");
+  document.documentElement.style.colorScheme = effective;
 }
 
-export function useTheme() {
-  const theme = useSyncExternalStore(subscribeTheme, getTheme);
-
-  const toggleTheme = useCallback(() => {
-    applyTheme(theme === "dark" ? "light" : "dark");
-  }, [theme]);
-
-  return { theme, toggleTheme };
+function applyPalette(palette: PaletteId): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.setAttribute("data-palette", palette);
 }
 
 // ---------------------------------------------------------------------------
-// UI Scale
+// localStorage stores with useSyncExternalStore subscriptions
+// ---------------------------------------------------------------------------
+
+const modeListeners = new Set<() => void>();
+const paletteListeners = new Set<() => void>();
+
+function notify(set: Set<() => void>) {
+  for (const cb of set) cb();
+}
+
+function getStoredMode(): ThemeMode | null {
+  if (typeof localStorage === "undefined") return null;
+  const v = localStorage.getItem(MODE_KEY);
+  if (v === "dark" || v === "light" || v === "system") return v;
+  return null;
+}
+
+function getStoredPalette(): PaletteId | null {
+  if (typeof localStorage === "undefined") return null;
+  const v = localStorage.getItem(PALETTE_KEY);
+  return v ? paletteFromId(v) : null;
+}
+
+function writeLocalMode(mode: ThemeMode) {
+  localStorage.setItem(MODE_KEY, mode);
+  notify(modeListeners);
+}
+
+function writeLocalPalette(palette: PaletteId) {
+  localStorage.setItem(PALETTE_KEY, palette);
+  notify(paletteListeners);
+}
+
+function clearLocalMode() {
+  localStorage.removeItem(MODE_KEY);
+  notify(modeListeners);
+}
+
+function clearLocalPalette() {
+  localStorage.removeItem(PALETTE_KEY);
+  notify(paletteListeners);
+}
+
+function subscribeMode(cb: () => void): () => void {
+  modeListeners.add(cb);
+  return () => {
+    modeListeners.delete(cb);
+  };
+}
+
+function subscribePalette(cb: () => void): () => void {
+  paletteListeners.add(cb);
+  return () => {
+    paletteListeners.delete(cb);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Backend (client_settings/web.theme)
+// ---------------------------------------------------------------------------
+
+interface BackendTheme {
+  mode?: ThemeMode;
+  palette?: string;
+}
+
+interface WebClientSettings {
+  theme?: BackendTheme;
+  // The blob can hold other keys (dismissed announcements etc.); we
+  // only read .theme here but keep the index signature loose so the
+  // query result type aligns with what other callers see.
+  [key: string]: unknown;
+}
+
+/** React-query key used for the web client settings record. Same key
+ *  is invalidated by other features (announcement dismissal etc.) so
+ *  a theme change here also propagates wherever else the blob is
+ *  consumed. */
+const WEB_SETTINGS_QUERY = ["client-settings", "web"] as const;
+
+async function fetchWebSettings(): Promise<WebClientSettings> {
+  try {
+    const res = await apiFetch<{ settings: WebClientSettings }>(
+      "/v1/settings/client/web",
+    );
+    return res.settings ?? {};
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public hook
+// ---------------------------------------------------------------------------
+
+export interface UseThemeResult {
+  /** The user's preference value, NOT the resolved light/dark when in
+   *  "system" mode. Use `effectiveMode` for the applied value. */
+  mode: ThemeMode;
+  /** Resolved light/dark — "system" reflects the OS preference, kept
+   *  live as the user toggles their OS theme. */
+  effectiveMode: "light" | "dark";
+  palette: PaletteId;
+  /** True when the active values came from the backend, i.e. this
+   *  browser is following the account-synced preference. False when
+   *  there's a localStorage override on this browser. */
+  synced: boolean;
+  setMode: (mode: ThemeMode) => void;
+  setPalette: (palette: PaletteId) => void;
+  /** Toggle whether this browser stays synced with the account or
+   *  pins to a local override. Flipping ON copies current values to
+   *  the backend and clears the local override. Flipping OFF writes
+   *  current values to localStorage and leaves the backend alone. */
+  setSynced: (synced: boolean) => void;
+  /** Convenience for the existing dark-only call sites: cycle the
+   *  effective light/dark. Never lands on "system" — users using the
+   *  quick toggle have made an explicit choice; "system" lives in
+   *  the Appearance settings. */
+  toggleEffective: () => void;
+}
+
+export function useTheme(): UseThemeResult {
+  const queryClient = useQueryClient();
+  const storedMode = useSyncExternalStore(
+    subscribeMode,
+    getStoredMode,
+    () => null,
+  );
+  const storedPalette = useSyncExternalStore(
+    subscribePalette,
+    getStoredPalette,
+    () => null,
+  );
+
+  // Backend value. Only fetched when authenticated — login / forgot-
+  // password pages don't have a session yet, so let them stay on
+  // localStorage / defaults until after sign-in.
+  const { data: backend } = useQuery({
+    queryKey: WEB_SETTINGS_QUERY,
+    queryFn: fetchWebSettings,
+    staleTime: 5 * 60 * 1000,
+    enabled: getAccessToken() !== null,
+    retry: false,
+  });
+
+  const backendMode = backend?.theme?.mode;
+  const backendPalette = backend?.theme?.palette
+    ? paletteFromId(backend.theme.palette)
+    : null;
+
+  // Resolution: localStorage > backend > defaults. Default mode is
+  // "dark" (matches what the app shipped with before this feature);
+  // default palette is "classic" (also matches the existing look).
+  const mode: ThemeMode = storedMode ?? backendMode ?? "dark";
+  const palette: PaletteId =
+    storedPalette ?? backendPalette ?? DEFAULT_PALETTE;
+  // synced reflects which tier the active values came from. If the
+  // user has any localStorage override, we report not-synced even
+  // when the backend happens to hold the same value — so the
+  // toggle's displayed state matches actual storage.
+  const synced = storedMode === null && storedPalette === null;
+
+  const effectiveMode = resolveEffective(mode);
+
+  // Push the effective mode + palette into the DOM whenever they
+  // change. The pre-paint script handles the very first paint; this
+  // covers subsequent in-app changes and the backend-arrives-after-
+  // mount case.
+  useEffect(() => {
+    applyMode(effectiveMode);
+  }, [effectiveMode]);
+  useEffect(() => {
+    applyPalette(palette);
+  }, [palette]);
+
+  // Re-apply when the OS theme flips, but only while we're actually
+  // listening (mode === "system"). Adds a listener for the duration
+  // of system mode and removes it on switch.
+  useEffect(() => {
+    if (mode !== "system") return;
+    const mq = prefersDarkMQ();
+    if (!mq) return;
+    const onChange = () => applyMode(resolveEffective("system"));
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [mode]);
+
+  const setMode = useCallback(
+    (next: ThemeMode) => {
+      if (synced) {
+        void patchWebSettings({ theme: { mode: next, palette } }).then(() => {
+          queryClient.invalidateQueries({ queryKey: WEB_SETTINGS_QUERY });
+        });
+      } else {
+        writeLocalMode(next);
+      }
+    },
+    [synced, palette, queryClient],
+  );
+
+  const setPalette = useCallback(
+    (next: PaletteId) => {
+      if (synced) {
+        void patchWebSettings({ theme: { mode, palette: next } }).then(() => {
+          queryClient.invalidateQueries({ queryKey: WEB_SETTINGS_QUERY });
+        });
+      } else {
+        writeLocalPalette(next);
+      }
+    },
+    [synced, mode, queryClient],
+  );
+
+  const setSynced = useCallback(
+    (next: boolean) => {
+      if (next === synced) return;
+      if (next) {
+        // Going synced: promote current effective values to the
+        // backend, then clear localStorage so subsequent reads come
+        // from the backend tier.
+        void patchWebSettings({ theme: { mode, palette } }).then(() => {
+          clearLocalMode();
+          clearLocalPalette();
+          queryClient.invalidateQueries({ queryKey: WEB_SETTINGS_QUERY });
+        });
+      } else {
+        // Going local: stash current values in localStorage so this
+        // browser stays pinned regardless of what the backend says
+        // now or later.
+        writeLocalMode(mode);
+        writeLocalPalette(palette);
+      }
+    },
+    [synced, mode, palette, queryClient],
+  );
+
+  const toggleEffective = useCallback(() => {
+    setMode(effectiveMode === "dark" ? "light" : "dark");
+  }, [effectiveMode, setMode]);
+
+  return {
+    mode,
+    effectiveMode,
+    palette,
+    synced,
+    setMode,
+    setPalette,
+    setSynced,
+    toggleEffective,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// UI Scale (unchanged)
 // ---------------------------------------------------------------------------
 
 export type UiScale = 75 | 100 | 125 | 150;
@@ -46,7 +345,9 @@ function getScale(): UiScale {
 
 function subscribeScale(cb: () => void) {
   scaleListeners.add(cb);
-  return () => scaleListeners.delete(cb);
+  return () => {
+    scaleListeners.delete(cb);
+  };
 }
 
 function applyScale(scale: UiScale) {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -115,6 +115,293 @@
   --sidebar-ring: oklch(0.439 0 0);
 }
 
+/* ===========================================================================
+ * Palette overrides
+ * ---------------------------------------------------------------------------
+ * The base :root / .dark blocks above ARE the Classic palette (= the look
+ * the web app has shipped with since launch). data-palette="classic" matches
+ * no selector below and inherits the base, so picking Classic is a no-op
+ * from the user's perspective and existing users see no visual change on
+ * upgrade.
+ *
+ * Hex values are direct ports from the matching Android palette files
+ * (sheaf-android/app/src/main/java/systems/lupine/sheaf/ui/theme/*.kt)
+ * so the two clients stay visually identifiable as "the same theme".
+ * Material 3's primaryContainer slot (Android FAB / nav indicator) doesn't
+ * have a 1:1 shadcn equivalent; we fold the recognisable flag colours into
+ * --primary itself on web because there's no FAB to carry them otherwise.
+ *
+ * Selector specificity: :root[data-palette=...] beats :root,
+ * .dark[data-palette=...] beats .dark. No need for !important.
+ * =========================================================================== */
+
+/* --- Purple ---------------------------------------------------------------
+ * iOS-aligned purple shipped as Android's default. Slightly violet tint on
+ * surfaces in dark mode. */
+:root[data-palette="purple"] {
+  --primary: #4F46E5;
+  --primary-foreground: #FFFFFF;
+  --secondary: #EEF2FF;
+  --secondary-foreground: #1E1B4B;
+  --accent: #EDE9FE;
+  --accent-foreground: #4338CA;
+  --ring: #8B7BFF;
+  --sidebar-primary: #4F46E5;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #EDE9FE;
+  --sidebar-accent-foreground: #4338CA;
+  --sidebar-ring: #8B7BFF;
+}
+.dark[data-palette="purple"] {
+  --background: #0F0C29;
+  --foreground: #E5DEFF;
+  --card: #15123A;
+  --card-foreground: #E5DEFF;
+  --popover: #15123A;
+  --popover-foreground: #E5DEFF;
+  --primary: #A78BFA;
+  --primary-foreground: #1E1B4B;
+  --secondary: #2A2452;
+  --secondary-foreground: #E5DEFF;
+  --muted: #2A2452;
+  --muted-foreground: #B8B1D9;
+  --accent: #312E81;
+  --accent-foreground: #E5DEFF;
+  --border: #2A2452;
+  --input: #2A2452;
+  --ring: #6D5FE6;
+  --sidebar: #15123A;
+  --sidebar-foreground: #E5DEFF;
+  --sidebar-primary: #A78BFA;
+  --sidebar-primary-foreground: #1E1B4B;
+  --sidebar-accent: #312E81;
+  --sidebar-accent-foreground: #E5DEFF;
+  --sidebar-border: #2A2452;
+  --sidebar-ring: #6D5FE6;
+}
+
+/* --- OLED -----------------------------------------------------------------
+ * True-black background for AMOLED-screen devices. Light mode stays mostly
+ * standard; the iconic look is the dark variant. */
+:root[data-palette="oled"] {
+  --primary: #8B5CF6;
+  --primary-foreground: #FFFFFF;
+  --secondary: #F5F3FF;
+  --secondary-foreground: #1A0F45;
+  --accent: #EDE9FE;
+  --accent-foreground: #5B21B6;
+  --ring: #8B5CF6;
+  --sidebar-primary: #8B5CF6;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #EDE9FE;
+  --sidebar-accent-foreground: #5B21B6;
+  --sidebar-ring: #8B5CF6;
+}
+.dark[data-palette="oled"] {
+  --background: #000000;
+  --foreground: #F5F3FF;
+  --card: #000000;
+  --card-foreground: #F5F3FF;
+  --popover: #0A0A0A;
+  --popover-foreground: #F5F3FF;
+  --primary: #8B5CF6;
+  --primary-foreground: #FFFFFF;
+  --secondary: #1A1A1A;
+  --secondary-foreground: #F5F3FF;
+  --muted: #1A1A1A;
+  --muted-foreground: #A8A8B8;
+  --accent: #2A1F50;
+  --accent-foreground: #F5F3FF;
+  --border: #1F1F1F;
+  --input: #1F1F1F;
+  --ring: #8B5CF6;
+  --sidebar: #000000;
+  --sidebar-foreground: #F5F3FF;
+  --sidebar-primary: #8B5CF6;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #2A1F50;
+  --sidebar-accent-foreground: #F5F3FF;
+  --sidebar-border: #1F1F1F;
+  --sidebar-ring: #8B5CF6;
+}
+
+/* --- Pride ----------------------------------------------------------------
+ * Rainbow-flag-inspired. Hero pink + orange/yellow secondary + purple accent
+ * so the chrome reads as the warm-to-cool sweep of the flag without
+ * dumping every stripe into the UI. */
+:root[data-palette="pride"] {
+  --background: #FFF8FA;
+  --foreground: #1F0A18;
+  --card: #FFFFFF;
+  --card-foreground: #1F0A18;
+  --popover: #FFFFFF;
+  --popover-foreground: #1F0A18;
+  --primary: #D81B60;
+  --primary-foreground: #FFFFFF;
+  --secondary: #FFF3D6;
+  --secondary-foreground: #3D2F00;
+  --muted: #F8E8EE;
+  --muted-foreground: #6E3A50;
+  --accent: #F3E5F5;
+  --accent-foreground: #4A148C;
+  --border: #E6BCC7;
+  --input: #E6BCC7;
+  --ring: #D81B60;
+  --sidebar: #FFF0F4;
+  --sidebar-foreground: #1F0A18;
+  --sidebar-primary: #D81B60;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #F3E5F5;
+  --sidebar-accent-foreground: #4A148C;
+  --sidebar-border: #E6BCC7;
+  --sidebar-ring: #D81B60;
+}
+.dark[data-palette="pride"] {
+  --background: #1A0F1A;
+  --foreground: #EAD6E0;
+  --card: #231423;
+  --card-foreground: #EAD6E0;
+  --popover: #231423;
+  --popover-foreground: #EAD6E0;
+  --primary: #F06292;
+  --primary-foreground: #3D0418;
+  --secondary: #D4A800;
+  --secondary-foreground: #3A2A00;
+  --muted: #3A1F30;
+  --muted-foreground: #C9A5B8;
+  --accent: #5E2D8C;
+  --accent-foreground: #F3E5F5;
+  --border: #503245;
+  --input: #503245;
+  --ring: #F06292;
+  --sidebar: #231423;
+  --sidebar-foreground: #EAD6E0;
+  --sidebar-primary: #F06292;
+  --sidebar-primary-foreground: #3D0418;
+  --sidebar-accent: #5E2D8C;
+  --sidebar-accent-foreground: #F3E5F5;
+  --sidebar-border: #503245;
+  --sidebar-ring: #F06292;
+}
+
+/* --- Trans ----------------------------------------------------------------
+ * Trans-flag pink + blue, with a soft white-stripe near-neutral for accent.
+ * Flag white doesn't work as a primary on white surfaces, so the deeper
+ * pink leads in light mode and the lighter flag pink leads in dark. */
+:root[data-palette="trans"] {
+  --background: #FFFAFC;
+  --foreground: #1B1A1F;
+  --card: #FFFFFF;
+  --card-foreground: #1B1A1F;
+  --popover: #FFFFFF;
+  --popover-foreground: #1B1A1F;
+  --primary: #E16A8C;
+  --primary-foreground: #FFFFFF;
+  --secondary: #DCF1FB;
+  --secondary-foreground: #062F45;
+  --muted: #F5E1E8;
+  --muted-foreground: #6E3A4F;
+  --accent: #E2EAF2;
+  --accent-foreground: #1B2638;
+  --border: #E9C0CC;
+  --input: #E9C0CC;
+  --ring: #E16A8C;
+  --sidebar: #FFF0F5;
+  --sidebar-foreground: #1B1A1F;
+  --sidebar-primary: #E16A8C;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #E2EAF2;
+  --sidebar-accent-foreground: #1B2638;
+  --sidebar-border: #E9C0CC;
+  --sidebar-ring: #E16A8C;
+}
+.dark[data-palette="trans"] {
+  --background: #161220;
+  --foreground: #E5E1EE;
+  --card: #1F1A2D;
+  --card-foreground: #E5E1EE;
+  --popover: #1F1A2D;
+  --popover-foreground: #E5E1EE;
+  --primary: #F7A8B8;
+  --primary-foreground: #3D0418;
+  --secondary: #2A9FD6;
+  --secondary-foreground: #FFFFFF;
+  --muted: #2D2B36;
+  --muted-foreground: #C4B8C8;
+  --accent: #3A4A5E;
+  --accent-foreground: #C9D6E2;
+  --border: #45354A;
+  --input: #45354A;
+  --ring: #F7A8B8;
+  --sidebar: #1F1A2D;
+  --sidebar-foreground: #E5E1EE;
+  --sidebar-primary: #F7A8B8;
+  --sidebar-primary-foreground: #3D0418;
+  --sidebar-accent: #3A4A5E;
+  --sidebar-accent-foreground: #C9D6E2;
+  --sidebar-border: #45354A;
+  --sidebar-ring: #F7A8B8;
+}
+
+/* --- Non-binary -----------------------------------------------------------
+ * NB-flag purple + yellow. Yellow doesn't pass contrast as a primary on
+ * white, so flag purple leads and yellow takes the secondary slot where
+ * it reads as a vivid accent. */
+:root[data-palette="nonbinary"] {
+  --background: #FCFAFD;
+  --foreground: #1B102B;
+  --card: #FFFFFF;
+  --card-foreground: #1B102B;
+  --popover: #FFFFFF;
+  --popover-foreground: #1B102B;
+  --primary: #7B3FA4;
+  --primary-foreground: #FFFFFF;
+  --secondary: #FFF5C2;
+  --secondary-foreground: #3D2F00;
+  --muted: #EDE3F5;
+  --muted-foreground: #5E4870;
+  --accent: #E8E2EE;
+  --accent-foreground: #2D1F3E;
+  --border: #D9C7E8;
+  --input: #D9C7E8;
+  --ring: #7B3FA4;
+  --sidebar: #F7F0FC;
+  --sidebar-foreground: #1B102B;
+  --sidebar-primary: #7B3FA4;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #E8E2EE;
+  --sidebar-accent-foreground: #2D1F3E;
+  --sidebar-border: #D9C7E8;
+  --sidebar-ring: #7B3FA4;
+}
+.dark[data-palette="nonbinary"] {
+  --background: #1A1B23;
+  --foreground: #E3D8EE;
+  --card: #22202B;
+  --card-foreground: #E3D8EE;
+  --popover: #22202B;
+  --popover-foreground: #E3D8EE;
+  --primary: #9C59D1;
+  --primary-foreground: #2E0F50;
+  --secondary: #B69500;
+  --secondary-foreground: #FFFFFF;
+  --muted: #2D1F3E;
+  --muted-foreground: #BFAFCC;
+  --accent: #3A2E4F;
+  --accent-foreground: #D8C8E8;
+  --border: #42384F;
+  --input: #42384F;
+  --ring: #9C59D1;
+  --sidebar: #22202B;
+  --sidebar-foreground: #E3D8EE;
+  --sidebar-primary: #9C59D1;
+  --sidebar-primary-foreground: #2E0F50;
+  --sidebar-accent: #3A2E4F;
+  --sidebar-accent-foreground: #D8C8E8;
+  --sidebar-border: #42384F;
+  --sidebar-ring: #9C59D1;
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/web/src/lib/palettes.ts
+++ b/web/src/lib/palettes.ts
@@ -1,0 +1,101 @@
+/**
+ * Shipped palette catalog for the web client. The actual colour values
+ * live in `index.css` under selectors like `[data-palette="purple"]`;
+ * this file exposes the metadata the picker UI needs (display name,
+ * a 3-colour swatch for the preview chip, and dark/light flags so the
+ * Appearance card can render the right preview without applying it).
+ *
+ * Adding a new palette = drop entries here + add the matching CSS
+ * block in index.css. The id is stable across releases and persisted
+ * to localStorage / backend, so it must not be renamed.
+ *
+ * The Android counterpart lives at
+ * `sheaf-android/app/src/main/java/systems/lupine/sheaf/ui/theme/`;
+ * the ids are intentionally aligned across clients so a future
+ * "current palette" sync (or just shared documentation) reads
+ * consistently. Material You is Android-only (no web equivalent) and
+ * is omitted here.
+ */
+
+/** Stable per-palette id. Persisted; do not rename. */
+export type PaletteId =
+  | "classic"
+  | "purple"
+  | "oled"
+  | "pride"
+  | "trans"
+  | "nonbinary";
+
+export interface PaletteMeta {
+  id: PaletteId;
+  displayName: string;
+  /** Three representative swatches for the picker preview chip.
+   *  Picked to read as "this is what this palette looks like" at a
+   *  glance — typically primary, secondary, and an accent. */
+  swatch: {
+    light: [string, string, string];
+    dark: [string, string, string];
+  };
+}
+
+export const PALETTES: PaletteMeta[] = [
+  {
+    id: "classic",
+    displayName: "Classic",
+    swatch: {
+      light: ["#0F0F0F", "#F4F4F4", "#737373"],
+      dark: ["#FAFAFA", "#404040", "#A3A3A3"],
+    },
+  },
+  {
+    id: "purple",
+    displayName: "Purple",
+    swatch: {
+      light: ["#4F46E5", "#EEF2FF", "#8B7BFF"],
+      dark: ["#A78BFA", "#15123A", "#6D5FE6"],
+    },
+  },
+  {
+    id: "oled",
+    displayName: "OLED",
+    swatch: {
+      light: ["#8B5CF6", "#F5F3FF", "#5B21B6"],
+      dark: ["#8B5CF6", "#000000", "#2A1F50"],
+    },
+  },
+  {
+    id: "pride",
+    displayName: "Pride",
+    swatch: {
+      light: ["#D81B60", "#FBC02D", "#8E24AA"],
+      dark: ["#F06292", "#D4A800", "#CE93D8"],
+    },
+  },
+  {
+    id: "trans",
+    displayName: "Trans",
+    swatch: {
+      light: ["#E16A8C", "#55CDFC", "#A0B6CC"],
+      dark: ["#F7A8B8", "#2A9FD6", "#C9D6E2"],
+    },
+  },
+  {
+    id: "nonbinary",
+    displayName: "Non-binary",
+    swatch: {
+      light: ["#7B3FA4", "#FCF434", "#4A4A55"],
+      dark: ["#9C59D1", "#FCF434", "#D8C8E8"],
+    },
+  },
+];
+
+export const DEFAULT_PALETTE: PaletteId = "classic";
+
+/** Resolve a persisted id back to a known palette; fall back to the
+ *  default if the id no longer matches anything (catalog rename /
+ *  removal between releases). */
+export function paletteFromId(id: string | null | undefined): PaletteId {
+  if (!id) return DEFAULT_PALETTE;
+  const match = PALETTES.find((p) => p.id === id);
+  return match ? match.id : DEFAULT_PALETTE;
+}

--- a/web/src/routes/forgot-password.tsx
+++ b/web/src/routes/forgot-password.tsx
@@ -1,16 +1,14 @@
 import { type FormEvent, useState } from "react";
 import { Link } from "react-router";
-import { useTheme } from "@/hooks/use-theme";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ThemeModeToggle } from "@/components/theme-mode-toggle";
 import { ApiError } from "@/lib/api-client";
 import { requestPasswordReset } from "@/lib/auth";
-import { Sun, Moon } from "lucide-react";
 
 export function ForgotPasswordPage() {
-  const { theme, toggleTheme } = useTheme();
   const [email, setEmail] = useState("");
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState("");
@@ -36,19 +34,7 @@ export function ForgotPasswordPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="absolute top-4 right-4 text-muted-foreground"
-        onClick={toggleTheme}
-        aria-label="Toggle theme"
-      >
-        {theme === "dark" ? (
-          <Sun className="h-4 w-4" />
-        ) : (
-          <Moon className="h-4 w-4" />
-        )}
-      </Button>
+      <ThemeModeToggle className="absolute top-4 right-4 text-muted-foreground" />
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl font-semibold">Sheaf</CardTitle>

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -1,7 +1,6 @@
 import { type FormEvent, useEffect, useState } from "react";
 import { Link, Navigate } from "react-router";
 import { useAuth } from "@/hooks/use-auth";
-import { useTheme } from "@/hooks/use-theme";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -13,13 +12,12 @@ import { Captcha } from "@/components/captcha";
 import { Logo } from "@/components/logo";
 import { LegalFooter } from "@/components/legal-footer";
 import { LoggedOutAnnouncementBanners } from "@/components/announcement-banners";
+import { ThemeModeToggle } from "@/components/theme-mode-toggle";
 import { ApiError } from "@/lib/api-client";
 import { type AuthConfig, getAuthConfig } from "@/lib/auth";
-import { Sun, Moon } from "lucide-react";
 
 export function LoginPage() {
   const { user, loading, login, register } = useAuth();
-  const { theme, toggleTheme } = useTheme();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [inviteCode, setInviteCode] = useState("");
@@ -89,19 +87,7 @@ export function LoginPage() {
   return (
     <div className="relative flex min-h-screen flex-col bg-background">
       <LoggedOutAnnouncementBanners />
-      <Button
-        variant="ghost"
-        size="icon"
-        className="absolute top-4 right-4 text-muted-foreground"
-        onClick={toggleTheme}
-        aria-label="Toggle theme"
-      >
-        {theme === "dark" ? (
-          <Sun className="h-4 w-4" />
-        ) : (
-          <Moon className="h-4 w-4" />
-        )}
-      </Button>
+      <ThemeModeToggle className="absolute top-4 right-4 text-muted-foreground" />
       <div className="flex flex-1 items-center justify-center p-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">

--- a/web/src/routes/reset-password.tsx
+++ b/web/src/routes/reset-password.tsx
@@ -1,6 +1,5 @@
 import { type FormEvent, useEffect, useState } from "react";
 import { useSearchParams, Link } from "react-router";
-import { useTheme } from "@/hooks/use-theme";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -12,12 +11,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PasswordField } from "@/components/password-field";
+import { ThemeModeToggle } from "@/components/theme-mode-toggle";
 import { ApiError } from "@/lib/api-client";
 import { resetPassword } from "@/lib/auth";
-import { Check, X, Sun, Moon } from "lucide-react";
+import { Check, X } from "lucide-react";
 
 export function ResetPasswordPage() {
-  const { theme, toggleTheme } = useTheme();
   const [params] = useSearchParams();
   const urlToken = params.get("token");
   const [manualToken, setManualToken] = useState("");
@@ -63,19 +62,7 @@ export function ResetPasswordPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="absolute top-4 right-4 text-muted-foreground"
-        onClick={toggleTheme}
-        aria-label="Toggle theme"
-      >
-        {theme === "dark" ? (
-          <Sun className="h-4 w-4" />
-        ) : (
-          <Moon className="h-4 w-4" />
-        )}
-      </Button>
+      <ThemeModeToggle className="absolute top-4 right-4 text-muted-foreground" />
       <Card className="w-full max-w-sm">
         {state === "form" && (
           <>

--- a/web/src/routes/settings/appearance.tsx
+++ b/web/src/routes/settings/appearance.tsx
@@ -1,9 +1,11 @@
+import { AppearanceCard } from "@/components/settings/appearance-card";
 import { DisplayPreferencesCard } from "@/components/settings/display-preferences-card";
 import { ClientSettingsCard } from "@/components/settings/client-settings-card";
 
 export function SettingsAppearancePage() {
   return (
     <>
+      <AppearanceCard />
       <DisplayPreferencesCard />
       <ClientSettingsCard />
     </>


### PR DESCRIPTION
Ports the per-palette theme system from the Android client (subset: Purple, Classic, OLED, Pride, Trans, Non-binary; Material You is Android-only and omitted on web). Classic is the base CSS and is exactly the look the web app already shipped with, so existing users see no visual change on upgrade.

## What ships

**Settings > Appearance** gains a single Appearance card with three controls in one place:

- Palette grid: six cards, each showing a three-colour swatch sampled from the palette's actual primary / secondary / accent values, rendered in the mode currently applied. Selected card gets a primary-coloured ring + check icon.
- Tri-state mode radio: System / Dark / Light, with icons. System follows `prefers-color-scheme` and updates live when the OS theme flips.
- Sync toggle: "Sync these settings across my devices" with explanatory copy that changes based on the current state.

**Quick mode toggle** in the sidebar header + the three pre-login pages (login, forgot-password, reset-password) refactored from the old binary Sun/Moon toggle to a shared `ThemeModeToggle` component that cycles dark -> system -> light. Users who never visit the Appearance card still get the same dark / light behaviour they had before.

## Storage model

Hybrid: sync ON writes to `client_settings/web.theme` (per-account, all browsers logged into this account); sync OFF writes to localStorage (this browser only). Resolution order on load: localStorage > backend > app defaults.

The pre-paint script in `index.html` reads localStorage synchronously and applies `data-palette` + `.dark` class before React mounts, so the first paint never shows the wrong palette on browsers with a local override. The backend value gets applied after auth + fetch settles; if a fresh browser has no localStorage but the account is synced, there's a one-time visual switch from defaults to the synced palette right after mount. Acceptable for that rare case.

## Migration

The existing `sheaf_theme` localStorage key (with values `dark` or `light`) is reused for the new mode preference. Both values are valid for the new tri-state, so existing users load directly into their previous choice with the default `classic` palette and report "not synced" (correctly — they have a local override). No data loss, no opt-in flow.

## Backend

Zero changes. The existing `client_settings/web` atomic-merge PATCH endpoint that handles announcement dismissals and other per-account UI state already supports a top-level `theme` key without any schema work.

## Files

New: `web/src/lib/palettes.ts`, `web/src/components/theme-mode-toggle.tsx`, `web/src/components/settings/appearance-card.tsx`.

Modified: `web/index.html` (pre-paint script + `data-palette="classic"` default), `web/src/index.css` (five new palette CSS blocks; Classic stays as the base), `web/src/hooks/use-theme.ts` (rewrite), plus seven existing useTheme callers (sonner, logo, bio-editor, app-sidebar, login, forgot-password, reset-password) and `routes/settings/appearance.tsx` (mount the card).

## Verification

- `cd web && npx tsc --noEmit` clean
- `cd web && npm run lint` clean
- `cd web && npx vite build` succeeds; CSS bundle picks up the new palette selectors
- Visual smoke checks done locally: palette picker re-skins the UI, sidebar tri-state cycles correctly, sync toggle persists across reloads
