### PR TITLE
Add leader-election + import-backlog observability metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Leader-election and import-backlog observability metrics.** New `sheaf_leader_is_leader` gauge (1 on the leader process, 0 on standbys; multiprocess_mode=livesum, so `sum(sheaf_leader_is_leader) != 1` alerts on a wedged election with zero leaders or, impossibly, a split brain - a gap previously only caught indirectly via the notification-backlog alert and so invisible during quiet periods), `sheaf_leader_transitions_total` counter for leadership-flap detection, and `sheaf_imports_oldest_pending_seconds` gauge mirroring the notifications outbox-age signal now that the import runner is NOTIFY-driven. The leader gauge is only published when `LEADER_ELECTION` is enabled. (The per-job freshness, run-count, and duration metrics the same pass would have wanted already existed: `sheaf_job_last_success_timestamp`, `sheaf_job_runs_total`, `sheaf_job_run_duration_seconds`.)
+
 ## [0.5.0] - 2026-06-09
 
 ### Added

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -19,7 +19,7 @@ This document covers:
 ## 1. Enabling and binding
 
 Six environment variables control the endpoint. The defaults expose
-metrics on `127.0.0.1:8090` with no auth — safe for a single-node
+metrics on `127.0.0.1:8090` with no auth - safe for a single-node
 deployment scraped via SSH tunnel or a private network, NOT safe to
 forward through your edge.
 
@@ -42,7 +42,7 @@ METRICS_GAUGE_REFRESH_SECONDS=60     # DB-sourced gauges refresh interval
 | Internal network | `BIND=separate`, `HOST=10.x.x.x`, `AUTH=none` | Multi-node deploy with a private network. Scrape from a Prometheus instance inside the network. Cloud SG / firewall is the perimeter. |
 | Token-gated | `BIND=separate` or `main`, `AUTH=token`, `TOKEN=<bearer>` | Anywhere the endpoint is reachable from anything you don't already trust. |
 
-The `main` bind ALWAYS forces token auth regardless of `METRICS_AUTH` —
+The `main` bind ALWAYS forces token auth regardless of `METRICS_AUTH` -
 sharing a listener with the public API surface makes "forgot to set
 auth" a foot-gun, so we just rule it out.
 
@@ -50,7 +50,7 @@ auth" a foot-gun, so we just rule it out.
 will warn loudly at startup. Loopback (`127.0.0.1`, `::1`) and RFC1918
 private ranges (`10/8`, `172.16/12`, `192.168/16`, etc.) are silent;
 anything else (including `0.0.0.0` and hostnames) prints a warning so
-you confirm the perimeter is doing the work — a containerised deploy
+you confirm the perimeter is doing the work - a containerised deploy
 that binds `0.0.0.0` inside the container but only publishes the host
 port on `127.0.0.1` is fine, but the app can't tell that on its own.
 
@@ -120,13 +120,13 @@ deliberately not a label).
 | `sheaf_auth_logins_total` | counter | `outcome` ∈ {success, user_not_found, password_incorrect, locked, totp_required, totp_invalid, recovery_code_used, trusted_device_bypass, captcha_failed, email_unverified, email_revalidation_required} |
 | `sheaf_auth_password_reset_total` | counter | `stage` ∈ {requested, completed, expired, abandoned} |
 | `sheaf_auth_email_verification_total` | counter | `outcome` ∈ {sent, completed, expired, resend_blocked} |
-| `sheaf_auth_recovery_codes_used_total` | counter | — |
+| `sheaf_auth_recovery_codes_used_total` | counter | - |
 | `sheaf_auth_sessions_invalidated_total` | counter | `reason` ∈ {logout, expiry, mass_invalidation, password_change, cf_shield, admin} |
 | `sheaf_auth_lockout_events_total` | counter | `reason` ∈ {login_failures, totp_failures} |
-| `sheaf_auth_lockouts_active` | gauge | — |
-| `sheaf_auth_trusted_devices_active` | gauge | — |
-| `sheaf_auth_sessions_active` | gauge | — |
-| `sheaf_auth_totp_enabled` | gauge | — |
+| `sheaf_auth_lockouts_active` | gauge | - |
+| `sheaf_auth_trusted_devices_active` | gauge | - |
+| `sheaf_auth_sessions_active` | gauge | - |
+| `sheaf_auth_totp_enabled` | gauge | - |
 
 Useful alerts: a sustained `password_incorrect` rate per hour (credential
 stuffing), `lockout_events_total` rate (active attack), `lockouts_active`
