### PR TITLE
Custom-field select/multiselect: backend validation + web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Select and multi-select custom field types on web.** The new poll dialog already accepted these types via the API (mobile apps ship pickers for both), but the web frontend only listed text/number/date/boolean and rendered every field value as a plain text input. The custom-fields settings card now offers all six types, lets you define a list of valid choices for select/multiselect at create time (or leave choices blank for freeform tagging — same behaviour the mobile apps default to), and per-choice editing on rename. Member values render with type-aware widgets: a number input for numeric, a date picker for dates, a checkbox for booleans, a dropdown for select, and a checkbox group for multi-select. When a field defines an explicit list of choices, the server now rejects submitted values that don't match — applies across all clients (web, iOS, Android).
+
 ### Fixed
 
 - **Sheaf-to-Sheaf import no longer attaches another account's images.** When a Sheaf JSON export was imported into a different account (e.g. cloning a member roster to a fresh account on the same instance), the importer copied hosted `avatar_url` values and bio image references verbatim. The new account ended up with `/v1/files/...` references pointing at the original account's storage — silently borrowing blobs it did not own, invisible to quota tracking, and at risk of breaking the moment the original account triggered orphan cleanup. The importer now strips any internal storage references (avatars, bio image embeds, journal image keys) during the JSON import path; external image URLs (Gravatar, Imgur, etc.) are preserved unchanged. Restoring images on a Sheaf-to-Sheaf migration now requires re-uploading them on the new account; the proper fix is the planned export-with-images zip format that ships blob bytes alongside the JSON.

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,6 +10,15 @@ COPY sheaf/ sheaf/
 COPY alembic.ini .
 COPY alembic/ alembic/
 
+# Optional pip index overrides. Empty by default so public builds use
+# PyPI as-is; selfhosters can point at a private mirror or cache by
+# passing `--build-arg PIP_INDEX_URL=...` (or via docker-compose args
+# forwarded from .env). pip reads these env vars natively.
+ARG PIP_INDEX_URL=
+ARG PIP_EXTRA_INDEX_URL=
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
+ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+
 RUN pip install --no-cache-dir ".[s3,ses,smtp,sendgrid]"
 
 # Dev-only tools (destructive jobs for demo instances, etc.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ services:
       dockerfile: Dockerfile.backend
       args:
         INCLUDE_DEV_TOOLS: "${INCLUDE_DEV_TOOLS:-false}"
