### PR TITLE
Friendly error toasts + status-code audit + Show technical errors setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **"Show technical error details" setting.** New Advanced tab in Settings with a toggle that swaps friendly error toasts for the raw HTTP status code and backend error message. Off by default; useful for reporting bugs or diagnosing flaky network paths. Backend-stored so the choice follows the account across browsers.
+
+### Changed
+
+- **Friendly error toasts.** Failed API calls now show a status-aware summary ("Not found.", "Slow down — too many requests.", "Server error — please try again.") instead of either a generic "Server error" or the raw backend detail. Inline error messages (red text under forms in the TOTP, password change, email change, import, and System Safety surfaces) follow the same toggle. Operators or bug reporters can opt back into raw detail via the new Advanced setting.
+- **Status codes audit.** Several endpoints that returned `400 Bad Request` for state mismatches ("Not pending" on already-cancelled trim notices, system-safety pending actions, and pending changes) now correctly return `409 Conflict`. Cosmetic raw-int `status_code=404`/`400` raises across the API layer were swapped for the named `status.HTTP_*` constants for consistency. No client-visible behaviour change beyond the 400→409 swaps above.
+
 ## [0.3.1] - 2026-06-02
 
 ### Added

--- a/selfhost-utils/cf-shield/README.md
+++ b/selfhost-utils/cf-shield/README.md
@@ -1,0 +1,166 @@
+# cf-shield
+
+Reference break-glass DDoS shield script for a Sheaf deployment on
+**AWS + Cloudflare**. Hardens the stack during an active L7 attack by
+routing all traffic through Cloudflare with UAM on the webapp host,
+revoking direct-origin SG ingress so an attacker who knows the origin
+IP can't bypass, and notifying the backend so it can invalidate
+opted-out users' sessions.
+
+**This is the version we run in production.** Public Terraform modules
+for the full infra shape are a future project; this script is included
+as a working reference so selfhosters with similar requirements have
+a starting point rather than a blank page.
+
+## What this assumes
+
+- **Hosting on AWS EC2** — uses `aws ec2 revoke-security-group-ingress`.
+  Selfhosters on different stacks (Hetzner, OVH, Vultr, bare-metal)
+  can adapt by replacing the `revoke_world_ingress` /
+  `restore_world_ingress` functions with whatever your firewall layer
+  uses (UFW, hosting-provider firewall, hardware appliance, etc.).
+- **DNS + edge on Cloudflare** — uses the CF API to flip `proxied` on
+  the webapp/API DNS records and set zone-level `security_level`.
+- **Two DNS records, distinct webapp + API hosts** — the design
+  separates them so a UAM challenge on the webapp doesn't break
+  non-browser API clients (mobile apps, webhooks, scripts). If you
+  serve both on the same host, you'd need to either accept that
+  API clients see UAM challenges during incidents, or restructure
+  to expose API on its own subdomain.
+- **One Cloudflare Configuration Rule, set up once in the dashboard**,
+  scoped to the API host:
+    - Phase: HTTP Config Settings (sometimes called "Configuration
+      Rules" in the UI)
+    - Expression: `(http.host eq "api.example.com")`
+    - Action parameter: `security_level = essentially_off`
+  Without this rule, the zone-wide `security_level=under_attack` that
+  `up` engages will hit the API host and 403 every non-browser
+  client. The rule overrides for the API host only.
+- **SG rules tagged by description.** The script identifies the
+  "world allow" rules to revoke / restore by matching the literal
+  string `HTTPS from world` in the rule's Description field. Your
+  SG should have something like:
+    - IPv4 ingress, port 443, source `0.0.0.0/0`,
+      Description: `HTTPS from world (cf-shield revokes this during incidents)`
+    - IPv6 ingress, port 443, source `::/0`,
+      Description: `HTTPS from world v6 (cf-shield revokes this during incidents)`
+  Plus a permanent SG rule allowing port 443 from the Cloudflare
+  IPv4 + IPv6 CIDR ranges (these stay open and are how CF reaches
+  the origin once world ingress is revoked). See the [Cloudflare IP
+  ranges page](https://www.cloudflare.com/ips/).
+- **Backend is Sheaf** with `SHIELD_MODE_ENABLED=true` and
+  `SHIELD_MODE_WEBHOOK_SECRET=<random>` set in the backend's env. The
+  same secret value is passed to this script as
+  `SHEAF_SHIELD_WEBHOOK_SECRET`. The HMAC contract is documented in
+  `docs/METRICS.md` (look for `sheaf_cf_shield_*` metrics) and in the
+  backend code at `sheaf/api/v1/shield_mode.py`.
+
+## What this does, step by step
+
+`cf-shield up`:
+
+1. **CF: flip both DNS records to `proxied=true`.** Webapp + API both
+   route through Cloudflare.
+2. **CF: set zone `security_level=under_attack`.** Webapp gets the UAM
+   JS interstitial; the Configuration Rule above keeps API at
+   `essentially_off` so non-browser clients keep working.
+3. **Backend: POST `{"active": true}` with HMAC signature** to
+   `/v1/internal/shield-mode/state`. Backend uses this to invalidate
+   sessions for users who've opted into the "disable CDN during DDoS"
+   preference.
+4. **SG: revoke the world-allow ingress rules** so anyone who knows
+   the origin IP can't bypass Cloudflare. CF IPs stay allowed.
+
+`cf-shield down` reverses, in safe order:
+
+1. SG: restore world ingress (so the webhook can reach origin).
+2. Backend: POST `{"active": false}`.
+3. CF: flip both DNS records back to `proxied=false`.
+4. CF: set zone `security_level=medium`.
+
+`cf-shield status` reads the current CF state, SG rules, and backend
+shield-mode endpoint (if `SHEAF_SHIELD_WEBHOOK_URL` is set).
+
+## Usage
+
+```sh
+# Required env
+export CF_API_TOKEN=<paste from your secret store>
+export CF_ZONE_ID=<your CF zone id>
+export CF_APP_RECORD_ID=<webapp DNS record id>
+export CF_API_RECORD_ID=<api DNS record id>
+export AWS_PROFILE=<your AWS profile>
+export SG_ID=<your instance SG id>
+
+# Optional (skips the backend notify if unset)
+export SHEAF_SHIELD_WEBHOOK_URL=https://api.example.com/v1/internal/shield-mode/state
+export SHEAF_SHIELD_WEBHOOK_SECRET=<same value as backend SHIELD_MODE_WEBHOOK_SECRET>
+
+./cf-shield status        # check current state, no changes
+./cf-shield up            # shield ON
+./cf-shield down          # shield OFF, restore steady state
+```
+
+For runtime safety, source these from a shell helper rather than
+typing tokens into your terminal history. Example:
+
+```sh
+cat > ~/.cf-shield.env <<'EOF'
+# Source me, don't commit.
+export AWS_PROFILE=prod
+export CF_API_TOKEN=$(your secret-fetch command)
+export CF_ZONE_ID=...
+export CF_APP_RECORD_ID=...
+export CF_API_RECORD_ID=...
+export SG_ID=...
+export SHEAF_SHIELD_WEBHOOK_URL=https://api.example.com/v1/internal/shield-mode/state
+export SHEAF_SHIELD_WEBHOOK_SECRET=$(your secret-fetch command)
+EOF
+chmod 600 ~/.cf-shield.env
+
+. ~/.cf-shield.env && ./cf-shield status
+```
+
+## Cloudflare API token scopes
+
+When creating the token in the Cloudflare dashboard:
+
+| Permission | Scope |
+|---|---|
+| Zone → DNS → Edit | Specific zone: your zone |
+| Zone → Zone Settings → Edit | Specific zone: your zone |
+
+(Optionally lock down by Client IP filtering to your incident-response
+workstation.)
+
+## Drift
+
+Your IaC tool (Terraform, Pulumi, OpenTofu, ...) will notice the
+following while shield is active:
+
+- **DNS record `proxied=true`** when your code says `false`.
+- **Missing world-allow SG rules** when your code says they exist.
+
+`cf-shield down` reverses both, and the next IaC apply reconciles. If
+the drift noise during an incident bothers you, add a
+`lifecycle.ignore_changes = [proxied]` on the relevant DNS record
+resource (Terraform syntax; equivalents exist in other tools).
+
+## Adapting
+
+The script is ~200 lines of bash. The pieces you'd change for a
+different hosting stack:
+
+- **`revoke_world_ingress` / `restore_world_ingress`** — replace AWS
+  CLI calls with whatever your firewall layer needs. Could be
+  `ufw delete allow 443/tcp` / `ufw allow 443/tcp` on a single box,
+  or hitting your hosting provider's firewall API.
+- **`AWS_PROFILE` / `SG_ID` env vars** — drop or replace if you're
+  not on AWS.
+
+The Cloudflare and backend-webhook pieces are reusable as long as you
+use Cloudflare as your edge and Sheaf as your backend.
+
+## License
+
+See the repository LICENSE.

--- a/selfhost-utils/cf-shield/cf-shield
+++ b/selfhost-utils/cf-shield/cf-shield
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# cf-shield — break-glass DDoS shield for a Sheaf deployment on
+# AWS + Cloudflare. See README.md for what it assumes and how to adapt.
+#
+# Steady state has BOTH the webapp and api DNS records grey-cloud
+# (direct to origin, deliberate privacy choice so CF never sees normal
+# traffic). Shield mode:
+#   1. Flips both records' proxied flag to true (CF in path for both).
+#   2. Turns on Cloudflare "Under Attack Mode" zone-wide. The webapp
+#      gets the JS interstitial; the api host is exempted by a
+#      Cloudflare Configuration Rule (zone scope, http_config_settings
+#      phase, expression `(http.host eq "<api host>")`) that pins it at
+#      security_level=essentially_off, so non-browser API clients
+#      (mobile, webhooks, scripts) never see a challenge. The api host
+#      still gets CF L3/L4 DDoS protection and the free managed WAF;
+#      just no L7 reputation challenges. You configure this rule
+#      once in the Cloudflare dashboard - see README.md.
+#   3. Revokes the SG ingress rule that allows 443 from 0.0.0.0/0+::/0,
+#      leaving only the Cloudflare-CIDR allowlist on the instance's SG.
+#      Both hosts are now reachable only via CF, killing direct-to-IP
+#      bypass for the duration of the incident.
+#
+# Usage:
+#   cf-shield up       # shield ON
+#   cf-shield down     # shield OFF, restore steady state
+#   cf-shield status   # show current proxied flag + UAM level
+#
+# Required env:
+#   CF_API_TOKEN       Cloudflare token, scope Zone:DNS:Edit +
+#                      Zone:Zone Settings:Edit on your zone. Fetch
+#                      from your operator secret store however you
+#                      normally would.
+#   CF_ZONE_ID         Cloudflare zone ID for your domain.
+#   CF_APP_RECORD_ID   DNS record ID of the webapp host (the user-
+#                      facing one that gets UAM during shield).
+#   CF_API_RECORD_ID   DNS record ID of the API host (stays challenge-
+#                      free via the Configuration Rule).
+#   AWS_PROFILE        Whatever your AWS profile/SSO arrangement is.
+#   SG_ID              Instance security group ID for the target env.
+#
+# Optional env (skips the backend webhook if either is unset — script
+# still flips Cloudflare + SG; the backend opt-out invalidation just
+# does not run):
+#   SHEAF_SHIELD_WEBHOOK_URL     e.g. https://api.example.com/v1/internal/shield-mode/state
+#                                Hits the api host; during shield mode
+#                                that's via CF (proxied) but the
+#                                Configuration Rule keeps it challenge-free.
+#                                Fired BEFORE revoke_world_ingress on
+#                                up and AFTER restore_world_ingress on
+#                                down so the SG never blocks it.
+#   SHEAF_SHIELD_WEBHOOK_SECRET  Shared HMAC secret. Matches the
+#                                backend's SHIELD_MODE_WEBHOOK_SECRET.
+#                                Fetch from your operator secret store.
+#
+# Your IaC tool (Terraform, Pulumi, OpenTofu, ...) will show drift on
+# the DNS record's `proxied` field and on the SG world rule while
+# shield is active. Expected — `cf-shield down` restores both and the
+# next apply reconciles. Add a lifecycle.ignore_changes on `proxied`
+# in your DNS record resource if the noise bothers you.
+
+set -euo pipefail
+
+: "${CF_API_TOKEN:?CF_API_TOKEN must be set}"
+: "${CF_ZONE_ID:?CF_ZONE_ID must be set}"
+: "${CF_APP_RECORD_ID:?CF_APP_RECORD_ID must be set}"
+: "${CF_API_RECORD_ID:?CF_API_RECORD_ID must be set}"
+: "${AWS_PROFILE:?AWS_PROFILE must be set}"
+: "${SG_ID:?SG_ID must be set (instance security group ID)}"
+
+CF_API="https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}"
+
+cf_curl() {
+  curl -fsS \
+    -H "Authorization: Bearer ${CF_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+patch_proxied() {
+  local record_id=$1 value=$2
+  cf_curl -X PATCH \
+    --data "{\"proxied\":${value}}" \
+    "${CF_API}/dns_records/${record_id}" >/dev/null
+}
+
+patch_security_level() {
+  local value=$1
+  cf_curl -X PATCH \
+    --data "{\"value\":\"${value}\"}" \
+    "${CF_API}/settings/security_level" >/dev/null
+}
+
+# Revoke the "HTTPS from world" ingress rules on the instance SG.
+# The script identifies them by SG rule description - your SG must
+# tag the world-allow rules with a description containing the
+# string "HTTPS from world". See README.md for the convention.
+revoke_world_ingress() {
+  local ids
+  ids=$(aws ec2 describe-security-group-rules \
+    --filters "Name=group-id,Values=${SG_ID}" \
+    --query 'SecurityGroupRules[?!IsEgress && contains(Description, `HTTPS from world`)].SecurityGroupRuleId' \
+    --output text)
+  if [ -z "$ids" ]; then
+    echo "cf-shield: no 'HTTPS from world' rules found on ${SG_ID} — already revoked?"
+    return 0
+  fi
+  for id in $ids; do
+    echo "Revoking SG rule $id"
+    aws ec2 revoke-security-group-ingress \
+      --group-id "${SG_ID}" \
+      --security-group-rule-ids "$id" >/dev/null
+  done
+}
+
+# POST {active: bool} to the backend's shield-mode webhook with an
+# HMAC-SHA256 signature so the backend can run its opt-out session
+# invalidation. Best-effort: failure logs a warning but does not
+# abort the Cloudflare/SG transition - the CF + SG state is the
+# source of truth, and the script can be re-run to converge the
+# backend.
+#
+# Called BETWEEN the CF flip and the SG revoke on the UP path so the
+# direct origin is still reachable, and AFTER the SG restore on the
+# DOWN path. Both env vars optional - empty means skip entirely.
+notify_backend() {
+  local active=$1
+  if [ -z "${SHEAF_SHIELD_WEBHOOK_URL:-}" ] || [ -z "${SHEAF_SHIELD_WEBHOOK_SECRET:-}" ]; then
+    echo "  (SHEAF_SHIELD_WEBHOOK_URL / _SECRET unset; backend not notified)"
+    return 0
+  fi
+  local body sig
+  body=$(printf '{"active":%s}' "$active")
+  sig=$(printf '%s' "$body" \
+    | openssl dgst -sha256 -hmac "$SHEAF_SHIELD_WEBHOOK_SECRET" \
+    | awk '{print $2}')
+  if ! curl -fsS -X POST "$SHEAF_SHIELD_WEBHOOK_URL" \
+      -H "Content-Type: application/json" \
+      -H "X-Sheaf-Signature: $sig" \
+      --data "$body" \
+      --max-time 10 \
+      -o /dev/null; then
+    echo "  WARN: backend webhook POST failed (active=$active). CF + SG still flipped; re-run when reachable." >&2
+  fi
+}
+
+# Re-add the world ingress rules (v4 + v6). Matches the rule
+# description shape the script also looks for on revoke, so your IaC
+# tool's next reconcile sees a matching rule and does not want to
+# recreate them.
+restore_world_ingress() {
+  echo "Authorizing 443 from 0.0.0.0/0 on ${SG_ID}"
+  aws ec2 authorize-security-group-ingress \
+    --group-id "${SG_ID}" \
+    --ip-permissions "IpProtocol=tcp,FromPort=443,ToPort=443,IpRanges=[{CidrIp=0.0.0.0/0,Description=\"HTTPS from world (cf-shield revokes this during incidents)\"}]" \
+    >/dev/null 2>&1 || echo "  (already present)"
+  echo "Authorizing 443 from ::/0 on ${SG_ID}"
+  aws ec2 authorize-security-group-ingress \
+    --group-id "${SG_ID}" \
+    --ip-permissions "IpProtocol=tcp,FromPort=443,ToPort=443,Ipv6Ranges=[{CidrIpv6=::/0,Description=\"HTTPS from world v6 (cf-shield revokes this during incidents)\"}]" \
+    >/dev/null 2>&1 || echo "  (already present)"
+}
+
+case "${1:-}" in
+  up)
+    echo "== cf-shield UP =="
+    echo "1a. Flipping webapp record ${CF_APP_RECORD_ID} to proxied=true"
+    patch_proxied "$CF_APP_RECORD_ID" true
+    echo "1b. Flipping api record ${CF_API_RECORD_ID} to proxied=true"
+    patch_proxied "$CF_API_RECORD_ID" true
+    echo "2. Setting zone security_level=under_attack"
+    echo "   (api host stays at essentially_off via Configuration Rule)"
+    patch_security_level under_attack
+    # Notify backend BEFORE revoking SG. The webhook endpoint lives on
+    # the api host (now proxied via CF), and the world-ingress SG rule
+    # still gates direct hits to the origin; once we revoke that rule,
+    # operator IPs that haven't been allowlisted on the SG can no
+    # longer reach the origin directly until cf-shield down restores
+    # it. The CF path keeps working throughout.
+    echo "3. Notifying backend shield-mode=active"
+    notify_backend true
+    echo "4. Revoking HTTPS-from-world SG ingress"
+    revoke_world_ingress
+    echo "Done. Both records now route through Cloudflare; webapp sees UAM,"
+    echo "api stays challenge-free via the Configuration Rule. Run"
+    echo "'cf-shield down' when over."
+    ;;
+  down)
+    echo "== cf-shield DOWN =="
+    # Restore SG ingress FIRST so the webhook below can reach the
+    # origin again, then flip the CF posture back.
+    echo "1. Restoring HTTPS-from-world SG ingress"
+    restore_world_ingress
+    echo "2. Notifying backend shield-mode=inactive"
+    notify_backend false
+    echo "3a. Flipping webapp record ${CF_APP_RECORD_ID} to proxied=false"
+    patch_proxied "$CF_APP_RECORD_ID" false
+    echo "3b. Flipping api record ${CF_API_RECORD_ID} to proxied=false"
+    patch_proxied "$CF_API_RECORD_ID" false
+    echo "4. Setting zone security_level=medium"
+    patch_security_level medium
+    echo "Done. Reconcile any dashboard-side changes back into your IaC before the next apply."
+    ;;
+  status)
+    echo "== cf-shield STATUS =="
+    app_proxied=$(cf_curl "${CF_API}/dns_records/${CF_APP_RECORD_ID}" | jq -r '.result.proxied')
+    api_proxied=$(cf_curl "${CF_API}/dns_records/${CF_API_RECORD_ID}" | jq -r '.result.proxied')
+    sec=$(cf_curl "${CF_API}/settings/security_level" | jq -r '.result.value')
+    world_rules=$(aws ec2 describe-security-group-rules \
+      --filters "Name=group-id,Values=${SG_ID}" \
+      --query 'SecurityGroupRules[?!IsEgress && contains(Description, `HTTPS from world`)].SecurityGroupRuleId' \
+      --output text)
+    echo "webapp_proxied=${app_proxied}"
+    echo "api_proxied=${api_proxied}"
+    echo "security_level=${sec}"
+    echo "sg_world_rules=${world_rules:-<none>}"
+    # Backend's view, unauthenticated. Helpful when diagnosing drift
+    # between the CF/SG side and what the app thinks. URL derivation:
+    # if SHEAF_SHIELD_WEBHOOK_URL is set, swap the path to /status;
+    # otherwise skip (no fallback - we won't guess hostnames).
+    if [ -n "${SHEAF_SHIELD_WEBHOOK_URL:-}" ]; then
+      status_url=${SHEAF_SHIELD_WEBHOOK_URL%/internal/shield-mode/state}/shield-mode/status
+      backend=$(curl -fsS "$status_url" 2>/dev/null || echo "<unreachable>")
+      echo "backend_status=${backend}"
+    fi
+    ;;
+  *)
+    sed -n '2,40p' "$0"
+    exit 64
+    ;;
+esac

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -63,7 +63,10 @@ async def _get_own_entry(
 ) -> JournalEntry:
     entry = await db.get(JournalEntry, entry_id)
     if entry is None or entry.system_id != system_id:
-        raise HTTPException(status_code=404, detail="Journal entry not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Journal entry not found",
+        )
     return entry
 
 
@@ -72,7 +75,10 @@ async def _verify_member_in_system(
 ) -> None:
     member = await db.get(Member, member_id)
     if member is None or member.system_id != system_id:
-        raise HTTPException(status_code=404, detail="Member not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Member not found",
+        )
 
 
 def _label_for(entry: JournalEntry) -> str:
@@ -174,7 +180,10 @@ async def create_entry(
             author_member_ids=body.author_member_ids,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     await db.commit()
     await db.refresh(entry)
     return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
@@ -225,7 +234,10 @@ async def patch_entry(
             author_member_ids=update_data.get("author_member_ids"),
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     await db.commit()
     await db.refresh(entry)
     return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
@@ -324,7 +336,10 @@ async def restore_revision(
         or revision.target_type != ContentRevisionTarget.JOURNAL_ENTRY.value
         or revision.target_id != entry.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     await restore_journal_revision(
         db=db, user=user, entry=entry, revision=revision
     )
@@ -352,11 +367,17 @@ async def pin_journal_revision(
         or revision.target_type != ContentRevisionTarget.JOURNAL_ENTRY.value
         or revision.target_id != entry.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     try:
         await pin_revision(db=db, user=user, system=system, revision=revision)
     except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
     await db.commit()
     await db.refresh(revision)
     return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
@@ -381,9 +402,15 @@ async def unpin_journal_revision(
         or revision.target_type != ContentRevisionTarget.JOURNAL_ENTRY.value
         or revision.target_id != entry.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     if revision.pinned_at is None:
-        raise HTTPException(status_code=409, detail="Revision is not pinned")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Revision is not pinned",
+        )
 
     if is_safeguarded(system, PendingActionType.REVISION_UNPIN):
         verify_destructive_auth(user, system, body.password, body.totp_code)

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -511,7 +511,10 @@ async def restore_bio_revision(
         or revision.target_type != ContentRevisionTarget.MEMBER_BIO.value
         or revision.target_id != member.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     await restore_member_bio_revision(
         db=db, user=user, member=member, revision=revision
     )
@@ -542,11 +545,17 @@ async def pin_bio_revision(
         or revision.target_type != ContentRevisionTarget.MEMBER_BIO.value
         or revision.target_id != member.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     try:
         await pin_revision(db=db, user=user, system=system, revision=revision)
     except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
     await db.commit()
     await db.refresh(revision)
     return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
@@ -571,9 +580,15 @@ async def unpin_bio_revision(
         or revision.target_type != ContentRevisionTarget.MEMBER_BIO.value
         or revision.target_id != member.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     if revision.pinned_at is None:
-        raise HTTPException(status_code=409, detail="Revision is not pinned")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Revision is not pinned",
+        )
 
     if is_safeguarded(system, PendingActionType.REVISION_UNPIN):
         verify_destructive_auth(user, system, body.password, body.totp_code)

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -682,7 +682,10 @@ async def restore_revision(
         or revision.target_type != ContentRevisionTarget.MESSAGE.value
         or revision.target_id != msg.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     await restore_message_revision(db=db, user=user, message=msg, revision=revision)
     await db.commit()
     await db.refresh(msg)
@@ -708,11 +711,17 @@ async def pin_message_revision(
         or revision.target_type != ContentRevisionTarget.MESSAGE.value
         or revision.target_id != msg.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     try:
         await pin_revision(db=db, user=user, system=system, revision=revision)
     except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
     await db.commit()
     await db.refresh(revision)
     return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
@@ -737,9 +746,15 @@ async def unpin_message_revision(
         or revision.target_type != ContentRevisionTarget.MESSAGE.value
         or revision.target_id != msg.id
     ):
-        raise HTTPException(status_code=404, detail="Revision not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Revision not found",
+        )
     if revision.pinned_at is None:
-        raise HTTPException(status_code=409, detail="Revision is not pinned")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Revision is not pinned",
+        )
 
     if is_safeguarded(system, PendingActionType.REVISION_UNPIN):
         verify_destructive_auth(user, system, body.password, body.totp_code)

--- a/sheaf/api/v1/retention.py
+++ b/sheaf/api/v1/retention.py
@@ -165,9 +165,17 @@ async def cancel_trim_notice(
     re-upgrade (`on_tier_change`)."""
     notice = await db.get(RetentionTrimNotice, notice_id)
     if notice is None or notice.user_id != user.id:
-        raise HTTPException(status_code=404, detail="Trim notice not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Trim notice not found",
+        )
     if notice.status != RetentionTrimStatus.PENDING:
-        raise HTTPException(status_code=400, detail="Not pending")
+        # 409: the resource exists but is in a state that doesn't permit
+        # the requested operation (already cancelled / already applied).
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Trim notice is not pending.",
+        )
     notice.status = RetentionTrimStatus.CANCELLED
     notice.cancelled_at = datetime.now(UTC)
     await db.commit()

--- a/sheaf/api/v1/system_safety.py
+++ b/sheaf/api/v1/system_safety.py
@@ -216,9 +216,16 @@ async def cancel_pending_action(
     system = await _get_user_system(user, db)
     pending = await db.get(PendingAction, pending_id)
     if pending is None or pending.system_id != system.id:
-        raise HTTPException(status_code=404, detail="Pending action not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Pending action not found",
+        )
     if pending.status != PendingActionStatus.PENDING:
-        raise HTTPException(status_code=400, detail="Not pending")
+        # 409: already cancelled, completed, or otherwise no longer pending.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Pending action is not pending.",
+        )
     pending.status = PendingActionStatus.CANCELLED
     pending.cancelled_at = datetime.now(UTC)
     pending.cancelled_by_user_id = user.id
@@ -241,9 +248,15 @@ async def cancel_pending_change(
     system = await _get_user_system(user, db)
     change = await db.get(SafetyChangeRequest, change_id)
     if change is None or change.system_id != system.id:
-        raise HTTPException(status_code=404, detail="Pending change not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Pending change not found",
+        )
     if change.status != SafetyChangeStatus.PENDING:
-        raise HTTPException(status_code=400, detail="Not pending")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Pending change is not pending.",
+        )
     change.status = SafetyChangeStatus.CANCELLED
     change.cancelled_at = datetime.now(UTC)
     await db.commit()

--- a/web/src/components/avatar-upload.tsx
+++ b/web/src/components/avatar-upload.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { uploadFile } from "@/lib/files";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { AvatarCropperDialog } from "@/components/avatar-cropper-dialog";
 import { Button } from "@/components/ui/button";
@@ -51,7 +52,7 @@ export function AvatarUpload({
         toast.info("Animated image was flattened to a single frame.");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Upload failed");
+      setError(apiErrorMessage(err, "Upload failed"));
     } finally {
       setUploading(false);
     }

--- a/web/src/components/change-email.tsx
+++ b/web/src/components/change-email.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useState } from "react";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/use-auth";
 import { changeEmail } from "@/lib/auth";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -48,7 +49,7 @@ export function ChangeEmail() {
       }
       toast.success(`Email changed to ${res.email}.${parts.length ? " " + parts.join(" ") : ""}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Change failed");
+      setError(apiErrorMessage(err, "Change failed"));
     } finally {
       setLoading(false);
     }

--- a/web/src/components/change-password.tsx
+++ b/web/src/components/change-password.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useState } from "react";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/use-auth";
 import { changePassword } from "@/lib/auth";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -56,7 +57,7 @@ export function ChangePassword() {
         toast.success("Password changed.");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Change failed");
+      setError(apiErrorMessage(err, "Change failed"));
     } finally {
       setLoading(false);
     }

--- a/web/src/components/image-picker.tsx
+++ b/web/src/components/image-picker.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { listFiles, uploadFile } from "@/lib/files";
+import { apiErrorMessage } from "@/lib/api-errors";
 import {
   Dialog,
   DialogContent,
@@ -109,7 +110,7 @@ function UploadTab({ onUploaded }: { onUploaded: (key: string) => void }) {
       onUploaded(res.key);
     },
     onError: (err) => {
-      setError(err instanceof Error ? err.message : "Upload failed");
+      setError(apiErrorMessage(err, "Upload failed"));
     },
   });
 

--- a/web/src/components/revision-retention-card.tsx
+++ b/web/src/components/revision-retention-card.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { useAuth } from "@/hooks/use-auth";
 import { getRetention, updateRetention } from "@/lib/retention";
 import { getSystemSafety } from "@/lib/system-safety";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -79,7 +80,7 @@ function RetentionForm({ settings }: { settings: RetentionSettings }) {
       });
       toast.success("Retention settings saved");
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
+    onError: (err) => setError(apiErrorMessage(err, "Failed")),
   });
 
   const parsedRev = parseOverride(draft.max_revisions);

--- a/web/src/components/settings/account-info-card.tsx
+++ b/web/src/components/settings/account-info-card.tsx
@@ -19,7 +19,7 @@ export function AccountInfoCard() {
       await refreshUser();
       toast.success("Preferences saved");
     },
-    onError: () => toast.error("Failed to save preferences"),
+    // api-client auto-toasts the error; no caller-side onError needed.
   });
 
   return (

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { showApiErrorToast } from "@/lib/api-errors";
 
 import { useAuth } from "@/hooks/use-auth";
 import {
@@ -177,8 +178,7 @@ export function DataExportCard() {
       setMode(null);
       toast.success("Account data downloaded");
     },
-    onError: (e) =>
-      toast.error(e instanceof Error ? e.message : "Failed to fetch account data"),
+    onError: (err) => showApiErrorToast(err, "Couldn't fetch account data."),
   });
 
   async function handleSyncJsonExport() {
@@ -195,8 +195,11 @@ export function DataExportCard() {
       a.click();
       URL.revokeObjectURL(url);
       toast.success("Data exported");
-    } catch {
-      toast.error("Export failed");
+    } catch (err) {
+      // API errors are already toasted by the api-client; this helper
+      // skips re-toasting them. Non-API failures (Blob/URL constructor)
+      // fall through to the fallback.
+      showApiErrorToast(err, "Couldn't export data.");
     } finally {
       setSyncing(false);
     }

--- a/web/src/components/settings/developer-prefs-card.tsx
+++ b/web/src/components/settings/developer-prefs-card.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { useDeveloperPrefs } from "@/hooks/use-developer-prefs";
+
+export function DeveloperPrefsCard() {
+  const { showTechnicalErrors, setShowTechnicalErrors } = useDeveloperPrefs();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Error reporting</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="show-technical-errors"
+            checked={showTechnicalErrors}
+            onCheckedChange={(v) => setShowTechnicalErrors(v === true)}
+          />
+          <div>
+            <Label
+              htmlFor="show-technical-errors"
+              className="text-sm font-medium cursor-pointer"
+            >
+              Show technical error details
+            </Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              When something goes wrong, show the HTTP status code and the
+              server's exact error message instead of a friendly summary.
+              Useful for reporting bugs; can be noisy day-to-day.
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/settings/privacy-card.tsx
+++ b/web/src/components/settings/privacy-card.tsx
@@ -35,7 +35,7 @@ export function PrivacyCard() {
       await refreshUser();
       toast.success("Preference saved");
     },
-    onError: () => toast.error("Failed to save preference"),
+    // api-client auto-toasts the error; no caller-side onError needed.
   });
 
   if (!shieldStatus?.feature_enabled) {

--- a/web/src/components/settings/uploaded-files-card.tsx
+++ b/web/src/components/settings/uploaded-files-card.tsx
@@ -25,6 +25,7 @@ import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import { cn, formatBytes } from "@/lib/utils";
 import { AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
+import { showApiErrorToast } from "@/lib/api-errors";
 
 /** In-app link for a reference target, or null if it isn't deep-linkable.
  * target_type covers both live refs ("system" / "member" / "journal_entry")
@@ -87,8 +88,7 @@ export function UploadedFilesCard() {
         toast.success("File deleted");
       }
     },
-    onError: (err) =>
-      toast.error(err instanceof Error ? err.message : "Delete failed"),
+    onError: (err) => showApiErrorToast(err, "Couldn't delete file."),
   });
 
   return (

--- a/web/src/components/system-safety-card.tsx
+++ b/web/src/components/system-safety-card.tsx
@@ -8,6 +8,7 @@ import {
   getSystemSafety,
   updateSystemSafety,
 } from "@/lib/system-safety";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -162,7 +163,7 @@ function SafetyForm({ settings }: { settings: SystemSafetySettings }) {
         toast.success("Safety settings saved");
       }
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
+    onError: (err) => setError(apiErrorMessage(err, "Failed")),
   });
 
   const dirty = hasDiff(settings, draft);

--- a/web/src/components/totp-setup.tsx
+++ b/web/src/components/totp-setup.tsx
@@ -8,6 +8,7 @@ import {
   regenerateRecoveryCodes,
   type TOTPSetupResponse,
 } from "@/lib/auth";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -30,7 +31,7 @@ export function TOTPSetup() {
       setSetup(data);
       setStep("qr");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Setup failed");
+      setError(apiErrorMessage(err, "Setup failed"));
     } finally {
       setLoading(false);
     }
@@ -58,7 +59,7 @@ export function TOTPSetup() {
       await refreshUser();
       setStep("recovery");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Verification failed");
+      setError(apiErrorMessage(err, "Verification failed"));
     } finally {
       setLoading(false);
     }
@@ -190,7 +191,7 @@ function TOTPDisable() {
       await refreshUser();
       setAction("idle");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to disable 2FA");
+      setError(apiErrorMessage(err, "Failed to disable 2FA"));
     } finally {
       setLoading(false);
     }
@@ -206,7 +207,7 @@ function TOTPDisable() {
       setAction("show-codes");
       setTotpCode("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to regenerate codes");
+      setError(apiErrorMessage(err, "Failed to regenerate codes"));
     } finally {
       setLoading(false);
     }

--- a/web/src/hooks/use-developer-prefs.ts
+++ b/web/src/hooks/use-developer-prefs.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { apiFetch, getAccessToken } from "@/lib/api-client";
+import { patchWebSettings } from "@/lib/client-settings";
+import { setShowTechnicalErrorsSnapshot } from "@/lib/developer-prefs-snapshot";
+
+/**
+ * Developer / power-user preferences. Backend-stored under
+ * `client_settings/web.developer`. Today there's just one:
+ *
+ *   - `showTechnicalErrors`: when true, error toasts show the raw
+ *     status code and backend detail. When false (default), toasts
+ *     show a friendly summary derived from the status class.
+ *
+ * The api-client module isn't React and toasts errors synchronously,
+ * so the resolved value is mirrored into the cycle-free snapshot
+ * module (`developer-prefs-snapshot`). The snapshot is updated whenever
+ * the backend value loads, and on user toggles.
+ */
+
+const WEB_SETTINGS_QUERY = ["client-settings", "web"] as const;
+
+interface DeveloperBlob {
+  show_technical_errors?: boolean;
+}
+
+interface WebSettingsShape {
+  developer?: DeveloperBlob;
+  [key: string]: unknown;
+}
+
+async function fetchWebSettings(): Promise<WebSettingsShape> {
+  try {
+    const res = await apiFetch<{ settings: WebSettingsShape }>(
+      "/v1/settings/client/web",
+    );
+    return res.settings ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export interface UseDeveloperPrefsResult {
+  showTechnicalErrors: boolean;
+  setShowTechnicalErrors: (next: boolean) => void;
+}
+
+export function useDeveloperPrefs(): UseDeveloperPrefsResult {
+  const queryClient = useQueryClient();
+
+  const { data: backend } = useQuery({
+    queryKey: WEB_SETTINGS_QUERY,
+    queryFn: fetchWebSettings,
+    staleTime: 5 * 60 * 1000,
+    enabled: getAccessToken() !== null,
+    retry: false,
+  });
+
+  const showTechnicalErrors =
+    backend?.developer?.show_technical_errors ?? false;
+
+  // Keep the module-level snapshot in lockstep with whatever React is
+  // rendering. Without this, the api-client would read a stale value
+  // until the next page reload.
+  useEffect(() => {
+    setShowTechnicalErrorsSnapshot(showTechnicalErrors);
+  }, [showTechnicalErrors]);
+
+  const setShowTechnicalErrors = useCallback(
+    (next: boolean) => {
+      // Optimistic snapshot update so the very next error toast picks
+      // up the new value even if the network round-trip is slow.
+      setShowTechnicalErrorsSnapshot(next);
+      void patchWebSettings({
+        developer: { show_technical_errors: next },
+      }).then(() => {
+        queryClient.invalidateQueries({ queryKey: WEB_SETTINGS_QUERY });
+      });
+    },
+    [queryClient],
+  );
+
+  return { showTechnicalErrors, setShowTechnicalErrors };
+}

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -1,5 +1,7 @@
 import { toast } from "sonner";
 
+import { getShowTechnicalErrors } from "./developer-prefs-snapshot";
+
 let accessToken: string | null = null;
 let refreshPromise: Promise<string | null> | null = null;
 
@@ -68,16 +70,12 @@ async function refreshAccessToken(): Promise<string | null> {
   }
 }
 
-export class ApiError extends Error {
-  status: number;
-  detail: string;
-
-  constructor(status: number, detail: string) {
-    super(detail);
-    this.status = status;
-    this.detail = detail;
-  }
-}
+// ApiError lives in `./api-error` so non-api-client modules (e.g. the
+// shared `showApiErrorToast` helper) can import the class without
+// pulling in this file's fetch implementation. Re-exported here so
+// existing imports of `ApiError` from `@/lib/api-client` keep working.
+export { ApiError } from "./api-error";
+import { ApiError } from "./api-error";
 
 interface ApiFetchOptions extends RequestInit {
   /** Skip automatic token refresh on 401. Use for login/register endpoints. */
@@ -136,19 +134,14 @@ export async function apiFetch<T>(
     }
 
     // Show toast for non-auth errors (auth errors during login/register are
-    // handled inline by the form, not via toast).
-    if (resp.status >= 500) {
-      toast.error("Server error — please try again");
-    } else if (resp.status === 401 && attemptedRefresh) {
-      // Post-retry 401: refresh succeeded but the action itself still
-      // came back unauthorized. Not an auth-flow concern (the silent
-      // refresh already ran) — surface it like any other error so the
-      // user sees what went wrong instead of clicking into silence.
-      toast.error(detail);
-    } else if (resp.status !== 401 && resp.status !== 409) {
-      // Skip pre-retry 401 (the refresh dance handles it) and 409
-      // (conflict, shown inline by the caller).
-      toast.error(detail);
+    // handled inline by the form, not via toast). Pre-retry 401 is handled
+    // by the silent-refresh dance, and 409 is shown inline by the caller.
+    if (resp.status === 401 && !attemptedRefresh) {
+      // pre-retry 401: silent refresh handles this; no toast.
+    } else if (resp.status === 409) {
+      // 409: caller shows it inline.
+    } else {
+      autoToastError(resp.status, detail);
     }
 
     throw new ApiError(resp.status, detail);
@@ -214,17 +207,38 @@ export async function apiFetchWithHeaders<T>(
       }, 1500);
       throw new ApiError(resp.status, detail);
     }
-    if (resp.status >= 500) {
-      toast.error("Server error — please try again");
-    } else if (resp.status === 401 && attemptedRefresh) {
-      // Post-retry 401: refresh succeeded but the action itself still
-      // came back unauthorized. Surface it like any other error.
-      toast.error(detail);
-    } else if (resp.status !== 401 && resp.status !== 409) {
-      toast.error(detail);
+    if (resp.status === 401 && !attemptedRefresh) {
+      // pre-retry 401: silent refresh handles this; no toast.
+    } else if (resp.status === 409) {
+      // 409: caller shows it inline.
+    } else {
+      autoToastError(resp.status, detail);
     }
     throw new ApiError(resp.status, detail);
   }
 
   return { body: await resp.json(), headers: resp.headers };
+}
+
+// Inline mirror of the friendly-summary mapping used by the shared
+// `showApiErrorToast` helper. Duplicated here (rather than imported)
+// to avoid a cycle: api-errors.ts already imports ApiError, and
+// importing showApiErrorToast back into api-client would close the
+// loop. Both paths consult the same module-level snapshot so the
+// behaviour stays consistent.
+function autoToastError(httpStatus: number, detail: string): void {
+  if (getShowTechnicalErrors()) {
+    toast.error(`[${httpStatus}] ${detail}`);
+    return;
+  }
+  if (httpStatus === 400) toast.error("Invalid request.");
+  else if (httpStatus === 401) toast.error("You need to sign in to do that.");
+  else if (httpStatus === 403) toast.error("You don't have permission to do that.");
+  else if (httpStatus === 404) toast.error("Not found.");
+  else if (httpStatus === 413) toast.error("That's too large.");
+  else if (httpStatus === 422) toast.error("We couldn't understand that request.");
+  else if (httpStatus === 423) toast.error("Account temporarily locked.");
+  else if (httpStatus === 429) toast.error("Slow down — too many requests.");
+  else if (httpStatus >= 500) toast.error("Server error — please try again.");
+  else toast.error(detail);
 }

--- a/web/src/lib/api-error.ts
+++ b/web/src/lib/api-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Standalone error class so non-api-client modules (toast helper,
+ * route guards, etc.) can `instanceof`-check or construct without
+ * importing the fetch wrapper.
+ */
+export class ApiError extends Error {
+  status: number;
+  detail: string;
+
+  constructor(status: number, detail: string) {
+    super(detail);
+    this.status = status;
+    this.detail = detail;
+  }
+}

--- a/web/src/lib/api-errors.ts
+++ b/web/src/lib/api-errors.ts
@@ -1,0 +1,98 @@
+import { toast } from "sonner";
+
+import { ApiError } from "./api-error";
+import { getShowTechnicalErrors } from "./developer-prefs-snapshot";
+
+/**
+ * Friendly summary for an HTTP status. Used when the user has NOT
+ * opted into technical error details. Falls back to the supplied
+ * fallback (or a generic message) for unmapped statuses.
+ */
+function friendlySummary(status: number, fallback?: string): string {
+  if (status === 400) return "Invalid request.";
+  if (status === 401) return "You need to sign in to do that.";
+  if (status === 403) return "You don't have permission to do that.";
+  if (status === 404) return "Not found.";
+  if (status === 409) return "Conflict — refresh and try again.";
+  if (status === 413) return "That's too large.";
+  if (status === 422) return "We couldn't understand that request.";
+  if (status === 423) return "Account temporarily locked.";
+  if (status === 429) return "Slow down — too many requests.";
+  if (status >= 500) return "Server error — please try again.";
+  return fallback ?? "Something went wrong.";
+}
+
+/**
+ * Statuses for which the api-client deliberately does NOT auto-toast,
+ * leaving the caller (this helper, or an inline error display) to
+ * handle. Currently just 409 - the others either fall under the
+ * silent-refresh dance (pre-retry 401) or are toasted by the client.
+ *
+ * Calls to `showApiErrorToast` from a mutation `onError` toast only
+ * when the status falls in this set, so we don't double-toast the
+ * statuses the client already covered.
+ */
+const STATUSES_CLIENT_SKIPS: ReadonlySet<number> = new Set([409]);
+
+/**
+ * Compute the same friendly-or-technical string the toast helper would
+ * use, but return it instead of toasting. For inline error display
+ * (red text under a form, etc.) where a toast would be the wrong UI
+ * shape. Same toggle, same fallback semantics.
+ */
+export function apiErrorMessage(err: unknown, fallback?: string): string {
+  const showTechnical = getShowTechnicalErrors();
+  if (err instanceof ApiError) {
+    return showTechnical
+      ? `[${err.status}] ${err.detail}`
+      : friendlySummary(err.status, fallback);
+  }
+  if (err instanceof Error) {
+    return showTechnical ? err.message : (fallback ?? err.message);
+  }
+  return fallback ?? "Something went wrong.";
+}
+
+/**
+ * Toast an error with technical detail iff the user has opted in.
+ *
+ * Designed for two callsite shapes:
+ *   - **Mutation `onError`**: the api-client already auto-toasts most
+ *     statuses, so this helper only fires for statuses the client
+ *     skipped (currently 409). Avoids double toasts.
+ *   - **Standalone catch**: pass `{ force: true }` to always toast,
+ *     for non-mutation paths that don't go through the api-client's
+ *     auto-toast at all.
+ *
+ * When `show_technical_errors` is on, the toast reads
+ * `[<status>] <backend detail>`. Off, a friendly summary is used,
+ * falling back to the supplied `fallback` string for unmapped
+ * statuses.
+ */
+export function showApiErrorToast(
+  err: unknown,
+  fallback?: string,
+  opts: { force?: boolean } = {},
+): void {
+  const showTechnical = getShowTechnicalErrors();
+
+  if (err instanceof ApiError) {
+    if (!opts.force && !STATUSES_CLIENT_SKIPS.has(err.status)) {
+      // The api-client already auto-toasted this; don't double up.
+      return;
+    }
+    if (showTechnical) {
+      toast.error(`[${err.status}] ${err.detail}`);
+    } else {
+      toast.error(friendlySummary(err.status, fallback));
+    }
+    return;
+  }
+
+  if (err instanceof Error) {
+    toast.error(showTechnical ? err.message : (fallback ?? err.message));
+    return;
+  }
+
+  toast.error(fallback ?? "Something went wrong.");
+}

--- a/web/src/lib/developer-prefs-snapshot.ts
+++ b/web/src/lib/developer-prefs-snapshot.ts
@@ -1,0 +1,17 @@
+/**
+ * Cycle-free module-level snapshot of the `show_technical_errors`
+ * developer pref. Imported by both `api-client.ts` (sync read at toast
+ * time) and `use-developer-prefs.ts` (writes from React on backend
+ * value change / user toggle). Keeping it standalone avoids a
+ * dependency cycle between those two files.
+ */
+
+let _showTechnicalErrors = false;
+
+export function getShowTechnicalErrors(): boolean {
+  return _showTechnicalErrors;
+}
+
+export function setShowTechnicalErrorsSnapshot(next: boolean): void {
+  _showTechnicalErrors = next;
+}

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { Loader2Icon } from "lucide-react";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { getMemberLimit } from "@/lib/members";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
@@ -171,7 +172,7 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
       setPreview(p);
       setStep("preview");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to parse file");
+      setError(apiErrorMessage(err, "Failed to parse file"));
     }
   }
 
@@ -202,7 +203,7 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
       });
       navigate(`/imports/${job.id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Import failed");
+      setError(apiErrorMessage(err, "Import failed"));
       setStep("preview");
     }
   }
@@ -388,7 +389,7 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
       setPreview(p);
       setStep("preview");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to parse file");
+      setError(apiErrorMessage(err, "Failed to parse file"));
     }
   }
 
@@ -412,7 +413,7 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
       });
       navigate(`/imports/${job.id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Import failed");
+      setError(apiErrorMessage(err, "Import failed"));
       setStep("preview");
     }
   }
@@ -567,7 +568,7 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
       setPreview(p);
       setStep("preview");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to parse file");
+      setError(apiErrorMessage(err, "Failed to parse file"));
     }
   }
 
@@ -622,7 +623,7 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
       setToken("");
       navigate(`/imports/${job.id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Import failed");
+      setError(apiErrorMessage(err, "Import failed"));
       setStep("preview");
     }
   }
@@ -864,7 +865,7 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
       setPreview(p);
       setStep("preview");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to parse file");
+      setError(apiErrorMessage(err, "Failed to parse file"));
     }
   }
 
@@ -884,7 +885,7 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
       });
       navigate(`/imports/${job.id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Import failed");
+      setError(apiErrorMessage(err, "Import failed"));
       setStep("preview");
     }
   }

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -11,6 +11,7 @@ import { SettingsIndex } from "./settings/index";
 import { SettingsSystemPage } from "./settings/system";
 import { SettingsSafetyPage } from "./settings/safety";
 import { SettingsAccountPage } from "./settings/account";
+import { SettingsAdvancedPage } from "./settings/advanced";
 import { SettingsAppearancePage } from "./settings/appearance";
 import { SettingsDataPage } from "./settings/data";
 import { SettingsDangerPage } from "./settings/danger";
@@ -91,6 +92,7 @@ export const router = createBrowserRouter([
           { path: "account", element: <SettingsAccountPage /> },
           { path: "appearance", element: <SettingsAppearancePage /> },
           { path: "data", element: <SettingsDataPage /> },
+          { path: "advanced", element: <SettingsAdvancedPage /> },
           { path: "danger", element: <SettingsDangerPage /> },
         ],
       },

--- a/web/src/routes/journals.$id.tsx
+++ b/web/src/routes/journals.$id.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/lib/journals";
 import { getSystemSafety } from "@/lib/system-safety";
 import { getMySystem } from "@/lib/systems";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { isDeleteQueued } from "@/types/api";
 
 const MarkdownPreview = lazy(() =>
@@ -264,7 +265,7 @@ function DeleteEntryDialog({
       onDeleted(isDeleteQueued(result));
       onClose();
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Failed"),
+    onError: (err) => setError(apiErrorMessage(err, "Failed")),
   });
 
   const needsPassword = authTier === "password" || authTier === "both";

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -23,6 +23,7 @@ import { ColorDot } from "@/components/color-dot";
 import { ContentRevisionList } from "@/components/content-revision-list";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { apiErrorMessage, showApiErrorToast } from "@/lib/api-errors";
 
 const BioEditor = lazy(() => import("@/components/bio-editor").then(m => ({ default: m.BioEditor })));
 const MarkdownPreview = lazy(() => import("@/components/bio-editor").then(m => ({ default: m.MarkdownPreview })));
@@ -352,7 +353,7 @@ function DeleteMemberDialog({
       { id: member.id, confirm: Object.keys(confirm).length > 0 ? confirm : undefined },
       {
         onSuccess: () => onDeleted(),
-        onError: (err) => setError(err instanceof Error ? err.message : "Delete failed"),
+        onError: (err) => setError(apiErrorMessage(err, "Delete failed")),
       },
     );
   }
@@ -436,8 +437,7 @@ function MemberTagsEditor({ memberId }: { memberId: string }) {
       setEditing(false);
       toast.success("Tags updated");
     },
-    onError: (err) =>
-      toast.error(err instanceof Error ? err.message : "Failed to update tags"),
+    onError: (err) => showApiErrorToast(err, "Couldn't update tags."),
   });
   const [editing, setEditing] = useState(false);
   const [draftIds, setDraftIds] = useState<string[]>([]);
@@ -545,8 +545,7 @@ function NotifyOnFrontEditor({ member }: { member: Member }) {
       qc.invalidateQueries({ queryKey: ["messages", "notify-settings", member.id] });
       toast.success("Notification preferences updated");
     },
-    onError: (err) =>
-      toast.error(err instanceof Error ? err.message : "Failed to update"),
+    onError: (err) => showApiErrorToast(err, "Couldn't update notification preferences."),
   });
 
   const [editing, setEditing] = useState(false);

--- a/web/src/routes/messages.tsx
+++ b/web/src/routes/messages.tsx
@@ -11,6 +11,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
+import { showApiErrorToast } from "@/lib/api-errors";
 
 import { useMembers } from "@/hooks/use-members";
 import { getCurrentFronts } from "@/lib/fronts";
@@ -655,7 +656,7 @@ function Composer({
       onClearReply();
       onPosted();
     },
-    onError: (err: Error) => toast.error(err.message),
+    onError: (err) => showApiErrorToast(err),
   });
 
   function submit() {
@@ -736,7 +737,7 @@ function EditDialog({
       toast.success("Edited");
       onSaved();
     },
-    onError: (err: Error) => toast.error(err.message),
+    onError: (err) => showApiErrorToast(err),
   });
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80">

--- a/web/src/routes/polls.$pollId.tsx
+++ b/web/src/routes/polls.$pollId.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { showApiErrorToast } from "@/lib/api-errors";
 
 import { useMembers } from "@/hooks/use-members";
 import { getCurrentFronts } from "@/lib/fronts";
@@ -231,7 +232,7 @@ function VoteCard({
       qc.invalidateQueries({ queryKey: ["poll", poll.id, "audit"] });
       toast.success("Vote recorded");
     },
-    onError: (err: Error) => toast.error(err.message),
+    onError: (err) => showApiErrorToast(err),
   });
 
   const withdrawMut = useMutation({
@@ -242,7 +243,7 @@ function VoteCard({
       setPicked(new Set());
       toast.success("Vote withdrawn");
     },
-    onError: (err: Error) => toast.error(err.message),
+    onError: (err) => showApiErrorToast(err),
   });
 
   if (frontingMembers.length === 0) {

--- a/web/src/routes/polls.tsx
+++ b/web/src/routes/polls.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { Plus, Trash2, Vote } from "lucide-react";
 import { toast } from "sonner";
+import { showApiErrorToast } from "@/lib/api-errors";
 
 import { getMySystem } from "@/lib/systems";
 import {
@@ -288,7 +289,7 @@ function CreatePollDialog({
       toast.success("Poll created");
       onClose();
     },
-    onError: (err: Error) => toast.error(err.message),
+    onError: (err) => showApiErrorToast(err),
   });
 
   const trimmedOptions = options.map((o) => o.trim()).filter(Boolean);

--- a/web/src/routes/settings/_layout.tsx
+++ b/web/src/routes/settings/_layout.tsx
@@ -7,6 +7,7 @@ import {
   KeyRound,
   Palette,
   Database,
+  Wrench,
   AlertTriangle,
 } from "lucide-react";
 
@@ -16,6 +17,7 @@ const sections = [
   { to: "/settings/account", label: "Account", icon: KeyRound },
   { to: "/settings/appearance", label: "Appearance", icon: Palette },
   { to: "/settings/data", label: "Data", icon: Database },
+  { to: "/settings/advanced", label: "Advanced", icon: Wrench },
   { to: "/settings/danger", label: "Danger zone", icon: AlertTriangle },
 ];
 

--- a/web/src/routes/settings/advanced.tsx
+++ b/web/src/routes/settings/advanced.tsx
@@ -1,0 +1,9 @@
+import { DeveloperPrefsCard } from "@/components/settings/developer-prefs-card";
+
+export function SettingsAdvancedPage() {
+  return (
+    <>
+      <DeveloperPrefsCard />
+    </>
+  );
+}

--- a/web/src/routes/verify-email.tsx
+++ b/web/src/routes/verify-email.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams, Link } from "react-router";
 import { apiFetch } from "@/lib/api-client";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Check, X } from "lucide-react";
@@ -24,7 +25,7 @@ export function VerifyEmailPage() {
       .then(() => setState("success"))
       .catch((err) => {
         setState("error");
-        setError(err instanceof Error ? err.message : "Verification failed");
+        setError(apiErrorMessage(err, "Verification failed"));
       });
   }, [token]);
 


### PR DESCRIPTION
## Summary

Three related cleanups landed together because they all touch error surfacing.

**Friendly error toasts.** Failed API calls now show a status-aware summary ("Not found.", "Slow down - too many requests.", "Server error - please try again.") instead of either a generic "Server error" or the raw backend detail. Inline error messages (red text under forms in the TOTP, password change, email change, import, and System Safety surfaces) follow the same friendly mapping via a new \`apiErrorMessage\` helper. The auto-toast in \`api-client\` and the helper share one source of truth, so behaviour stays consistent across the toast and inline paths.

**\"Show technical error details\" setting.** New Advanced tab in Settings with a toggle that swaps the friendly summary for the raw HTTP status code and backend message - useful for bug reports or diagnosing flaky network paths. Off by default. Backend-stored under \`client_settings/web.developer\`, so the choice follows the account. A small standalone module (\`developer-prefs-snapshot\`) lets the non-React \`api-client\` read the current value synchronously at toast time without introducing a dependency cycle with the hook.

**Status-code audit.** A few endpoints raised \`400 Bad Request\` for state mismatches that should have been \`409 Conflict\` - cancelling an already-cancelled retention trim notice, pending action, or pending change. Now corrected. Bonus consistency sweep: all raw-int \`status_code=404/400\` raises across \`journals.py\`, \`members.py\`, \`messages.py\`, \`retention.py\`, and \`system_safety.py\` were swapped for the named \`status.HTTP_*\` constants.

Audited the \`except Exception\` blocks in \`admin.py\` along the way - all are intentional graceful-fallback paths (decrypt failure to \`<encrypted>\` sentinel; email-send failure logged, approval flow continues) and don't fall through to 500. Left alone.

## Test plan

- [x] \`ruff\`, \`tsc\`, \`eslint\` clean
- [x] \`./run_tests.sh\` full integration sweep
- [x] Localdev with toggle off: trigger a 4xx (e.g. delete something that's already gone) and confirm the toast reads \"Not found.\" rather than a raw detail
- [x] Localdev with toggle on: same action, confirm the toast reads \`[404] <backend detail>\`
- [x] Confirm cancelling an already-cancelled pending action returns 409 instead of 400
- [x] Confirm the inline error red-text on the TOTP / password-change / import surfaces respects the toggle too
- [x] Confirm the 409 toast path on the poll-vote / message-post / poll-create surfaces still fires (api-client skips 409 by design; the caller \`onError\` covers it)