### PR TITLE
Strip cross-account image refs during Sheaf JSON import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sheaf-to-Sheaf import no longer attaches another account's images.** When a Sheaf JSON export was imported into a different account (e.g. cloning a member roster to a fresh account on the same instance), the importer copied hosted `avatar_url` values and bio image references verbatim. The new account ended up with `/v1/files/...` references pointing at the original account's storage — silently borrowing blobs it did not own, invisible to quota tracking, and at risk of breaking the moment the original account triggered orphan cleanup. The importer now strips any internal storage references (avatars, bio image embeds, journal image keys) during the JSON import path; external image URLs (Gravatar, Imgur, etc.) are preserved unchanged. Restoring images on a Sheaf-to-Sheaf migration now requires re-uploading them on the new account; the proper fix is the planned export-with-images zip format that ships blob bytes alongside the JSON.
+
 ## [0.3.1] - 2026-06-02
 
 ### Added

--- a/sheaf/services/import_image_strip.py
+++ b/sheaf/services/import_image_strip.py
@@ -1,0 +1,101 @@
+"""Strip hosted image references from imported entities.
+
+A Sheaf-to-Sheaf JSON export carries `avatar_url` and bio markdown that
+point at the original instance's `/v1/files/<key>` paths or bare storage
+keys (e.g. `avatars/<owner_user_id>/<uuid>.png`). When the import lands
+on a different account (or even the same instance under a different
+user), those keys reference blobs owned by the original user. The
+import currently has no way to fetch and re-host the bytes, so we
+strip the references entirely and let the user re-upload.
+
+External image URLs (`https://gravatar.com/...`, `https://imgur.com/...`)
+are preserved as-is: they're not tied to anyone's storage and they
+behave the same on any instance.
+
+The proper long-term fix is the export-with-images zip path: the export
+ships the blob bytes alongside the JSON, the importer re-uploads them
+as the importer's `UploadedFile` rows, and the references get rewritten
+to the new keys. Tracked in project_future_work.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sheaf.files import _MD_IMAGE_URL_RE, _to_internal_key
+
+# Image keys live in flat strings (Member.avatar_url, System.avatar_url),
+# JSON arrays (JournalEntry.image_keys, ContentRevision.image_keys), and
+# markdown bodies (Member.description, JournalEntry.body, ContentRevision.body,
+# Message.body, Reminder.body, Group.description). Cover all three.
+
+
+def is_internal_image_ref(value: str | None) -> bool:
+    """True iff `value` points at this-instance hosted storage.
+
+    Wraps `_to_internal_key`, which recognises the three forms an
+    internal reference can take: `/v1/files/<key>`, `{cdn}/<key>`,
+    and a bare storage key. Returns False for None, empty, or any
+    URL whose host is not ours (gravatar, imgur, etc).
+    """
+    if not value:
+        return False
+    return _to_internal_key(value) is not None
+
+
+def strip_internal_avatar_url(value: str | None) -> str | None:
+    """Null out `value` if it's a hosted reference; pass external URLs through.
+
+    Used on `Member.avatar_url` and `System.avatar_url` at import time.
+    """
+    return None if is_internal_image_ref(value) else value
+
+
+def strip_internal_image_refs_md(text: str | None) -> str | None:
+    """Remove `![alt](url)` embeds whose URL is internal; preserve externals.
+
+    Operates on raw markdown plaintext. The regex matches the same
+    embed shape `sheaf/files.py:_MD_IMAGE_URL_RE` uses (`![alt](url)`),
+    and we apply `_to_internal_key` to each url to decide. Internal
+    matches are dropped entirely (including their alt text); externals
+    survive unchanged. Surrounding markdown (paragraphs, links, headings)
+    is untouched.
+
+    Returns None when the input is None. An input that consisted only
+    of internal embeds may return an empty string — callers that store
+    these fields as nullable should treat empty as null.
+    """
+    if text is None:
+        return None
+
+    def _maybe_strip(m: re.Match[str]) -> str:
+        url = m.group(2)
+        return "" if _to_internal_key(url) is not None else m.group(0)
+
+    return _MD_IMAGE_URL_RE.sub(_maybe_strip, text)
+
+
+def strip_internal_image_refs_md_to_none(text: str | None) -> str | None:
+    """Same as `strip_internal_image_refs_md`, but collapses empty / whitespace
+    results to None. For fields that are nullable in the DB and where an
+    empty string is semantically the same as absent.
+    """
+    cleaned = strip_internal_image_refs_md(text)
+    if cleaned is None:
+        return None
+    return cleaned if cleaned.strip() else None
+
+
+def strip_internal_image_keys(keys: list[str] | None) -> list[str]:
+    """Filter out internal keys from a pre-extracted image_keys list.
+
+    These lists (`JournalEntry.image_keys`, `ContentRevision.image_keys`)
+    are by design hosted-only — they're cached at write time precisely
+    so the orphan-cleanup pass doesn't have to re-parse the markdown.
+    A foreign instance's keys in here are always wrong on import, so
+    the effective behaviour is "always return []" — we still iterate
+    in case a future change ever puts external URLs in the list.
+    """
+    if not keys:
+        return []
+    return [k for k in keys if not is_internal_image_ref(k)]

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -63,6 +63,12 @@ from sheaf.models.system import DateFormat, PrivacyLevel, System
 from sheaf.models.tag import Tag
 from sheaf.models.watch_token import WatchToken
 from sheaf.services.custom_fields import encrypt_field_value
+from sheaf.services.import_image_strip import (
+    strip_internal_avatar_url,
+    strip_internal_image_keys,
+    strip_internal_image_refs_md,
+    strip_internal_image_refs_md_to_none,
+)
 from sheaf.services.member_limits import enforce_import_member_cap
 
 logger = logging.getLogger("sheaf.import.sheaf")
@@ -219,7 +225,11 @@ async def run_import(
             if sys_data.get("name"):
                 system.name = sys_data["name"][:100]
             if sys_data.get("description") is not None:
-                system.description = sys_data["description"]
+                # Strip any /v1/files/... image embeds — those keys belong
+                # to the exporting account, not this one.
+                system.description = strip_internal_image_refs_md(
+                    sys_data["description"]
+                )
             if sys_data.get("tag") is not None:
                 system.tag = sys_data["tag"][:8] if sys_data["tag"] else None
             if sys_data.get("color") is not None:
@@ -229,10 +239,18 @@ async def run_import(
             # Notes are encrypted at rest. Empty-string clears (matches the
             # PATCH /systems/me semantics).
             if "note" in sys_data:
-                note_val = sys_data["note"]
+                note_val = strip_internal_image_refs_md_to_none(
+                    sys_data.get("note")
+                )
                 system.note = encrypt(note_val) if note_val else None
             if sys_data.get("avatar_url") is not None:
-                system.avatar_url = _trunc(sys_data["avatar_url"], 500)
+                # An avatar key like avatars/<old_user_id>/<uuid>.png points
+                # at the original account's storage; we can't fetch the
+                # bytes, so drop the reference. External URLs (gravatar
+                # etc.) pass through unchanged.
+                system.avatar_url = _trunc(
+                    strip_internal_avatar_url(sys_data["avatar_url"]), 500
+                )
             if "replace_fronts_default" in sys_data:
                 system.replace_fronts_default = bool(
                     sys_data["replace_fronts_default"]
@@ -292,8 +310,15 @@ async def run_import(
     for m_data in export_members:
         old_id = m_data.get("id", "")
         plaintext_name = (m_data.get("name") or "unnamed")[:100]
-        plaintext_description = m_data.get("description")
-        plaintext_note = m_data.get("note")
+        # Drop /v1/files/... markdown image embeds in the bio + note;
+        # the keys point at the exporting account's storage and we can't
+        # rehost them on import. External URLs survive.
+        plaintext_description = strip_internal_image_refs_md(
+            m_data.get("description")
+        )
+        plaintext_note = strip_internal_image_refs_md_to_none(
+            m_data.get("note")
+        )
         member = Member(
             id=uuid.uuid4(),
             system_id=system.id,
@@ -311,7 +336,9 @@ async def run_import(
                 else None
             ),
             pronouns=_trunc(m_data.get("pronouns"), 100),
-            avatar_url=_trunc(m_data.get("avatar_url"), 500),
+            avatar_url=_trunc(
+                strip_internal_avatar_url(m_data.get("avatar_url")), 500
+            ),
             color=_trunc(m_data.get("color"), 7),
             birthday=_trunc(m_data.get("birthday"), 10),
             pluralkit_id=_trunc(m_data.get("pluralkit_id"), 8),
@@ -436,7 +463,7 @@ async def run_import(
                 id=uuid.uuid4(),
                 system_id=system.id,
                 name=(g_data.get("name") or "unnamed")[:100],
-                description=g_data.get("description"),
+                description=strip_internal_image_refs_md(g_data.get("description")),
                 color=_trunc(g_data.get("color"), 7),
             )
             db.add(group)
@@ -525,7 +552,9 @@ async def run_import(
                 system_id=system.id,
                 member_id=member.id if member else None,
                 title=encrypt(title) if title else None,
-                body=encrypt(j_data.get("body") or ""),
+                body=encrypt(
+                    strip_internal_image_refs_md(j_data.get("body")) or ""
+                ),
                 visibility=j_data.get("visibility") or "system",
                 # The original authoring account is meaningless on this
                 # instance; attribute the fallback author to the importing user.
@@ -537,7 +566,12 @@ async def run_import(
                     )
                 ],
                 author_member_names=_str_list(j_data.get("author_member_names")),
-                image_keys=_str_list(j_data.get("image_keys")),
+                # image_keys is a pre-extracted hosted-keys list; every entry
+                # here is by construction a key belonging to the exporting
+                # account. Drop them all rather than carrying dangling refs.
+                image_keys=strip_internal_image_keys(
+                    _str_list(j_data.get("image_keys"))
+                ),
             )
             created = _parse_iso(j_data.get("created_at"))
             if created:
@@ -581,8 +615,12 @@ async def run_import(
             ],
             editor_member_names=_str_list(r_data.get("editor_member_names")),
             title=encrypt(title) if title else None,
-            body=encrypt(r_data.get("body") or ""),
-            image_keys=_str_list(r_data.get("image_keys")),
+            body=encrypt(
+                strip_internal_image_refs_md(r_data.get("body")) or ""
+            ),
+            image_keys=strip_internal_image_keys(
+                _str_list(r_data.get("image_keys"))
+            ),
             pinned_at=_parse_iso(r_data.get("pinned_at")),
         )
         created = _parse_iso(r_data.get("created_at"))
@@ -613,7 +651,9 @@ async def run_import(
                 board_kind=board_kind,
                 board_member_id=board_member.id if board_member else None,
                 author_member_id=author.id if author else None,
-                body=encrypt(msg_data.get("body") or ""),
+                body=encrypt(
+                    strip_internal_image_refs_md(msg_data.get("body")) or ""
+                ),
             )
             created = _parse_iso(msg_data.get("created_at"))
             if created:
@@ -885,7 +925,7 @@ async def run_import(
                     f"Reminder '{rm_data.get('name', '?')}' trigger member "
                     "was not imported; kept without a member trigger"
                 )
-            body = rm_data.get("body")
+            body = strip_internal_image_refs_md_to_none(rm_data.get("body"))
             reminder = Reminder(
                 id=uuid.uuid4(),
                 system_id=system.id,

--- a/tests/test_import_image_strip.py
+++ b/tests/test_import_image_strip.py
@@ -1,0 +1,150 @@
+"""Unit tests for sheaf.services.import_image_strip.
+
+These run in-process — no server needed. They cover the helper logic
+that decides what counts as an internal hosted image reference and
+strips it from import payloads.
+"""
+
+from __future__ import annotations
+
+from sheaf.services.import_image_strip import (
+    is_internal_image_ref,
+    strip_internal_avatar_url,
+    strip_internal_image_keys,
+    strip_internal_image_refs_md,
+    strip_internal_image_refs_md_to_none,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_internal_image_ref
+# ---------------------------------------------------------------------------
+
+def test_internal_serve_path_is_internal():
+    assert is_internal_image_ref(
+        "/v1/files/avatars/00000000-0000-0000-0000-000000000001/abc.png"
+    )
+
+
+def test_bare_storage_key_is_internal():
+    assert is_internal_image_ref(
+        "avatars/00000000-0000-0000-0000-000000000001/abc.png"
+    )
+
+
+def test_external_https_url_is_not_internal():
+    assert not is_internal_image_ref("https://gravatar.com/avatar/hash.png")
+
+
+def test_external_http_url_is_not_internal():
+    assert not is_internal_image_ref("http://example.com/avatar.png")
+
+
+def test_none_is_not_internal():
+    assert not is_internal_image_ref(None)
+
+
+def test_empty_string_is_not_internal():
+    assert not is_internal_image_ref("")
+
+
+# ---------------------------------------------------------------------------
+# strip_internal_avatar_url
+# ---------------------------------------------------------------------------
+
+def test_strip_avatar_clears_internal_key():
+    assert strip_internal_avatar_url(
+        "avatars/00000000-0000-0000-0000-000000000001/abc.png"
+    ) is None
+
+
+def test_strip_avatar_clears_internal_serve_path():
+    assert strip_internal_avatar_url(
+        "/v1/files/avatars/00000000-0000-0000-0000-000000000001/abc.png"
+    ) is None
+
+
+def test_strip_avatar_preserves_external_url():
+    url = "https://gravatar.com/avatar/abc.png"
+    assert strip_internal_avatar_url(url) == url
+
+
+def test_strip_avatar_passes_none_through():
+    assert strip_internal_avatar_url(None) is None
+
+
+# ---------------------------------------------------------------------------
+# strip_internal_image_refs_md
+# ---------------------------------------------------------------------------
+
+def test_strip_md_removes_internal_serve_embed():
+    text = "Hi! ![pic](/v1/files/bios/00000000-0000-0000-0000-000000000001/a.png) bye"
+    cleaned = strip_internal_image_refs_md(text)
+    assert "v1/files" not in cleaned
+    assert cleaned.startswith("Hi!")
+    assert cleaned.endswith("bye")
+
+
+def test_strip_md_removes_bare_internal_key_embed():
+    text = "before ![alt](bios/00000000-0000-0000-0000-000000000001/k.png) after"
+    cleaned = strip_internal_image_refs_md(text)
+    assert "bios/" not in cleaned
+
+
+def test_strip_md_preserves_external_embed():
+    text = "look ![at](https://imgur.com/x.png) this"
+    assert strip_internal_image_refs_md(text) == text
+
+
+def test_strip_md_mixes_internal_and_external():
+    text = (
+        "external ![a](https://imgur.com/x.png) "
+        "internal ![b](/v1/files/bios/00000000-0000-0000-0000-000000000001/k.png) "
+        "both"
+    )
+    cleaned = strip_internal_image_refs_md(text)
+    assert "imgur.com" in cleaned
+    assert "v1/files" not in cleaned
+
+
+def test_strip_md_none_passes_through():
+    assert strip_internal_image_refs_md(None) is None
+
+
+def test_strip_md_preserves_non_image_markdown():
+    # Plain links shouldn't be touched; only ![alt](...) embeds get stripped.
+    text = "see [the docs](https://docs.example.com) for more"
+    assert strip_internal_image_refs_md(text) == text
+
+
+# ---------------------------------------------------------------------------
+# strip_internal_image_refs_md_to_none
+# ---------------------------------------------------------------------------
+
+def test_strip_md_to_none_returns_none_when_text_was_only_internal_embeds():
+    text = "  ![a](/v1/files/bios/00000000-0000-0000-0000-000000000001/x.png)  "
+    assert strip_internal_image_refs_md_to_none(text) is None
+
+
+def test_strip_md_to_none_keeps_text_when_other_content_remains():
+    text = "hello ![a](/v1/files/bios/00000000-0000-0000-0000-000000000001/x.png) world"
+    out = strip_internal_image_refs_md_to_none(text)
+    assert out is not None
+    assert "hello" in out and "world" in out
+
+
+# ---------------------------------------------------------------------------
+# strip_internal_image_keys
+# ---------------------------------------------------------------------------
+
+def test_strip_keys_drops_internal_keys():
+    keys = [
+        "avatars/00000000-0000-0000-0000-000000000001/a.png",
+        "bios/00000000-0000-0000-0000-000000000002/b.png",
+    ]
+    assert strip_internal_image_keys(keys) == []
+
+
+def test_strip_keys_handles_empty_and_none():
+    assert strip_internal_image_keys(None) == []
+    assert strip_internal_image_keys([]) == []

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -441,3 +441,103 @@ def test_sheaf_runner_hard_fails_over_member_cap(admin_client: httpx.Client):
 
     # Nothing was written: the account still has zero members.
     assert admin_client.get("/v1/members/limit").json()["current"] == 0
+
+
+# A foreign-looking owner UUID. Doesn't have to exist as a real user; the
+# import only inspects the structural shape of the key path, not whether
+# the embedded user_id resolves to anything live.
+_FOREIGN_OWNER = "99999999-9999-9999-9999-999999999999"
+
+# Export carrying every kind of cross-account image reference the
+# importer used to leak through. Designed so the resulting account ends
+# up with zero references back to the foreign owner's storage.
+_CROSS_ACCOUNT_EXPORT = {
+    "version": "2",
+    "system": {
+        "name": "Borrowed",
+        "avatar_url": f"avatars/{_FOREIGN_OWNER}/sysav.png",
+        "description": (
+            "Hi see "
+            f"![pic](/v1/files/bios/{_FOREIGN_OWNER}/inline.png)"
+            " also https://gravatar.com/x.png"
+        ),
+        "note": f"note ![n](/v1/files/bios/{_FOREIGN_OWNER}/n.png)",
+    },
+    "members": [
+        {
+            "id": "mx",
+            "name": "Borrower",
+            "avatar_url": f"avatars/{_FOREIGN_OWNER}/m-av.png",
+            "description": (
+                "bio with internal "
+                f"![inline](/v1/files/bios/{_FOREIGN_OWNER}/m-inline.png)"
+                " plus external ![ext](https://imgur.com/x.png)"
+            ),
+        },
+        {
+            "id": "my",
+            "name": "Externals",
+            "avatar_url": "https://gravatar.com/avatar/hash.png",
+            "description": "just ![ok](https://imgur.com/y.png)",
+        },
+    ],
+    "fronts": [],
+    "groups": [],
+    "tags": [],
+    "custom_fields": [],
+    "journals": [
+        {
+            "id": "j1",
+            "title": "entry",
+            "body": (
+                f"body ![pic](/v1/files/bios/{_FOREIGN_OWNER}/j-pic.png)"
+            ),
+            "image_keys": [
+                f"avatars/{_FOREIGN_OWNER}/jk1.png",
+                f"bios/{_FOREIGN_OWNER}/jk2.png",
+            ],
+        }
+    ],
+}
+
+
+def test_sheaf_runner_strips_cross_account_image_refs(auth_client: httpx.Client):
+    """Importing an export whose image refs point at another account's
+    storage strips those refs rather than carrying them through. External
+    URLs (gravatar, imgur) are preserved."""
+    me = auth_client.get("/v1/auth/me").json()
+    importer_id = me["id"]
+    assert importer_id != _FOREIGN_OWNER
+
+    job = _post_file(
+        auth_client, payload=json.dumps(_CROSS_ACCOUNT_EXPORT).encode()
+    )
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    # System avatar with foreign owner -> dropped. Description keeps the
+    # external https URL but loses the /v1/files embed.
+    system = auth_client.get("/v1/systems/me").json()
+    assert system["avatar_url"] is None, system
+    assert "v1/files" not in (system["description"] or "")
+    assert "gravatar.com" in (system["description"] or "")
+
+    # Members:
+    #  - The borrowing member's foreign-key avatar -> None; the external-
+    #    URL member's avatar survives untouched.
+    members = {m["name"]: m for m in auth_client.get("/v1/members").json()}
+    assert members["Borrower"]["avatar_url"] is None, members["Borrower"]
+    assert members["Externals"]["avatar_url"] == (
+        "https://gravatar.com/avatar/hash.png"
+    ), members["Externals"]
+    # Borrower's bio dropped the internal embed, kept the external one.
+    borrower_bio = members["Borrower"]["description"] or ""
+    assert "v1/files" not in borrower_bio
+    assert "imgur.com" in borrower_bio
+
+    # Journal entry body lost the internal embed; image_keys is now empty.
+    journals = auth_client.get("/v1/journals").json()
+    j = next(j for j in journals["items"] if j["title"] == "entry")
+    assert "v1/files" not in (j["body"] or "")
+    assert j["image_keys"] == [], j


### PR DESCRIPTION
## Summary

A Sheaf JSON export carries hosted image references (`avatar_url`, bio markdown embeds, journal `image_keys`) as paths like `/v1/files/avatars/<owner_user_id>/<uuid>.png` or bare storage keys (`avatars/<owner_user_id>/...`). When the export was imported into a different account on the same instance, those references were copied verbatim. The new account ended up pointing at the original account's storage - silently borrowing blobs it did not own, invisible to its own quota tracking, and at risk of breaking the moment the lender ran an orphan cleanup or deleted their account.

Caught while cloning a Google-Play-review account to an Apple-side review account on the smoke-test prod instance.

## The fix

`sheaf.services.import_image_strip` provides three helpers built on the existing `_to_internal_key` from `sheaf/files.py`:

- `strip_internal_avatar_url(value)`: returns `None` for internal paths (`/v1/files/`, bare key forms), passes external URLs (Gravatar, Imgur, etc.) through unchanged.
- `strip_internal_image_refs_md(text)`: walks `![alt](url)` embeds, drops any whose URL is internal, preserves externals.
- `strip_internal_image_keys(list)`: clears internal entries from `JournalEntry.image_keys` / `ContentRevision.image_keys` (which are by design hosted-keys-only, so the effective behaviour is "always returns []").

The Sheaf importer (`sheaf/services/sheaf_import.py`) applies these at every assignment that touches an image-ref-bearing field:

- `System.avatar_url`, `System.description`, `System.note`
- `Member.avatar_url`, `Member.description`, `Member.note`
- `Group.description`
- `JournalEntry.body`, `JournalEntry.image_keys`
- `ContentRevision.body`, `ContentRevision.image_keys`
- `Message.body`
- `Reminder.body`

The proper long-term fix is the planned export-with-images zip format that ships blob bytes alongside the JSON (tracked in project future-work notes); this PR is the interim that stops the leak in the JSON path. Re-importing a Sheaf-to-Sheaf migration now requires re-uploading images manually on the new account.

## Test plan

- [x] 20 unit cases for the strip helpers in `tests/test_import_image_strip.py` - all pass locally
- [x] `ruff` clean
- [x] `./run_tests.sh` full integration sweep including the new `test_sheaf_runner_strips_cross_account_image_refs` case
- [x] Localdev: export a system that has avatars + bio image embeds, import into a second account, confirm the second account has no `/v1/files` refs back to the first account's storage
- [x] Confirm external image URLs (Gravatar, Imgur) survive the strip