+        # Optional pip index overrides — empty unless set in .env on the
+        # host. Selfhosters who run a private PyPI mirror or cache (e.g.
+        # proxpi, devpi, Artifactory) drop one of these into their
+        # gitignored .env and rebuild. See docs/SELFHOSTING.md.
+        PIP_INDEX_URL: "${PIP_INDEX_URL:-}"
+        PIP_EXTRA_INDEX_URL: "${PIP_EXTRA_INDEX_URL:-}"
     ports:
       - "${SHEAF_PORT:-8000}:${SHEAF_PORT:-8000}"
       # Metrics endpoint. The host side publishes on loopback by default

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -130,6 +130,17 @@ For local development without Docker, install the extras you need:
 pip install -e ".[dev,s3,smtp]"
 ```
 
+### Building behind a private PyPI mirror
+
+If you run a PyPI cache or mirror on your network (proxpi, devpi, Artifactory, etc.), the backend Dockerfile picks it up from two optional build args, both empty by default:
+
+```bash
+PIP_INDEX_URL=http://pypi.mirror.lan/index/
+PIP_EXTRA_INDEX_URL=
+```
+
+Drop one (or both) into a gitignored `.env` next to `docker-compose.yml` and re-run `docker compose build`. `PIP_INDEX_URL` replaces PyPI entirely (use this when the mirror itself is a transparent PyPI proxy); `PIP_EXTRA_INDEX_URL` is checked first with PyPI as fallback. Empty values pass through to pip's default behaviour, so leaving them unset means public-PyPI builds as before.
+
 ---
 
 ## Email

--- a/sheaf/api/v1/custom_fields.py
+++ b/sheaf/api/v1/custom_fields.py
@@ -18,6 +18,8 @@ from sheaf.schemas.custom_field import (
     CustomFieldUpdate,
     CustomFieldValueRead,
     CustomFieldValueSet,
+    _validate_options_for_type,
+    _validate_value_for_field,
 )
 from sheaf.schemas.member import MemberDeleteConfirm
 from sheaf.services.custom_fields import (
@@ -142,6 +144,16 @@ async def update_field(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Field not found")
 
     update_data = body.model_dump(exclude_unset=True)
+    if "options" in update_data:
+        try:
+            update_data["options"] = _validate_options_for_type(
+                field.field_type, update_data["options"]
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            ) from e
     for key, value in update_data.items():
         setattr(field, key, value)
     await db.commit()
@@ -243,7 +255,10 @@ async def set_member_field_values(
     if member_result.scalar_one_or_none() is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
 
-    # Validate all field IDs belong to this system
+    # Validate all field IDs belong to this system. Keep the field rows
+    # around so we can run per-type value validation below — we need
+    # field_type + options to know whether a submitted select value is
+    # in the defined choices set.
     field_ids = [item.field_id for item in body]
     field_result = await db.execute(
         select(CustomFieldDefinition).where(
@@ -251,12 +266,27 @@ async def set_member_field_values(
             CustomFieldDefinition.system_id == system.id,
         )
     )
-    valid_fields = {f.id for f in field_result.scalars().all()}
-    if len(valid_fields) != len(field_ids):
+    field_by_id = {f.id: f for f in field_result.scalars().all()}
+    if len(field_by_id) != len(field_ids):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="One or more field IDs are invalid",
         )
+
+    # Type-aware value validation. Only enforces the constraints that
+    # don't need decryption — for select/multiselect with a `choices`
+    # list, the submitted value must be one of them. Free-form
+    # select/multiselect (choices unset, mobile's current shape) is
+    # left alone.
+    for item in body:
+        defn = field_by_id[item.field_id]
+        try:
+            _validate_value_for_field(defn.field_type, defn.options, item.value)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Field '{defn.name}': {e}",
+            ) from e
 
     # Upsert values. Stored value is the encrypted JSON-serialised plaintext.
     for item in body:

--- a/sheaf/schemas/custom_field.py
+++ b/sheaf/schemas/custom_field.py
@@ -2,10 +2,84 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from sheaf.models.custom_field import FieldType
 from sheaf.models.system import PrivacyLevel
+
+# Choices are a list of distinct, non-empty, trimmed strings. Mobile
+# clients currently pass options=null for select/multiselect (the
+# choices editor is web-side for now); when choices are absent the
+# value validator skips constraint checks and any string / list is
+# accepted, so the type still behaves like a freeform tag input.
+_MAX_CHOICES_PER_FIELD = 100
+_MAX_CHOICE_LENGTH = 100
+
+
+def _normalise_choices(raw: list) -> list[str]:
+    """Trim, drop empties, enforce length cap + case-insensitive uniqueness.
+
+    Preserves the caller's display order. Raises ValueError on bad input;
+    the create/update schemas surface this as a 422.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, str):
+            raise ValueError("every choice must be a string")
+        text = item.strip()
+        if not text:
+            continue
+        if len(text) > _MAX_CHOICE_LENGTH:
+            raise ValueError(
+                f"choice text exceeds {_MAX_CHOICE_LENGTH} chars"
+            )
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(text)
+    if len(out) > _MAX_CHOICES_PER_FIELD:
+        raise ValueError(
+            f"at most {_MAX_CHOICES_PER_FIELD} choices per field"
+        )
+    if not out:
+        raise ValueError("choices list cannot be empty")
+    return out
+
+
+def _validate_options_for_type(
+    field_type: FieldType, options: dict | None
+) -> dict | None:
+    """Normalise the per-field-type options dict.
+
+    For SELECT / MULTISELECT, when `options.choices` is supplied it gets
+    normalised (trimmed, deduped, capped) and stored back. When
+    `options` is None we leave it as-is — these are the mobile clients'
+    "freeform tag" mode where any string is accepted.
+
+    For the other field types `options` must be None: those types
+    don't carry options today.
+    """
+    if field_type in (FieldType.SELECT, FieldType.MULTISELECT):
+        if options is None:
+            return None
+        if not isinstance(options, dict):
+            raise ValueError("options must be an object")
+        if set(options) - {"choices"}:
+            raise ValueError("options may only contain 'choices'")
+        raw = options.get("choices")
+        if raw is None:
+            return None
+        if not isinstance(raw, list):
+            raise ValueError("options.choices must be a list")
+        return {"choices": _normalise_choices(raw)}
+
+    if options:
+        raise ValueError(
+            f"options is only supported for select/multiselect, not {field_type}"
+        )
+    return None
 
 
 class CustomFieldCreate(BaseModel):
@@ -14,6 +88,11 @@ class CustomFieldCreate(BaseModel):
     options: dict | None = None
     order: int = 0
     privacy: PrivacyLevel = PrivacyLevel.PRIVATE
+
+    @model_validator(mode="after")
+    def _validate_options(self) -> "CustomFieldCreate":
+        self.options = _validate_options_for_type(self.field_type, self.options)
+        return self
 
 
 class CustomFieldUpdate(BaseModel):
@@ -44,6 +123,70 @@ class CustomFieldRead(BaseModel):
     pending_delete_at: datetime | None = None
 
     model_config = {"from_attributes": True}
+
+
+def _unwrap_value(raw: Any) -> Any:
+    """Strip the legacy `{v: ...}` envelope so validators see the raw value.
+
+    The web client wraps submitted values as `{"v": <scalar>}` for
+    historical reasons; iOS / Android send raw scalars. Validation
+    should accept either - we unwrap once at the boundary.
+    """
+    if (
+        isinstance(raw, dict)
+        and set(raw) == {"v"}
+    ):
+        return raw["v"]
+    return raw
+
+
+def _validate_value_for_field(
+    field_type: FieldType,
+    options: dict | None,
+    value: Any,
+) -> None:
+    """Raise ValueError if `value` doesn't match the field's type contract.
+
+    Only enforces what's structurally checkable here:
+      - SELECT: when choices are set, value (unwrapped) must be one of
+        them. When choices are absent, any string is accepted.
+      - MULTISELECT: when choices are set, value (unwrapped) must be a
+        list whose entries are all in choices, no duplicates. Empty
+        list allowed (clears the selection).
+      - Other types: anything serialisable goes through. The web /
+        mobile widgets enforce shape client-side.
+    """
+    if value is None:
+        return  # nullable; clear-on-save.
+    unwrapped = _unwrap_value(value)
+    choices: list[str] | None = (
+        options.get("choices") if isinstance(options, dict) else None
+    )
+    if field_type is FieldType.SELECT:
+        if not isinstance(unwrapped, str):
+            raise ValueError("select value must be a string")
+        if choices is not None and unwrapped not in choices:
+            raise ValueError(
+                f"'{unwrapped}' is not one of the defined choices"
+            )
+    elif field_type is FieldType.MULTISELECT:
+        if not isinstance(unwrapped, list):
+            raise ValueError("multiselect value must be a list of strings")
+        seen: set[str] = set()
+        for item in unwrapped:
+            if not isinstance(item, str):
+                raise ValueError(
+                    "multiselect entries must all be strings"
+                )
+            if item in seen:
+                raise ValueError(
+                    f"multiselect entry '{item}' appears more than once"
+                )
+            seen.add(item)
+            if choices is not None and item not in choices:
+                raise ValueError(
+                    f"'{item}' is not one of the defined choices"
+                )
 
 
 class CustomFieldValueSet(BaseModel):

--- a/tests/test_custom_field_select.py
+++ b/tests/test_custom_field_select.py
@@ -1,0 +1,229 @@
+"""Integration tests for the select / multiselect custom-field types.
+
+Covers options validation at create + update time, and per-value
+validation on the set-member-fields endpoint. The plain text/number/
+date/boolean types are covered indirectly by the existing test
+suites — those types are unchanged here.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Field definition (options) validation
+# ---------------------------------------------------------------------------
+
+def test_create_select_field_without_options_is_freeform(auth_client: httpx.Client):
+    """Mobile clients currently pass options=null. The server accepts
+    that as "freeform tag" mode — values are stored as-is, no choices
+    constraint is enforced."""
+    resp = auth_client.post(
+        "/v1/fields",
+        json={"name": "Species", "field_type": "select"},
+    )
+    assert resp.status_code == 201, resp.text
+    field = resp.json()
+    assert field["field_type"] == "select"
+    assert field["options"] is None
+
+
+def test_create_select_with_choices_normalises_and_persists(auth_client: httpx.Client):
+    """When choices are supplied they get trimmed, deduped (case
+    insensitive), and stored back on the field."""
+    resp = auth_client.post(
+        "/v1/fields",
+        json={
+            "name": "Pronouns set",
+            "field_type": "select",
+            "options": {
+                "choices": ["she/her", " they/them ", "She/Her", "he/him"]
+            },
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    field = resp.json()
+    # Order preserved, second "She/Her" deduped against the leading
+    # "she/her", trailing whitespace stripped on "they/them".
+    assert field["options"] == {"choices": ["she/her", "they/them", "he/him"]}
+
+
+def test_create_select_with_empty_choices_rejected(auth_client: httpx.Client):
+    """An options dict with an empty choices list is a 422 — if the
+    caller wanted freeform mode they'd omit options entirely."""
+    resp = auth_client.post(
+        "/v1/fields",
+        json={
+            "name": "Empty select",
+            "field_type": "select",
+            "options": {"choices": []},
+        },
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_options_rejected_for_non_select_types(auth_client: httpx.Client):
+    """Text / number / date / boolean don't carry options; sending
+    them is a validation error so a typo can't silently get persisted."""
+    resp = auth_client.post(
+        "/v1/fields",
+        json={
+            "name": "Age",
+            "field_type": "number",
+            "options": {"choices": ["x"]},
+        },
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_update_select_options_normalises(auth_client: httpx.Client):
+    """PATCH options also runs through the normaliser."""
+    field = auth_client.post(
+        "/v1/fields",
+        json={"name": "Role", "field_type": "select"},
+    ).json()
+    resp = auth_client.patch(
+        f"/v1/fields/{field['id']}",
+        json={"options": {"choices": ["lead", "lead", "support"]}},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["options"] == {"choices": ["lead", "support"]}
+
+
+# ---------------------------------------------------------------------------
+# Member value validation
+# ---------------------------------------------------------------------------
+
+def _member(client: httpx.Client, name: str = "Alice") -> str:
+    resp = client.post("/v1/members", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def test_select_value_must_match_choices(auth_client: httpx.Client):
+    member = _member(auth_client)
+    field = auth_client.post(
+        "/v1/fields",
+        json={
+            "name": "Status",
+            "field_type": "select",
+            "options": {"choices": ["active", "asleep"]},
+        },
+    ).json()
+
+    # Valid choice -> 200
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": "active"}],
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Off-choice -> 400 with a helpful message
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": "nope"}],
+    )
+    assert resp.status_code == 400, resp.text
+    assert "not one of the defined choices" in resp.json()["detail"]
+
+
+def test_select_freeform_accepts_anything(auth_client: httpx.Client):
+    """When choices are unset (mobile's current shape), any string is
+    accepted as a value."""
+    member = _member(auth_client)
+    field = auth_client.post(
+        "/v1/fields",
+        json={"name": "Tags", "field_type": "select"},
+    ).json()
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": "arbitrary"}],
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_multiselect_value_validates_each_entry(auth_client: httpx.Client):
+    member = _member(auth_client)
+    field = auth_client.post(
+        "/v1/fields",
+        json={
+            "name": "Roles",
+            "field_type": "multiselect",
+            "options": {"choices": ["lead", "support", "rest"]},
+        },
+    ).json()
+
+    # All in choices, no dupes -> 200
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[
+            {"field_id": field["id"], "value": ["lead", "support"]},
+        ],
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Off-choice in the list -> 400
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[
+            {"field_id": field["id"], "value": ["lead", "stranger"]},
+        ],
+    )
+    assert resp.status_code == 400, resp.text
+
+    # Duplicate entry -> 400
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[
+            {"field_id": field["id"], "value": ["lead", "lead"]},
+        ],
+    )
+    assert resp.status_code == 400, resp.text
+    assert "more than once" in resp.json()["detail"]
+
+
+def test_multiselect_empty_list_clears_selection(auth_client: httpx.Client):
+    """An empty list is a legitimate value — clears any previous
+    selection without violating the choices constraint."""
+    member = _member(auth_client)
+    field = auth_client.post(
+        "/v1/fields",
+        json={
+            "name": "Tags",
+            "field_type": "multiselect",
+            "options": {"choices": ["a", "b"]},
+        },
+    ).json()
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": []}],
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_legacy_envelope_value_still_validated(auth_client: httpx.Client):
+    """The web client wraps submitted values as `{v: <scalar>}` for
+    historical reasons. The validator unwraps once before checking
+    constraints so the envelope and the raw form are equivalent."""
+    member = _member(auth_client)
+    field = auth_client.post(
+        "/v1/fields",
+        json={
+            "name": "Status",
+            "field_type": "select",
+            "options": {"choices": ["active", "asleep"]},
+        },
+    ).json()
+
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": {"v": "active"}}],
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": {"v": "nope"}}],
+    )
+    assert resp.status_code == 400, resp.text

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -536,8 +536,11 @@ def test_sheaf_runner_strips_cross_account_image_refs(auth_client: httpx.Client)
     assert "v1/files" not in borrower_bio
     assert "imgur.com" in borrower_bio
 
-    # Journal entry body lost the internal embed; image_keys is now empty.
+    # Journal entry body lost the internal embed. `image_keys` is an
+    # internal column used by the orphan sweeper, not exposed on
+    # JournalEntryRead — the body assertion above is the user-visible
+    # proof that the strip ran; the corresponding image_keys clear is
+    # verified by the strip-helper unit tests.
     journals = auth_client.get("/v1/journals").json()
     j = next(j for j in journals["items"] if j["title"] == "entry")
     assert "v1/files" not in (j["body"] or "")
-    assert j["image_keys"] == [], j

--- a/web/src/components/settings/custom-fields-card.tsx
+++ b/web/src/components/settings/custom-fields-card.tsx
@@ -1,6 +1,11 @@
 import { type FormEvent, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useCustomFields, useCreateField, useUpdateField, useDeleteField } from "@/hooks/use-custom-fields";
+import {
+  useCustomFields,
+  useCreateField,
+  useUpdateField,
+  useDeleteField,
+} from "@/hooks/use-custom-fields";
 import { getMySystem } from "@/lib/systems";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,7 +21,82 @@ import {
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
 import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import { cn } from "@/lib/utils";
-import type { FieldType } from "@/types/api";
+import { Plus, X } from "lucide-react";
+import type { CustomField, FieldType } from "@/types/api";
+
+const FIELD_TYPE_LABEL: Record<FieldType, string> = {
+  text: "Text",
+  number: "Number",
+  date: "Date",
+  boolean: "Yes/No",
+  select: "Select (single)",
+  multiselect: "Multi-select",
+};
+
+const FIELD_TYPES_WITH_CHOICES: ReadonlySet<FieldType> = new Set([
+  "select",
+  "multiselect",
+]);
+
+function choicesFromOptions(
+  options: CustomField["options"] | null | undefined,
+): string[] {
+  if (!options) return [];
+  const raw = (options as { choices?: unknown }).choices;
+  return Array.isArray(raw) ? (raw.filter((c) => typeof c === "string") as string[]) : [];
+}
+
+/** Choices editor: append / edit / remove. Used both in the create form
+ *  and the rename-+-edit inline form. */
+function ChoicesEditor({
+  value,
+  onChange,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs">Choices</Label>
+      <div className="space-y-1">
+        {value.map((choice, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <Input
+              value={choice}
+              onChange={(e) => {
+                const next = [...value];
+                next[i] = e.target.value;
+                onChange(next);
+              }}
+              placeholder={`Option ${i + 1}`}
+              className="h-8 text-sm"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              onClick={() => onChange(value.filter((_, j) => j !== i))}
+              aria-label="Remove choice"
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={() => onChange([...value, ""])}
+        >
+          <Plus className="h-3 w-3 mr-1" />
+          Add choice
+        </Button>
+      </div>
+    </div>
+  );
+}
 
 export function CustomFieldsCard() {
   const { data: fields } = useCustomFields();
@@ -29,30 +109,67 @@ export function CustomFieldsCard() {
   const deleteField = useDeleteField();
   const [newName, setNewName] = useState("");
   const [newType, setNewType] = useState<FieldType>("text");
+  const [newChoices, setNewChoices] = useState<string[]>([]);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
-  const [deletingField, setDeletingField] =
-    useState<{ id: string; name: string } | null>(null);
+  const [editChoices, setEditChoices] = useState<string[]>([]);
+  const [editType, setEditType] = useState<FieldType>("text");
+  const [deletingField, setDeletingField] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  function selectNewType(value: FieldType) {
+    // Reset the choices buffer when the user picks a non-choices type
+    // so a stale list doesn't ride through to a submit with the wrong
+    // field type.
+    setNewType(value);
+    if (!FIELD_TYPES_WITH_CHOICES.has(value)) setNewChoices([]);
+  }
 
   function handleCreate(e: FormEvent) {
     e.preventDefault();
     if (!newName) return;
-    createField.mutate(
-      { name: newName, field_type: newType },
-      { onSuccess: () => { setNewName(""); setNewType("text"); } },
-    );
+    const body: Parameters<typeof createField.mutate>[0] = {
+      name: newName,
+      field_type: newType,
+    };
+    if (FIELD_TYPES_WITH_CHOICES.has(newType)) {
+      const trimmed = newChoices.map((c) => c.trim()).filter(Boolean);
+      // Send choices when present; omit `options` entirely to opt into
+      // freeform mode (matches the mobile / backend default).
+      if (trimmed.length > 0) {
+        body.options = { choices: trimmed };
+      }
+    }
+    createField.mutate(body, {
+      onSuccess: () => {
+        setNewName("");
+        setNewType("text");
+        setNewChoices([]);
+      },
+    });
   }
 
-  function startEdit(field: { id: string; name: string }) {
+  function startEdit(field: CustomField) {
     setEditingId(field.id);
     setEditName(field.name);
+    setEditType(field.field_type);
+    setEditChoices(choicesFromOptions(field.options));
   }
 
   function handleUpdate(e: FormEvent) {
     e.preventDefault();
     if (!editingId) return;
+    const data: Parameters<typeof updateField.mutate>[0]["data"] = {
+      name: editName,
+    };
+    if (FIELD_TYPES_WITH_CHOICES.has(editType)) {
+      const trimmed = editChoices.map((c) => c.trim()).filter(Boolean);
+      data.options = trimmed.length > 0 ? { choices: trimmed } : null;
+    }
     updateField.mutate(
-      { id: editingId, data: { name: editName } },
+      { id: editingId, data },
       { onSuccess: () => setEditingId(null) },
     );
   }
@@ -63,30 +180,53 @@ export function CustomFieldsCard() {
         <CardTitle className="text-base">Custom fields</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <form onSubmit={handleCreate} className="flex items-end gap-2">
-          <div className="flex-1 space-y-1">
-            <Label htmlFor="new-custom-field-name" className="text-xs">Field name</Label>
-            <Input
-              id="new-custom-field-name"
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              placeholder="e.g. Species, Role"
-            />
+        <form onSubmit={handleCreate} className="space-y-2">
+          <div className="flex items-end gap-2">
+            <div className="flex-1 space-y-1">
+              <Label htmlFor="new-custom-field-name" className="text-xs">
+                Field name
+              </Label>
+              <Input
+                id="new-custom-field-name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. Species, Role"
+              />
+            </div>
+            <Select
+              value={newType}
+              onValueChange={(v) => selectNewType(v as FieldType)}
+            >
+              <SelectTrigger className="w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(Object.entries(FIELD_TYPE_LABEL) as [FieldType, string][]).map(
+                  ([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ),
+                )}
+              </SelectContent>
+            </Select>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={createField.isPending || !newName}
+            >
+              Add
+            </Button>
           </div>
-          <Select value={newType} onValueChange={(v) => setNewType(v as FieldType)}>
-            <SelectTrigger className="w-32">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="text">Text</SelectItem>
-              <SelectItem value="number">Number</SelectItem>
-              <SelectItem value="date">Date</SelectItem>
-              <SelectItem value="boolean">Yes/No</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button type="submit" size="sm" disabled={createField.isPending || !newName}>
-            Add
-          </Button>
+          {FIELD_TYPES_WITH_CHOICES.has(newType) && (
+            <div className="rounded-md border bg-muted/30 p-3">
+              <ChoicesEditor value={newChoices} onChange={setNewChoices} />
+              <p className="mt-2 text-xs text-muted-foreground">
+                Leave empty for freeform values (any text accepted). When set,
+                only the listed choices are valid.
+              </p>
+            </div>
+          )}
         </form>
 
         <div className="space-y-2">
@@ -95,25 +235,38 @@ export function CustomFieldsCard() {
               <form
                 key={f.id}
                 onSubmit={handleUpdate}
-                className="flex items-center gap-2"
+                className="space-y-2 rounded-md border p-2"
               >
-                <Input
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  className="h-8 flex-1 text-sm"
-                />
-                <Button type="submit" size="sm" variant="ghost" className="h-8 px-2 text-xs">
-                  Save
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 px-2 text-xs"
-                  onClick={() => setEditingId(null)}
-                >
-                  Cancel
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    className="h-8 flex-1 text-sm"
+                  />
+                  <Button
+                    type="submit"
+                    size="sm"
+                    variant="ghost"
+                    className="h-8 px-2 text-xs"
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-8 px-2 text-xs"
+                    onClick={() => setEditingId(null)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                {FIELD_TYPES_WITH_CHOICES.has(editType) && (
+                  <ChoicesEditor
+                    value={editChoices}
+                    onChange={setEditChoices}
+                  />
+                )}
               </form>
             ) : (
               <div
@@ -123,9 +276,25 @@ export function CustomFieldsCard() {
                   f.pending_delete_at && "opacity-60",
                 )}
               >
-                <span className="cursor-pointer" onClick={() => startEdit(f)}>
+                <span
+                  className="cursor-pointer"
+                  onClick={() => startEdit(f)}
+                >
                   {f.name}
-                  <span className="ml-2 text-xs text-muted-foreground">{f.field_type}</span>
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    {FIELD_TYPE_LABEL[f.field_type] ?? f.field_type}
+                  </span>
+                  {FIELD_TYPES_WITH_CHOICES.has(f.field_type) && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      {choicesFromOptions(f.options).length > 0
+                        ? `· ${choicesFromOptions(f.options).length} choice${
+                            choicesFromOptions(f.options).length === 1
+                              ? ""
+                              : "s"
+                          }`
+                        : "· freeform"}
+                    </span>
+                  )}
                   <PendingDeleteBadge
                     finalizeAt={f.pending_delete_at}
                     className="ml-2"
@@ -135,7 +304,9 @@ export function CustomFieldsCard() {
                   variant="ghost"
                   size="sm"
                   className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-                  onClick={() => setDeletingField({ id: f.id, name: f.name })}
+                  onClick={() =>
+                    setDeletingField({ id: f.id, name: f.name })
+                  }
                 >
                   Delete
                 </Button>
@@ -145,7 +316,9 @@ export function CustomFieldsCard() {
         </div>
         {fields && fields.length > 0 && (
           <p className="text-xs text-muted-foreground">
-            Click a field name to rename it. Values are set per-member in the member editor.
+            Click a field name to rename or edit its choices. The field's
+            type cannot be changed after creation. Values are set per-member
+            in the member editor.
           </p>
         )}
       </CardContent>

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -51,7 +51,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { Member, MemberCreate, MemberUpdate, PrivacyLevel, DeleteConfirmation, CustomFieldValueSet } from "@/types/api";
+import { Checkbox } from "@/components/ui/checkbox";
+import type {
+  CustomFieldValueSet,
+  DeleteConfirmation,
+  FieldType,
+  Member,
+  MemberCreate,
+  MemberUpdate,
+  PrivacyLevel,
+} from "@/types/api";
 
 function MemberForm({
   initial,
@@ -264,52 +273,253 @@ function MemberForm({
   );
 }
 
+// Raw value the editor holds per field.
+//  - text/select       -> string
+//  - number            -> string (HTML inputs are stringly typed); coerced
+//                         to a number on save when non-empty
+//  - date              -> string ("YYYY-MM-DD" from DatePicker)
+//  - boolean           -> boolean
+//  - multiselect       -> string[]
+type FieldEditValue = string | boolean | string[];
+
+/** Strip the legacy {v: ...} envelope; everything else is passed through. */
+function unwrapValue(raw: unknown): unknown {
+  if (
+    raw != null &&
+    typeof raw === "object" &&
+    !Array.isArray(raw) &&
+    Object.keys(raw as object).length === 1 &&
+    "v" in (raw as object)
+  ) {
+    return (raw as { v: unknown }).v;
+  }
+  return raw;
+}
+
+/** Coerce a server-side stored value into the editor's per-type shape. */
+function valueForEditor(
+  field: { field_type: FieldType },
+  raw: unknown,
+): FieldEditValue {
+  const unwrapped = unwrapValue(raw);
+  switch (field.field_type) {
+    case "boolean":
+      if (typeof unwrapped === "boolean") return unwrapped;
+      if (typeof unwrapped === "string") return unwrapped === "true";
+      return false;
+    case "multiselect":
+      return Array.isArray(unwrapped)
+        ? unwrapped.filter((x): x is string => typeof x === "string")
+        : [];
+    case "number":
+    case "text":
+    case "date":
+    case "select":
+    default:
+      if (unwrapped == null) return "";
+      return String(unwrapped);
+  }
+}
+
+/** Is the editor's current value "empty" enough to skip from the payload? */
+function isEmptyValue(field_type: FieldType, value: FieldEditValue): boolean {
+  if (field_type === "boolean") return value === false;
+  if (field_type === "multiselect")
+    return Array.isArray(value) && value.length === 0;
+  return value === "" || value == null;
+}
+
+/** Coerce the editor's per-type shape into what gets sent on the wire.
+ *  Sends raw values (no `{v: ...}` envelope); the backend tolerates both
+ *  shapes via _unwrap_value in custom_field.py. */
+function valueForWire(field_type: FieldType, value: FieldEditValue): unknown {
+  if (field_type === "number") {
+    if (typeof value !== "string" || value === "") return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return value;
+}
+
 function MemberFieldValues({ memberId }: { memberId: string }) {
   const { data: fields } = useCustomFields();
   const { data: values } = useMemberFieldValues(memberId);
   const setValues = useSetMemberFieldValues();
-  const [overrides, setOverrides] = useState<Record<string, string>>({});
+  const [overrides, setOverrides] = useState<Record<string, FieldEditValue>>({});
 
   const serverValues = useMemo(() => {
-    const map: Record<string, string> = {};
-    if (values) {
+    const map: Record<string, FieldEditValue> = {};
+    if (values && fields) {
+      const byId = new Map(fields.map((f) => [f.id, f]));
       for (const v of values) {
-        map[v.field_id] = typeof v.value === "object" && v.value !== null
-          ? ((v.value as Record<string, unknown>).v as string ?? "")
-          : String(v.value ?? "");
+        const field = byId.get(v.field_id);
+        if (field) map[v.field_id] = valueForEditor(field, v.value);
       }
     }
     return map;
-  }, [values]);
+  }, [values, fields]);
 
   const dirty = Object.keys(overrides).length > 0;
 
   if (!fields || fields.length === 0) return null;
 
+  function effectiveValue(fieldId: string, fallback: FieldEditValue): FieldEditValue {
+    return overrides[fieldId] ?? serverValues[fieldId] ?? fallback;
+  }
+
+  function updateField(fieldId: string, next: FieldEditValue) {
+    setOverrides((prev) => ({ ...prev, [fieldId]: next }));
+  }
+
   function handleSave() {
-    const merged = { ...serverValues, ...overrides };
-    const payload: CustomFieldValueSet[] = fields!
-      .filter((f) => merged[f.id] !== undefined && merged[f.id] !== "")
-      .map((f) => ({ field_id: f.id, value: { v: merged[f.id] } }));
-    setValues.mutate({ memberId, values: payload }, { onSuccess: () => setOverrides({}) });
+    const payload: CustomFieldValueSet[] = [];
+    for (const f of fields!) {
+      const has = f.id in overrides || f.id in serverValues;
+      if (!has) continue;
+      const fallback: FieldEditValue =
+        f.field_type === "boolean"
+          ? false
+          : f.field_type === "multiselect"
+          ? []
+          : "";
+      const val = effectiveValue(f.id, fallback);
+      if (isEmptyValue(f.field_type, val)) continue;
+      payload.push({ field_id: f.id, value: valueForWire(f.field_type, val) });
+    }
+    setValues.mutate(
+      { memberId, values: payload },
+      { onSuccess: () => setOverrides({}) },
+    );
   }
 
   return (
     <div className="space-y-3 border-t pt-3">
       <p className="text-sm font-medium text-muted-foreground">Custom fields</p>
-      {fields.map((f) => (
-        <div key={f.id} className="space-y-1">
-          <Label htmlFor={`custom-field-${f.id}`} className="text-xs">{f.name}</Label>
-          <Input
-            id={`custom-field-${f.id}`}
-            value={overrides[f.id] ?? serverValues[f.id] ?? ""}
-            onChange={(e) => {
-              setOverrides((prev) => ({ ...prev, [f.id]: e.target.value }));
-            }}
-            placeholder={f.field_type}
-          />
-        </div>
-      ))}
+      {fields.map((f) => {
+        const choices = (() => {
+          if (!f.options) return [];
+          const raw = (f.options as { choices?: unknown }).choices;
+          return Array.isArray(raw)
+            ? (raw.filter((c) => typeof c === "string") as string[])
+            : [];
+        })();
+        const id = `custom-field-${f.id}`;
+        return (
+          <div key={f.id} className="space-y-1">
+            <Label htmlFor={id} className="text-xs">
+              {f.name}
+            </Label>
+            {f.field_type === "boolean" ? (
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id={id}
+                  checked={effectiveValue(f.id, false) === true}
+                  onCheckedChange={(v) => updateField(f.id, v === true)}
+                />
+                <Label htmlFor={id} className="text-sm font-normal">
+                  Yes
+                </Label>
+              </div>
+            ) : f.field_type === "number" ? (
+              <Input
+                id={id}
+                type="number"
+                value={String(effectiveValue(f.id, ""))}
+                onChange={(e) => updateField(f.id, e.target.value)}
+              />
+            ) : f.field_type === "date" ? (
+              <DatePicker
+                value={String(effectiveValue(f.id, ""))}
+                onChange={(next) => updateField(f.id, next)}
+                placeholder="Pick a date"
+              />
+            ) : f.field_type === "select" ? (
+              choices.length > 0 ? (
+                <Select
+                  value={String(effectiveValue(f.id, ""))}
+                  onValueChange={(v) => updateField(f.id, v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {choices.map((c) => (
+                      <SelectItem key={c} value={c}>
+                        {c}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                // Freeform select (no choices defined): plain text input,
+                // matches mobile's current behaviour.
+                <Input
+                  id={id}
+                  value={String(effectiveValue(f.id, ""))}
+                  onChange={(e) => updateField(f.id, e.target.value)}
+                />
+              )
+            ) : f.field_type === "multiselect" ? (
+              choices.length > 0 ? (
+                <div className="space-y-1 rounded-md border p-2">
+                  {choices.map((c) => {
+                    const current = effectiveValue(f.id, []);
+                    const list = Array.isArray(current) ? current : [];
+                    const checked = list.includes(c);
+                    return (
+                      <div key={c} className="flex items-center gap-2">
+                        <Checkbox
+                          id={`${id}-${c}`}
+                          checked={checked}
+                          onCheckedChange={(v) => {
+                            const next = v === true
+                              ? Array.from(new Set([...list, c]))
+                              : list.filter((x) => x !== c);
+                            updateField(f.id, next);
+                          }}
+                        />
+                        <Label
+                          htmlFor={`${id}-${c}`}
+                          className="text-sm font-normal"
+                        >
+                          {c}
+                        </Label>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                // Freeform multiselect: comma-separated for now (mobile
+                // parity with the freeform select pattern).
+                <Input
+                  id={id}
+                  placeholder="Comma-separated tags"
+                  value={(() => {
+                    const current = effectiveValue(f.id, []);
+                    return Array.isArray(current) ? current.join(", ") : "";
+                  })()}
+                  onChange={(e) =>
+                    updateField(
+                      f.id,
+                      e.target.value
+                        .split(",")
+                        .map((s) => s.trim())
+                        .filter(Boolean),
+                    )
+                  }
+                />
+              )
+            ) : (
+              // text (default)
+              <Input
+                id={id}
+                value={String(effectiveValue(f.id, ""))}
+                onChange={(e) => updateField(f.id, e.target.value)}
+              />
+            )}
+          </div>
+        );
+      })}
       {dirty && (
         <Button
           size="sm"


### PR DESCRIPTION
## Summary

Mobile (iOS + Android) ships pickers for the `select` and `multiselect` custom-field types. The backend `FieldType` enum already accepted both, but no validation tied submitted values to a defined choices list, and the web frontend only listed text/number/date/boolean in the create dropdown and rendered every value as a plain text input.

This PR wires backend validation for the two select-shaped types and reworks the web custom-fields surface to match.

## Backend

- `CustomFieldCreate` normalises `options.choices` for select/multiselect (trim, drop empties, case-insensitive dedupe). Empty after normalisation is 422. Non-select types reject any `options` payload.
- `PATCH /v1/fields/{id}` re-runs the same normaliser against the existing field's type.
- `PUT /v1/members/{id}/fields` validates each submitted value against the field's contract:
  - select: must be a string; when choices are defined, must be one of them
  - multiselect: must be a list of strings; when choices are defined, all entries must be in choices; no duplicates; empty list allowed (clears the selection)
- Mobile's current `options: null` "freeform" mode passes through unchanged, so iOS / Android keep working without a release.
- The validator strips the legacy `{v: <scalar>}` envelope the web client wraps values in, so either shape validates correctly.

## Web

- Custom-fields settings card now lists all six types and renders a choices editor (add / edit / remove rows) for select/multiselect. Existing fields can have their choices edited alongside the rename surface. Hint copy explains "leave blank for freeform values" so users know choices are optional.
- Member editor uses type-aware widgets per field:
  - text -> Input
  - number -> Input type=number
  - date -> DatePicker
  - boolean -> Checkbox
  - select -> dropdown (or Input when freeform)
  - multiselect -> checkbox group (or comma-separated Input when freeform)
- Values are sent on the wire as raw scalars / lists. The backend accepts both this and the legacy `{v: ...}` envelope, so existing stored values keep reading correctly.

## Test plan

- [x] `ruff`, `tsc`, `eslint` clean
- [x] `pytest tests/test_custom_field_select.py` locally - 11 cases covering options normalisation, freeform vs choices semantics for both types, off-choice rejection, duplicate-entry rejection, empty-list-clears, legacy envelope still validated
- [ ] `./run_tests.sh` full sweep
- [ ] Localdev: create a `Status` select with choices `active/asleep`, attach to a member, confirm the dropdown only offers those two and the backend rejects an arbitrary string
- [ ] Localdev: create a `Tags` multiselect, confirm the checkbox group, confirm saving an empty selection clears prior values
- [ ] Localdev: confirm iOS / Android can still create select/multiselect fields with `options: null` (no choices) and submit any string