### PR TITLE
Admin audit log: state-changing actions + user-facing transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Admin audit log.** Every state-changing admin action (user updates, approvals, rejections, member-limit changes — and the safety-reset / pending-bypass endpoints landing in the next PR) now writes a row to a new `admin_audit_events` table with the acting admin's identity, the target, before/after diffs for changed fields, and optional reason text. Two read surfaces: a paginated, filterable admin panel under Admin > Audit log, and a per-account "Admin activity on your account" card in Settings > Account so every user can see what admins have done to their account. Routine reads (list users, single-user detail, search) are deliberately not logged so the table stays signal-rich for abuse detection — logging every browse would let a malicious admin hide their data trawls in the noise. The log is append-only by design; there is no edit or delete endpoint.
+
 ## [0.3.2] - 2026-06-03
 
 ### Added

--- a/alembic/versions/d3a4b5c6e7f8_add_admin_audit_events.py
+++ b/alembic/versions/d3a4b5c6e7f8_add_admin_audit_events.py
@@ -1,0 +1,122 @@
+"""Add admin_audit_events table
+
+Revision ID: d3a4b5c6e7f8
+Revises: c2f3a4b5d6e7
+Create Date: 2026-06-04
+
+Append-only log of state-changing admin actions (user_update, approve,
+reject, member-limit, safety-reset, pending-bypass) plus the few
+privacy-sensitive admin reads worth recording (import-log views).
+Routine list / get reads are deliberately not logged — the table is
+mutation-rich, not browse-noisy.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d3a4b5c6e7f8"
+down_revision: Union[str, None] = "c2f3a4b5d6e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_ACTION_VALUES = [
+    "user_update",
+    "user_approve",
+    "user_reject",
+    "user_member_limit_set",
+    "user_safety_reset",
+    "user_pending_bypass",
+    "import_log_view",
+]
+
+_TARGET_TYPE_VALUES = [
+    "user",
+    "system",
+    "pending_action",
+    "import_job",
+]
+
+
+def upgrade() -> None:
+    action_enum = postgresql.ENUM(
+        *_ACTION_VALUES, name="admin_audit_action", create_type=True
+    )
+    target_enum = postgresql.ENUM(
+        *_TARGET_TYPE_VALUES, name="admin_audit_target_type", create_type=True
+    )
+    action_enum.create(op.get_bind(), checkfirst=True)
+    target_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "admin_audit_events",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "admin_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column(
+            "action",
+            postgresql.ENUM(
+                *_ACTION_VALUES, name="admin_audit_action", create_type=False
+            ),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "target_type",
+            postgresql.ENUM(
+                *_TARGET_TYPE_VALUES,
+                name="admin_audit_target_type",
+                create_type=False,
+            ),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "target_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column(
+            "target_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("before_json", postgresql.JSONB(), nullable=True),
+        sa.Column("after_json", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("admin_email", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("admin_audit_events")
+    postgresql.ENUM(name="admin_audit_action").drop(
+        op.get_bind(), checkfirst=True
+    )
+    postgresql.ENUM(name="admin_audit_target_type").drop(
+        op.get_bind(), checkfirst=True
+    )

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -13,10 +13,12 @@ from sheaf.config import settings
 from sheaf.crypto import decrypt_field
 from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
+from sheaf.models.admin_audit_event import AdminAuditAction, AdminAuditTargetType
 from sheaf.models.member import Member
 from sheaf.models.system import System
 from sheaf.models.uploaded_file import UploadedFile
 from sheaf.models.user import AccountStatus, User, UserTier
+from sheaf.services.admin_audit import log_admin_action
 from sheaf.services.file_cleanup import cleanup_orphaned_files
 from sheaf.services.front_retention import prune_free_tier_fronts
 
@@ -287,6 +289,17 @@ async def update_user(
     if target is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
+    # Snapshot only the fields the audit log cares about, before any
+    # mutation. The diff is computed at write time so unchanged keys
+    # don't pollute the row.
+    before_snapshot: dict[str, object] = {
+        "tier": str(target.tier.value),
+        "is_admin": target.is_admin,
+        "can_upload_images": target.can_upload_images,
+        "can_upload_animated_images": target.can_upload_animated_images,
+        "member_limit": target.member_limit,
+    }
+
     if body.tier is not None:
         target.tier = body.tier
     if body.is_admin is not None:
@@ -299,6 +312,30 @@ async def update_user(
         target.member_limit = None
     elif body.member_limit is not None:
         target.member_limit = body.member_limit
+
+    after_snapshot: dict[str, object] = {
+        "tier": str(target.tier.value),
+        "is_admin": target.is_admin,
+        "can_upload_images": target.can_upload_images,
+        "can_upload_animated_images": target.can_upload_animated_images,
+        "member_limit": target.member_limit,
+    }
+    changed = {
+        k for k in before_snapshot if before_snapshot[k] != after_snapshot[k]
+    }
+    diff_before = {k: before_snapshot[k] for k in changed}
+    diff_after = {k: after_snapshot[k] for k in changed}
+    if changed:
+        await log_admin_action(
+            db,
+            admin=admin,
+            action=AdminAuditAction.USER_UPDATE,
+            target_type=AdminAuditTargetType.USER,
+            target_id=target.id,
+            target_user_id=target.id,
+            before=diff_before,
+            after=diff_after,
+        )
 
     # Get member count and storage for response
     member_count = await db.scalar(
@@ -380,7 +417,7 @@ async def list_pending_approvals(
 @router.post("/users/{user_id}/approve")
 async def approve_user(
     user_id: uuid.UUID,
-    _admin: User = Depends(get_admin_write_user),
+    admin: User = Depends(get_admin_write_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Approve a pending user account."""
@@ -395,6 +432,16 @@ async def approve_user(
         )
 
     target.account_status = AccountStatus.ACTIVE
