### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to Sheaf are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and Sheaf adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-`v0.x.y` releases are betas — APIs and database schema may still change. The first stable release will be `v1.0.0`.
+`v1.0.0` is the first stable release. The `v0.x.y` releases were betas; from 1.0 on, the v1 API and database schema carry semver compatibility guarantees.
 
-## [Unreleased]
+## [1.0.0] - 2026-06-12
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sheaf"
-version = "0.5.1"
+version = "1.0.0"
 description = "Open-source plural system tracking"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1639,7 +1639,7 @@ wheels = [
 
 [[package]]
 name = "sheaf"
-version = "0.5.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.5.1",
+      "version": "1.0.0",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
         "@tailwindcss/typography": "^0.5.19",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.5.1",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
v1.0.0 lfg 🚀 

### Added

- **Admin: per-account rate-limit hit history.** When a rate-limit check blocks a request that belongs to a logged-in account, the hit (bucket, route, time, IP) is recorded to a short-lived, size-capped Redis list, and admins get a per-account view of it: `GET /v1/admin/users/{id}/rate-limit-history` plus a section in the Explain-account panel showing per-bucket totals and recent entries. This is the per-account drill-down the aggregate Prometheus counters can't provide ("what has THIS account tripped recently"). Only blocked checks are recorded, nothing touches Postgres, retention and size are bounded (`RATE_LIMIT_HISTORY_HOURS`, default 48h; `RATE_LIMIT_HISTORY_MAX_ENTRIES`, default 200; `RATE_LIMIT_HISTORY_ENABLED` to turn it off), the key is purged on account deletion rather than waiting out the TTL, and the history is included in the admin DSAR dossier since it is held personal data. Anonymous traffic (failed logins from logged-out clients, the global per-IP backstop) is not attributable to an account and is not recorded. Reading the history writes no audit row, same as the other read-only triage endpoints.
- **Re-import is now fully idempotent (content dedup).** Import deduplication covers everything, not just members: tags and groups match by name, fronts by their exact interval and member set, and journals, edit-history revisions, board messages, polls, reminders, and notification config by the source timestamps every importer already preserves. Importing the same export twice - any source: native JSON, the with-images archive, PluralKit, SimplyPlural, Tupperbox, PluralSpace, or Prism - adds nothing the second time; each section reports a `*_skipped` count on the import detail page instead. `conflict_strategy=create` keeps the old append-everything behaviour. This also fixes a crash on re-import in the SimplyPlural, PluralSpace, and Prism importers: a reused custom-field definition plus an already-present (deduped) member violated the one-value-per-(field, member) constraint and failed the whole job; the value and group-membership guards are now pre-seeded with what the system already has.
- **Export-with-images archive import.** The zip the async export job produces (export.json + images/) can now be uploaded straight back through Settings -> Import: avatars, markdown image embeds, and journal/revision image attachments are re-uploaded to the importing account through the same pipeline as regular uploads (format sniff, EXIF strip + dimension cap, storage quota) and every reference is rewritten to the new keys. Previously the zip's images were carry-your-own: the JSON imported but image references were stripped and re-uploading was manual. The plain JSON import is unchanged. Restore is quota-aware (stops cleanly with a warning when full), runs the member-cap check before writing any blob so a failed import never strands storage, and discards uploads nothing ends up referencing (e.g. when the dedup pass skips an already-present member) so re-imports don't leak quota. The image-ingest pipeline itself is now shared code (`import_media`) used by the PluralSpace and Prism importers too, instead of three private copies.
- **Import deduplication.** Every importer (PluralKit, SimplyPlural, Tupperbox, PluralSpace, Prism, and Sheaf native re-import) now matches each incoming member against the system's existing roster before writing, so re-importing the same export no longer doubles your members. Matching is by PluralKit ID where present (exact, so PK round-trips cleanly) and otherwise by name, scoped so a member and a custom front sharing a name never collide. A new `conflict_strategy` option chooses what happens on a match: `skip` (default - leave the existing member untouched and add nothing), `update` (overwrite the existing member's importable fields from the export), or `create` (the old append-everything behaviour, kept as an escape hatch). The tier member cap now counts only the members an import would actually create, so re-importing into a near-full system no longer trips the cap on members that already exist. The PluralKit member HID is now also confirmed to land in each member's `pluralkit_id` field, which doubles as the dedup key. (Non-member content dedup landed alongside - see the entry above.)
- **SimplyPlural chat history import.** The SP importer can now bring across chat messages (opt-in, off by default since chat can be large). SP's multi-channel chat collapses onto the Sheaf system board with each message prefixed by its channel name, authors resolved to the imported members, reply threads preserved, and SP `<###@member###>` mention tokens rewritten to readable `@name`. It reads both export shapes (the `messages` channel map and the flat `chatMessages` array) plus their field-name aliases. Legacy exports whose message bodies are still encrypted in SimplyPlural's old, undocumented format are detected and skipped with a clear warning advising a fresh export or an API import - Sheaf can't decrypt them (the format isn't published and no client does). No chat content is ever quoted into the import log.

### Fixed

- **Build provenance for local compose builds.** `GET /v1/version` reports the commit/tag/build-time the backend was built from; CI-built ghcr images already set these, but a local `docker compose build` left them null because the compose `args` didn't forward them. The app service now accepts `GIT_COMMIT` / `GIT_TAG` / `BUILD_TIME` from the host environment (documented in SELFHOSTING.md), so a compose build can identify itself too. Unset values stay null, same as before.
- **SimplyPlural importer survives real-world export variants.** SP exports are a decade of MongoDB-into-Firebase sediment, and the shapes tidy test fixtures never produce were failing or silently dropping data on live imports. The importer now handles: collections exported as either an array or a map keyed by id (a map previously crashed the whole job); timestamps as integer/float millis, numeric strings, zone-less ISO strings, or Firebase `{_seconds, _nanoseconds}` objects (the old int-only parser silently skipped or crashed on the rest, dropping entire front histories); the renamed collection keys (`frontStatuses`/`customFronts`, `frontHistory`/`fronters`, system profile under `settings` or `users[0]`); avatars stored as an `avatarUuid` plus owner id (constructed to the serve URL, still policy-gated); and 8-hex ARGB colours. Wrong-typed name/description/colour fields are coerced away instead of crashing, and the import detail page now logs what the export contained alongside what imported so a partial import is diagnosable at a glance. Cross-referenced against the Prism importer's handling of the same quirks.
