### PR TITLE
Clearer errors when browser-push subscription fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 `v1.0.0` is the first stable release. The `v0.x.y` releases were betas; from 1.0 on, the v1 API and database schema carry semver compatibility guarantees.
 
+## [Unreleased]
+
+### Fixed
+
+- **Clearer errors when browser-push subscription fails.** When a recipient subscribes to web push, the browser's own `pushManager.subscribe()` can fail with an opaque message (e.g. Chrome's "Registration failed - push service error") if it can't reach its push backend - and the redeem page showed that raw string with nothing logged for debugging. The page now logs the full exception to the console, maps the common failures to actionable guidance ("permission was denied", "your browser couldn't reach its push service - check that notifications or Google Play services aren't blocked"), and refuses to attempt a keyless subscribe when the server's VAPID key can't be loaded (which produced that same opaque error) in favour of a clear "couldn't load the push key" message.
+
 ## [1.0.2] - 2026-06-14
 
 ### Added

--- a/web/src/routes/notifications.redeem.tsx
+++ b/web/src/routes/notifications.redeem.tsx
@@ -52,7 +52,9 @@ async function getOrCreatePushSubscription(): Promise<PushSubscription | null> {
   if (existing) return existing;
 
   // Pull the deployment's VAPID public key from /v1/version. Browsers
-  // reject subscribe() without applicationServerKey.
+  // reject subscribe() without applicationServerKey, and Chrome's failure
+  // for a missing/undefined key is the opaque "Registration failed - push
+  // service error", so guard it explicitly with a clearer message.
   let appKey: BufferSource | undefined;
   try {
     const resp = await fetch("/v1/version");
@@ -63,13 +65,37 @@ async function getOrCreatePushSubscription(): Promise<PushSubscription | null> {
       }
     }
   } catch {
-    // ignore; fall through
+    // ignore; handled by the missing-key check below
+  }
+  if (!appKey) {
+    throw new Error(
+      "Couldn't load this server's push key. Refresh and try again; if it " +
+        "keeps failing, web push may not be configured on this instance.",
+    );
   }
 
   return reg.pushManager.subscribe({
     userVisibleOnly: true,
     applicationServerKey: appKey,
   });
+}
+
+// The browser's own push-subscription failures surface as opaque DOMException
+// messages (e.g. Chrome's "Registration failed - push service error"). Map the
+// common ones to something actionable; fall back to the raw message otherwise.
+function pushErrorMessage(exc: unknown): string {
+  if (!(exc instanceof Error)) return String(exc);
+  const name = (exc as { name?: string }).name;
+  if (name === "NotAllowedError") {
+    return "Notification permission was denied. Allow notifications for this site, then try again.";
+  }
+  if (name === "AbortError" || /push service/i.test(exc.message)) {
+    return (
+      "Your browser couldn't reach its push service. Check that notifications " +
+      "(and Google Play services, on Android) aren't blocked or offline, then try again."
+    );
+  }
+  return exc.message;
 }
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
@@ -161,10 +187,11 @@ export function NotificationsRedeemPage() {
         managementUrl: resp.management_url,
       });
     } catch (exc) {
-      setPhase({
-        kind: "error",
-        message: exc instanceof Error ? exc.message : String(exc),
-      });
+      // The browser's push failures are opaque and otherwise leave nothing to
+      // debug, so log the raw exception (name + stack) to the console and show
+      // a mapped, actionable message in the UI.
+      console.error("Web push subscription failed:", exc);
+      setPhase({ kind: "error", message: pushErrorMessage(exc) });
     }
   }
 


### PR DESCRIPTION
From a user report: subscribing to web push showed `Registration failed - push service error` with nothing in the console to debug, while the network request returned 200.

That string is the **browser's own** error from `pushManager.subscribe()` (Chrome's message when it can't register with its push backend / FCM) - not a Sheaf response. The 200 request was the separate `/v1/version` VAPID-key fetch. The redeem page displayed the raw browser message and logged nothing, so it was undebuggable. Not reproducible in-house because it's environment-specific (the reporter's browser/network couldn't reach its push service - de-Googled Chromium, blocked FCM, etc.).

Changes (frontend only, `notifications.redeem.tsx`):
- **Log the full exception** (name + stack) to the console - closes the "nothing to debug" gap.
- **Map common failures to actionable messages:** `NotAllowedError` -> permission denied; `AbortError` / "push service" -> "your browser couldn't reach its push service - check that notifications or Google Play services aren't blocked". Unknown errors still fall back to the raw message.
- **Refuse a keyless subscribe:** if the VAPID key can't be loaded from `/v1/version`, the old code fell through to `subscribe({ applicationServerKey: undefined })`, which Chrome rejects with that *same* opaque error. It now throws a clear "couldn't load the push key" instead.

Success path is unchanged. This makes the next report self-diagnosing rather than a mystery. For 1.0.3.

Verification: tsc + eslint clean.