### PR TITLE
Member banner photo + edge-to-edge image cropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Member banner photo.** Members now have an optional wide header image (`banner_url`) alongside their avatar, shown across the top of the member profile. It rides the same upload pipeline and trust model as avatars: upload-and-crop (landscape 3:1) or paste an external URL, gated by the same instance image-upload and external-image policies, stored as a bare key and signed on read. Banners are included in the data export, round-trip through native re-import and the with-images archive, and are tracked by the orphaned-file cleanup and the "where is this image used?" view so a banner blob is never garbage-collected while still referenced.
+
+### Changed
+
+- **Image cropper: edge-to-edge crops and quarter-turn buttons.** Every crop surface that shares the dialog - avatars, bio and journal image embeds, and the new member banner - can now zoom out and pan past the image edges, so a fixed-aspect crop (the round avatar, the 3:1 banner) can include the whole of an image whose ratio doesn't match, letterboxed, instead of forcing the corners or sides off. The rotation control also gained rotate-left / rotate-right buttons that snap to the nearest 90 degrees, alongside the free slider for fine angles.
+
 ### Fixed
 
 - **Route labels in metrics and rate-limit history dropped the `/v1` prefix.** Starlette 1.0 changed `request.scope["route"].path` to be relative to the outermost prefixed router (reporting `/members/{id}` instead of `/v1/members/{id}`) without moving the prefix into `root_path`, which silently relabelled every `sheaf_http_requests_total` series and rate-limit bucket and made the per-account rate-limit history record routes without their prefix. A shared `route_template()` helper now reconstructs the full template (keeping path params as placeholders so cardinality stays bounded), used by both the metrics middleware and the rate-limit middleware.
+- **Custom-field date "No year" label.** The optional-year checkbox on a date custom field read "No birth year", borrowed from the member Birthday field; it now reads "No year" everywhere except the Birthday field, which keeps its specific wording.
+- **Export build worker no longer spins the job loop every 10s.** The pending-export poll interval defaulted to 10 seconds (with a mislabelled comment), and because the background job runner wakes at the smallest registered interval, that held the whole registry to a 10-second tick. Exports are a deferred build-then-download/email flow, so the default is now 60 seconds, cutting idle wakeups across all background jobs. Override with `EXPORT_BUILD_INTERVAL_SECONDS`.
 
 ## [1.0.1] - 2026-06-12
 

