### PR TITLE
Normalise mis-ordered front intervals on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 ### Fixed
 
 - **Clearer errors when browser-push subscription fails.** When a recipient subscribes to web push, the browser's own `pushManager.subscribe()` can fail with an opaque message (e.g. Chrome's "Registration failed - push service error") if it can't reach its push backend - and the redeem page showed that raw string with nothing logged for debugging. The page now logs the full exception to the console, maps the common failures to actionable guidance ("permission was denied", "your browser couldn't reach its push service - check that notifications or Google Play services aren't blocked"), and refuses to attempt a keyless subscribe when the server's VAPID key can't be loaded (which produced that same opaque error) in favour of a clear "couldn't load the push key" message.
+- **Imports no longer abort on a front whose end is before its start.** Some exports (notably SimplyPlural) carry a front-history entry whose end timestamp precedes its start. Since 1.0.2 the `ck_fronts_ended_after_started` DB constraint rejects those, which aborted the entire import job. Every importer (SimplyPlural, PluralKit, Tupperbox, PluralSpace, Prism, and Sheaf native re-import) now normalises a mis-ordered interval by swapping the two timestamps - the most data-preserving fix, keeping the interval's duration - and records a per-import warning so the affected entries can be reviewed.
 
 ## [1.0.2] - 2026-06-14
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -22,9 +22,26 @@ Yes. Export your data from SimplyPlural, then use the import feature in Sheaf. Y
 
 Yes, both ways: upload a `pk;export` JSON file, or paste the token from `pk;token` to pull live from the PluralKit API. PK's switch log is converted into Sheaf's front-interval model, and each member's PK HID is stored on the imported member so you can keep cross-referencing between the two. Tokens are forwarded once and never stored. See [docs/IMPORT.md](docs/IMPORT.md) for details.
 
+### Can I import my data from other system trackers?
+
+Yes. Export your data, then use the import feature in Sheaf. You can choose exactly what to import — specific members, front history, custom fields, groups, etc.
+
+We currently support imports from:
+
+* Simply Plural
+* PluralKit
+* Tupperbox
+* Octocon and compatible forks
+* Plural Space
+* Prism Pluram
+
 ### Does Sheaf have mobile apps?
 
-Yes, iOS and Android apps are in development.
+Yes, iOS and Android apps are available, and also include wearables (WearOS/WatchOS support)?
+
+### What about a client for $insert_platform_here? 
+
+Not currently, but Sheaf is designed to support custom clients with full first-party feature support via an open API. See [docs/CLIENT_DESIGN.md](docs/CLIENT_DESIGN.md) for details. Build a new client and show us!
 
 ## Self-Hosting
 
@@ -52,7 +69,7 @@ No. The AGPL only applies when run for the public. There are no such restriction
 
 ### Is my data encrypted?
 
-Application-level encryption protects email addresses and TOTP secrets at rest. Beyond that, you should encrypt your server's disk (LUKS, encrypted EBS volumes, etc). See the Security section of the README for details.
+Application-level encryption protects sensitive data such as member data, email addresses, and TOTP secrets at rest. Beyond that, you should encrypt your server's disk (LUKS, encrypted EBS volumes, etc). See the Security section of the README for details.
 
 ### Can I use a cloud database instead of the Docker one?
 
@@ -70,11 +87,11 @@ The biggest realworld risk is probably of a hosted instance shutting down due to
 
 On a self-hosted instance: only what you put in. There is no telemetry, no analytics, no phoning home.
 
-A future hosted service would collect only what's needed to provide the service (account email, your system data). No selling data, no ads, ever.
+On our hosted instance (app.sheaf.sh), this is the same - only what's needed to provide the service (account email, your system data). No selling data, no ads, ever.
 
 ### Is Sheaf end-to-end encrypted?
 
