### PR TITLE
Restore /v1 prefix in metric + rate-limit route labels (Starlette 1.0 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 `v1.0.0` is the first stable release. The `v0.x.y` releases were betas; from 1.0 on, the v1 API and database schema carry semver compatibility guarantees.
 
+## [Unreleased]
+
+### Fixed
+
+- **Route labels in metrics and rate-limit history dropped the `/v1` prefix.** Starlette 1.0 changed `request.scope["route"].path` to be relative to the outermost prefixed router (reporting `/members/{id}` instead of `/v1/members/{id}`) without moving the prefix into `root_path`, which silently relabelled every `sheaf_http_requests_total` series and rate-limit bucket and made the per-account rate-limit history record routes without their prefix. A shared `route_template()` helper now reconstructs the full template (keeping path params as placeholders so cardinality stays bounded), used by both the metrics middleware and the rate-limit middleware.
+
 ## [1.0.1] - 2026-06-12
 
 ### Added

--- a/sheaf/middleware/rate_limit.py
+++ b/sheaf/middleware/rate_limit.py
@@ -31,6 +31,7 @@ from starlette.responses import JSONResponse
 
 from sheaf.config import settings
 from sheaf.observability.metrics import rate_limit_checks_total
+from sheaf.observability.middleware import route_template
 
 logger = logging.getLogger("sheaf.ratelimit")
 
@@ -268,10 +269,12 @@ def rate_limit(
 
         allowed, remaining, reset = await _check_limit(r, redis_key, limit)
 
-        # Bucket is derived from the matched route template when available
-        # so per-instance path noise doesn't bloat label cardinality.
-        route_obj = request.scope.get("route")
-        bucket = _route_to_bucket(getattr(route_obj, "path", None) or route)
+        # Bucket is derived from the matched route template (with path params
+        # left as placeholders) so per-instance path noise doesn't bloat label
+        # cardinality. route_template restores the "/v1" prefix Starlette 1.0
+        # drops from route.path.
+        full_route = route_template(request)
+        bucket = _route_to_bucket(full_route)
         scope_label = "per_user" if (key == "user" and identifier.startswith("user:")) else "per_ip"
         rate_limit_checks_total.labels(
             bucket=bucket,
@@ -292,7 +295,7 @@ def rate_limit(
                         hit_user_id,
                         bucket=bucket,
                         scope=scope_label,
-                        route=getattr(route_obj, "path", None) or route,
+                        route=full_route,
                         ip=_client_ip(request),
                     )
                 except Exception:

--- a/sheaf/observability/middleware.py
+++ b/sheaf/observability/middleware.py
@@ -30,17 +30,37 @@ def _status_class(status: int) -> str:
     return f"{status // 100}xx"
 
 
-def _route_template(request: Request) -> str:
-    """Return the Starlette route template, or '<unmatched>'.
+def route_template(request: Request) -> str:
+    """Return the full matched route template, e.g. '/v1/members/{id}'.
 
-    `request.scope["route"]` is set by Starlette's router after the
-    route resolves. If we get here without a match (404), there's no
-    template — collapse to a single label so URL scanners can't
-    explode cardinality.
+    `request.scope["route"]` is set by Starlette's router after the route
+    resolves. If we get here without a match (404), there's no template -
+    collapse to a single label so URL scanners can't explode cardinality.
+
+    Starlette 1.0 changed `route.path` to be relative to the outermost
+    prefixed router: a route under `APIRouter(prefix="/v1")` reports
+    "/members/{id}", not "/v1/members/{id}", and the dropped prefix is NOT
+    moved into root_path. Left as-is that silently relabels every metric and
+    rate-limit bucket without the "/v1" prefix. Reconstruct the full template
+    by prepending the leading segments of the real request path that the
+    relative template omits, keeping the path params templated so cardinality
+    stays bounded.
     """
     route = request.scope.get("route")
-    path = getattr(route, "path", None)
-    return path or "<unmatched>"
+    tmpl = getattr(route, "path", None)
+    if not tmpl:
+        return "<unmatched>"
+    real = request.scope.get("path") or request.url.path
+    real_segs = [s for s in real.split("/") if s]
+    tmpl_segs = [s for s in tmpl.split("/") if s]
+    missing = len(real_segs) - len(tmpl_segs)
+    if missing > 0:
+        return "/" + "/".join(real_segs[:missing]) + tmpl
+    return tmpl
+
+
+# Backwards-compatible private alias (kept so existing imports don't break).
+_route_template = route_template
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):

--- a/tests/test_route_template.py
+++ b/tests/test_route_template.py
@@ -1,0 +1,51 @@
+"""Unit tests for route_template (observability.middleware).
+
+Locks the Starlette-1.0 fix: route.path is relative to the outermost
+prefixed router (the "/v1" is dropped and not moved to root_path), so the
+full template must be reconstructed from the real request path. These are
+pure-function tests with synthetic request scopes - no app or stack needed.
+"""
+
+from types import SimpleNamespace
+
+from sheaf.observability.middleware import route_template
+
+
+def _req(route_path: str | None, scope_path: str):
+    scope: dict = {"path": scope_path}
+    if route_path is not None:
+        scope["route"] = SimpleNamespace(path=route_path)
+    return SimpleNamespace(scope=scope, url=SimpleNamespace(path=scope_path))
+
+
+def test_restores_dropped_v1_prefix():
+    # Starlette 1.0 reports "/import/prism/preview" for a route mounted at
+    # /v1/import/prism/preview; the helper must restore the full path.
+    assert (
+        route_template(_req("/import/prism/preview", "/v1/import/prism/preview"))
+        == "/v1/import/prism/preview"
+    )
+
+
+def test_keeps_path_params_templated():
+    # The real path carries a concrete id; the reconstructed template must
+    # keep the {id} placeholder so metric/bucket cardinality stays bounded.
+    assert (
+        route_template(_req("/members/{id}", "/v1/members/abc-123"))
+        == "/v1/members/{id}"
+    )
+
+
+def test_already_full_template_unchanged():
+    assert (
+        route_template(_req("/v1/auth/config", "/v1/auth/config"))
+        == "/v1/auth/config"
+    )
+
+
+def test_unmatched_route_returns_placeholder():
+    assert route_template(_req(None, "/whatever")) == "<unmatched>"
+
+
+def test_root_path():
+    assert route_template(_req("/", "/")) == "/"


### PR DESCRIPTION
CI on main is red (caught on the two open feature PRs, but the cause is on main): `test_metrics::test_http_requests_total_increments` and `test_rate_limit::test_per_user_block_records_admin_history` both fail because route labels lost their `/v1` prefix.

Root cause: Starlette 1.0 changed `request.scope["route"].path` to be relative to the outermost prefixed router. A route mounted at `/v1/import/prism/preview` now reports `/import/prism/preview` via `route.path`, and the dropped `/v1` is NOT moved into `root_path` (confirmed by a minimal repro: `route.path='/import/prism/preview'`, `root_path=''`, `scope['path']='/v1/import/prism/preview'`). Both the metrics middleware and the rate-limit middleware derived their route label from `route.path`, so every `sheaf_http_requests_total` series and rate-limit bucket got silently relabelled without the prefix, and the per-account rate-limit history recorded prefix-less routes.

Fix: a shared `route_template()` helper reconstructs the full template from the real request path (prepending the leading segments the relative template omits) while keeping path params as `{placeholders}` so metric/bucket cardinality stays bounded. Used by both middlewares. Stack-free regression tests cover the prefix restore, param templating, the already-full and unmatched cases.

This is independent of the two open feature PRs (#143 member banner, #144 front-edit fixes) - both fail the same two tests because they branch off this same main. Merging this first turns all three green; the feature PRs just need a rebase onto the fixed main.

Verification: `tests/test_route_template.py` passes (5/5); ruff (sheaf + tests) clean. The two originally-failing suites need the docker stack + rate-limit/metrics configs to run, so they'll confirm on CI here.