### PR TITLE
Fix front-edit date validation, log 4xx/5xx reasons, guard front ordering

### DIFF
--- a/alembic/versions/k1d2c3b4a5e6_front_ended_after_started_check.py
+++ b/alembic/versions/k1d2c3b4a5e6_front_ended_after_started_check.py
@@ -1,0 +1,38 @@
+"""Add fronts ended-after-started CHECK constraint
+
+Revision ID: k1d2c3b4a5e6
+Revises: j9a0b1c2d3e4
+Create Date: 2026-06-14
+
+A closed front can't end before it starts. The front edit endpoint already
+rejects this, but the create and import paths build Front rows directly and
+bypassed the check, so a mis-ordered front could be persisted and then become
+un-editable (every edit re-runs the guard on the bad pair). This adds the
+constraint as the mechanical backstop across all write paths.
+
+Added NOT VALID so the constraint is enforced for all new inserts/updates
+without retroactively validating (and potentially failing on) any pre-existing
+rows. A later migration can VALIDATE it once existing data is confirmed clean.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "k1d2c3b4a5e6"
+down_revision: Union[str, None] = "j9a0b1c2d3e4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE fronts ADD CONSTRAINT ck_fronts_ended_after_started "
+        "CHECK (ended_at IS NULL OR ended_at >= started_at) NOT VALID"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE fronts DROP CONSTRAINT ck_fronts_ended_after_started"
+    )

--- a/sheaf/main.py
+++ b/sheaf/main.py
@@ -5,7 +5,10 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from sheaf import __version__
@@ -180,6 +183,55 @@ async def body_too_large_handler(
     return JSONResponse(
         status_code=413,
         content={"detail": f"Request body too large. Max: {mb}MB"},
+    )
+
+
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    # Log the reason for every deliberate client/server error so a bare
+    # status code in the access log can be traced to *why* without
+    # reproducing. `exc.detail` is the same user-facing string already
+    # returned in the body; no request body or secrets are logged. 5xx is
+    # surfaced at WARNING, 4xx at INFO (filter-friendly on a busy public
+    # instance where 401/404 probes are routine). The response is byte-for-
+    # byte the FastAPI default, headers included.
+    if exc.status_code >= 500:
+        logger.warning(
+            "%s %s -> %d: %s",
+            request.method, request.url.path, exc.status_code, exc.detail,
+        )
+    elif exc.status_code >= 400:
+        logger.info(
+            "%s %s -> %d: %s",
+            request.method, request.url.path, exc.status_code, exc.detail,
+        )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail},
+        headers=getattr(exc, "headers", None),
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    # 422s are request-shape mismatches. Log the field locations, messages,
+    # and error types - deliberately NOT the submitted `input` values, which
+    # can carry user data - so a malformed client request is diagnosable. The
+    # response body keeps the FastAPI default shape (which does include the
+    # inputs, same as before this handler existed).
+    safe = [
+        {"loc": e.get("loc"), "msg": e.get("msg"), "type": e.get("type")}
+        for e in exc.errors()
+    ]
+    logger.info(
+        "%s %s -> 422 validation: %s", request.method, request.url.path, safe
+    )
+    return JSONResponse(
+        status_code=422, content={"detail": jsonable_encoder(exc.errors())}
     )
 
 

--- a/sheaf/models/front.py
+++ b/sheaf/models/front.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, Text
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -45,4 +45,13 @@ class Front(UUIDMixin, Base):
         Index("ix_fronts_system_started", "system_id", "started_at"),
         # Fast lookup for "who is currently fronting" (ended_at IS NULL)
         Index("ix_fronts_system_current", "system_id", "ended_at"),
+        # A closed front can't end before it starts. The edit endpoint already
+        # checks this, but creation/import paths build Front rows directly and
+        # bypassed it - this is the mechanical backstop so a mis-ordered front
+        # can never be persisted (and then become un-editable). Added NOT VALID
+        # in the migration so pre-existing rows aren't retroactively rejected.
+        CheckConstraint(
+            "ended_at IS NULL OR ended_at >= started_at",
+            name="ck_fronts_ended_after_started",
+        ),
     )

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -89,6 +89,12 @@ export function DatePicker({
         />
         No birth year
       </label>
+      <p className="text-xs text-muted-foreground">
+        Format: {yearOptional ? "MM-DD" : "YYYY-MM-DD"}
+        {value && !date && (
+          <span className="text-destructive"> - that isn't a valid date</span>
+        )}
+      </p>
     </div>
   );
 }

--- a/web/src/components/edit-front-dialog.tsx
+++ b/web/src/components/edit-front-dialog.tsx
@@ -42,6 +42,7 @@ export function EditFrontDialog({
   onSaved?: () => void;
 }) {
   const updateFront = useUpdateFront();
+  const [error, setError] = useState("");
 
   // Reinit the form on the open transition without useEffect (lint
   // blocks setState-in-effect). Tracking which front the form was
@@ -71,12 +72,32 @@ export function EditFrontDialog({
       reopen: false,
       customStatus: front.custom_status ?? "",
     });
+    setError("");
   } else if (!front && draft.fromFrontId !== null) {
     setDraft((d) => ({ ...d, fromFrontId: null }));
   }
 
   function handleSave() {
     if (!front) return;
+
+    // Validate the *effective* resulting times before sending. A
+    // datetime-local that the browser couldn't represent (e.g. an
+    // impossible date like 31 April) comes through empty; without this
+    // check the empty start would be silently omitted from the PATCH
+    // while ended_at still goes, leaving an end before the unchanged
+    // start that the server rejects with a generic 400. Catch it here
+    // with a precise message instead.
+    if (!draft.startedAt) {
+      setError("A start time is required.");
+      return;
+    }
+    const effEnded = draft.reopen ? "" : draft.endedAt;
+    if (effEnded && new Date(effEnded) < new Date(draft.startedAt)) {
+      setError("The end time can't be before the start time.");
+      return;
+    }
+    setError("");
+
     const body: {
       started_at?: string;
       ended_at?: string | null;
@@ -177,6 +198,11 @@ export function EditFrontDialog({
           </div>
         </div>
 
+        <p className="text-xs text-muted-foreground">
+          Times are in your device's local timezone, in the date format your
+          browser uses.
+        </p>
+
         {front?.ended_at && (
           <div className="flex items-center gap-2">
             <Checkbox
@@ -213,6 +239,8 @@ export function EditFrontDialog({
             maxLength={500}
           />
         </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
 
         <DialogFooter>
           <Button


### PR DESCRIPTION
From a user report: editing a front entry returned a generic "invalid request". The PATCH sent only `ended_at` (an end before the front's actual start), with no `started_at`, because the dialog silently dropped a start the browser couldn't represent (an impossible date like 31 April came through empty). The server's ended-after-started guard correctly rejected it, but nothing surfaced *why* - the friendly toast said "Invalid request" and the access log showed a bare 400.

Four independent commits, all from that one report:

Validate front-edit times client-side: the edit dialog now requires a start and rejects an end earlier than the start before sending, with a precise inline message, instead of omitting a cleared/invalid start while still sending the end. Adds a short note that times use the device's local timezone and browser date format.

Log the reason for 4xx/5xx responses: deliberate HTTPExceptions (and 422 validation errors) returned the detail to the client but logged nothing server-side, so a status code in the access log couldn't be traced to why. New exception handlers log method, path, status, and detail (5xx at WARNING, 4xx at INFO), returning the byte-for-byte default response. The 422 handler logs field locations/messages/types but never the submitted input values.

Guard front date ordering at the DB: the ended-after-started check lived only on the edit endpoint, so the create/import paths could persist a mis-ordered front that then became un-editable. Adds a CHECK constraint as the mechanical backstop across all write paths, applied NOT VALID so existing rows aren't retroactively rejected.

DatePicker format hint: the date custom-field / birthday text input now shows the expected format (MM-DD or YYYY-MM-DD) and flags an unparseable date inline, so an impossible date is caught at entry.

Note for the migration: `k1d2c3b4a5e6` branches off the same head as the member-banner migration on the other open PR, so landing both will need an alembic merge head (or a rebase that re-parents one onto the other).

Verification: ruff (sheaf + tests), tsc, and eslint all green; the export/import parity guard passes (22/22).