-No. The server encrypts sensitive fields (email, TOTP secrets) at rest, but it holds the encryption key when running. This means a server operator *could* read data if they wanted to (they shouldn't, but technically could).
+No. The server encrypts sensitive fields (email, TOTP secrets, member data) at rest, but it holds the encryption key when running. This means a server operator *could* read data if they wanted to (they shouldn't, but technically could).
 
 True end-to-end encryption (where the server can't read your data at all) is a fundamentally different architecture that also makes features like server-side search impossible. If you want that level of protection, self-host, and secure the database with disk encryption at the server level where you control the encryption key yourself.
 
@@ -102,7 +119,9 @@ Yes! See [CONTRIBUTING.md](CONTRIBUTING.md). We welcome code contributions, bug 
 
 ### What contributions are you most interested in receiving?
 
-At this time, probably the web UI and Android app, although PRs are welcome for all aspects.
+At this time, probably the web UI and mobile apps, although PRs are welcome for all aspects. If you can not contribute code, bug reports and feedback are also welcome.
+
+If you speak a language other than English and are willing to discuss your background with the language (just as a basic quality filter) and commit to what we will admit is sometimes difficult and repetitive work but with a real impact, register your interest in translating Sheaf #i18n-translation on the Discord server or in GitHub discussions. i18n work represents a significant expenditure of our energy and time in a domain of software engineering we have never worked in before, where we will likely need to seek outside assistance, so we want to make 100% sure that we have enough people committed to working on it to make it worth our time.
 
 ## Terminology
 

--- a/sheaf/services/import_content_dedup.py
+++ b/sheaf/services/import_content_dedup.py
@@ -210,6 +210,24 @@ def front_key(
     return (started_at, ended_at, frozenset(member_ids))
 
 
+def normalize_front_interval(
+    started_at: datetime, ended_at: datetime | None
+) -> tuple[datetime, datetime | None, bool]:
+    """Ensure a closed front's end isn't before its start.
+
+    Source exports (notably SimplyPlural) occasionally carry a front whose
+    end timestamp precedes its start - transposed or otherwise corrupt data.
+    The `ck_fronts_ended_after_started` DB constraint rejects those, which
+    would abort the whole import, so importers normalise first: swap the two
+    (the most data-preserving fix - it keeps the interval's duration and span)
+    and report it. Returns `(started_at, ended_at, swapped)`; open fronts
+    (ended_at is None) and already-ordered intervals pass through untouched.
+    """
+    if ended_at is not None and ended_at < started_at:
+        return ended_at, started_at, True
+    return started_at, ended_at, False
+
+
 async def load_journal_index(
     db: AsyncSession, system_id: uuid.UUID
 ) -> ContentMatchIndex:

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -49,6 +49,7 @@ from sheaf.services.import_content_dedup import (
     load_front_index,
     load_group_index,
     load_group_member_guard,
+    normalize_front_interval,
 )
 from sheaf.services.import_dedup import ImportConflictStrategy
 from sheaf.services.import_parsing import sanitize_external_avatar_url
@@ -312,6 +313,7 @@ async def import_switches(
 
     imported = 0
     skipped = 0
+    fronts_swapped = 0
     missing_hids: set[str] = set()
     dedupe = conflict_strategy != ImportConflictStrategy.CREATE
     front_index = (
@@ -340,6 +342,9 @@ async def import_switches(
             continue
 
         ended_at = parsed[i + 1][0] if i + 1 < len(parsed) else None
+        ts, ended_at, swapped = normalize_front_interval(ts, ended_at)
+        if swapped:
+            fronts_swapped += 1
         if dedupe:
             fkey = front_key(ts, ended_at, {m.id for m in members})
             if front_index.get(fkey) is not None:
@@ -365,6 +370,12 @@ async def import_switches(
         warnings.append(
             f"Skipped {len(missing_hids)} member references in switch history "
             "that pointed to members not selected for import."
+        )
+    if fronts_swapped:
+        warnings.append(
+            f"Adjusted {fronts_swapped} switch "
+            f"{'interval' if fronts_swapped == 1 else 'intervals'} whose end "
+            "time was before the start time (swapped the two)."
         )
 
     return imported, skipped, warnings

--- a/sheaf/services/pluralspace_import.py
+++ b/sheaf/services/pluralspace_import.py
@@ -106,6 +106,7 @@ from sheaf.services.import_content_dedup import (
     load_journal_index,
     load_message_count_index,
     load_poll_index,
+    normalize_front_interval,
 )
 from sheaf.services.import_dedup import (
     ImportConflictStrategy,
@@ -900,6 +901,7 @@ async def _import_fronts(
     )
     unknown_types: set[str] = set()
     missing_members = 0
+    fronts_swapped = 0
     for f_data in fronts_in:
         if not isinstance(f_data, dict):
             continue
@@ -915,6 +917,11 @@ async def _import_fronts(
         if member is None:
             missing_members += 1
             continue
+        started_at, ended_at, swapped = normalize_front_interval(
+            started_at, ended_at
+        )
+        if swapped:
+            fronts_swapped += 1
         if dedupe:
             fkey = front_key(started_at, ended_at, {member.id})
             if front_index.get(fkey) is not None:
@@ -949,6 +956,12 @@ async def _import_fronts(
             "Front entry types other than 'front' were preserved as basic "
             f"fronts (saw: {', '.join(sorted(unknown_types))}). PluralSpace's "
             "type taxonomy doesn't fully map to Sheaf today."
+        )
+    if fronts_swapped:
+        warnings.append(
+            f"Adjusted {fronts_swapped} front "
+            f"{'entry' if fronts_swapped == 1 else 'entries'} whose end time "
+            "was before the start time (swapped the two)."
         )
     return imported, skipped
 

--- a/sheaf/services/prism_import.py
+++ b/sheaf/services/prism_import.py
@@ -111,6 +111,7 @@ from sheaf.services.import_content_dedup import (
     load_journal_index,
     load_message_count_index,
     load_poll_index,
+    normalize_front_interval,
 )
 from sheaf.services.import_dedup import (
     ImportConflictStrategy,
@@ -772,6 +773,7 @@ async def _import_front_sessions(
         await load_front_index(db, system_id) if dedupe else ContentMatchIndex()
     )
     missing = 0
+    fronts_swapped = 0
     for s in sessions_in:
         if not isinstance(s, dict):
             continue
@@ -788,6 +790,11 @@ async def _import_front_sessions(
         if handle is None:
             missing += 1
             continue
+        started_at, ended_at, swapped = normalize_front_interval(
+            started_at, ended_at
+        )
+        if swapped:
+            fronts_swapped += 1
         if dedupe:
             fkey = front_key(started_at, ended_at, {handle.member.id})
             if front_index.get(fkey) is not None:
@@ -811,6 +818,12 @@ async def _import_front_sessions(
     if missing:
         warnings.append(
             f"Skipped {missing} front sessions whose headmate wasn't imported."
+        )
+    if fronts_swapped:
+        warnings.append(
+            f"Adjusted {fronts_swapped} front "
+            f"{'session' if fronts_swapped == 1 else 'sessions'} whose end "
+            "time was before the start time (swapped the two)."
         )
     return imported, skipped
 

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -87,6 +87,7 @@ from sheaf.services.import_content_dedup import (
     load_revision_index,
     load_tag_index,
     load_watch_token_index,
+    normalize_front_interval,
 )
 from sheaf.services.import_dedup import (
     ImportConflictStrategy,
@@ -714,6 +715,7 @@ async def run_import(
         front_index = (
             await load_front_index(db, system.id) if dedupe else ContentMatchIndex()
         )
+        fronts_swapped = 0
         for f_data in data.get("fronts", []):
             started_at = _parse_iso(f_data.get("started_at"))
             if not started_at:
@@ -730,6 +732,12 @@ async def run_import(
             ]
             if not front_member_ids:
                 continue
+
+            started_at, ended_at, swapped = normalize_front_interval(
+                started_at, ended_at
+            )
+            if swapped:
+                fronts_swapped += 1
 
             # Dedup key: same interval, same (resolved) member set.
             # Works because skipped members resolve onto their existing
@@ -763,6 +771,12 @@ async def run_import(
                     )
                 )
             result.fronts_imported += 1
+        if fronts_swapped:
+            warnings.append(
+                f"Adjusted {fronts_swapped} front "
+                f"{'entry' if fronts_swapped == 1 else 'entries'} whose end "
+                "time was before the start time (swapped the two)."
+            )
 
     # --- Journals ---
     if journals:

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -47,6 +47,7 @@ from sheaf.services.import_content_dedup import (
     load_group_index,
     load_group_member_guard,
     load_message_count_index,
+    normalize_front_interval,
 )
 from sheaf.services.import_dedup import (
     ImportConflictStrategy,
@@ -632,6 +633,7 @@ async def run_import(
         # Live/current fronts live under `fronters` in some exports; fall back to
         # it when `frontHistory` is absent (rows carry member + startTime, no
         # endTime, so they map to open fronts).
+        fronts_swapped = 0
         for sp_f in _get_collection_alt(data, "frontHistory", "fronters"):
             sp_member_id = sp_f.get("member")
             if not sp_member_id:
@@ -653,6 +655,10 @@ async def run_import(
             is_live = sp_f.get("live", False)
             if is_live:
                 ended = None
+
+            started, ended, swapped = normalize_front_interval(started, ended)
+            if swapped:
+                fronts_swapped += 1
 
             if dedupe:
                 fkey = front_key(started, ended, {member.id})
@@ -690,6 +696,12 @@ async def run_import(
             warnings.append(
                 f"Skipped {fronts_bad_timestamp} front-history rows with a "
                 "missing or unparseable startTime."
+            )
+        if fronts_swapped:
+            warnings.append(
+                f"Adjusted {fronts_swapped} front-history "
+                f"{'entry' if fronts_swapped == 1 else 'entries'} whose end "
+                "time was before the start time (swapped the two)."
             )
 
     # --- Notes (skipped until journal feature) ---

--- a/tests/test_front_interval_normalize.py
+++ b/tests/test_front_interval_normalize.py
@@ -1,0 +1,42 @@
+"""Unit tests for normalize_front_interval (import_content_dedup).
+
+Pure-function tests, no stack needed. The helper is the shared guard every
+importer applies before persisting a front so a source export whose end time
+precedes its start can't violate the ck_fronts_ended_after_started constraint
+and abort the whole import.
+"""
+
+from datetime import UTC, datetime
+
+from sheaf.services.import_content_dedup import normalize_front_interval
+
+
+def _dt(hour: int) -> datetime:
+    return datetime(2026, 1, 1, hour, 0, tzinfo=UTC)
+
+
+def test_swaps_when_end_before_start():
+    started, ended, swapped = normalize_front_interval(_dt(10), _dt(9))
+    assert swapped is True
+    assert started == _dt(9)
+    assert ended == _dt(10)
+
+
+def test_ordered_interval_untouched():
+    started, ended, swapped = normalize_front_interval(_dt(9), _dt(10))
+    assert swapped is False
+    assert (started, ended) == (_dt(9), _dt(10))
+
+
+def test_equal_endpoints_allowed():
+    # ended == started satisfies the >= constraint; no swap.
+    started, ended, swapped = normalize_front_interval(_dt(9), _dt(9))
+    assert swapped is False
+    assert (started, ended) == (_dt(9), _dt(9))
+
+
+def test_open_front_untouched():
+    started, ended, swapped = normalize_front_interval(_dt(9), None)
+    assert swapped is False
+    assert started == _dt(9)
+    assert ended is None

--- a/tests/test_imports_tb_sp_runner.py
+++ b/tests/test_imports_tb_sp_runner.py
@@ -224,6 +224,36 @@ def test_sp_warns_when_front_history_member_missing(auth_client: httpx.Client):
     ), warnings
 
 
+def test_sp_swaps_front_with_end_before_start(auth_client: httpx.Client):
+    # A front whose end precedes its start would violate the
+    # ck_fronts_ended_after_started DB constraint and abort the whole import.
+    # The importer must normalise it (swap the two) and warn, not crash.
+    payload = _sp_payload(
+        frontHistory=[
+            {
+                "_id": "fh-swap",
+                "member": "spm1",
+                "startTime": 1_700_000_100_000,
+                "endTime": 1_700_000_000_000,  # 100s BEFORE startTime
+            },
+        ],
+    )
+    job = _post_file(
+        auth_client,
+        source="simplyplural_file",
+        payload=payload,
+        options={"front_history": True},
+    )
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert any(
+        "before the start time" in w and "swapped" in w
+        for w in _warnings(final["events"])
+    ), final["events"]
+
+
 def test_sp_warns_when_group_members_or_parent_missing(auth_client: httpx.Client):
     payload = _sp_payload(
         groups=[


### PR DESCRIPTION
Reported on a SimplyPlural import: a front-history entry whose **end is before its start**. Since 1.0.2 the `ck_fronts_ended_after_started` DB constraint rejects those, so the whole import job aborted.

Fix: a shared `normalize_front_interval(started, ended) -> (started, ended, swapped)` helper (beside `front_key` in `import_content_dedup`) swaps a mis-ordered pair - the most data-preserving fix, keeping the interval's duration - and reports it. Applied before the dedup key and `Front()` construction in **every** importer that builds fronts:

- **SimplyPlural** (the reported case), **PluralSpace**, **Prism** - take explicit export timestamps, the real exposure.
- **PluralKit**, **Sheaf native re-import** - derive ordered intervals so won't trip it, but carry the guard for uniformity.
- Tupperbox / Ampersand have no front history; the with-images archive importer inherits via `sheaf_import`.

Each importer counts swaps and emits one per-import warning so the affected entries can be reviewed (swap is recoverable - the user can edit later).

Tests: a stack-free unit test of the helper (swap / ordered / equal / open cases) and an SP runner integration test that a front with end-before-start now imports **complete** with a swap warning instead of aborting the job.

For 1.0.3. Verification: ruff clean; unit test passes locally; the SP integration test runs in the docker suite on CI.