### PR TITLE
Fix security.txt Encryption key + reconcile with SECURITY.md

### DIFF
--- a/SECURITY-PGP-KEY.asc
+++ b/SECURITY-PGP-KEY.asc
@@ -1,0 +1,21 @@
+Sheaf Security Team <security@sheaf.sh>
+Fingerprint: 90AC C2BB 6C88 6DD8 EBD0  11B9 BBB8 ABBC 92D6 A17C
+
+Use this key to encrypt security reports sent to security@sheaf.sh.
+This key is published here rather than on a public keyserver; the raw
+URL is referenced from /.well-known/security.txt (the Encryption field)
+so reporters can fetch it programmatically.
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEagvuLBYJKwYBBAHaRw8BAQdA3Sh9lADcKDL97DVNIed0ktYBVpfwnUUu9TuK
+RU5rsLy0J1NoZWFmIFNlY3VyaXR5IFRlYW0gPHNlY3VyaXR5QHNoZWFmLnNoPoiT
+BBMWCgA7FiEEkKzCu2yIbdjr0BG5u7irvJLWoXwFAmoL7iwCGwMFCwkIBwICIgIG
+FQoJCAsCBBYCAwECHgcCF4AACgkQu7irvJLWoXw8FgD/RxodfGyzYvCfRdH2G0F6
++URBhC6TlRzPfg8KSR0eJ0EA/262sOYTRaLfFtDbfjkIgJHyg992T+Byvk4aNbQw
+sTEDuDgEagvuYBIKKwYBBAGXVQEFAQEHQKaBBMsiR31a0ASqTL9DMa3pQS7Azq4g
+bygrXSPZvFYgAwEIB4h4BBgWCgAgFiEEkKzCu2yIbdjr0BG5u7irvJLWoXwFAmoL
+7mACGwwACgkQu7irvJLWoXwIMwD9EsqA8Vs9KtaLzorl5LXaF/1825qEpNJhfK4T
+t9DNRHkA/ixCXg3I7Mc8WERSo+yvHqP4J3fgjZHDY4F9llzjt1wJ
+=DQmd
+-----END PGP PUBLIC KEY BLOCK-----

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Sheaf handles deeply personal identity data — GDPR Article 9 special category 
 
 **Do not open a public issue for security vulnerabilities.**
 
-Please report vulnerabilities by emailing **sheaf-security@lupine.systems**, or by opening a private security advisory on GitHub.
+Please report vulnerabilities by emailing **security@sheaf.sh**, or by opening a private security advisory on GitHub.
 
 Include:
 - Description of the vulnerability
@@ -15,6 +15,15 @@ Include:
 - Suggested fix, if you have one
 
 We will acknowledge your report within 48 hours and aim to provide a fix timeline within a week.
+
+### Encrypting your report
+
+If you'd like to encrypt your report, use our PGP key:
+
+- **Fingerprint:** `90AC C2BB 6C88 6DD8 EBD0  11B9 BBB8 ABBC 92D6 A17C`
+- **Key:** [`SECURITY-PGP-KEY.asc`](SECURITY-PGP-KEY.asc) in this repo
+
+The same key is referenced from the `Encryption` field of any Sheaf instance's `/.well-known/security.txt`. It is published in this repo rather than on a public keyserver, so fetch it from here (or the raw URL in security.txt) rather than a keyserver lookup. Encryption is optional — an unencrypted report to the address above is fine.
 
 ## Scope
 

