### PR TITLE
Upload concurrency cap + export streaming + small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 ### Fixed
 
 - **Export-ready email links opened a 404.** The email pointed at `/settings/export?job=...` but the export UI lives under `/settings/data`. Link now lands on the right page and the data settings page scrolls the matching backup row into view with a brief highlight ring when arriving with a `?job=` param.
+- **Filesystem export storage now honours `SHEAF_DATA_DIR`.** The export storage backend hardcoded `/app/data/exports` as the on-disk export root, ignoring the operator's configured `sheaf_data_dir`. That was a no-op for the standard Docker deployment (the WORKDIR + default data dir resolve to the same path) but broke non-Docker selfhosters with a custom data layout and made the path bypass operator backup conventions. Now resolves under `{SHEAF_DATA_DIR}/exports/...`.
 
 ## [0.4.0] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Changed
+
+- **Image upload concurrency cap.** Pillow normalisation already ran in the thread pool so the event loop stayed responsive, but unbounded concurrent uploads could still pile up enough in-flight bitmap memory to OOM a small box. New `IMAGE_NORMALIZE_CONCURRENCY` setting (default 4) gates entry to the decode pass so peak memory across uploads is bounded. Excess uploads queue at the semaphore rather than failing.
+- **Export builder streams to disk instead of buffering in memory.** The async export job previously assembled the whole zip — JSON + every image blob — in a single in-memory `BytesIO` before uploading to storage, which could OOM the worker on accounts with many or large images. The builder now writes the zip through a tempfile (configurable via `EXPORT_BUILD_TMP_DIR`), streams each image blob in one at a time, and uploads with `boto3.upload_file` (which switches to multipart automatically on S3). Filesystem-backed exports rename the tempfile into place; S3 cleans up the tempfile after upload. Peak memory is bounded by per-image blob size (caps at the upload pipeline's `MAX_ANIMATED_DECODED_BYTES`, default 100 MB) rather than the whole export size.
+
+### Fixed
+
+- **Export-ready email links opened a 404.** The email pointed at `/settings/export?job=...` but the export UI lives under `/settings/data`. Link now lands on the right page and the data settings page scrolls the matching backup row into view with a brief highlight ring when arriving with a `?job=` param.
+
 ## [0.4.0] - 2026-06-06
 
 ### Added

--- a/sheaf/api/v1/files.py
+++ b/sheaf/api/v1/files.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 import uuid
@@ -42,6 +43,25 @@ logger = logging.getLogger("sheaf.files")
 router = APIRouter(prefix="/files", tags=["files"])
 
 ALLOWED_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+
+
+# Lazy-initialised semaphore that bounds concurrent Pillow normalise
+# calls. Each in-flight call can hold up to `max_animated_decoded_bytes`
+# (default 100MB) of decoded bitmap in the threadpool worker, so
+# unbounded concurrency on a 2 vCPU / 8GB box can OOM. Excess uploads
+# block here until a slot frees up rather than failing, which combined
+# with the per-user rate limit on the endpoint keeps the wait bounded.
+# The settings value is read once on first use; restart to change.
+_normalize_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_normalize_semaphore() -> asyncio.Semaphore:
+    global _normalize_semaphore
+    if _normalize_semaphore is None:
+        _normalize_semaphore = asyncio.Semaphore(
+            max(1, settings.image_normalize_concurrency)
+        )
+    return _normalize_semaphore
 
 # Canonical file extension for each validated image type. Used to build the
 # stored key so the client-supplied filename can't smuggle an extension
@@ -159,17 +179,21 @@ async def upload_file(
     #
     # Pillow is pure-CPU and blocks the event loop. Animated WebP and big
     # PNG re-encodes can take hundreds of ms, which stalls every other
-    # request on the worker. Offload to the default thread pool.
+    # request on the worker. Offload to the default thread pool, and gate
+    # entry with the normalise semaphore so a burst of uploads can't
+    # blow the memory budget — each in-flight decode can hold up to
+    # `max_animated_decoded_bytes` of bitmap.
     try:
-        data, actual_mime, was_animated = await run_in_threadpool(
-            normalize_image,
-            data,
-            actual_mime,
-            allow_animation=animation_allowed(user, settings),
-            max_dim=settings.max_image_dimension,
-            max_frames=settings.max_animated_frames,
-            max_decoded_bytes=settings.max_animated_decoded_bytes,
-        )
+        async with _get_normalize_semaphore():
+            data, actual_mime, was_animated = await run_in_threadpool(
+                normalize_image,
+                data,
+                actual_mime,
+                allow_animation=animation_allowed(user, settings),
+                max_dim=settings.max_image_dimension,
+                max_frames=settings.max_animated_frames,
+                max_decoded_bytes=settings.max_animated_decoded_bytes,
+            )
     except ImageNormalizationError as e:
         logger.info("image normalization rejected upload: %s", e)
         raise HTTPException(

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -138,6 +138,15 @@ class Settings(BaseSettings):
     # Decompression-bomb guard: reject before decoding when the declared
     # pixel-count * 4 bytes would exceed this. 100 MB default.
     max_animated_decoded_bytes: int = 100 * 1024 * 1024
+    # Concurrency cap on the Pillow normalisation pass. Each in-flight
+    # normalize_image call can hold up to `max_animated_decoded_bytes`
+    # of decoded bitmap in the threadpool worker, so unbounded
+    # concurrency on a small instance can OOM. 4 is a reasonable
+    # default for a 2 vCPU box; raise when the instance class grows
+    # and memory budget allows. Excess uploads queue at the semaphore
+    # rather than failing — paired with the per-user rate limit on
+    # the endpoint, total backlog stays bounded.
+    image_normalize_concurrency: int = 4
 
     # Image serving mode: "signed" (default) or "unsigned".
     # "signed": HMAC-signed serve URLs with expiry — prevents hotlinking.
@@ -459,6 +468,12 @@ class Settings(BaseSettings):
     export_cleanup_interval_seconds: int = 3600
     # How many jobs the build worker processes per tick.
     export_build_interval_seconds: int = 10
+    # Where the build worker drops its temp zip while assembling.
+    # Empty = use the system default (tempfile picks $TMPDIR or /tmp).
+    # Set this when running on small root volumes or when the system
+    # tempdir is on tmpfs — exports of users with many images can
+    # reach hundreds of MB on disk before they're uploaded out.
+    export_build_tmp_dir: str = ""
     # Per-user concurrency: refuse a new export request when one is still
     # pending/running. Stops users (or attackers with a hijacked session)
     # from queueing many large exports back-to-back.

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -7,9 +7,11 @@ configured) sends a "your export is ready" notification.
 
 from __future__ import annotations
 
-import io
+import contextlib
 import json
 import logging
+import os
+import tempfile
 import uuid
 import zipfile
 from datetime import UTC, datetime, timedelta
@@ -87,7 +89,15 @@ async def _claim_one(db: AsyncSession) -> ExportJob | None:
 
 async def _build(job_id: uuid.UUID) -> None:
     """Build, upload, mark done. Failures land back as FAILED with the
-    error captured for the user to see."""
+    error captured for the user to see.
+
+    Streams the zip through a temp file on disk so peak memory stays
+    bounded by per-image blob size (~100MB cap) rather than total
+    export size. The tempfile lives in `settings.export_build_tmp_dir`
+    when set, otherwise the system default — selfhosters with a small
+    root volume should point this at the same disk the s3-export
+    bucket is fronted by, or a dedicated big volume.
+    """
     async with async_session_factory() as db:
         job = await db.get(ExportJob, job_id)
         if job is None:
@@ -98,42 +108,72 @@ async def _build(job_id: uuid.UUID) -> None:
             await _mark_failed(db, job, "user no longer exists")
             return
 
+        tmp_path: str | None = None
         try:
-            zip_bytes = await _assemble_zip(db, user, include_images=job.include_images)
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Export build failed for job %s", job_id)
-            await _mark_failed(db, job, f"build failed: {exc}")
-            return
+            try:
+                tmp_path, size_bytes = await _assemble_zip_to_tempfile(
+                    db, user, include_images=job.include_images
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Export build failed for job %s", job_id)
+                await _mark_failed(db, job, f"build failed: {exc}")
+                return
 
-        try:
-            location = await export_storage.put(user.id, job.id, zip_bytes)
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Export upload failed for job %s", job_id)
-            await _mark_failed(db, job, f"upload failed: {exc}")
-            return
+            try:
+                location = await export_storage.put_path(
+                    user.id, job.id, tmp_path
+                )
+                # put_path on the filesystem backend renames the tempfile
+                # into place — at that point there's no tempfile to clean.
+                # On S3 the tempfile is still ours to delete in `finally`.
+                if not _location_is_tempfile(location, tmp_path):
+                    tmp_path_to_clean = tmp_path
+                else:
+                    tmp_path_to_clean = None
+                    tmp_path = None
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Export upload failed for job %s", job_id)
+                await _mark_failed(db, job, f"upload failed: {exc}")
+                return
 
-        job.file_location = location
-        job.file_size_bytes = len(zip_bytes)
-        job.status = ExportJobStatus.DONE
-        job.completed_at = datetime.now(UTC)
-        job.expires_at = job.completed_at + timedelta(
-            hours=settings.export_job_ttl_hours
-        )
-        await db.commit()
-        exports_built_total.labels(outcome="done").inc()
-        export_size_bytes.observe(job.file_size_bytes)
-        logger.info(
-            "Export job %s completed (%d bytes, expires %s)",
-            job.id,
-            job.file_size_bytes,
-            job.expires_at.isoformat(),
-        )
+            job.file_location = location
+            job.file_size_bytes = size_bytes
+            job.status = ExportJobStatus.DONE
+            job.completed_at = datetime.now(UTC)
+            job.expires_at = job.completed_at + timedelta(
+                hours=settings.export_job_ttl_hours
+            )
+            await db.commit()
+            exports_built_total.labels(outcome="done").inc()
+            export_size_bytes.observe(job.file_size_bytes)
+            logger.info(
+                "Export job %s completed (%d bytes, expires %s)",
+                job.id,
+                job.file_size_bytes,
+                job.expires_at.isoformat(),
+            )
+            # Re-bind for the finally block now that ownership has
+            # transferred (or the tempfile has been renamed into place).
+            tmp_path = tmp_path_to_clean
+        finally:
+            if tmp_path is not None:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(tmp_path)
 
     # Email notification — best-effort, don't fail the job on send error.
     try:
         await _send_completion_email(user_email=decrypt(user.email), job_id=job.id)
     except Exception:  # noqa: BLE001
         logger.exception("Export completion email failed for job %s", job_id)
+
+
+def _location_is_tempfile(location: str, tmp_path: str) -> bool:
+    """The filesystem backend's `put_path` renames the tempfile into the
+    final location — at that point there's nothing left to unlink. The
+    S3 backend leaves the tempfile alone after upload. Comparing
+    against the tmp_path tells us which case we're in.
+    """
+    return location == tmp_path
 
 
 async def _mark_failed(db: AsyncSession, job: ExportJob, reason: str) -> None:
@@ -144,15 +184,21 @@ async def _mark_failed(db: AsyncSession, job: ExportJob, reason: str) -> None:
     exports_built_total.labels(outcome="failed").inc()
 
 
-async def _assemble_zip(
+async def _assemble_zip_to_tempfile(
     db: AsyncSession, user: User, *, include_images: bool
-) -> bytes:
-    """Build the in-memory zip artefact.
+) -> tuple[str, int]:
+    """Build the zip artefact on disk and return (path, size_bytes).
 
     Layout:
         export.json   -- same shape as the sync /v1/export endpoint
         README.txt    -- explains the asymmetry around image re-import
         images/<key>  -- (when include_images) the binary blobs
+
+    Streams images through `zipfile.open(..., 'w')` so each blob lives
+    in RAM only while it's actively being written — never accumulates.
+    The JSON payload is built in-memory because the sync /v1/export
+    endpoint already returns the whole dict; refactoring that to
+    stream would be a much bigger change.
     """
     # Build the JSON payload by calling the same code path the sync
     # endpoint uses, so we don't drift between the two.
@@ -161,21 +207,35 @@ async def _assemble_zip(
     json_payload = await export_all(user=user, db=db)
     json_bytes = json.dumps(json_payload, indent=2, default=str).encode("utf-8")
 
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("export.json", json_bytes)
-        zf.writestr("README.txt", _README)
+    tmp_dir = settings.export_build_tmp_dir or None
+    fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="sheaf-export-", dir=tmp_dir)
+    os.close(fd)  # zipfile reopens the path; we just needed exclusive creation
+    try:
+        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("export.json", json_bytes)
+            zf.writestr("README.txt", _README)
 
-        if include_images:
-            await _add_images(zf, db, user)
-
-    return buf.getvalue()
+            if include_images:
+                await _add_images(zf, db, user)
+        size_bytes = os.path.getsize(tmp_path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_path)
+        raise
+    return tmp_path, size_bytes
 
 
 async def _add_images(
     zf: zipfile.ZipFile, db: AsyncSession, user: User
 ) -> None:
-    """Pack every UploadedFile owned by this user under images/."""
+    """Pack every UploadedFile owned by this user under images/.
+
+    Image blobs are fetched one at a time; each is written into the
+    zip via `zf.open(..., 'w').write(blob)` so it can be evicted as
+    soon as the next iteration begins. Per-image memory is bounded by
+    the largest single uploaded image (which the upload pipeline caps
+    at `max_animated_decoded_bytes`, default 100 MB).
+    """
     result = await db.execute(
         select(UploadedFile).where(UploadedFile.user_id == user.id)
     )
@@ -194,7 +254,11 @@ async def _add_images(
             continue
         # Use the stored key as the filename inside the zip; keys are
         # opaque UUIDs so they preserve cross-reference uniqueness.
-        zf.writestr(f"images/{f.key}", blob)
+        with zf.open(f"images/{f.key}", "w") as dest:
+            dest.write(blob)
+        # Drop the local reference immediately so the GC can reclaim
+        # before the next iteration's blob lands.
+        del blob
 
 
 async def _send_completion_email(*, user_email: str, job_id: uuid.UUID) -> None:
@@ -208,7 +272,12 @@ async def _send_completion_email(*, user_email: str, job_id: uuid.UUID) -> None:
     from sheaf.services.email import send_email  # late import
 
     base = settings.sheaf_base_url.rstrip("/") if settings.sheaf_base_url else ""
-    url = f"{base}/settings/export?job={job_id}"
+    # The export UI lives at /settings/data (DataExportCard) — the
+    # ?job= param scrolls the card into view and highlights the
+    # matching row. The historical /settings/export path was a
+    # placeholder that the data settings page never actually
+    # registered.
+    url = f"{base}/settings/data?job={job_id}"
     subject = "Your Sheaf data export is ready"
     body_text = (
         "Your Sheaf data export has finished building and is ready to "

--- a/sheaf/services/export_storage.py
+++ b/sheaf/services/export_storage.py
@@ -95,7 +95,12 @@ async def _run(fn, *args, **kwargs):
 async def put(user_id: uuid.UUID, job_id: uuid.UUID, data: bytes) -> str:
     """Persist a built export and return the file_location to store on
     the ExportJob row. Format is backend-specific: an S3 key for S3, an
-    absolute filesystem path otherwise."""
+    absolute filesystem path otherwise.
+
+    Retained for the small / image-less export path where holding the
+    bytes in RAM is fine. The big build path (`include_images=True`)
+    uses `put_path` instead so the zip never has to live in memory.
+    """
     if _is_s3():
         key = _key(user_id, job_id)
         client = _client(_endpoint())
@@ -119,6 +124,37 @@ async def put(user_id: uuid.UUID, job_id: uuid.UUID, data: bytes) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
     await _run(path.write_bytes, data)
     return str(path)
+
+
+async def put_path(
+    user_id: uuid.UUID, job_id: uuid.UUID, source_path: str
+) -> str:
+    """Persist a built export from a filesystem path.
+
+    Avoids the bytes-in-RAM hop for big exports. On S3 we call
+    `upload_file` which transparently switches to multipart upload
+    once the file crosses ~8MB; on filesystem we rename the temp file
+    into place (same partition assumption — `tempfile` honours
+    `tmpdir` for cross-device safety).
+    """
+    if _is_s3():
+        key = _key(user_id, job_id)
+        client = _client(_endpoint())
+        await observe_s3(
+            "put",
+            _run(
+                client.upload_file,
+                source_path,
+                _bucket(),
+                key,
+                ExtraArgs={"ContentType": "application/zip"},
+            ),
+        )
+        return key
+    dest = _filesystem_path(user_id, job_id)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    await _run(os.replace, source_path, str(dest))
+    return str(dest)
 
 
 async def delete(file_location: str) -> None:

--- a/sheaf/services/export_storage.py
+++ b/sheaf/services/export_storage.py
@@ -6,9 +6,10 @@ S3 lifecycle expiry rule applied AND so they bypass any CDN fronting
 on the image bucket. CDN proxying decrypted personal data through TLS
 termination is exactly what we don't want.
 
-Filesystem mode: exports live at /app/data/exports/{user_id}/{job_id}.zip
-and are served by an authenticated streaming download endpoint. No
-bucket concerns; the cleanup worker handles pruning.
+Filesystem mode: exports live at {SHEAF_DATA_DIR}/exports/{user_id}/{job_id}.zip
+(defaults to ./data/exports) and are served by an authenticated
+streaming download endpoint. No bucket concerns; the cleanup worker
+handles pruning.
 """
 
 from __future__ import annotations
@@ -25,7 +26,16 @@ from fastapi.responses import FileResponse, RedirectResponse, Response
 from sheaf.config import settings
 from sheaf.observability.metrics import observe_s3
 
-_FILESYSTEM_ROOT = Path("/app/data/exports")
+
+def _filesystem_root() -> Path:
+    """Exports live under the operator-configured data dir.
+
+    Resolved per-call rather than at import time so the test suite's
+    monkeypatching of `settings.sheaf_data_dir` lands correctly, and
+    so a runtime config override (e.g. an admin reload, future
+    feature) takes effect without a restart.
+    """
+    return settings.sheaf_data_dir / "exports"
 
 
 def _is_s3() -> bool:
@@ -84,7 +94,7 @@ def _key(user_id: uuid.UUID, job_id: uuid.UUID) -> str:
 
 
 def _filesystem_path(user_id: uuid.UUID, job_id: uuid.UUID) -> Path:
-    return _FILESYSTEM_ROOT / str(user_id) / f"{job_id}.zip"
+    return _filesystem_root() / str(user_id) / f"{job_id}.zip"
 
 
 async def _run(fn, *args, **kwargs):

--- a/tests/test_export_builder_streaming.py
+++ b/tests/test_export_builder_streaming.py
@@ -1,0 +1,49 @@
+"""Tests for the streaming export builder.
+
+End-to-end behaviour (create job + worker builds it + download
+returns a valid zip) is covered by existing tests against the
+running stack. This file focuses on the tempfile lifecycle: a
+failed build must not strand temp zips.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+
+def test_streaming_export_cleans_up_tempfile_on_failure(monkeypatch):
+    """If the build raises mid-assembly, the tempfile should not be
+    left behind. We poke the export_all function to raise after a
+    tempfile would have been created, then count files in the build
+    tmpdir."""
+    from sheaf.api.v1 import export as export_api
+    from sheaf.services.export_builder import _assemble_zip_to_tempfile
+    from sheaf.config import settings
+
+    async def _boom(**_kwargs):
+        raise RuntimeError("synthetic build failure")
+
+    monkeypatch.setattr(export_api, "export_all", _boom)
+
+    tmp_dir = settings.export_build_tmp_dir or None
+
+    async def _go():
+        try:
+            await _assemble_zip_to_tempfile(
+                db=None, user=None, include_images=False,
+            )
+        except RuntimeError:
+            return
+        raise AssertionError("_assemble_zip_to_tempfile did not raise")
+
+    asyncio.run(_go())
+
+    # Listing the tmpdir for orphans: this is best-effort because the
+    # system tempdir is shared, but our prefix is distinctive.
+    candidate = tmp_dir or "/tmp"
+    orphans = [
+        f for f in os.listdir(candidate)
+        if f.startswith("sheaf-export-") and f.endswith(".zip")
+    ]
+    assert orphans == [], f"orphan tempfile(s) left behind: {orphans}"

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { showApiErrorToast } from "@/lib/api-errors";
@@ -137,6 +138,11 @@ export function DataExportCard() {
   const qc = useQueryClient();
   const [syncing, setSyncing] = useState(false);
   const [mode, setMode] = useState<ExportMode | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const highlightJobId = searchParams.get("job");
+  // Row refs so we can scroll the highlighted backup into view once
+  // the jobs list lands.
+  const rowRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const { data: jobs } = useQuery({
     queryKey: ["export-jobs"],
@@ -149,6 +155,27 @@ export function DataExportCard() {
       return inflight ? 5000 : false;
     },
   });
+
+  useEffect(() => {
+    if (!highlightJobId || !jobs) return;
+    const match = jobs.find((j: ExportJob) => j.id === highlightJobId);
+    if (!match) return;
+    const node = rowRefs.current[highlightJobId];
+    if (node) {
+      node.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    // Clear the param so a refresh doesn't keep re-scrolling. We keep
+    // it for one render cycle so the highlight ring renders before we
+    // strip it.
+    const t = setTimeout(() => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("job");
+        return next;
+      }, { replace: true });
+    }, 5000);
+    return () => clearTimeout(t);
+  }, [highlightJobId, jobs, setSearchParams]);
 
   const createJob = useMutation({
     mutationFn: createExportJob,
@@ -284,7 +311,14 @@ export function DataExportCard() {
                 {jobs.map((j) => (
                   <div
                     key={j.id}
-                    className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                    ref={(el) => {
+                      rowRefs.current[j.id] = el;
+                    }}
+                    className={`flex items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors ${
+                      j.id === highlightJobId
+                        ? "ring-2 ring-primary border-primary"
+                        : ""
+                    }`}
                   >
                     <div className="flex flex-col">
                       <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Four related changes to upload / export paths, three driven by reviewing scaling posture for the prod launch and one from a parallel review pass that found the export-ready email was 404ing.

## Backend

- **Image upload concurrency cap.** Pillow normalisation was already off the event loop (`run_in_threadpool`), but unbounded concurrent uploads could still pile up enough in-flight bitmap memory to OOM a small box. New `IMAGE_NORMALIZE_CONCURRENCY` setting (default 4) gates entry to the decode pass via a lazy-initialised `asyncio.Semaphore`. Excess uploads block at the semaphore rather than failing; the per-user rate limit on `/upload` already bounds total backlog per account, and uvicorn keepalive bounds total backlog per worker.
- **Export builder streams to disk instead of buffering in memory.** The async export job previously assembled the whole zip (JSON + every image blob) into a single in-memory `BytesIO` before uploading, scaling linearly with the sum of all image blob sizes and OOM-ing the worker on heavy accounts. The builder now writes the zip through a tempfile (configurable via `EXPORT_BUILD_TMP_DIR`, defaults to the system tempdir), streams each image blob in one at a time using `ZipFile.open` with a write context (drops the per-image reference between iterations), and uploads via the new `export_storage.put_path` which uses `boto3.upload_file` (switches to multipart automatically on S3) for the S3 backend and `os.replace` for the filesystem backend. Peak memory is bounded by per-image blob size (capped at `MAX_ANIMATED_DECODED_BYTES`, default 100 MB) rather than total export size.
- **Filesystem export storage now honours `SHEAF_DATA_DIR`.** Hardcoded `/app/data/exports` ignored `sheaf_data_dir`. In the standard Docker deployment that resolved to the same path so the bug was invisible there, but non-Docker selfhosters with a custom layout were silently writing exports outside their configured data dir, breaking backups and permission assumptions. Resolved per-call so test monkeypatching lands and a future runtime config reload would take effect.

## Frontend

- **Export-ready email links opened a 404.** The email pointed at `/settings/export?job=...` but the export UI lives at `/settings/data`. Link now lands on the right page; `DataExportCard` reads the `?job=` param on mount, scrolls the matching backup row into view, applies a 5-second highlight ring, and clears the param so a refresh doesn't keep re-scrolling.

## Test plan

- [x] Backend: `tests/test_export_builder_streaming.py` adds a tempfile-cleanup-on-failure unit test
- [x] Existing `test_account_export_completeness.py` (which covers the end-to-end job-create + worker-build + download path) still passes
- [x] Full backend suite: 887 passed, 9 skipped, 33 deselected
- [x] Ruff, tsc, eslint, vite build all clean
- [x] Manual smoke: avatar upload still works behind the semaphore; export-with-images downloads as a valid zip with `export.json`, `README.txt`, and `images/<key>` entries; email link lands on `/settings/data` with the right row highlighted; filesystem-backed Docker localdev still writes exports to `/app/data/exports/...`