@@ -140,10 +140,10 @@ high-water mark (failure-mode tracking).
 | `sheaf_rate_limit_active_blocks` | gauge | `bucket` |
 | `sheaf_captcha_challenges_total` | counter | `outcome` ∈ {issued, solved, failed} |
 | `sheaf_webhook_signature_failures_total` | counter | `endpoint` ∈ {sendgrid, cf_shield, notification_dispatch} |
-| `sheaf_requests_per_ip_per_minute` | histogram | — |
-| `sheaf_requests_per_account_per_minute` | histogram | — |
+| `sheaf_requests_per_ip_per_minute` | histogram | - |
+| `sheaf_requests_per_account_per_minute` | histogram | - |
 
-`bucket` is derived from the request route — values include `login`,
+`bucket` is derived from the request route - values include `login`,
 `register`, `password_reset`, `totp`, `email_verification`,
 `account_delete`, `account_change`, `account_data`, `upload`, `export`,
 `redeem`, `webhook`, `admin`, `global`, `other`. New endpoints land
@@ -163,8 +163,8 @@ percentiles means abuse.
 | `sheaf_notifications_dispatched_total` | counter | `channel_type`, `outcome` ∈ {success, transient_failure, permanent_failure, filtered, revoked, dropped} |
 | `sheaf_notifications_dispatch_duration_seconds` | histogram | `channel_type` |
 | `sheaf_notifications_dispatch_lag_seconds` | histogram | `channel_type` |
-| `sheaf_notifications_outbox_depth` | gauge | — |
-| `sheaf_notifications_outbox_oldest_pending_seconds` | gauge | — |
+| `sheaf_notifications_outbox_depth` | gauge | - |
+| `sheaf_notifications_outbox_oldest_pending_seconds` | gauge | - |
 | `sheaf_notifications_subscriptions_active` | gauge | `channel_type` |
 
 `channel_type` ∈ {web_push, mobile_push, webhook, ntfy, pushover, discord, email}.
@@ -202,7 +202,38 @@ deletion_reminder, deletion_confirmed, announcement, other}.
 | `sheaf_job_consecutive_failures` | gauge | `job` |
 
 `job` is the name registered via `register_job()`. Alert on
-`time() - last_success_timestamp > N` for stuck-job detection.
+`time() - last_success_timestamp > N` for stuck-job detection. (The
+timestamp gauge predates the `_seconds` naming convention; it is a unix
+timestamp in seconds despite the missing suffix.)
+
+### Leader election
+
+| Metric | Type | Labels |
+|---|---|---|
+| `sheaf_leader_is_leader` | gauge (livesum) | none |
+| `sheaf_leader_transitions_total` | counter | none |
+
+`sheaf_leader_is_leader` is 1 on the process holding background-loop
+leadership and 0 on standbys; `multiprocess_mode=livesum` means
+`sum(sheaf_leader_is_leader)` across live workers is the leader count.
+The invariant alert is the point of this metric:
+
+```
+sum(sheaf_leader_is_leader) != 1   for 10m
+```
+
+0 means the election is wedged and all background work (job runner,
+dispatcher, import runner) is stalled, which a quiet period would
+otherwise hide since the notification-backlog alert only fires when
+there's traffic to back up. 2+ is a split brain that shouldn't be
+possible by construction; the metric proves the invariant rather than
+assuming it. Only published when `LEADER_ELECTION` is enabled; with it
+off, every process runs the loops and this metric is absent, so the
+`!= 1` alert does not apply.
+
+`sheaf_leader_transitions_total` increments on each acquisition; a high
+`rate(sheaf_leader_transitions_total[15m])` is leadership flapping,
+usually an unstable DB connection.
 
 ### Imports / exports
 
@@ -210,12 +241,19 @@ deletion_reminder, deletion_confirmed, announcement, other}.
 |---|---|---|
 | `sheaf_imports_started_total` | counter | `source` |
 | `sheaf_imports_completed_total` | counter | `source`, `outcome` ∈ {complete, failed, cancelled} |
-| `sheaf_imports_in_progress` | gauge | — |
+| `sheaf_imports_in_progress` | gauge | - |
+| `sheaf_imports_oldest_pending_seconds` | gauge | none |
 | `sheaf_exports_built_total` | counter | `outcome` ∈ {done, failed, expired} |