--- a/alembic/versions/k0a1b2c3d4e5_add_member_banner_url.py
+++ b/alembic/versions/k0a1b2c3d4e5_add_member_banner_url.py
@@ -1,0 +1,30 @@
+"""Add banner_url to members
+
+Revision ID: k0a1b2c3d4e5
+Revises: k1d2c3b4a5e6
+Create Date: 2026-06-13
+
+Wide header image for member profiles. Same storage/trust model as
+avatar_url (bare storage key or external URL); nullable, no default.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "k0a1b2c3d4e5"
+down_revision: Union[str, None] = "k1d2c3b4a5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "members",
+        sa.Column("banner_url", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("members", "banner_url")

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -230,6 +230,7 @@ async def export_all(
                 "description": description,
                 "pronouns": m.pronouns,
                 "avatar_url": m.avatar_url,
+                "banner_url": m.banner_url,
                 "color": m.color,
                 "birthday": m.birthday,
                 "pluralkit_id": m.pluralkit_id,

--- a/sheaf/api/v1/files.py
+++ b/sheaf/api/v1/files.py
@@ -123,7 +123,7 @@ def _effective_size_limit_mb(purpose: str) -> int:
 )
 async def upload_file(
     file: UploadFile,
-    purpose: str = Query(default="avatar", pattern="^(avatar|bio)$"),
+    purpose: str = Query(default="avatar", pattern="^(avatar|bio|banner)$"),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -223,7 +223,7 @@ async def upload_file(
     # Server-derived extension + content-type from validated MIME. Never
     # trust file.filename or file.content_type for the stored object.
     ext = _MIME_EXT[actual_mime]
-    prefix = "bios" if purpose == "bio" else "avatars"
+    prefix = {"bio": "bios", "banner": "banners"}.get(purpose, "avatars")
     key = f"{prefix}/{user.id}/{uuid.uuid4().hex}.{ext}"
 
     storage = get_storage()

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -538,8 +538,12 @@ class Settings(BaseSettings):
     export_job_ttl_hours: int = 72
     # How often the cleanup worker sweeps for expired jobs.
     export_cleanup_interval_seconds: int = 3600
-    # How many jobs the build worker processes per tick.
-    export_build_interval_seconds: int = 10
+    # How often the build worker polls for pending export jobs to assemble.
+    # Exports are a deferred "request now, download/email later" flow with no
+    # wake signal, so a minute of pickup latency is fine - and since the job
+    # runner wakes at the smallest registered interval, a tight value here
+    # spins the whole registry loop needlessly.
+    export_build_interval_seconds: int = 60
     # Where the build worker drops its temp zip while assembling.
     # Empty = use the system default (tempfile picks $TMPDIR or /tmp).
     # Set this when running on small root volumes or when the system

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -80,6 +80,10 @@ class Member(UUIDMixin, TimestampMixin, Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     pronouns: Mapped[str | None] = mapped_column(String(100), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Wide header image for the member profile. Same storage/trust model as
+    # avatar_url (bare storage key or external URL, gated by
+    # allow_external_images); differs only in aspect ratio at the UI layer.
+    banner_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     color: Mapped[str | None] = mapped_column(String(7), nullable=True)
     # Stored as "MM-DD" or "YYYY-MM-DD" to support year-optional birthdays
     birthday: Mapped[str | None] = mapped_column(String(10), nullable=True)

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -18,6 +18,7 @@ class MemberCreate(BaseModel):
     description: str | None = None
     pronouns: str | None = Field(default=None, max_length=100)
     avatar_url: str | None = Field(default=None, max_length=500)
+    banner_url: str | None = Field(default=None, max_length=500)
     color: str | None = Field(default=None, max_length=7)
     birthday: str | None = Field(default=None, max_length=10)
     pluralkit_id: str | None = Field(default=None, max_length=8)
@@ -27,7 +28,9 @@ class MemberCreate(BaseModel):
     note: str | None = Field(default=None, max_length=5000)
     quick_switch_pin: int | None = Field(default=None, ge=0)
 
-    @field_validator("avatar_url", mode="before")
+    # banner_url shares the avatar normaliser: both are image storage keys /
+    # external URLs with the same allow_external_images gate.
+    @field_validator("avatar_url", "banner_url", mode="before")
     @classmethod
     def _normalize_avatar(cls, v: str | None) -> str | None:
         return normalize_avatar_url(v)
@@ -44,6 +47,7 @@ class MemberUpdate(BaseModel):
     description: str | None = None
     pronouns: str | None = Field(default=None, max_length=100)
     avatar_url: str | None = Field(default=None, max_length=500)
+    banner_url: str | None = Field(default=None, max_length=500)
     color: str | None = Field(default=None, max_length=7)
     birthday: str | None = Field(default=None, max_length=10)
     pluralkit_id: str | None = Field(default=None, max_length=8)
@@ -54,7 +58,7 @@ class MemberUpdate(BaseModel):
     # Explicit null clears the pin (unpins); omitted leaves it untouched.
     quick_switch_pin: int | None = Field(default=None, ge=0)
 
-    @field_validator("avatar_url", mode="before")
+    @field_validator("avatar_url", "banner_url", mode="before")
     @classmethod
     def _normalize_avatar(cls, v: str | None) -> str | None:
         return normalize_avatar_url(v)
@@ -91,6 +95,7 @@ class MemberRead(BaseModel):
     description: str | None
     pronouns: str | None
     avatar_url: str | None
+    banner_url: str | None
     color: str | None
     birthday: str | None
     pluralkit_id: str | None
@@ -114,7 +119,7 @@ class MemberRead(BaseModel):
 
     model_config = {"from_attributes": True}
 
-    @field_serializer("avatar_url")
+    @field_serializer("avatar_url", "banner_url")
     def _sign_avatar_url(self, v: str | None) -> str | None:
         return resolve_avatar_url(v)
 

--- a/sheaf/services/file_cleanup.py
+++ b/sheaf/services/file_cleanup.py
@@ -68,15 +68,16 @@ async def find_orphaned_files(
     for (avatar_url,) in result:
         referenced.update(_key_from_avatar(avatar_url))
 
-    # Member avatars and bios
+    # Member avatars, banners, and bios
     result = await db.execute(
-        select(Member.avatar_url, Member.description)
+        select(Member.avatar_url, Member.banner_url, Member.description)
         .join(System)
         .join(User)
         .where(User.id == user_id)
     )
-    for avatar_url, description in result:
+    for avatar_url, banner_url, description in result:
         referenced.update(_key_from_avatar(avatar_url))
+        referenced.update(_key_from_avatar(banner_url))
         # Member.description is encrypted at rest; decrypt for the markdown
         # scan. This runs in the app container which has the key.
         if description is not None:
@@ -169,6 +170,13 @@ async def find_file_references(
             refs.append({
                 "kind": "member_avatar",
                 "label": f"{name}'s avatar",
+                "target_type": "member",
+                "target_id": str(m.id),
+            })
+        if m.banner_url == key:
+            refs.append({
+                "kind": "member_banner",
+                "label": f"{name}'s banner",
                 "target_type": "member",
                 "target_id": str(m.id),
             })

--- a/sheaf/services/import_dedup.py
+++ b/sheaf/services/import_dedup.py
@@ -68,6 +68,7 @@ _OVERWRITE_IF_SET = (
     "description",
     "pronouns",
     "avatar_url",
+    "banner_url",
     "color",
     "birthday",
     "pluralkit_id",

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -82,6 +82,7 @@ def decrypt_member_for_read(
         "description": member_description_plaintext(member),
         "pronouns": member.pronouns,
         "avatar_url": member.avatar_url,
+        "banner_url": member.banner_url,
         "color": member.color,
         "birthday": member.birthday,
         "pluralkit_id": member.pluralkit_id,

--- a/sheaf/services/sheaf_archive_import.py
+++ b/sheaf/services/sheaf_archive_import.py
@@ -240,6 +240,7 @@ def collect_image_references(data: dict) -> dict[str, list[str]]:
             continue
         mid = m_data.get("id", "?")
         _from_url(m_data.get("avatar_url"), f"member {mid} avatar")
+        _from_url(m_data.get("banner_url"), f"member {mid} banner")
         for fld in _MD_FIELDS_MEMBER:
             _from_md(m_data.get(fld), f"member {mid} {fld}")
 

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -462,6 +462,12 @@ async def run_import(
                 ),
                 500,
             ),
+            banner_url=_trunc(
+                rewrite_internal_avatar_url(
+                    m_data.get("banner_url"), _ikm, member_used
+                ),
+                500,
+            ),
             color=_trunc(m_data.get("color"), 7),
             birthday=_trunc(m_data.get("birthday"), 10),
             pluralkit_id=_trunc(m_data.get("pluralkit_id"), 8),

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -95,6 +95,7 @@ CLASSIFICATION: dict[type, dict] = {
     Member: {
         "exported": {
             "name", "display_name", "description", "pronouns", "avatar_url",
+            "banner_url",
             "color", "birthday", "pluralkit_id", "emoji", "is_custom_front",
             "privacy", "note", "quick_switch_pin", "created_at",
             "notify_on_front_global", "notify_on_front_self",

--- a/web/src/components/avatar-cropper-dialog.tsx
+++ b/web/src/components/avatar-cropper-dialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Cropper from "react-easy-crop";
 import type { Area } from "react-easy-crop";
+import { RotateCcw, RotateCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,12 +19,31 @@ import { Label } from "@/components/ui/label";
 // the upload payload sensible without losing user-visible quality.
 const MAX_OUTPUT_DIM = 1024;
 
+const clampRotation = (v: number): number => Math.max(-180, Math.min(180, v));
+
+// Quarter-turn buttons: jump to the next multiple of 90 in each direction.
+// The +/-1 nudge means landing exactly on a multiple advances to the next one
+// rather than sticking. The slider itself stays free for fine adjustment.
+const rotateToPrev90 = (r: number): number =>
+  clampRotation(Math.floor((r - 1) / 90) * 90);
+const rotateToNext90 = (r: number): number =>
+  clampRotation(Math.ceil((r + 1) / 90) * 90);
+
 interface AvatarCropperDialogProps {
   open: boolean;
   file: File | null;
   aspect?: number;          // 1 for avatars; undefined => freeform
   cropShape?: "round" | "rect";
   outputMime?: "image/png" | "image/jpeg" | "image/webp";
+  // Smallest zoom (1 = "cover" the frame). Below 1 the image can shrink
+  // inside the frame, letterboxing, so the crop can include the whole image.
+  // Defaults below 1 so any crop (round avatar, rect embed, banner) can zoom
+  // out to fit the whole image rather than forcing the corners/edges off.
+  minZoom?: number;
+  // When false, the image can be panned so the crop frame reaches past its
+  // edges (the overflow renders transparent). Off by default so a crop can go
+  // right to the edge of an image whose ratio doesn't match the frame.
+  restrictPosition?: boolean;
   onConfirm: (cropped: Blob) => void;
   onCancel: () => void;
 }
@@ -34,6 +54,8 @@ export function AvatarCropperDialog({
   aspect = 1,
   cropShape = "round",
   outputMime = "image/png",
+  minZoom = 0.1,
+  restrictPosition = false,
   onConfirm,
   onCancel,
 }: AvatarCropperDialogProps) {
@@ -116,6 +138,8 @@ export function AvatarCropperDialog({
               aspect={aspect}
               cropShape={cropShape}
               showGrid={cropShape === "rect"}
+              minZoom={minZoom}
+              restrictPosition={restrictPosition}
               onCropChange={setCrop}
               onCropComplete={onCropComplete}
               onZoomChange={setZoom}
@@ -129,7 +153,7 @@ export function AvatarCropperDialog({
             <Label className="text-xs text-muted-foreground">Zoom</Label>
             <input
               type="range"
-              min={1}
+              min={minZoom}
               max={4}
               step={0.01}
               value={zoom}
@@ -140,16 +164,40 @@ export function AvatarCropperDialog({
           </div>
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">Rotation</Label>
-            <input
-              type="range"
-              min={-180}
-              max={180}
-              step={1}
-              value={rotation}
-              onChange={(e) => setRotation(Number(e.target.value))}
-              className="w-full accent-primary"
-              aria-label="Rotation"
-            />
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                onClick={() => setRotation(rotateToPrev90(rotation))}
+                title="Rotate 90 left"
+                aria-label="Rotate 90 degrees left"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+              </Button>
+              <input
+                type="range"
+                min={-180}
+                max={180}
+                step={1}
+                value={rotation}
+                onChange={(e) => setRotation(Number(e.target.value))}
+                className="w-full accent-primary"
+                aria-label="Rotation"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                onClick={() => setRotation(rotateToNext90(rotation))}
+                title="Rotate 90 right"
+                aria-label="Rotate 90 degrees right"
+              >
+                <RotateCw className="h-3.5 w-3.5" />
+              </Button>
+            </div>
           </div>
         </div>
 

--- a/web/src/components/banner-upload.tsx
+++ b/web/src/components/banner-upload.tsx
@@ -1,0 +1,175 @@
+import { type FormEvent, useRef, useState } from "react";
+import { toast } from "sonner";
+import { uploadFile } from "@/lib/files";
+import { apiErrorMessage } from "@/lib/api-errors";
+import { AvatarCropperDialog } from "@/components/avatar-cropper-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Camera, X, Link, Image as ImageIcon } from "lucide-react";
+import { useAuth } from "@/hooks/use-auth";
+
+// Wide header image for a member profile. Crops to a fixed 3:1 banner shape,
+// but unlike the avatar the crop can zoom out and pan past the image edges
+// (minZoom < 1 + restrictPosition off), so an image whose ratio isn't 3:1 can
+// still be used whole (letterboxed) rather than forcing the sides off.
+export function BannerUpload({
+  url,
+  onUpload,
+  onRemove,
+}: {
+  url: string | null;
+  onUpload: (key: string) => void;
+  onRemove?: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState("");
+  const [showUrlInput, setShowUrlInput] = useState(false);
+  const [urlValue, setUrlValue] = useState("");
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const { user } = useAuth();
+  const uploadsAllowed = user?.uploads_allowed ?? true;
+  const externalAllowed = user?.external_images_allowed ?? true;
+  const shown = previewUrl ?? url;
+
+  async function handleCroppedBlob(blob: Blob) {
+    setPendingFile(null);
+    setError("");
+    setUploading(true);
+    try {
+      const named = new File([blob], "banner.png", { type: blob.type });
+      const res = await uploadFile(named, "banner");
+      setPreviewUrl(res.url);
+      onUpload(res.key);
+      if (res.animated) {
+        toast.info("Animated image was flattened to a single frame.");
+      }
+    } catch (err) {
+      setError(apiErrorMessage(err, "Upload failed"));
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) setPendingFile(file);
+    e.target.value = "";
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith("image/")) setPendingFile(file);
+  }
+
+  function handleUrlSubmit(e: FormEvent) {
+    e.preventDefault();
+    // Nested <form>; stop the submit bubbling to the parent profile form
+    // (see AvatarUpload for the full rationale).
+    e.stopPropagation();
+    const trimmed = urlValue.trim();
+    if (!trimmed) return;
+    if (!/^https?:\/\//i.test(trimmed)) {
+      setError("Image URL must start with http:// or https://");
+      return;
+    }
+    setError("");
+    onUpload(trimmed);
+    setUrlValue("");
+    setShowUrlInput(false);
+  }
+
+  return (
+    <div className="space-y-1">
+      <div
+        className={`group relative aspect-[3/1] w-full overflow-hidden rounded-md border bg-muted ${
+          uploadsAllowed ? "cursor-pointer" : ""
+        }`}
+        onClick={uploadsAllowed ? () => inputRef.current?.click() : undefined}
+        onDrop={uploadsAllowed ? handleDrop : undefined}
+        onDragOver={uploadsAllowed ? (e) => e.preventDefault() : undefined}
+      >
+        {shown ? (
+          <img src={shown} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <ImageIcon className="h-6 w-6" />
+          </div>
+        )}
+        {uploadsAllowed && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+            <Camera className="h-5 w-5 text-white" />
+          </div>
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        className="hidden"
+        onChange={handleChange}
+      />
+      <div className="flex gap-1">
+        {uploadsAllowed && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => inputRef.current?.click()}
+            disabled={uploading}
+          >
+            {uploading ? "Uploading..." : "Upload"}
+          </Button>
+        )}
+        {externalAllowed && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setShowUrlInput(!showUrlInput)}
+            title="Use image URL"
+          >
+            <Link className="h-3 w-3" />
+          </Button>
+        )}
+        {shown && onRemove && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => { setPreviewUrl(null); onRemove(); }}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+      {showUrlInput && (
+        <form onSubmit={handleUrlSubmit} className="flex gap-1">
+          <Input
+            value={urlValue}
+            onChange={(e) => setUrlValue(e.target.value)}
+            placeholder="https://..."
+            className="h-7 text-xs"
+            type="url"
+            autoFocus
+          />
+          <Button type="submit" size="sm" variant="ghost" className="h-7 px-2 text-xs">
+            Set
+          </Button>
+        </form>
+      )}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <AvatarCropperDialog
+        open={pendingFile !== null}
+        file={pendingFile}
+        aspect={3}
+        cropShape="rect"
+        outputMime="image/png"
+        onConfirm={handleCroppedBlob}
+        onCancel={() => setPendingFile(null)}
+      />
+    </div>
+  );
+}

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -23,11 +23,13 @@ export function DatePicker({
   onChange,
   placeholder = "Pick a date",
   includeYear = true,
+  noYearLabel = "No year",
 }: {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
   includeYear?: boolean;
+  noYearLabel?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [yearOptional, setYearOptional] = useState(!includeYear || !!(value && !value.includes("-", 3)));
@@ -87,7 +89,7 @@ export function DatePicker({
           onChange={(e) => setYearOptional(e.target.checked)}
           className="rounded"
         />
-        No birth year
+        {noYearLabel}
       </label>
       <p className="text-xs text-muted-foreground">
         Format: {yearOptional ? "MM-DD" : "YYYY-MM-DD"}

--- a/web/src/lib/files.ts
+++ b/web/src/lib/files.ts
@@ -11,7 +11,7 @@ interface UploadResponse {
   animated: boolean;
 }
 
-export function uploadFile(file: File, purpose: "avatar" | "bio" = "avatar"): Promise<UploadResponse> {
+export function uploadFile(file: File, purpose: "avatar" | "bio" | "banner" = "avatar"): Promise<UploadResponse> {
   const form = new FormData();
   form.append("file", file);
   return apiFetch<UploadResponse>(`/v1/files/upload?purpose=${purpose}`, {
@@ -61,6 +61,7 @@ export function listFiles() {
 export type FileReferenceKind =
   | "system_avatar"
   | "member_avatar"
+  | "member_banner"
   | "member_bio"
   | "journal"
   | "revision";

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -18,6 +18,7 @@ import { listTags } from "@/lib/tags";
 import { getNotifySettings, setNotifySettings } from "@/lib/messages";
 import { getSystemSafety } from "@/lib/system-safety";
 import { AvatarUpload } from "@/components/avatar-upload";
+import { BannerUpload } from "@/components/banner-upload";
 import { Badge } from "@/components/ui/badge";
 import { ColorDot } from "@/components/color-dot";
 import { ContentRevisionList } from "@/components/content-revision-list";
@@ -76,6 +77,7 @@ function MemberForm({
   const [name, setName] = useState(initial?.name ?? "");
   const [displayName, setDisplayName] = useState(initial?.display_name ?? "");
   const [avatarUrl, setAvatarUrl] = useState(initial?.avatar_url ?? null);
+  const [bannerUrl, setBannerUrl] = useState(initial?.banner_url ?? null);
   const [pronouns, setPronouns] = useState(initial?.pronouns ?? "");
   const [color, setColor] = useState(initial?.color ?? "#6366f1");
   const [description, setDescription] = useState(initial?.description ?? "");
@@ -98,6 +100,7 @@ function MemberForm({
       name,
       display_name: displayName || null,
       avatar_url: avatarUrl,
+      banner_url: bannerUrl,
       pronouns: pronouns || null,
       color: color || null,
       description: description || null,
@@ -119,6 +122,14 @@ function MemberForm({
         onUpload={setAvatarUrl}
         onRemove={() => setAvatarUrl(null)}
       />
+      <div className="space-y-2">
+        <Label>Banner</Label>
+        <BannerUpload
+          url={bannerUrl}
+          onUpload={setBannerUrl}
+          onRemove={() => setBannerUrl(null)}
+        />
+      </div>
       <div className="space-y-2">
         <Label htmlFor="member-name">Name</Label>
         <Input id="member-name" value={name} onChange={(e) => setName(e.target.value)} required />
@@ -179,6 +190,7 @@ function MemberForm({
             value={birthday}
             onChange={setBirthday}
             placeholder="Birthday"
+            noYearLabel="No birth year"
           />
         </div>
       </div>
@@ -976,6 +988,13 @@ function MemberView({
           </div>
         </DialogHeader>
         <div className="space-y-4">
+          {member.banner_url && (
+            <img
+              src={member.banner_url}
+              alt=""
+              className="aspect-[3/1] w-full rounded-md object-cover"
+            />
+          )}
           {/* Header: avatar + name + pronouns */}
           <div className="flex items-center gap-4">
             <Avatar className="size-16">
@@ -1253,11 +1272,21 @@ function MemberGrid({
         <Card
           key={m.id}
           className={cn(
-            "cursor-pointer transition-colors hover:bg-accent/50",
+            "cursor-pointer overflow-hidden transition-colors hover:bg-accent/50",
+            // Banner sits flush to the card's top edge: drop the card's top
+            // padding and the flex gap so it isn't inset below them.
+            m.banner_url && "gap-0 pt-0",
             m.pending_delete_at && "opacity-60",
           )}
           onClick={() => onView(m)}
         >
+          {m.banner_url && (
+            <img
+              src={m.banner_url}
+              alt=""
+              className="aspect-[3/1] w-full object-cover"
+            />
+          )}
           <CardContent className="flex items-center gap-3 p-4">
             <Avatar>
               {m.avatar_url && <AvatarImage src={m.avatar_url} />}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -98,6 +98,7 @@ export interface Member {
   description: string | null;
   pronouns: string | null;
   avatar_url: string | null;
+  banner_url: string | null;
   color: string | null;
   birthday: string | null;
   pluralkit_id: string | null;
@@ -131,6 +132,7 @@ export interface MemberCreate {
   description?: string | null;
   pronouns?: string | null;
   avatar_url?: string | null;
+  banner_url?: string | null;
   color?: string | null;
   birthday?: string | null;
   pluralkit_id?: string | null;
@@ -147,6 +149,7 @@ export interface MemberUpdate {
   description?: string | null;
   pronouns?: string | null;
   avatar_url?: string | null;
+  banner_url?: string | null;
   color?: string | null;
   birthday?: string | null;
   pluralkit_id?: string | null;


### PR DESCRIPTION
Adds an optional wide header image to members, plus a usability pass on the shared image cropper and a couple of small fixes that surfaced alongside.

Member banner photo: members gain an optional `banner_url` shown across the top of the member profile and on the member grid card. It reuses the avatar machinery end to end - the same upload pipeline (format sniff, EXIF strip, dimension cap, storage quota), the same normalise/resolve/strip URL helpers and `allow_external_images` gate, the same export and native/archive re-import round-trip, and the same orphaned-file cleanup + "where is this image used?" tracking so a banner blob is never garbage-collected while referenced. New nullable `Member.banner_url` column (migration included) and the field is registered in the export/import parity classification.

Image cropper, edge-to-edge crops: the shared crop dialog now defaults to letting a crop reach (and pan past) the image edges and zoom out below "cover", so every surface that uses it - round avatars, bio and journal image embeds, and the new banner - can include the whole of an image whose aspect ratio doesn't match the frame (letterboxed) instead of forcing the corners or sides off. The rotation control also gains rotate-left / rotate-right buttons that snap to the nearest 90 degrees, alongside the existing free slider.

Misc fixes folded in: the date custom-field's optional-year checkbox now reads "No year" instead of the borrowed "No birth year" (the member Birthday field keeps its specific wording); and the export build worker's poll interval now defaults to 60s instead of 10s - the old comment mislabelled it as a job count, and because the background job runner wakes at the smallest registered interval, the 10s value was holding the entire job loop to a 10-second tick. Exports are a deferred build-then-download/email flow, so the longer interval is fine and quietly cuts idle wakeups across all background jobs.

Verification: ruff, tsc, eslint all green; the export/import parity guard passes (22/22).