--- a/sheaf/main.py
+++ b/sheaf/main.py
@@ -242,9 +242,19 @@ async def health():
 def _security_txt_body() -> str:
     expires = (datetime.now(UTC) + timedelta(days=365)).strftime("%Y-%m-%dT%H:%M:%SZ")
     lines = [
-        "Contact: mailto:sheaf-security@lupine.systems",
+        # Two channels, mirroring SECURITY.md: email first, then the
+        # GitHub private security advisory form. RFC 9116 reads multiple
+        # Contact fields in listed preference order.
+        "Contact: mailto:security@sheaf.sh",
+        "Contact: https://github.com/sheaf-project/sheaf/security/advisories/new",
         f"Expires: {expires}",
-        "Encryption: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0315B7582C0B170DE1C1AC48722EB40ADED799AE",
+        # The team key is published in-repo rather than on a public
+        # keyserver — keyserver entries are append-only and can't be
+        # rotated or removed. The raw URL serves the ASCII-armored
+        # block; SECURITY.md carries the same fingerprint for the
+        # human-readable path.
+        # Fingerprint: 90AC C2BB 6C88 6DD8 EBD0  11B9 BBB8 ABBC 92D6 A17C
+        "Encryption: https://raw.githubusercontent.com/sheaf-project/sheaf/main/SECURITY-PGP-KEY.asc",
         "Preferred-Languages: en",
         "Policy: https://github.com/sheaf-project/sheaf/blob/main/SECURITY.md",
     ]

--- a/tests/test_security_txt.py
+++ b/tests/test_security_txt.py
@@ -16,7 +16,13 @@ def test_well_known_security_txt(client: httpx.Client):
     # Recommended extras we've committed to.
     assert "Preferred-Languages: en" in body
     assert "Policy:" in body
-    assert "Encryption:" in body
+    # Encryption points at the in-repo ASCII-armored key, not a
+    # keyserver (the team key is deliberately kept off keyservers).
+    assert (
+        "Encryption: https://raw.githubusercontent.com/sheaf-project/sheaf/main/SECURITY-PGP-KEY.asc"
+        in body
+    )
+    assert "keyserver" not in body
 
 
 def test_security_txt_legacy_path_also_served(client: httpx.Client):


### PR DESCRIPTION
## Summary

The `Encryption:` field in `/.well-known/security.txt` pointed at a keyserver URL carrying the **wrong** fingerprint (`0315B758…`), so a reporter following it would fetch a key that doesn't exist. This replaces it with the real security team key and brings SECURITY.md and security.txt into agreement (the E8 reconcile).

## Changes

- **`SECURITY-PGP-KEY.asc`** (new, repo root) — the team public key, fingerprint `90AC C2BB 6C88 6DD8 EBD0  11B9 BBB8 ABBC 92D6 A17C`, uid `Sheaf Security Team <security@sheaf.sh>`. Verified to parse with the correct fingerprint via `gpg --show-keys`. Published in-repo rather than on a public keyserver — keyserver entries are append-only and can't be rotated or removed, so in-repo hosting makes key rotation a tracked commit.
- **`Encryption:`** now points at the raw URL of that file (`https://raw.githubusercontent.com/sheaf-project/sheaf/main/SECURITY-PGP-KEY.asc`).
- **`Contact:`** moved to `mailto:security@sheaf.sh` to match the key uid (the old `sheaf-security@lupine.systems` address routed to the same place), plus a second `Contact:` line for the GitHub private security advisory form — so security.txt now lists both reporting channels SECURITY.md already documents.
- **SECURITY.md** — contact address updated, new "Encrypting your report" section with the fingerprint + link to the key.
- **Test** pins the new Encryption URL and asserts the `keyserver` reference is gone, so this can't silently regress.

## Notes

- The raw URL hardcodes `sheaf-project/sheaf@main` intentionally: every instance's security.txt advertises the upstream project's key, since software-vuln reports go upstream (the `Policy:` field already points at the upstream SECURITY.md the same way).
- Full WKD (`gpg --locate-keys security@sheaf.sh`) on sheaf.sh is the heavier "proper" hosting path and is tracked as separate follow-up work; the in-repo key satisfies the security.txt `Encryption` requirement now.

## Test plan

- [x] `gpg --show-keys SECURITY-PGP-KEY.asc` confirms the armored block parses and the fingerprint matches
- [x] `_security_txt_body()` renders the new Contact/Encryption lines correctly
- [x] `pytest tests/test_security_txt.py -v` — all 3 pass against a rebuilt container
- [x] `ruff check sheaf/` clean