-| `sheaf_export_size_bytes` | histogram | — |
+| `sheaf_export_size_bytes` | histogram | - |
 
 `source` ∈ {pluralkit_file, pluralkit_api, tupperbox_file,
-simplyplural_file, sheaf_file}.
+simplyplural_file, sheaf_file, pluralspace_file, prism_file,
+ampersand_file}.
+
+`sheaf_imports_oldest_pending_seconds` is the age of the oldest
+unclaimed import. The runner is NOTIFY-driven, so a value climbing past
+a few seconds means it isn't draining (wedged leader or a disconnected
+LISTEN). Mirrors `sheaf_notifications_outbox_oldest_pending_seconds`.
 
 ### System Safety
 
@@ -234,8 +272,8 @@ message_thread_delete, revision_unpin, watch_token_revoke).
 | Metric | Type | Labels |
 |---|---|---|
 | `sheaf_cf_shield_engagements_total` | counter | `direction` ∈ {activated, deactivated} |
-| `sheaf_cf_shield_session_revocations_total` | counter | — |
-| `sheaf_cf_shield_active` | gauge | — |
+| `sheaf_cf_shield_session_revocations_total` | counter | - |
+| `sheaf_cf_shield_active` | gauge | - |
 
 `sheaf_cf_shield_active` is 1 when the backend believes shield mode is
 currently engaged, else 0. Use it to alert on "shield-mode active for
@@ -246,8 +284,8 @@ currently engaged, else 0. Use it to alert on "shield-mode active for
 | Metric | Type | Labels |
 |---|---|---|
 | `sheaf_decrypt_failures_total` | counter | `field` |
-| `sheaf_users_total` | gauge | — |
-| `sheaf_users_pending_delete` | gauge | — |
+| `sheaf_users_total` | gauge | - |
+| `sheaf_users_pending_delete` | gauge | - |
 | `sheaf_tier_limit_hits_total` | counter | `limit`, `tier` |
 
 `limit` ∈ {members, storage, polls_concurrent, pushover_user,
@@ -256,7 +294,7 @@ pushover_global}.
 `tier` ∈ {free, plus, self_hosted, unknown}.
 
 Tracks where users bump into per-tier caps. Useful for pricing and
-limit-adjustment decisions — a sustained `members{tier="free"}` rate
+limit-adjustment decisions - a sustained `members{tier="free"}` rate
 suggests the free cap needs revisiting.
 
 `field` ∈ {email, totp_secret, recovery_codes, channel_config, other}.
@@ -268,9 +306,9 @@ detect non-zero from the first scrape.
 
 | Metric | Type | Labels |
 |---|---|---|
-| `sheaf_systems_total` | gauge | — |
-| `sheaf_members_total` | gauge | — |
-| `sheaf_members_custom_front` | gauge | — |
+| `sheaf_systems_total` | gauge | - |
+| `sheaf_members_total` | gauge | - |
+| `sheaf_members_custom_front` | gauge | - |
 
 ### Infra
 
@@ -278,11 +316,11 @@ detect non-zero from the first scrape.
 |---|---|---|
 | `sheaf_db_pool_connections` | gauge | `state` ∈ {checked_in, checked_out} |
 | `sheaf_db_query_duration_seconds` | histogram | `operation` ∈ {select, insert, update, delete, ddl, other} |
-| `sheaf_redis_up` | gauge | — |
+| `sheaf_redis_up` | gauge | - |
 | `sheaf_s3_operations_total` | counter | `op`, `outcome` ∈ {success, error} |
 | `sheaf_s3_operation_duration_seconds` | histogram | `op` |
 
-`db_query_duration_seconds` complements the HTTP RED histogram — handler
+`db_query_duration_seconds` complements the HTTP RED histogram - handler
 latency is the user-facing number, but a query-time spike vs handler-
 time spike tells you where to look.
 
@@ -302,7 +340,7 @@ than the slower DB-counts refresh.
 |---|---|---|
 | `sheaf_build_info` | gauge (always 1) | `version`, `sheaf_mode`, `git_commit` |
 
-Standard pattern — value is meaningless, labels carry the dimensions.
+Standard pattern - value is meaningless, labels carry the dimensions.
 Use it in Grafana for "running version" by joining against this metric.
 
 ---
@@ -350,7 +388,7 @@ The metrics module is multi-worker-ready anyway, controlled by the
 
 If you bump uvicorn or gunicorn workers up later, the only thing to be
 aware of is that gauges need a `multiprocess_mode` declared. The
