### PR TITLE
Allow banners/ prefix in the selfhost image worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 `v1.0.0` is the first stable release. The `v0.x.y` releases were betas; from 1.0 on, the v1 API and database schema carry semver compatibility guarantees.
 
+## [Unreleased]
+
+### Fixed
+
+- **Member banners 403 behind the image worker.** Banner images are stored under a new `banners/` storage prefix (added in 1.0.2), but the bundled `selfhost-utils/cf-image-worker` allowlist (`ALLOWED_KEY_PREFIXES`) still only permitted `avatars/,bios/`, so the worker rejected every banner with a 403 before reaching S3. The bundled default now includes `banners/`. **Selfhost operators running the image worker must add `banners/` to their `ALLOWED_KEY_PREFIXES`** (redeploy the worker) for member banners to load.
+
 ## [1.0.2] - 2026-06-14
 
 ### Added

--- a/selfhost-utils/cf-image-worker/wrangler.toml
+++ b/selfhost-utils/cf-image-worker/wrangler.toml
@@ -13,8 +13,8 @@ S3_REGION = "us-east-1"
 S3_ENDPOINT = ""
 # Optional whitelist — only keys starting with one of these prefixes are
 # served. Comma-separated. Leave unset to allow any key the token validates.
-# Recommended: "avatars/,bios/"
-ALLOWED_KEY_PREFIXES = "avatars/,bios/"
+# Recommended: "avatars/,bios/,banners/"
+ALLOWED_KEY_PREFIXES = "avatars/,bios/,banners/"
 
 # Secrets below are set via `wrangler secret put <NAME>`, not here.
 # Required secrets:


### PR DESCRIPTION
Member banners (1.0.2) are stored under a new `banners/` storage prefix, but the bundled `selfhost-utils/cf-image-worker` allowlist (`ALLOWED_KEY_PREFIXES`) still only permitted `avatars/,bios/` - so the worker 403s every banner before the S3 fetch (`isAllowedKey()` runs before fetch). Same root cause hit the hosted deployment; this keeps the bundled worker in sync.

Adds `banners/` to the bundled default in `wrangler.toml`. **Selfhost operators running the image worker must add `banners/` to their own `ALLOWED_KEY_PREFIXES` and redeploy** for member banners to load - called out in the changelog.

For 1.0.3.