### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-09
+
 ### Added
 
 - **PluralSpace importer.** New source on the import picker that takes a PluralSpace data export zip (manifest + data + media) and brings across system profile, members, custom fronts, member groups, custom fields, fronts, journal entries, polls, and avatars. Member roles import as Sheaf tags, multi-channel chat history collapses onto the system board with channel-name prefixes, and open-ended polls get a one-year close window since Sheaf polls require one. Format mappings that don't have a clean Sheaf equivalent surface user-facing warning events on the import detail page rather than silently dropping data: journal `visibility_level` is dropped, multi-value custom fields collapse to newline-joined text, and `thoughts[]` is unsupported pending a Sheaf surface for it. Avatars run through the same normalize_image pipeline as regular uploads (EXIF strip, dim cap, animation gate, quota check) so the importer can't be used as an upload-policy bypass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sheaf"
-version = "0.4.0"
+version = "0.5.0"
 description = "Open-source plural system tracking"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1639,7 +1639,7 @@ wheels = [
 
 [[package]]
 name = "sheaf"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
         "@tailwindcss/typography": "^0.5.19",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump to 0.5.0. All five version locations updated (pyproject, uv.lock sheaf block, web/package.json, the two package-lock spots), and the `[Unreleased]` changelog moved under `## [0.5.0] - 2026-06-09`.

## What 0.5.0 ships

The headline is breadth: this is the release that takes Sheaf from "well-built beta" to "cleared for traffic".

**Importers.** PluralSpace, Prism (encryption-aware, server-side passphrase decryption), and Ampersand importers, plus an Octocon-to-PluralKit shim. All of them, and the existing PK/SP/TB/native importers, now enforce the tier member cap, reject decompression bombs, parse off the event loop, and route avatar URLs through a shared http(s)-only + external-image-policy gate.

**Security and prod-readiness review, fully cleared.** Every finding from the 2026-06-09 review: owner-only system reads, password-gated 2FA enrolment, single-use TOTP, password-reset session revocation, per-session admin step-up, audited admin recovery cluster with opaque session handles, right-to-left X-Forwarded-For, CSRF Origin checks, SSRF connection pinning, the login timing oracle, log redaction, Argon2 off the event loop, and the job-runner rework (advisory-lock leader election, lease-based outbox reclaim, stale-export recovery, real wake cadence, NOTIFY-driven imports).

**Features.** Image cropper + server-side normalization with an animation gate, a Prometheus metrics surface, the admin tooling suite (explain/suspend/ban/dossier/session-terminate/key-rotate), Cloudflare shield mode, nine new web palettes for Android parity, and a unified async import job runner with a live progress UI.

See the changelog section for the itemised list.

## Verification

- Version appears once in `pyproject.toml`, once in the `uv.lock` sheaf block, once in `web/package.json`, twice in `web/package-lock.json`.
- No migration or behaviour change in this PR - it is purely the version bump and changelog roll.

## After merge

```
git tag -s v0.5.0 -m "v0.5.0"
git push origin v0.5.0
```