-`_G(...)` helper in `metrics.py` does this — `livesum` is the default
+`_G(...)` helper in `metrics.py` does this - `livesum` is the default
 for "count of things right now" gauges, `max` for high-water marks,
 `mostrecent` for the build-info gauge. Adding a new gauge without
 picking a mode is a clear code-review item.
@@ -440,6 +478,6 @@ histogram_quantile(0.99,
   below by `job_check_interval_minutes * 60`. Refresh-second values
   below that are effectively rounded up to the next loop tick.
 - The per-IP / per-account rate histograms bail out cleanly if the
-  Redis SCAN exceeds 50k keys per refresh — on deployments at that
+  Redis SCAN exceeds 50k keys per refresh - on deployments at that
   scale, switch to redis-exporter for per-IP visibility instead of
   trying to stream everything through this single sample pass.

--- a/sheaf/observability/gauges.py
+++ b/sheaf/observability/gauges.py
@@ -28,6 +28,7 @@ from sheaf.observability.metrics import (
     cf_shield_active,
     db_pool_connections,
     imports_in_progress,
+    imports_oldest_pending_seconds,
     members_custom_front,
     members_total,
     notifications_outbox_depth,
@@ -188,6 +189,21 @@ async def _refresh_imports_in_progress(db: AsyncSession) -> None:
         )
     )
     imports_in_progress.set(int(n or 0))
+
+    # Oldest still-pending import: age in seconds. The runner is
+    # NOTIFY-driven, so anything beyond a few seconds means it isn't
+    # draining. created_at is enqueue time, and the row stays pending
+    # until a worker claims it, so this is the time-to-pickup.
+    oldest = await db.scalar(
+        select(func.min(ImportJob.created_at)).where(
+            ImportJob.status == ImportJobStatus.PENDING.value
+        )
+    )
+    if oldest is None:
+        imports_oldest_pending_seconds.set(0)
+    else:
+        age = (datetime.now(UTC) - oldest).total_seconds()
+        imports_oldest_pending_seconds.set(max(age, 0))
 
 
 async def _refresh_subscriptions(db: AsyncSession) -> None:

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -351,6 +351,27 @@ job_consecutive_failures = _G(
 )
 
 # ---------------------------------------------------------------------------
+# Leader election (background-loop coordination)
+# ---------------------------------------------------------------------------
+
+leader_is_leader = _G(
+    "sheaf_leader_is_leader",
+    "1 on the process currently holding background-loop leadership, else 0. "
+    "multiprocess_mode=livesum so sum() across live worker processes is the "
+    "leader count - alert on sum(sheaf_leader_is_leader) != 1 to catch a "
+    "wedged election (0 leaders, background work stalled) or, impossibly, a "
+    "split brain (2+). Only meaningful with LEADER_ELECTION enabled; with it "
+    "off every process runs the loops and this metric is not published.",
+    multiprocess_mode="livesum",
+)
+leader_transitions_total = _C(
+    "sheaf_leader_transitions_total",
+    "Background-loop leadership acquisitions. A steady climb (high "
+    "rate(sheaf_leader_transitions_total[15m])) signals leadership flapping, "
+    "usually an unstable DB connection dropping and reacquiring the lock.",
+)
+
+# ---------------------------------------------------------------------------
 # Imports / exports
 # ---------------------------------------------------------------------------
 