+    await log_admin_action(
+        db,
+        admin=admin,
+        action=AdminAuditAction.USER_APPROVE,
+        target_type=AdminAuditTargetType.USER,
+        target_id=target.id,
+        target_user_id=target.id,
+        before={"account_status": "pending_approval"},
+        after={"account_status": "active"},
+    )
     await db.commit()
 
     # Send approval notification email if configured
@@ -417,7 +464,7 @@ async def approve_user(
 @router.post("/users/{user_id}/reject")
 async def reject_user(
     user_id: uuid.UUID,
-    _admin: User = Depends(get_admin_write_user),
+    admin: User = Depends(get_admin_write_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Reject a pending user account. Deletes the user and their system."""
@@ -430,6 +477,21 @@ async def reject_user(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"User is not pending approval (status: {target.account_status})",
         )
+
+    # Audit-log BEFORE the cascade delete clears the target user
+    # row out from under us. target_user_id is captured here; the
+    # row will SET NULL once the user is deleted, but the audit
+    # row remains attributable via admin_email + reason.
+    await log_admin_action(
+        db,
+        admin=admin,
+        action=AdminAuditAction.USER_REJECT,
+        target_type=AdminAuditTargetType.USER,
+        target_id=target.id,
+        target_user_id=target.id,
+        before={"account_status": "pending_approval"},
+        after={"account_status": "deleted"},
+    )
 
     # Send rejection notification email if configured
     try:

--- a/sheaf/api/v1/admin_audit.py
+++ b/sheaf/api/v1/admin_audit.py
@@ -1,0 +1,115 @@
+"""Admin audit-log read endpoints.
+
+Two surfaces:
+
+  - `GET /v1/admin/audit-events` — admin-only, paginated, filterable.
+    For operators reviewing what their fellow admins have been up to.
+  - `GET /v1/auth/admin-activity` — self-only, returns rows where
+    target_user_id == the caller. The transparency layer: every user
+    can see what admins have done to their account, with the admin's
+    email and the reason text. Pairs with the published admin-panel
+    documentation (planned) so the data on offer is auditable from
+    the outside.
+
+Writes happen via `sheaf.services.admin_audit.log_admin_action`,
+called inline from each admin endpoint that mutates state. There is
+no write endpoint here — the log is append-only by callsite, not by
+external API.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_admin_user, get_current_user
+from sheaf.database import get_db
+from sheaf.models.admin_audit_event import AdminAuditEvent
+from sheaf.models.user import User
+from sheaf.schemas.admin_audit import AdminAuditEventRead, UserAdminActivityRead
+
+router = APIRouter(tags=["admin audit"])
+
+
+@router.get(
+    "/admin/audit-events",
+    response_model=list[AdminAuditEventRead],
+)
+async def list_admin_audit_events(
+    target_user_id: uuid.UUID | None = None,
+    admin_user_id: uuid.UUID | None = None,
+    action: str | None = None,
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=50, ge=1, le=200),
+    _: User = Depends(get_admin_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[AdminAuditEvent]:
+    """Paginated admin audit log. Filters on target user, acting
+    admin, or action type — all optional. Most-recent first."""
+    stmt = select(AdminAuditEvent).order_by(
+        desc(AdminAuditEvent.created_at),
+        # Tiebreaker: id desc so same-second rows have a stable order
+        # across page boundaries.
+        desc(AdminAuditEvent.id),
+    )
+    if target_user_id is not None:
+        stmt = stmt.where(AdminAuditEvent.target_user_id == target_user_id)
+    if admin_user_id is not None:
+        stmt = stmt.where(AdminAuditEvent.admin_user_id == admin_user_id)
+    if action is not None:
+        stmt = stmt.where(AdminAuditEvent.action == action)
+    offset = (page - 1) * limit
+    stmt = stmt.offset(offset).limit(limit)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+@router.get(
+    "/admin/audit-events/{event_id}",
+    response_model=AdminAuditEventRead,
+)
+async def get_admin_audit_event(
+    event_id: uuid.UUID,
+    _: User = Depends(get_admin_user),
+    db: AsyncSession = Depends(get_db),
+) -> AdminAuditEvent:
+    event = await db.get(AdminAuditEvent, event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Audit event not found",
+        )
+    return event
+
+
+@router.get(
+    "/auth/admin-activity",
+    response_model=list[UserAdminActivityRead],
+)
+async def list_admin_activity_on_self(
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=50, ge=1, le=200),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[AdminAuditEvent]:
+    """List admin actions taken against the caller's account.
+
+    Returns rows where `target_user_id == self.id`. Visible to every
+    authenticated user with no admin gate — this is the user-facing
+    transparency layer over the audit log.
+    """
+    stmt = (
+        select(AdminAuditEvent)
+        .where(AdminAuditEvent.target_user_id == user.id)
+        .order_by(
+            desc(AdminAuditEvent.created_at),
+            desc(AdminAuditEvent.id),
+        )
+        .offset((page - 1) * limit)
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from sheaf.api.v1 import (
     account,
     admin,
+    admin_audit,
     analytics,
     announcements,
     auth,
@@ -50,6 +51,9 @@ v1_router.include_router(shield_mode.router)
 # Auth, admin, announcements: no scope enforcement
 v1_router.include_router(auth.router)
 v1_router.include_router(admin.router)
+# Admin audit log: per-endpoint admin gate on the admin listings;
+# the user-facing /auth/admin-activity is self-only.
+v1_router.include_router(admin_audit.router)
 # Account-level (Article 15 etc.) — session/JWT auth only, body-gated
 # step-up. Lives outside the scope-gated section since API key access
 # is refused inline by the endpoint.

--- a/sheaf/models/admin_audit_event.py
+++ b/sheaf/models/admin_audit_event.py
@@ -1,0 +1,132 @@
+"""Admin action audit log.
+
+Every privileged admin action writes a row here so:
+
+  - Operators have an append-only trail of who did what when, with
+    optional before/after JSON snapshots for state-changing actions.
+  - Affected users can see what an admin did to their account via
+    `/v1/auth/admin-activity` — accountability, not just trust-us.
+
+The table is append-only by design. There is no UPDATE / DELETE
+endpoint; rows are kept indefinitely. If an admin user is removed the
+FK is SET NULL so history survives, but the row preserves the action
+context (which can still be attributed via the historical email if
+the operator captured it in before_json).
+
+**What we log:** state-changing admin actions (user_update, approve,
+reject, member-limit, safety-reset, pending-bypass) and unusual
+privacy-sensitive reads (import-log views; future additions like
+dossier exports as those land). What we DON'T log: routine reads
+like the admin user list, single-user detail views, or search.
+Logging every browse would swamp the table and actively hurt the
+abuse-detection use case — a malicious admin browsing user data
+wouldn't stand out against the noise floor. Mutation-only is the
+signal-rich shape.
+"""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sheaf.models.base import Base, UUIDMixin
+
+
+class AdminAuditAction(enum.StrEnum):
+    """Enumerated admin actions. Extend when new admin endpoints land."""
+
+    USER_UPDATE = "user_update"          # PATCH /v1/admin/users/{id} — tier, flags, member_limit
+    USER_APPROVE = "user_approve"        # registration approval
+    USER_REJECT = "user_reject"          # registration rejection
+    USER_MEMBER_LIMIT_SET = "user_member_limit_set"
+    USER_SAFETY_RESET = "user_safety_reset"        # PR 2: drop safeguards forward
+    USER_PENDING_BYPASS = "user_pending_bypass"    # PR 2: finalise all pending actions now
+    IMPORT_LOG_VIEW = "import_log_view"            # PR 2: viewing an import job log
+
+
+class AdminAuditTargetType(enum.StrEnum):
+    """What kind of object the action operated on."""
+
+    USER = "user"
+    SYSTEM = "system"
+    PENDING_ACTION = "pending_action"
+    IMPORT_JOB = "import_job"
+
+
+class AdminAuditEvent(UUIDMixin, Base):
+    __tablename__ = "admin_audit_events"
+
+    # Admin who took the action. SET NULL so we keep history even if
+    # the admin's account is later removed — the before_json should
+    # have captured an identifier (email/id) at action time for
+    # post-deletion attribution.
+    admin_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    action: Mapped[AdminAuditAction] = mapped_column(
+        # `name=...` must match the type created by the migration,
+        # otherwise SQLAlchemy autoderives `adminauditaction` from the
+        # class name and INSERT fails with "type does not exist".
+        Enum(
+            AdminAuditAction,
+            name="admin_audit_action",
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+        index=True,
+    )
+
+    target_type: Mapped[AdminAuditTargetType] = mapped_column(
+        Enum(
+            AdminAuditTargetType,
+            name="admin_audit_target_type",
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+        index=True,
+    )
+
+    # The specific object identifier (e.g. user.id, pending_action.id).
+    # Not a hard FK so deleted targets don't strand the history.
+    target_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+
+    # Convenience denormalisation: the user whose ACCOUNT was affected.
+    # Usually == target_id when target_type is USER; for nested targets
+    # (pending_action, import_job) it's the owning user. Lets the
+    # "admin activity on my account" view fast-filter without joins.
+    target_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Required for destructive / irreversible actions, optional for
+    # routine ones. Surfaced verbatim to both admin viewers and
+    # affected users.
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # State snapshots. For USER_UPDATE the diff is the only useful
+    # record (e.g. tier free -> plus). NULL is allowed when the
+    # action doesn't naturally have a before/after.
+    before_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    after_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+    # The admin's email at the time of the action, captured here so
+    # row-level reads don't need to join + decrypt the users table.
+    # NOT a privacy regression — admin emails are already exposed via
+    # the admin users listing.
+    admin_email: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/sheaf/schemas/admin_audit.py
+++ b/sheaf/schemas/admin_audit.py
@@ -1,0 +1,46 @@
+"""Schemas for the admin audit-log endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class AdminAuditEventRead(BaseModel):
+    """Single audit-log row as returned by /v1/admin/audit-events."""
+
+    id: uuid.UUID
+    admin_user_id: uuid.UUID | None
+    admin_email: str | None
+    action: str
+    target_type: str
+    target_id: uuid.UUID | None
+    target_user_id: uuid.UUID | None
+    reason: str | None
+    before_json: dict[str, Any] | None
+    after_json: dict[str, Any] | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class UserAdminActivityRead(BaseModel):
+    """User-facing view: an admin action affecting the caller's
+    account. Same row as `AdminAuditEventRead` minus the admin's
+    user id (not a useful identifier outside the admin surface) and
+    minus the target_user_id (always self when shown to the user)."""
+
+    id: uuid.UUID
+    admin_email: str | None
+    action: str
+    target_type: str
+    target_id: uuid.UUID | None
+    reason: str | None
+    before_json: dict[str, Any] | None
+    after_json: dict[str, Any] | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/sheaf/services/admin_audit.py
+++ b/sheaf/services/admin_audit.py
@@ -1,0 +1,74 @@
+"""Helper for writing admin audit-log rows.
+
+Every admin endpoint that mutates state (or performs an unusual
+privacy-sensitive read) calls `log_admin_action` to append a row.
+The caller commits — this keeps the write atomic with the action's
+own transaction, so a rollback of the action also rolls back its
+audit row instead of leaving a phantom "we did X" entry.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.crypto import decrypt
+from sheaf.models.admin_audit_event import (
+    AdminAuditAction,
+    AdminAuditEvent,
+    AdminAuditTargetType,
+)
+from sheaf.models.user import User
+
+
+def _safe_decrypt_email(user: User) -> str | None:
+    """Decrypt the admin's email for the audit row.
+
+    A decrypt failure must NOT abort the action being logged — admin
+    audit-write is a side-effect of the action, not a precondition.
+    Falls back to None so the row is still written and remains useful
+    via admin_user_id + before_json attribution.
+    """
+    try:
+        return decrypt(user.email)
+    except Exception:
+        return None
+
+
+async def log_admin_action(
+    db: AsyncSession,
+    *,
+    admin: User,
+    action: AdminAuditAction,
+    target_type: AdminAuditTargetType,
+    target_id: uuid.UUID | None = None,
+    target_user_id: uuid.UUID | None = None,
+    reason: str | None = None,
+    before: dict[str, Any] | None = None,
+    after: dict[str, Any] | None = None,
+) -> AdminAuditEvent:
+    """Append an admin audit-log row. Caller commits.
+
+    `before` and `after` should be small dicts of human-readable
+    fields, not whole-row dumps — the table is browse-friendly and
+    big JSONs hurt readability. For USER_UPDATE pass only the keys
+    that actually changed; the helper does no diff itself.
+    """
+    event = AdminAuditEvent(
+        id=uuid.uuid4(),
+        admin_user_id=admin.id,
+        action=action,
+        target_type=target_type,
+        target_id=target_id,
+        target_user_id=target_user_id,
+        reason=reason,
+        before_json=before,
+        after_json=after,
+        created_at=datetime.now(UTC),
+        admin_email=_safe_decrypt_email(admin),
+    )
+    db.add(event)
+    return event

--- a/tests/test_admin_audit.py
+++ b/tests/test_admin_audit.py
@@ -1,0 +1,158 @@
+"""End-to-end tests for the admin audit log.
+
+Covers:
+  - Admin mutations write rows: tier change, approve, reject.
+  - The user-facing /v1/auth/admin-activity endpoint returns only
+    rows targeting the caller.
+  - The admin listing supports filters by target_user_id + action.
+  - Routine browse endpoints (list_users, etc.) do NOT write rows.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+
+def _make_user(admin_client: httpx.Client) -> str:
+    """Register a fresh user (open registration in test stack) and
+    return their user id by inspecting the admin users list."""
+    email = f"audit-target-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = httpx.post(
+        f"{admin_client.base_url}/v1/auth/register",
+        json={"email": email, "password": "correct-horse-battery"},
+        timeout=10,
+    )
+    assert resp.status_code in (200, 201), resp.text
+    users = admin_client.get("/v1/admin/users").json()
+    match = next(u for u in users if u["email"] == email)
+    return match["id"]
+
+
+def test_user_update_writes_audit_row(admin_client: httpx.Client):
+    target = _make_user(admin_client)
+
+    resp = admin_client.patch(
+        f"/v1/admin/users/{target}", json={"can_upload_images": True}
+    )
+    assert resp.status_code == 200, resp.text
+
+    events = admin_client.get(
+        f"/v1/admin/audit-events?target_user_id={target}"
+    ).json()
+    assert len(events) >= 1
+    e = events[0]
+    assert e["action"] == "user_update"
+    assert e["target_type"] == "user"
+    assert e["target_user_id"] == target
+    assert e["before_json"] == {"can_upload_images": False}
+    assert e["after_json"] == {"can_upload_images": True}
+    assert e["admin_email"]  # captured at write time
+
+
+def test_user_update_with_no_changed_fields_writes_nothing(
+    admin_client: httpx.Client,
+):
+    """Sending a PATCH whose effective diff is empty (re-asserting
+    the current state) must not pollute the audit log."""
+    target = _make_user(admin_client)
+
+    # Existing state: can_upload_images=False. Setting it to False
+    # again is a no-op diff.
+    resp = admin_client.patch(
+        f"/v1/admin/users/{target}", json={"can_upload_images": False}
+    )
+    assert resp.status_code == 200, resp.text
+
+    events = admin_client.get(
+        f"/v1/admin/audit-events?target_user_id={target}"
+    ).json()
+    assert events == []
+
+
+def test_audit_filter_by_action(admin_client: httpx.Client):
+    target = _make_user(admin_client)
+    admin_client.patch(
+        f"/v1/admin/users/{target}", json={"can_upload_images": True}
+    )
+
+    matching = admin_client.get(
+        f"/v1/admin/audit-events?target_user_id={target}&action=user_update"
+    ).json()
+    other = admin_client.get(
+        f"/v1/admin/audit-events?target_user_id={target}&action=user_approve"
+    ).json()
+    assert len(matching) >= 1
+    assert other == []
+
+
+def test_routine_browse_does_not_log(admin_client: httpx.Client):
+    """Listing or fetching a single user is a browse — must not log."""
+    target = _make_user(admin_client)
+
+    # These reads should leave no audit rows.
+    admin_client.get("/v1/admin/users")
+    # (Single-user-get endpoint doesn't exist as such; list_users covers it.)
+
+    events = admin_client.get(
+        f"/v1/admin/audit-events?target_user_id={target}"
+    ).json()
+    assert events == []
+
+
+def test_user_can_see_admin_actions_on_self(auth_client: httpx.Client, admin_client: httpx.Client):
+    """The /v1/auth/admin-activity endpoint returns rows targeting the
+    caller — non-admin users still get to see the log."""
+    me = auth_client.get("/v1/auth/me").json()
+    my_id = me["id"]
+
+    # Admin grants the user uploads.
+    resp = admin_client.patch(
+        f"/v1/admin/users/{my_id}", json={"can_upload_images": True}
+    )
+    assert resp.status_code == 200, resp.text
+
+    # User reads their own activity.
+    events = auth_client.get("/v1/auth/admin-activity").json()
+    assert any(
+        e["action"] == "user_update" and e["after_json"] == {"can_upload_images": True}
+        for e in events
+    )
+    # Crucially, the user does NOT see the admin's user_id field — only
+    # admin_email is exposed on this surface.
+    assert all("admin_user_id" not in e for e in events)
+
+
+def test_admin_activity_self_only(auth_client: httpx.Client, admin_client: httpx.Client):
+    """A user can only see rows where target_user_id matches their own
+    user id. An admin acting on a different user does not leak into the
+    caller's feed."""
+    other_target = _make_user(admin_client)
+    # Admin acts on a different user.
+    admin_client.patch(
+        f"/v1/admin/users/{other_target}", json={"can_upload_images": True}
+    )
+
+    # Caller (auth_client, a different user) sees nothing for this row.
+    events = auth_client.get("/v1/auth/admin-activity").json()
+    assert all(
+        e.get("after_json") != {"can_upload_images": True}
+        or e.get("target_id") != other_target
+        for e in events
+    )
+
+
+def test_audit_event_detail(admin_client: httpx.Client):
+    target = _make_user(admin_client)
+    admin_client.patch(
+        f"/v1/admin/users/{target}", json={"can_upload_images": True}
+    )
+    events = admin_client.get(
+        f"/v1/admin/audit-events?target_user_id={target}"
+    ).json()
+    event_id = events[0]["id"]
+
+    detail = admin_client.get(f"/v1/admin/audit-events/{event_id}").json()
+    assert detail["id"] == event_id
+    assert detail["target_user_id"] == target

--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -48,6 +48,7 @@ const adminItems = [
   { to: "/admin/invites", label: "Invites" },
   { to: "/admin/announcements", label: "Announcements" },
   { to: "/admin/jobs", label: "Jobs" },
+  { to: "/admin/audit", label: "Audit log" },
 ];
 
 export function AppSidebar({

--- a/web/src/components/settings/admin-activity-card.tsx
+++ b/web/src/components/settings/admin-activity-card.tsx
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyAdminActivity, type UserAdminActivityEvent } from "@/lib/admin";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+function formatDiff(
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null,
+): string {
+  if (!before && !after) return "";
+  const keys = new Set([
+    ...Object.keys(before ?? {}),
+    ...Object.keys(after ?? {}),
+  ]);
+  const parts: string[] = [];
+  for (const k of keys) {
+    parts.push(`${k}: ${JSON.stringify(before?.[k])} -> ${JSON.stringify(after?.[k])}`);
+  }
+  return parts.join(", ");
+}
+
+export function AdminActivityCard() {
+  const { data: events, isLoading } = useQuery({
+    queryKey: ["admin-activity", "me"],
+    queryFn: () => getMyAdminActivity(),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Admin activity on your account</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground max-w-prose">
+          Every state-changing action an administrator takes against your
+          account is recorded here. The admin's email, the action, the
+          before/after values for any changed fields, and any reason text
+          they entered are visible to you.
+        </p>
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        )}
+        {events && events.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No admin actions have been taken against your account.
+          </p>
+        )}
+        {events && events.length > 0 && (
+          <div className="space-y-3">
+            {events.map((e: UserAdminActivityEvent) => (
+              <div
+                key={e.id}
+                className="space-y-1 rounded-md border p-3 text-sm"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="text-[10px]">
+                      {e.action}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {e.admin_email ?? "(admin deleted)"}
+                    </span>
+                  </div>
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {new Date(e.created_at).toLocaleString()}
+                  </span>
+                </div>
+                {e.reason && (
+                  <p className="italic text-xs text-muted-foreground">
+                    Reason: "{e.reason}"
+                  </p>
+                )}
+                {(e.before_json || e.after_json) && (
+                  <p className="font-mono text-xs text-muted-foreground">
+                    {formatDiff(e.before_json, e.after_json)}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -98,6 +98,54 @@ export function getPushoverUsage() {
   return apiFetch<PushoverUsage>("/v1/admin/pushover-usage");
 }
 
+export interface AdminAuditEvent {
+  id: string;
+  admin_user_id: string | null;
+  admin_email: string | null;
+  action: string;
+  target_type: string;
+  target_id: string | null;
+  target_user_id: string | null;
+  reason: string | null;
+  before_json: Record<string, unknown> | null;
+  after_json: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export function getAdminAuditEvents(opts: {
+  target_user_id?: string;
+  admin_user_id?: string;
+  action?: string;
+  page?: number;
+  limit?: number;
+} = {}) {
+  const params = new URLSearchParams();
+  if (opts.target_user_id) params.set("target_user_id", opts.target_user_id);
+  if (opts.admin_user_id) params.set("admin_user_id", opts.admin_user_id);
+  if (opts.action) params.set("action", opts.action);
+  params.set("page", String(opts.page ?? 1));
+  params.set("limit", String(opts.limit ?? 50));
+  return apiFetch<AdminAuditEvent[]>(`/v1/admin/audit-events?${params}`);
+}
+
+export interface UserAdminActivityEvent {
+  id: string;
+  admin_email: string | null;
+  action: string;
+  target_type: string;
+  target_id: string | null;
+  reason: string | null;
+  before_json: Record<string, unknown> | null;
+  after_json: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export function getMyAdminActivity(page = 1, limit = 50) {
+  return apiFetch<UserAdminActivityEvent[]>(
+    `/v1/auth/admin-activity?page=${page}&limit=${limit}`,
+  );
+}
+
 export function getPendingApprovals() {
   return apiFetch<PendingUser[]>("/v1/admin/approvals");
 }

--- a/web/src/routes/admin/audit.tsx
+++ b/web/src/routes/admin/audit.tsx
@@ -1,0 +1,182 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getAdminAuditEvents, type AdminAuditEvent } from "@/lib/admin";
+import { PageHeader } from "@/components/page-header";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+const ACTION_OPTIONS = [
+  "",
+  "user_update",
+  "user_approve",
+  "user_reject",
+  "user_member_limit_set",
+  "user_safety_reset",
+  "user_pending_bypass",
+  "import_log_view",
+];
+
+function formatDiff(
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null,
+): string {
+  if (!before && !after) return "";
+  const keys = new Set([
+    ...Object.keys(before ?? {}),
+    ...Object.keys(after ?? {}),
+  ]);
+  const parts: string[] = [];
+  for (const k of keys) {
+    const b = before?.[k];
+    const a = after?.[k];
+    parts.push(`${k}: ${JSON.stringify(b)} -> ${JSON.stringify(a)}`);
+  }
+  return parts.join(", ");
+}
+
+export function AdminAuditPage() {
+  const [targetUserId, setTargetUserId] = useState("");
+  const [action, setAction] = useState("");
+  const [page, setPage] = useState(1);
+
+  const filters = useMemo(
+    () => ({
+      target_user_id: targetUserId || undefined,
+      action: action || undefined,
+      page,
+      limit: 50,
+    }),
+    [targetUserId, action, page],
+  );
+
+  const { data: events } = useQuery({
+    queryKey: ["admin", "audit", filters],
+    queryFn: () => getAdminAuditEvents(filters),
+  });
+
+  return (
+    <>
+      <PageHeader title="Admin audit log" />
+      <p className="text-sm text-muted-foreground max-w-prose mb-4">
+        Append-only log of state-changing admin actions. Browsing user data
+        (list, detail, search) is deliberately not logged so the table stays
+        signal-rich for abuse detection.
+      </p>
+      <div className="grid gap-3 sm:grid-cols-3 mb-4">
+        <div className="space-y-1">
+          <Label htmlFor="audit-target" className="text-xs">
+            Target user ID
+          </Label>
+          <Input
+            id="audit-target"
+            value={targetUserId}
+            onChange={(e) => {
+              setTargetUserId(e.target.value);
+              setPage(1);
+            }}
+            placeholder="UUID"
+            className="font-mono text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="audit-action" className="text-xs">
+            Action
+          </Label>
+          <select
+            id="audit-action"
+            value={action}
+            onChange={(e) => {
+              setAction(e.target.value);
+              setPage(1);
+            }}
+            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+          >
+            {ACTION_OPTIONS.map((a) => (
+              <option key={a} value={a}>
+                {a || "(all)"}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b text-xs text-muted-foreground">
+                <th className="py-2 px-3 text-left font-medium">When</th>
+                <th className="py-2 px-3 text-left font-medium">Admin</th>
+                <th className="py-2 px-3 text-left font-medium">Action</th>
+                <th className="py-2 px-3 text-left font-medium">Target</th>
+                <th className="py-2 px-3 text-left font-medium">Diff / reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events?.map((e: AdminAuditEvent) => (
+                <tr key={e.id} className="border-b text-sm last:border-0">
+                  <td className="py-2 px-3 align-top whitespace-nowrap">
+                    {new Date(e.created_at).toLocaleString()}
+                  </td>
+                  <td className="py-2 px-3 align-top">
+                    {e.admin_email ?? <span className="text-muted-foreground">deleted</span>}
+                  </td>
+                  <td className="py-2 px-3 align-top">
+                    <Badge variant="outline" className="text-[10px]">
+                      {e.action}
+                    </Badge>
+                  </td>
+                  <td className="py-2 px-3 align-top font-mono text-xs text-muted-foreground">
+                    <div>{e.target_type}</div>
+                    <div>{e.target_user_id ?? e.target_id ?? ""}</div>
+                  </td>
+                  <td className="py-2 px-3 align-top text-xs">
+                    {e.reason && (
+                      <div className="italic mb-1">"{e.reason}"</div>
+                    )}
+                    <div className="font-mono text-muted-foreground">
+                      {formatDiff(e.before_json, e.after_json)}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {events?.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="py-6 px-3 text-center text-sm text-muted-foreground"
+                  >
+                    No audit events match the current filters.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page === 1}
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+        >
+          Previous
+        </Button>
+        <span className="text-xs text-muted-foreground">Page {page}</span>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={!events || events.length < 50}
+          onClick={() => setPage((p) => p + 1)}
+        >
+          Next
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -40,6 +40,7 @@ import { AdminApprovalsPage } from "./admin/approvals";
 import { AdminInvitesPage } from "./admin/invites";
 import { AdminAnnouncementsPage } from "./admin/announcements";
 import { AdminJobsPage } from "./admin/jobs";
+import { AdminAuditPage } from "./admin/audit";
 
 export const router = createBrowserRouter([
   {
@@ -110,6 +111,7 @@ export const router = createBrowserRouter([
           { path: "invites", element: <AdminInvitesPage /> },
           { path: "announcements", element: <AdminAnnouncementsPage /> },
           { path: "jobs", element: <AdminJobsPage /> },
+          { path: "audit", element: <AdminAuditPage /> },
         ],
       },
       // Catch-all under AppLayout: unknown paths render the 404 inside the

--- a/web/src/routes/settings/account.tsx
+++ b/web/src/routes/settings/account.tsx
@@ -1,4 +1,5 @@
 import { AccountInfoCard } from "@/components/settings/account-info-card";
+import { AdminActivityCard } from "@/components/settings/admin-activity-card";
 import { ApiKeysCard } from "@/components/settings/api-keys-card";
 import { ActiveSessionsCard } from "@/components/settings/active-sessions-card";
 import { PrivacyCard } from "@/components/settings/privacy-card";
@@ -12,6 +13,7 @@ export function SettingsAccountPage() {
       <ApiKeysCard />
       <ActiveSessionsCard />
       <TrustedDevicesCard />
+      <AdminActivityCard />
     </>
   );
 }


### PR DESCRIPTION
## Summary

First of two PRs implementing the admin upgrades. This one lays the audit-log foundation; PR 2 adds reset-safety / bypass-pending / import-log view on top, all writing through the same `log_admin_action` helper.

Every state-changing admin action now writes a row to a new `admin_audit_events` table. Two read surfaces:

- `GET /v1/admin/audit-events` — admin-only, paginated, filterable by `target_user_id` / `admin_user_id` / `action`. Backed by a new admin panel page under **Admin > Audit log**.
- `GET /v1/auth/admin-activity` — self-only, returns rows targeting the caller. Backed by an "Admin activity on your account" card in **Settings > Account** so every user can see what admins have done to their account, including the admin's email, the action, before/after diffs, and any reason text.

Wired into:
- `update_user` (tier / is_admin / can_upload_images / can_upload_animated_images / member_limit). Computes a field-level diff so no-op patches leave no row.
- `approve_user`
- `reject_user` (logged before the cascade delete clears the target)

## Mutation-only by design

Routine reads (list-users, single-user detail, search) are deliberately not logged. Logging every admin browse would swamp the table and actively hurt the abuse-detection use case — a malicious admin trawling user data wouldn't stand out against the noise floor. The exception is `import_log_view` (landing in PR 2) where the read itself is privacy-sensitive enough to deserve a row.

## Append-only

No edit or delete endpoint. Admin FK is `SET NULL` so history survives if the admin's account is later removed; the captured `admin_email` field preserves attribution.

## Test plan

- [x] `ruff`, `tsc`, `eslint` clean
- [x] First full-suite run surfaced a SQLAlchemy enum-name mismatch — `Enum(AdminAuditAction)` was auto-deriving `adminauditaction` but the migration created `admin_audit_action`. Fixed in the amended commit by naming the types explicitly on the model; should clear all ten 500-on-PATCH failures the run flagged.
- [x] `./run_tests.sh` full sweep with the fix in place
- [x] Localdev: as admin, PATCH a user's tier; confirm the row appears in /admin/audit. Verify routine list / get reads do NOT add rows.
- [x] Localdev: as the patched user, open Settings > Account and confirm the action shows up with the admin's email.