### PR TITLE
Forward build provenance args to local compose builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Build provenance for local compose builds.** `GET /v1/version` reports the commit/tag/build-time the backend was built from; CI-built ghcr images already set these, but a local `docker compose build` left them null because the compose `args` didn't forward them. The app service now accepts `GIT_COMMIT` / `GIT_TAG` / `BUILD_TIME` from the host environment (documented in SELFHOSTING.md), so a compose build can identify itself too. Unset values stay null, same as before.
+
 ## [0.5.1] - 2026-06-10
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,17 @@ services:
         # gitignored .env and rebuild. See docs/SELFHOSTING.md.
         PIP_INDEX_URL: "${PIP_INDEX_URL:-}"
         PIP_EXTRA_INDEX_URL: "${PIP_EXTRA_INDEX_URL:-}"
+        # Build provenance surfaced at GET /v1/version. CI-built ghcr
+        # images set these automatically; for a local `compose build` they
+        # are empty unless you pass them from the host, where git is
+        # available (compose can't run git itself). One-liner:
+        #   GIT_COMMIT=$(git rev-parse --short HEAD) \
+        #   GIT_TAG=$(git describe --tags --always) \
+        #   BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+        #   docker compose up --build -d app
+        GIT_COMMIT: "${GIT_COMMIT:-}"
+        GIT_TAG: "${GIT_TAG:-}"
+        BUILD_TIME: "${BUILD_TIME:-}"
     ports:
       - "${SHEAF_PORT:-8000}:${SHEAF_PORT:-8000}"
       # Metrics endpoint. The host side publishes on loopback by default

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -141,6 +141,19 @@ PIP_EXTRA_INDEX_URL=
 
 Drop one (or both) into a gitignored `.env` next to `docker-compose.yml` and re-run `docker compose build`. `PIP_INDEX_URL` replaces PyPI entirely (use this when the mirror itself is a transparent PyPI proxy); `PIP_EXTRA_INDEX_URL` is checked first with PyPI as fallback. Empty values pass through to pip's default behaviour, so leaving them unset means public-PyPI builds as before.
 
+### Build provenance in `/v1/version`
+
+`GET /v1/version` reports the running version plus the commit, tag, and build time it was built from. The official ghcr images set those automatically in CI. For a **local `docker compose build`** they default to empty, because compose can't run git itself; pass them from the host (where git is available) if you want `/v1/version` to identify your build:
+
+```bash
+GIT_COMMIT=$(git rev-parse --short HEAD) \
+GIT_TAG=$(git describe --tags --always) \
+BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+docker compose up --build -d app
+```
+
+Leaving them unset is harmless; only the provenance fields read back as null. See [VERIFYING.md](VERIFYING.md) for the full supply-chain verification story.
+
 ---
 
 ## Email


### PR DESCRIPTION
Closes the one gap in build provenance. `GET /v1/version` reports the commit/tag/build-time the backend was built from - useful for confirming which commit a deployed instance is actually running.

The Dockerfile already consumes `GIT_COMMIT` / `GIT_TAG` / `BUILD_TIME` into `SHEAF_*` env, and `ci.yml` passes them on every ghcr image build, so the official images already carry provenance. The gap was a **local `docker compose build`**: the app service's `args` block forwarded `INCLUDE_DEV_TOOLS` and the pip-mirror vars but not the git ones, so a compose-built image reported null commit/tag/time.

The app service now forwards `GIT_COMMIT` / `GIT_TAG` / `BUILD_TIME` from the host environment (compose can't run git itself; the host populates them). SELFHOSTING.md documents the one-liner:

```bash
GIT_COMMIT=$(git rev-parse --short HEAD) \
GIT_TAG=$(git describe --tags --always) \
BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
docker compose up --build -d app
```

Unset values stay empty, so nothing changes for anyone who doesn't opt in. Verified the env-to-arg substitution with `docker compose config`; the arg-to-ENV-to-/v1/version chain is unchanged from what CI already exercises.

Docs/infra only - no Python, no migration.