@@ -367,6 +388,14 @@ imports_completed_total = _C(
 imports_in_progress = _G(
     "sheaf_imports_in_progress",
     "Imports currently pending or running.",
+)
+imports_oldest_pending_seconds = _G(
+    "sheaf_imports_oldest_pending_seconds",
+    "Age of the oldest still-pending import, in seconds (0 when none are "
+    "pending). The import runner is NOTIFY-driven, so a value that climbs "
+    "past a few seconds means the runner isn't draining - the leader is "
+    "wedged or the listener is disconnected. Mirrors "
+    "notifications_outbox_oldest_pending_seconds.",
 )
 exports_built_total = _C(
     "sheaf_exports_built_total",

--- a/sheaf/services/leader.py
+++ b/sheaf/services/leader.py
@@ -65,6 +65,15 @@ async def leader_loop(
     consistent.
     """
     from sheaf.database import engine
+    from sheaf.observability.metrics import (
+        leader_is_leader,
+        leader_transitions_total,
+    )
+
+    # Publish a baseline immediately so every process exposes the gauge
+    # (standbys at 0). With multiprocess_mode=livesum, sum() across live
+    # processes is then the leader count from the first scrape onward.
+    leader_is_leader.set(0)
 
     while True:
         try:
@@ -78,8 +87,10 @@ async def leader_loop(
                 if not got:
                     # Someone else leads. The held connection goes back to
                     # the pool while we wait out the retry interval.
-                    pass
+                    leader_is_leader.set(0)
                 else:
+                    leader_transitions_total.inc()
+                    leader_is_leader.set(1)
                     logger.info(
                         "Leadership acquired; starting %d background loops",
                         len(loops),
@@ -98,6 +109,7 @@ async def leader_loop(
                             # dead session.
                             await conn.execute(text("SELECT 1"))
                     finally:
+                        leader_is_leader.set(0)
                         logger.info("Standing down; stopping background loops")
                         for t in tasks:
                             t.cancel()
@@ -112,8 +124,15 @@ async def leader_loop(
                         with contextlib.suppress(Exception):
                             await conn.invalidate()
         except asyncio.CancelledError:
+            # Shutdown: stop counting this process toward the leader sum.
+            with contextlib.suppress(Exception):
+                leader_is_leader.set(0)
             raise
         except Exception:
+            # Lost the lock connection mid-lease: we are no longer leader
+            # until the next acquisition, so reflect that before retrying.
+            with contextlib.suppress(Exception):
+                leader_is_leader.set(0)
             logger.exception(
                 "Leader election connection error; retrying in %ss",
                 _RETRY_SECONDS,

--- a/tests/test_job_runner_rework.py
+++ b/tests/test_job_runner_rework.py
@@ -368,6 +368,126 @@ def test_fresh_running_export_is_left_alone(
 
 
 # ---------------------------------------------------------------------------
+# Leader + import observability metrics
+
+
+def _sample(name: str) -> float | None:
+    from sheaf.observability.registry import get_registry
+
+    return get_registry().get_sample_value(name)
+
+
+@pytest.mark.skipif(
+    bool(os.environ.get("PROMETHEUS_MULTIPROC_DIR")),
+    reason="gauge read needs the single-process registry",
+)
+def test_leader_is_leader_gauge_and_transitions():
+    """Acquiring leadership flips sheaf_leader_is_leader to 1 and bumps the
+    transitions counter; standing down returns it to 0."""
+    from unittest.mock import patch
+
+    import sheaf.database as database_module
+    from sheaf.services.leader import leader_loop
+
+    async def run() -> None:
+        engine = _test_engine()
+        started = asyncio.Event()
+
+        async def dummy() -> None:
+            started.set()
+            while True:
+                await asyncio.sleep(3600)
+
+        try:
+            with patch.object(database_module, "engine", engine):
+                before = _sample("sheaf_leader_transitions_total") or 0.0
+                task = asyncio.create_task(
+                    leader_loop([("dummy", dummy)], lock_key=_TEST_LOCK_KEY)
+                )
+                await asyncio.wait_for(started.wait(), timeout=5)
+
+                # Leadership held.
+                assert _sample("sheaf_leader_is_leader") == 1.0
+                assert (
+                    _sample("sheaf_leader_transitions_total") or 0.0
+                ) == before + 1
+
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+                # Stood down.
+                assert _sample("sheaf_leader_is_leader") == 0.0
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_imports_oldest_pending_gauge_reflects_backlog(auth_client: httpx.Client):
+    """A pending import the runner hasn't claimed shows up as a non-zero
+    oldest-pending age once the gauge refresher runs; an empty queue reads
+    0."""
+    import os as _os
+
+    if _os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        pytest.skip("gauge read needs the single-process registry")
+
+    me = auth_client.get("/v1/auth/me").json()
+
+    async def run() -> float | None:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.import_job import (
+            ImportJob,
+            ImportJobSource,
+            ImportJobStatus,
+        )
+        from sheaf.observability.gauges import _refresh_imports_in_progress
+
+        engine = _test_engine()
+        session_factory = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        job_id = uuid.uuid4()
+        try:
+            async with session_factory() as db:
+                db.add(
+                    ImportJob(
+                        id=job_id,
+                        user_id=uuid.UUID(me["id"]),
+                        source=ImportJobSource.PLURALKIT_FILE.value,
+                        status=ImportJobStatus.PENDING.value,
+                        idempotency_key=str(uuid.uuid4()),
+                        payload_storage_key=f"imports/{job_id}.json",
+                        payload_metadata=None,
+                        counts={},
+                        events=[],
+                        created_at=datetime.now(UTC) - timedelta(seconds=120),
+                    )
+                )
+                await db.commit()
+
+            async with session_factory() as db:
+                await _refresh_imports_in_progress(db)
+            age = _sample("sheaf_imports_oldest_pending_seconds")
+
+            # Cleanup so we don't leave a perpetual pending row behind.
+            async with session_factory() as db:
+                row = await db.get(ImportJob, job_id)
+                if row is not None:
+                    await db.delete(row)
+                    await db.commit()
+            return age
+        finally:
+            await engine.dispose()
+
+    age = asyncio.run(run())
+    assert age is not None and age >= 100, age
+
+
+# ---------------------------------------------------------------------------
 # Import-enqueue NOTIFY listener
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -209,3 +209,26 @@ def test_webhook_signature_failures_total_prewarmed():
             body, "sheaf_webhook_signature_failures_total", {"endpoint": endpoint},
         )
         assert val is not None, f"missing prewarmed series for endpoint={endpoint}"
+
+
+# ---------------------------------------------------------------------------
+# Leader election
+# ---------------------------------------------------------------------------
+
+def test_leader_is_leader_gauge_is_one():
+    """The test stack is a single process with leader election on, so it
+    holds leadership: sheaf_leader_is_leader must be present and 1.
+
+    In prod, the alert is sum(sheaf_leader_is_leader) != 1; this is the
+    single-node analogue."""
+    body = _scrape()
+    val = _series_value(body, "sheaf_leader_is_leader")
+    assert val is not None, "sheaf_leader_is_leader missing from scrape"
+    assert val == 1.0, f"expected sole leader to report 1, got {val}"
+
+
+def test_leader_transitions_total_present():
+    body = _scrape()
+    val = _series_value(body, "sheaf_leader_transitions_total")
+    # At least one acquisition happened at startup.
+    assert val is not None and val >= 1.0, val


### PR DESCRIPTION
Observability for the job runner and leader election (requested follow-up). The advisory-lock leader landed in 0.5.0 with no metrics, so a wedged election was only catchable indirectly via the notification-backlog alert - slow, and silent during quiet periods with no traffic to back up.

## Added

| Metric | Type | mp_mode | Labels |
|---|---|---|---|
| `sheaf_leader_is_leader` | gauge | livesum | none |
| `sheaf_leader_transitions_total` | counter | sum | none |
| `sheaf_imports_oldest_pending_seconds` | gauge | livesum | none |

**`sheaf_leader_is_leader`** is the headline: 1 on the leader process, 0 on standbys. `multiprocess_mode=livesum` is deliberate so `sum()` across live workers is the leader count - the prod alert is `sum(sheaf_leader_is_leader{env="prod"}) != 1 for 10m`, which catches 0 leaders (background work stalled) and the impossible 2+ split brain. Only published when `LEADER_ELECTION` is enabled; with it off, every process runs the loops and the metric is absent, so the alert is prod-only.

**`sheaf_leader_transitions_total`** increments on each acquisition - `rate(...[15m])` high means leadership is flapping (unstable DB connection).

**`sheaf_imports_oldest_pending_seconds`** is the age of the oldest unclaimed import, mirroring `sheaf_notifications_outbox_oldest_pending_seconds` now that the import runner is NOTIFY-driven; a climbing value means the runner isn't draining.

## Deliberately not added (already existed)

The per-job freshness / run-count / duration metrics a job-runner observability pass would also want were already wired in `run_job`: `sheaf_job_last_success_timestamp`, `sheaf_job_runs_total{job,outcome}`, `sheaf_job_run_duration_seconds`, `sheaf_job_items_processed_total`, `sheaf_job_consecutive_failures`. So freshness and failure-rate alerts are writable against existing series with no backend change. METRICS.md documents them and flags that `sheaf_job_last_success_timestamp` predates the `_seconds` naming convention (left un-renamed to avoid breaking existing dashboards).

## Tests

Full suite green (1018 passed). In-process: `leader_loop` flips `sheaf_leader_is_leader` to 1 and bumps the transitions counter on acquire, back to 0 on standdown; the import gauge reflects a planted pending row. Scrape-level assertions (leader gauge == 1 on the single-process test stack, transitions present) run in the metrics test config row.

## Note for the alerting side

`PROMETHEUS_MULTIPROC_DIR` multiprocess mode means `livesum` is what makes `sum(sheaf_leader_is_leader)` equal the leader count rather than a max/last-write artefact; the gauge carries no `pid` label.
