### PR TITLE
Make poll fronter-only voting an opt-in per poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Changed
+
+- **Polls no longer require voters to be fronting by default.** Voting is now open to any system member regardless of front state, matching the journals authoring model (an author doesn't need to be in the current front either). Polls that genuinely want the fronter-only gate ("what should we wear today") opt in via a new "Restrict voting to current fronters" checkbox at create time. Existing polls in v0.3.1 betas adopt the new permissive default; create restricted polls when you want the old behaviour. The custom-front exclusion (`include_custom_fronts`) still applies independently — system-state members like Asleep / Away can't vote unless that flag is on.
+
 ## [0.3.1] - 2026-06-02
 
 ### Added

--- a/alembic/versions/c2f3a4b5d6e7_add_restrict_voting_to_fronters.py
+++ b/alembic/versions/c2f3a4b5d6e7_add_restrict_voting_to_fronters.py
@@ -1,0 +1,39 @@
+"""Add polls.restrict_voting_to_fronters
+
+Revision ID: c2f3a4b5d6e7
+Revises: b1e2f3a4c5d6
+Create Date: 2026-06-03
+
+Per-poll opt-in for "voter must be in current front at vote time".
+Previously the gate was hardcoded on. New default is False so polls
+behave like journals (any member can author / vote regardless of front
+state). The server_default 'false' covers existing rows; pre-existing
+polls in v0.3.1 betas adopt the new permissive default.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c2f3a4b5d6e7"
+down_revision: Union[str, None] = "b1e2f3a4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "polls",
+        sa.Column(
+            "restrict_voting_to_fronters",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("polls", "restrict_voting_to_fronters")

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -541,6 +541,7 @@ def _poll_dict(poll) -> dict:
         "closes_at": poll.closes_at.isoformat(),
         "retention_days": poll.retention_days,
         "include_custom_fronts": poll.include_custom_fronts,
+        "restrict_voting_to_fronters": poll.restrict_voting_to_fronters,
         "created_at": poll.created_at.isoformat(),
         "options": [
             {

--- a/sheaf/api/v1/polls.py
+++ b/sheaf/api/v1/polls.py
@@ -155,6 +155,7 @@ def _to_read(
         closes_at=poll.closes_at,
         retention_days=poll.retention_days,
         include_custom_fronts=poll.include_custom_fronts,
+        restrict_voting_to_fronters=poll.restrict_voting_to_fronters,
         options=options,
         is_closed=poll.closes_at <= now,
         closed_since=poll.closes_at if poll.closes_at <= now else None,
@@ -268,6 +269,7 @@ async def create_poll(
         closes_at=body.closes_at,
         retention_days=retention_days,
         include_custom_fronts=body.include_custom_fronts,
+        restrict_voting_to_fronters=body.restrict_voting_to_fronters,
     )
     for index, opt in enumerate(body.options):
         poll.options.append(

--- a/sheaf/models/poll.py
+++ b/sheaf/models/poll.py
@@ -86,6 +86,14 @@ class Poll(UUIDMixin, TimestampMixin, Base):
     include_custom_fronts: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default="false", default=False
     )
+    # When true, only members in the current front at vote time may cast
+    # or change a vote. Default false matches the journals model (any
+    # member can author / vote regardless of front state). Set true on
+    # creation for decisions the system wants the active fronters to own
+    # ("what to wear today") rather than opening to absent members.
+    restrict_voting_to_fronters: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
 
     options: Mapped[list[PollOption]] = relationship(
         back_populates="poll",

--- a/sheaf/schemas/poll.py
+++ b/sheaf/schemas/poll.py
@@ -33,6 +33,11 @@ class PollCreate(BaseModel):
     closes_at: datetime
     retention_days: int | None = Field(default=None, ge=1, le=3650)
     include_custom_fronts: bool = False
+    # When True, voting is gated on the voted-as member being part of
+    # the current front at vote/withdraw time. When False (default),
+    # any system member may vote regardless of front state — matches
+    # the journals model where any member can author.
+    restrict_voting_to_fronters: bool = False
     options: list[PollOptionCreate] = Field(min_length=2, max_length=20)
 
     @field_validator("options")
@@ -68,6 +73,7 @@ class PollRead(BaseModel):
     closes_at: datetime
     retention_days: int
     include_custom_fronts: bool
+    restrict_voting_to_fronters: bool
     options: list[PollOptionRead]
 
     is_closed: bool

--- a/sheaf/services/polls.py
+++ b/sheaf/services/polls.py
@@ -215,8 +215,10 @@ async def record_vote(
     - Refuses if the poll is closed.
     - Refuses if any option_id isn't part of the poll.
     - Refuses if the kind is single_choice and more than one option supplied.
-    - Refuses if the voted-as member isn't currently fronting (per
-      `member_is_currently_fronting`).
+    - Refuses if the voted-as member isn't currently fronting AND the
+      poll was created with `restrict_voting_to_fronters=True`. Polls
+      without that flag accept votes from any system member regardless
+      of front state, matching the journals authoring model.
 
     Writes both the current-state poll_votes row and the audit event in
     the same transaction. The caller commits.
@@ -251,11 +253,11 @@ async def record_vote(
             "This poll does not accept votes from custom fronts."
         )
 
-    if not await member_is_currently_fronting(
+    if poll.restrict_voting_to_fronters and not await member_is_currently_fronting(
         db, system_id=poll.system_id, member_id=voted_as_member_id
     ):
         raise VoteError(
-            "The voted-as member must be part of the current front."
+            "This poll only accepts votes from members in the current front."
         )
 
     fronting_ids = await current_front_member_ids(db, system_id=poll.system_id)
@@ -313,7 +315,7 @@ async def withdraw_vote(
     if poll.closes_at <= now:
         raise VoteError("Poll is closed.")
 
-    if not await member_is_currently_fronting(
+    if poll.restrict_voting_to_fronters and not await member_is_currently_fronting(
         db, system_id=poll.system_id, member_id=voted_as_member_id
     ):
         raise VoteError(

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -666,6 +666,9 @@ async def run_import(
                 include_custom_fronts=bool(
                     p_data.get("include_custom_fronts", False)
                 ),
+                restrict_voting_to_fronters=bool(
+                    p_data.get("restrict_voting_to_fronters", False)
+                ),
             )
             created = _parse_iso(p_data.get("created_at"))
             if created:

--- a/tests/test_polls_api.py
+++ b/tests/test_polls_api.py
@@ -7,8 +7,13 @@ from datetime import UTC, datetime, timedelta
 import httpx
 
 
-def _member(client: httpx.Client, name: str) -> str:
-    resp = client.post("/v1/members", json={"name": name})
+def _member(
+    client: httpx.Client, name: str, *, is_custom_front: bool = False
+) -> str:
+    resp = client.post(
+        "/v1/members",
+        json={"name": name, "is_custom_front": is_custom_front},
+    )
     assert resp.status_code == 201, resp.text
     return resp.json()["id"]
 
@@ -32,6 +37,7 @@ def _create_poll(
     closes_at: str | None = None,
     options: list[str] | None = None,
     include_custom_fronts: bool = False,
+    restrict_voting_to_fronters: bool = False,
 ) -> dict:
     resp = client.post(
         "/v1/polls",
@@ -41,6 +47,7 @@ def _create_poll(
             "results_visibility": visibility,
             "closes_at": closes_at or _closes_in(86400),
             "include_custom_fronts": include_custom_fronts,
+            "restrict_voting_to_fronters": restrict_voting_to_fronters,
             "options": [{"text": t} for t in (options or ["Pizza", "Sushi"])],
         },
     )
@@ -130,13 +137,15 @@ def test_reject_too_few_options(auth_client: httpx.Client):
 # --- Voting ---------------------------------------------------------------
 
 
-def test_cast_vote_requires_fronting(auth_client: httpx.Client):
-    """A member who isn't fronting cannot cast a vote attributed to them."""
+def test_cast_vote_requires_fronting_when_restricted(auth_client: httpx.Client):
+    """A poll created with restrict_voting_to_fronters=True only accepts
+    votes from members currently in the front."""
     alice = _member(auth_client, "Alice")
     bob = _member(auth_client, "Bob")
     _front(auth_client, [alice])  # only alice is up
 
-    poll = _create_poll(auth_client)
+    poll = _create_poll(auth_client, restrict_voting_to_fronters=True)
+    assert poll["restrict_voting_to_fronters"] is True
 
     # Attempt to vote as Bob (not fronting)
     resp = auth_client.post(
@@ -148,6 +157,71 @@ def test_cast_vote_requires_fronting(auth_client: httpx.Client):
     )
     assert resp.status_code == 400
     assert "front" in resp.json()["detail"].lower()
+
+
+def test_cast_vote_open_to_non_fronting_member_by_default(auth_client: httpx.Client):
+    """The default poll (restrict_voting_to_fronters=False) accepts votes
+    from any system member, regardless of front state — matches the
+    journals authoring model."""
+    alice = _member(auth_client, "Alice")
+    bob = _member(auth_client, "Bob")
+    _front(auth_client, [alice])  # only alice is up
+
+    poll = _create_poll(auth_client)
+    assert poll["restrict_voting_to_fronters"] is False
+
+    # Bob is not fronting but the poll is open to all members.
+    resp = auth_client.post(
+        f"/v1/polls/{poll['id']}/votes",
+        json={
+            "voted_as_member_id": bob,
+            "option_ids": [poll["options"][0]["id"]],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_withdraw_vote_open_to_non_fronting_member_by_default(
+    auth_client: httpx.Client,
+):
+    """Withdraw obeys the same gate: by default, non-fronting members can
+    withdraw a vote they cast earlier."""
+    alice = _member(auth_client, "Alice")
+    bob = _member(auth_client, "Bob")
+    _front(auth_client, [alice, bob])
+    poll = _create_poll(auth_client)
+    resp = auth_client.post(
+        f"/v1/polls/{poll['id']}/votes",
+        json={
+            "voted_as_member_id": bob,
+            "option_ids": [poll["options"][0]["id"]],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    # Bob steps out of the front.
+    _front(auth_client, [alice])
+
+    resp = auth_client.delete(f"/v1/polls/{poll['id']}/votes/{bob}")
+    assert resp.status_code == 204, resp.text
+
+
+def test_custom_front_exclusion_still_applies_when_unrestricted(
+    auth_client: httpx.Client,
+):
+    """Even with restrict_voting_to_fronters=False, a custom-front member
+    can't vote unless include_custom_fronts is also set."""
+    nap = _member(auth_client, "Asleep", is_custom_front=True)
+    poll = _create_poll(auth_client)  # neither flag set
+
+    resp = auth_client.post(
+        f"/v1/polls/{poll['id']}/votes",
+        json={
+            "voted_as_member_id": nap,
+            "option_ids": [poll["options"][0]["id"]],
+        },
+    )
+    assert resp.status_code == 400
+    assert "custom front" in resp.json()["detail"].lower()
 
 
 def test_cast_vote_succeeds_for_fronting_member(auth_client: httpx.Client):

--- a/web/src/routes/polls.$pollId.tsx
+++ b/web/src/routes/polls.$pollId.tsx
@@ -133,6 +133,11 @@ export function PollDetailPage() {
                 ? "Live results"
                 : "Results at close"}
             </Badge>
+            <Badge variant="outline">
+              {poll.restrict_voting_to_fronters
+                ? "Fronters only"
+                : "Open to all members"}
+            </Badge>
             {poll.is_closed ? (
               <Badge variant="secondary">Closed</Badge>
             ) : (
@@ -196,18 +201,29 @@ function VoteCard({
   memberById: Map<string, Member>;
 }) {
   const qc = useQueryClient();
-  const frontingMembers = useMemo(
+  // Eligible voter set:
+  //  - When the poll restricts voting to current fronters, only members
+  //    in the front (minus custom fronts unless include_custom_fronts).
+  //  - Otherwise, any system member, with the same custom-front exclusion.
+  const eligibleMembers = useMemo(
     () =>
-      members.filter(
-        (m) =>
-          frontingIds.has(m.id) &&
-          (poll.include_custom_fronts || !m.is_custom_front),
-      ),
-    [members, frontingIds, poll.include_custom_fronts],
+      members.filter((m) => {
+        if (!poll.include_custom_fronts && m.is_custom_front) return false;
+        if (poll.restrict_voting_to_fronters && !frontingIds.has(m.id)) {
+          return false;
+        }
+        return true;
+      }),
+    [
+      members,
+      frontingIds,
+      poll.include_custom_fronts,
+      poll.restrict_voting_to_fronters,
+    ],
   );
 
   const [selectedMemberId, setSelectedMemberId] = useState<string>(
-    () => frontingMembers[0]?.id ?? "",
+    () => eligibleMembers[0]?.id ?? "",
   );
   const [picked, setPicked] = useState<Set<string>>(() => {
     if (!poll.votes || !selectedMemberId) return new Set();
@@ -245,15 +261,18 @@ function VoteCard({
     onError: (err: Error) => toast.error(err.message),
   });
 
-  if (frontingMembers.length === 0) {
+  if (eligibleMembers.length === 0) {
     const allFrontingAreCustom =
+      poll.restrict_voting_to_fronters &&
       !poll.include_custom_fronts &&
       members.some((m) => frontingIds.has(m.id) && m.is_custom_front);
     return (
       <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
         {allFrontingAreCustom
           ? "Only custom fronts are currently fronting, and this poll doesn't accept votes from custom fronts."
-          : "No member is currently fronting. A member has to be in the front to cast or change a vote."}
+          : poll.restrict_voting_to_fronters
+          ? "No member is currently fronting. A member has to be in the front to cast or change a vote on this poll."
+          : "No eligible voters in this system."}
       </div>
     );
   }
@@ -284,7 +303,7 @@ function VoteCard({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {frontingMembers.map((m) => {
+            {eligibleMembers.map((m) => {
               const member = memberById.get(m.id) ?? m;
               return (
                 <SelectItem key={m.id} value={m.id}>

--- a/web/src/routes/polls.tsx
+++ b/web/src/routes/polls.tsx
@@ -267,6 +267,7 @@ function CreatePollDialog({
   const [visibility, setVisibility] = useState<PollResultsVisibility>("live");
   const [closesAtLocal, setClosesAtLocal] = useState(defaultClosesAtLocal());
   const [includeCustomFronts, setIncludeCustomFronts] = useState(false);
+  const [restrictToFronters, setRestrictToFronters] = useState(false);
   const [retentionDays, setRetentionDays] = useState<number>(
     serverConfig?.default_retention_days ?? 30,
   );
@@ -308,6 +309,7 @@ function CreatePollDialog({
       results_visibility: visibility,
       closes_at: closesAt,
       include_custom_fronts: includeCustomFronts,
+      restrict_voting_to_fronters: restrictToFronters,
       retention_days: retentionDays,
       options: trimmedOptions.map((text) => ({ text })),
     });
@@ -433,6 +435,24 @@ function CreatePollDialog({
               <span className="text-xs text-muted-foreground">
                 Custom fronts (Asleep, Away, etc.) are normally system states,
                 not voters. Off by default.
+              </span>
+            </div>
+          </label>
+
+          <label className="flex items-start gap-2 rounded-md border p-3 cursor-pointer hover:bg-accent">
+            <Checkbox
+              checked={restrictToFronters}
+              onCheckedChange={(v) => setRestrictToFronters(v === true)}
+            />
+            <div className="grid gap-1">
+              <span className="text-sm font-medium">
+                Restrict voting to current fronters
+              </span>
+              <span className="text-xs text-muted-foreground">
+                When on, only members in the front at vote time can cast or
+                change a vote. Off by default — any member may vote, matching
+                journals. Turn on for decisions you want the active fronters
+                to own (e.g. &quot;what to wear today&quot;).
               </span>
             </div>
           </label>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -915,6 +915,10 @@ export interface Poll {
   closes_at: string;
   retention_days: number;
   include_custom_fronts: boolean;
+  /** When true, only members in the current front at vote time may
+   *  cast or change a vote. Default false; matches the journals model
+   *  where any member can author regardless of front state. */
+  restrict_voting_to_fronters: boolean;
   options: PollOption[];
   is_closed: boolean;
   closed_since: string | null;
@@ -940,6 +944,7 @@ export interface PollCreate {
   closes_at: string;
   retention_days?: number | null;
   include_custom_fronts?: boolean;
+  restrict_voting_to_fronters?: boolean;
   options: PollOptionCreate[];
 }
 


### PR DESCRIPTION
## Summary

Voting on a poll is no longer gated on the voted-as member being part of the current front. By default any system member can cast or change a vote regardless of front state, matching the journals authoring model. Polls that genuinely want the old behaviour (for example "what to wear today" decisions you want the active fronters to own) opt in via a new checkbox at create time.

The `include_custom_fronts` flag continues to apply independently: custom-front members (Asleep, Away, etc.) can't vote unless that flag is explicitly on, regardless of whether the fronter restriction is set.

The audit log still records `fronting_member_ids` at vote time on every event, so "X voted while not fronting" remains discoverable from the poll history.

## Backend

- New `polls.restrict_voting_to_fronters` column (boolean, server_default false). Migration `c2f3a4b5d6e7`.
- `PollCreate` / `PollRead` gain the field. `record_vote` and `withdraw_vote` skip the `member_is_currently_fronting` check when the flag is false.
- Exporter + importer carry the new field.
- Existing polls in v0.3.1 betas adopt the permissive default; the prod smoke instance has 0 real users so no data backfill is needed.

## Frontend

- "Restrict voting to current fronters" checkbox in the create dialog (default off).
- Eligible-voter set in the vote UI widens to all members when restriction is off, narrows to current fronters when on. Custom-front exclusion still applies via `include_custom_fronts`.
- Poll header badge surfaces the policy ("Fronters only" vs "Open to all members").

## Test plan

- [x] `ruff`, `tsc`, `eslint` clean
- [x] `./run_tests.sh tests/test_polls_api.py` — new cases:
  - [x] `test_cast_vote_requires_fronting_when_restricted` (gate fires when flag on)
  - [x] `test_cast_vote_open_to_non_fronting_member_by_default` (non-fronter can vote when off)
  - [x] `test_withdraw_vote_open_to_non_fronting_member_by_default` (withdraw obeys the same gate)
  - [x] `test_custom_front_exclusion_still_applies_when_unrestricted` (Asleep can't vote even when unrestricted)
- [x] Localdev: create a poll with the checkbox off, vote as a non-fronting member, confirm it lands
- [x] Localdev: create a poll with the checkbox on, confirm the existing fronter-only flow still works
- [x] Localdev: confirm the poll header badge reads correctly for both states
- [ ] Round-trip: export a system with one of each policy + re-import, confirm the flag survives