### PR TITLE
Fix multiprocess metrics: duplicate exposition, listener port race, shared-dir wipe

### DIFF
--- a/sheaf/observability/endpoint.py
+++ b/sheaf/observability/endpoint.py
@@ -19,8 +19,10 @@ Three deployment shapes, controlled by `metrics_bind`:
 from __future__ import annotations
 
 import asyncio
+import errno
 import hmac
 import logging
+import socket
 import threading
 
 from fastapi import FastAPI, Request
@@ -78,6 +80,12 @@ def setup_metrics_endpoint(app: FastAPI, settings: Settings) -> None:
         return
 
     if settings.metrics_bind == "separate":
+        # Multi-worker deployments (WEB_CONCURRENCY > 1): every worker
+        # runs this lifespan and races to bind the metrics port. Losing
+        # is fine - the multiprocess collector reads ALL workers' mmap
+        # files, so any single worker serving the port exports complete
+        # data. Without this tolerance the losing worker dies on
+        # EADDRINUSE and the supervisor respawns it in a loop.
         if settings.metrics_auth == "token":
             _start_token_listener(
                 settings.metrics_bind_host,
@@ -87,11 +95,21 @@ def setup_metrics_endpoint(app: FastAPI, settings: Settings) -> None:
             )
         else:
             global _separate_server
-            _separate_server = start_http_server(
-                port=settings.metrics_bind_port,
-                addr=settings.metrics_bind_host,
-                registry=registry,
-            )
+            try:
+                _separate_server = start_http_server(
+                    port=settings.metrics_bind_port,
+                    addr=settings.metrics_bind_host,
+                    registry=registry,
+                )
+            except OSError as exc:
+                if exc.errno != errno.EADDRINUSE:
+                    raise
+                logger.info(
+                    "metrics port %s:%d already served by another worker; skipping",
+                    settings.metrics_bind_host,
+                    settings.metrics_bind_port,
+                )
+                return
             logger.info(
                 "metrics listener (no auth) on %s:%d",
                 settings.metrics_bind_host,
@@ -116,6 +134,24 @@ def _start_token_listener(host: str, port: int, token: str, registry) -> None:
 
     app = Starlette(routes=[Route("/metrics", metrics)])
 
+    # Bind here, in the caller, so a lost bind race surfaces as a clean
+    # skip instead of an async crash inside the listener thread (which
+    # would kill the whole worker on multi-worker deployments - see the
+    # comment at the call site).
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, port))
+    except OSError as exc:
+        sock.close()
+        if exc.errno != errno.EADDRINUSE:
+            raise
+        logger.info(
+            "metrics port %s:%d already served by another worker; skipping",
+            host, port,
+        )
+        return
+
     def _run() -> None:
         import uvicorn
 
@@ -125,7 +161,7 @@ def _start_token_listener(host: str, port: int, token: str, registry) -> None:
         server = uvicorn.Server(config)
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        loop.run_until_complete(server.serve())
+        loop.run_until_complete(server.serve(sockets=[sock]))
 
     t = threading.Thread(target=_run, name="metrics-listener", daemon=True)
     t.start()

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -33,7 +33,7 @@ from sheaf.observability.buckets import (
     HTTP_LATENCY_BUCKETS,
     RATE_DISTRIBUTION_BUCKETS,
 )
-from sheaf.observability.registry import get_registry
+from sheaf.observability.registry import get_metric_registry
 
 # ---------------------------------------------------------------------------
 # Label-value type aliases
@@ -113,11 +113,15 @@ StatusClass = Literal["1xx", "2xx", "3xx", "4xx", "5xx"]
 
 
 # ---------------------------------------------------------------------------
-# Wrappers binding every metric to the shared registry
+# Wrappers binding every metric to the metric-object registry. NOTE:
+# get_metric_registry(), not get_registry() - in multiprocess mode the
+# objects must stay OUT of the scraped registry or every family is
+# exported twice (live-object zeros + the real multiproc aggregate).
+# See registry.get_metric_registry for the full story.
 # ---------------------------------------------------------------------------
 
 def _C(name: str, doc: str, labels: list[str] | None = None) -> Counter:
-    return Counter(name, doc, labels or [], registry=get_registry())
+    return Counter(name, doc, labels or [], registry=get_metric_registry())
 
 
 def _H(
@@ -125,7 +129,7 @@ def _H(
     buckets: tuple = HTTP_LATENCY_BUCKETS,
 ) -> Histogram:
     return Histogram(
-        name, doc, labels or [], buckets=buckets, registry=get_registry()
+        name, doc, labels or [], buckets=buckets, registry=get_metric_registry()
     )
 
 
@@ -140,7 +144,7 @@ def _G(
     # background worker.
     return Gauge(
         name, doc, labels or [],
-        registry=get_registry(),
+        registry=get_metric_registry(),
         multiprocess_mode=multiprocess_mode,
     )
 

--- a/sheaf/observability/registry.py
+++ b/sheaf/observability/registry.py
@@ -36,13 +36,12 @@ def init_registry() -> CollectorRegistry:
     if multiproc_dir:
         path = Path(multiproc_dir)
         path.mkdir(parents=True, exist_ok=True)
-        # Wipe stale files from previous container lives so resurrected
-        # counter values don't bleed across deploys.
-        for f in path.glob("*.db"):
-            try:
-                f.unlink()
-            except OSError as exc:
-                logger.warning("could not remove stale metrics file %s: %s", f, exc)
+        # NOTE: no stale-file wipe here, deliberately. init_registry()
+        # runs per PROCESS, and the mmap dir is shared by every worker:
+        # a respawning worker calling this used to wipe all the other
+        # workers' accumulated values. The once-per-container wipe is
+        # the entrypoint's job (rm -f "$PROMETHEUS_MULTIPROC_DIR"/*.db
+        # before the server starts, while there is exactly one process).
         registry = CollectorRegistry()
         MultiProcessCollector(registry)
         logger.info("metrics registry: multiproc mode at %s", multiproc_dir)
@@ -59,3 +58,29 @@ def get_registry() -> CollectorRegistry:
     if _registry is None:
         return init_registry()
     return _registry
+
+
+def get_metric_registry() -> CollectorRegistry | None:
+    """Registry that metric OBJECTS should bind to at definition time.
+
+    Deliberately different from get_registry() (the registry the
+    /metrics endpoint serves):
+
+    * Single-process mode: the in-process registry. Object registration
+      IS the export path; both functions return the same registry.
+
+    * Multiprocess mode: None (unregistered). Metric values still reach
+      the mmap files - prometheus_client routes writes there whenever
+      PROMETHEUS_MULTIPROC_DIR is set, registered or not - and the
+      MultiProcessCollector in the scrape registry aggregates them
+      across all worker processes. Registering the objects into the
+      scrape registry as well makes generate_latest() emit every family
+      TWICE: once from the live object (this process's view, typically
+      0 for gauges another worker maintains) and once from the
+      collector (the real cross-process aggregate). Scrapers keep
+      whichever sample they parse first, so dashboards randomly show
+      zeros depending on collector ordering.
+    """
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        return None
+    return get_registry()

--- a/tests/test_multiproc_registry.py
+++ b/tests/test_multiproc_registry.py
@@ -1,0 +1,100 @@
+"""Unit tests for the multiprocess metrics registry invariants.
+
+These run a child interpreter with PROMETHEUS_MULTIPROC_DIR set,
+because multiprocess mode is decided at import time and must not leak
+into the rest of the suite (which runs the in-process registry path).
+No server stack needed - pure library behaviour.
+
+Regression coverage for the duplicate-exposition bug: metric objects
+registered into the same registry as the MultiProcessCollector made
+generate_latest() emit every family twice - the live object's
+per-process view (zeros for gauges another worker maintains) plus the
+collector's real cross-process aggregate. Scrapers keep whichever
+sample they parse first, so dashboards randomly showed zeros.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def _run_child(code: str, extra_env: dict[str, str] | None = None,
+               drop: tuple[str, ...] = ()) -> str:
+    env = {k: v for k, v in os.environ.items() if k not in drop}
+    env.update(extra_env or {})
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True, text=True, env=env, timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout
+
+
+def test_multiproc_exposition_has_no_duplicate_families(tmp_path):
+    body = _run_child(
+        """
+        from prometheus_client import generate_latest
+        from sheaf.observability.registry import get_registry
+        from sheaf.observability import metrics
+
+        metrics.users_total.set(6)
+        metrics.http_requests_total.labels(
+            method="GET", route="/health", status_class="2xx"
+        ).inc()
+
+        print(generate_latest(get_registry()).decode())
+        """,
+        extra_env={"PROMETHEUS_MULTIPROC_DIR": str(tmp_path)},
+    )
+    lines = [ln for ln in body.splitlines() if not ln.startswith("#") and ln.strip()]
+
+    # Exactly one sample per series - the bug exported two.
+    users_lines = [ln for ln in lines if ln.startswith("sheaf_users_total")]
+    assert len(users_lines) == 1, f"duplicate family exported: {users_lines}"
+    assert users_lines[0].split()[-1] == "6.0"
+
+    http_lines = [ln for ln in lines if ln.startswith("sheaf_http_requests_total{")]
+    assert len(http_lines) == 1, f"duplicate family exported: {http_lines}"
+    assert http_lines[0].split()[-1] == "1.0"
+
+
+def test_multiproc_metric_objects_stay_out_of_scrape_registry(tmp_path):
+    out = _run_child(
+        """
+        from sheaf.observability.registry import get_metric_registry, get_registry
+        from sheaf.observability import metrics  # noqa: F401 - triggers definitions
+
+        scrape = get_registry()
+        # In multiproc mode the objects are unregistered (None) and the
+        # scrape registry holds only the MultiProcessCollector.
+        print(get_metric_registry() is None)
+        print(len(list(scrape._collector_to_names)))
+        """,
+        extra_env={"PROMETHEUS_MULTIPROC_DIR": str(tmp_path)},
+    )
+    objects_unregistered, collector_count = out.split()
+    assert objects_unregistered == "True"
+    assert collector_count == "1"
+
+
+def test_single_process_mode_unchanged():
+    out = _run_child(
+        """
+        from prometheus_client import generate_latest
+        from sheaf.observability.registry import get_metric_registry, get_registry
+        from sheaf.observability import metrics
+
+        assert get_metric_registry() is get_registry()
+        metrics.users_total.set(3)
+        body = generate_latest(get_registry()).decode()
+        lines = [ln for ln in body.splitlines()
+                 if ln.startswith("sheaf_users_total")]
+        assert len(lines) == 1 and lines[0].split()[-1] == "3.0", lines
+        print("ok")
+        """,
+        drop=("PROMETHEUS_MULTIPROC_DIR",),
+    )
+    assert out.strip() == "ok"


### PR DESCRIPTION
## Summary

Running uvicorn with `WEB_CONCURRENCY > 1` and `METRICS_BIND=separate` exposed three related bugs in the multiprocess metrics path:

**1. Every metric family exported twice.** Metric objects were registered into the same registry as the `MultiProcessCollector`, so `generate_latest()` emitted both the live object's per-process view (zeros, for gauges another worker maintains) and the collector's real cross-process aggregate. Scrapers keep whichever sample they parse first, so dashboards could randomly show zeros for the DB-derived gauges. Metric objects now bind via `get_metric_registry()`: `None` (unregistered) in multiproc mode, where values still reach the mmap files and only the collector should be scraped; the in-process registry otherwise, where object registration is the export path.

**2. Separate metrics listener port race.** Every worker's lifespan tried to bind the metrics port; the loser died on `EADDRINUSE` and the supervisor respawned it in a loop (observed: a respawn every ~17s, meaning the deployment was effectively single-worker plus continuous spawn churn). Losing the race is harmless by design, since the multiproc collector reads all workers' files and any single listener exports complete data, so the bind now skips gracefully. The token-auth path pre-binds the socket in the caller so a lost race surfaces as a clean skip rather than an async crash inside the listener thread.

**3. Per-process wipe of the shared mmap dir.** `init_registry()` deleted `PROMETHEUS_MULTIPROC_DIR/*.db` on first call in each process. The directory is shared across workers, so every (re)spawned worker erased everyone else's accumulated values. Combined with bug 2, counters were being reset continuously. The once-per-container wipe belongs to the entrypoint (which already does it, pre-fork); the per-process wipe is removed.

## Testing

- All three bugs reproduced and diagnosed on a live 2-worker deployment (duplicate families in the raw exposition, zeroed DB-derived gauges, EADDRINUSE respawn loop in the logs, single pid's mmap files).
- Fix verified via new `tests/test_multiproc_registry.py`: regression tests run a child interpreter with `PROMETHEUS_MULTIPROC_DIR` set (multiproc mode is decided at import time, so it must not leak into the rest of the suite). Covers: no duplicate families in the exposition, objects stay out of the scrape registry, single-process mode unchanged.
- `ruff` clean.
- Not yet verified on a live multi-worker deployment; that happens with the next release rollout and should show: one listener bind with the other worker logging the skip, stable worker count, gauges matching DB truth.