### PR TITLE
Add security-event log and admin IP search tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Security-event log and admin IP search.** The auth funnel (logins with every success/failure outcome, registrations, password-reset requests/completions, and self-service password changes) is now recorded to an append-only `security_events` table with the originating client IP, so an operator can answer questions the per-account lockout counter and Prometheus aggregates can't: "is this IP credential-stuffing?" (one IP failing against many distinct accounts), "show me everything from this IP or subnet", and "what happened on this account before the takeover report came in?". Three admin tools sit on top: `POST /v1/admin/security/ip-lookup` (exact IP or CIDR subnet, with the distinct accounts seen from there), `GET /v1/admin/security/stuffing` (top failing IPs in a window, ranked by distinct accounts targeted), and `POST /v1/admin/users/{id}/security-events` (one account's auth timeline). The two reads that target a specific IP or account require a reason and write an admin audit row, like dossier export; the aggregate stuffing view is an operational read. Rows age out via a daily cleanup job after `SECURITY_EVENT_RETENTION_DAYS` (default 30) - IP is personal data, so retention is a bounded investigation window, not a permanent archive. Failed logins against a non-existent account record no account link and never store the attempted address. Admin audit rows now also capture the acting admin's IP and user-agent, so an admin action from an unexpected origin is visible.
+
 ### Fixed
 
 - **Member banners 403 behind the image worker.** Banner images are stored under a new `banners/` storage prefix (added in 1.0.2), but the bundled `selfhost-utils/cf-image-worker` allowlist (`ALLOWED_KEY_PREFIXES`) still only permitted `avatars/,bios/`, so the worker rejected every banner with a 403 before reaching S3. The bundled default now includes `banners/`. **Selfhost operators running the image worker must add `banners/` to their `ALLOWED_KEY_PREFIXES`** (redeploy the worker) for member banners to load.

--- a/alembic/versions/l3m4n5o6p7q8_add_security_events.py
+++ b/alembic/versions/l3m4n5o6p7q8_add_security_events.py
@@ -1,0 +1,105 @@
+"""Add security_events log + IP/user-agent on admin_audit_events
+
+Revision ID: l3m4n5o6p7q8
+Revises: k0a1b2c3d4e5
+Create Date: 2026-06-17
+
+Append-only auth-funnel log (logins, registrations, password reset /
+change) with the originating client IP, for credential-stuffing
+detection and IP-based search. IP is INET (not String(45)) so subnet
+queries work. Also backfills admin_audit_events with ip/user_agent so
+admin actions can be checked for an unexpected origin.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "l3m4n5o6p7q8"
+down_revision: Union[str, None] = "k0a1b2c3d4e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_EVENT_TYPE_VALUES = (
+    "login",
+    "register",
+    "password_reset_request",
+    "password_reset_complete",
+    "password_change",
+)
+
+
+def upgrade() -> None:
+    event_type = postgresql.ENUM(
+        *_EVENT_TYPE_VALUES, name="security_event_type", create_type=True
+    )
+    event_type.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "security_events",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "event_type",
+            postgresql.ENUM(
+                *_EVENT_TYPE_VALUES,
+                name="security_event_type",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("outcome", sa.String(length=40), nullable=False),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("ip", postgresql.INET(), nullable=True),
+        sa.Column("user_agent", sa.Text(), nullable=True),
+        sa.Column("detail", postgresql.JSONB(), nullable=True),
+    )
+    op.create_index(
+        "ix_security_events_ip_created",
+        "security_events",
+        ["ip", "created_at"],
+    )
+    op.create_index(
+        "ix_security_events_user_created",
+        "security_events",
+        ["user_id", "created_at"],
+    )
+    op.create_index(
+        "ix_security_events_type_created",
+        "security_events",
+        ["event_type", "created_at", "ip"],
+    )
+
+    op.add_column(
+        "admin_audit_events",
+        sa.Column("ip", postgresql.INET(), nullable=True),
+    )
+    op.add_column(
+        "admin_audit_events",
+        sa.Column("user_agent", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("admin_audit_events", "user_agent")
+    op.drop_column("admin_audit_events", "ip")
+    op.drop_index("ix_security_events_type_created", table_name="security_events")
+    op.drop_index("ix_security_events_user_created", table_name="security_events")
+    op.drop_index("ix_security_events_ip_created", table_name="security_events")
+    op.drop_table("security_events")
+    postgresql.ENUM(name="security_event_type").drop(
+        op.get_bind(), checkfirst=True
+    )

--- a/alembic/versions/m4n5o6p7q8r9_add_admin_audit_security_views.py
+++ b/alembic/versions/m4n5o6p7q8r9_add_admin_audit_security_views.py
@@ -1,0 +1,41 @@
+"""Add security-view actions to admin_audit_action
+
+Revision ID: m4n5o6p7q8r9
+Revises: l3m4n5o6p7q8
+Create Date: 2026-06-17
+
+Two new enum values for auditing privacy-sensitive reads of the new
+security-event log:
+
+  - security_ip_lookup: admin searched activity by IP / subnet.
+  - security_history_view: admin viewed one account's security events.
+
+Kept in its own migration because ALTER TYPE ... ADD VALUE cannot run
+inside a transaction block alongside the table DDL.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "m4n5o6p7q8r9"
+down_revision: Union[str, None] = "l3m4n5o6p7q8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+    op.execute("COMMIT")
+    op.execute(
+        "ALTER TYPE admin_audit_action ADD VALUE IF NOT EXISTS 'security_ip_lookup'"
+    )
+    op.execute(
+        "ALTER TYPE admin_audit_action ADD VALUE IF NOT EXISTS 'security_history_view'"
+    )
+
+
+def downgrade() -> None:
+    # Postgres has no DROP VALUE; leave the type widened (idempotent on
+    # re-upgrade), matching the other enum-extension migrations.
+    pass

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -770,7 +770,21 @@ RATE_LIMIT_HISTORY_HOURS=48          # retention window
 RATE_LIMIT_HISTORY_MAX_ENTRIES=200   # cap per user
 ```
 
-Set `RATE_LIMIT_HISTORY_ENABLED=false` to record nothing new; anything recorded before the switch remains visible until its retention TTL lapses. Anonymous traffic (failed logins from logged-out clients, the global per-IP backstop) is not attributable to an account and is never recorded here - the Prometheus metrics cover those in aggregate.
+Set `RATE_LIMIT_HISTORY_ENABLED=false` to record nothing new; anything recorded before the switch remains visible until its retention TTL lapses. Anonymous traffic (failed logins from logged-out clients, the global per-IP backstop) is not attributable to an account and is never recorded *here* - the Prometheus metrics cover it in aggregate, and the security-event log below records failed logins (with IP) durably for abuse investigation.
+
+### Security-event log
+
+The auth funnel - logins (success and every failure reason), registrations, password-reset requests/completions, and self-service password changes - is recorded to an append-only `security_events` table in Postgres, each row carrying the originating client IP and user-agent. Unlike the per-user hit history above, this captures anonymous failures too: a failed login against a non-existent account is recorded with no account link, and the attempted address is never stored. That is what lets an operator spot credential stuffing and account-takeover attempts the per-account lockout and aggregate metrics miss.
+
+Three admin endpoints read it: `POST /v1/admin/security/ip-lookup` (everything seen from an exact IP or CIDR subnet), `GET /v1/admin/security/stuffing` (top failing IPs in a window, ranked by how many distinct accounts each targeted), and `POST /v1/admin/users/{id}/security-events` (one account's auth timeline). The two per-target reads require a reason and write an admin audit row. Admin audit rows themselves now also record the acting admin's IP and user-agent, so an admin action from an unexpected origin is visible.
+
+IP addresses are personal data, so rows age out automatically rather than accumulating:
+
+```env
+SECURITY_EVENT_RETENTION_DAYS=30   # delete security-event rows older than this
+```
+
+If you run a public instance, this is new processing of personal data (client IPs tied to authentication events): make sure your privacy policy covers logging IP and device information for security and abuse prevention, and states the retention period.
 
 ### Trusted proxies
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -41,6 +41,24 @@ if [[ "${1:-}" == "--no-build" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Single-runner lock
+# ---------------------------------------------------------------------------
+# The test stack is a singleton: a fixed compose project (sheaf-test) on
+# fixed host ports (8001/5433/6380). Two runs from different checkouts
+# race on those ports and the shared volumes and wedge each other. Take a
+# system-wide advisory lock before touching the stack so concurrent runs
+# queue instead of colliding. fd stays open for the life of the script;
+# the lock releases automatically on exit. Override the path with
+# SHEAF_TEST_LOCK if /tmp isn't shared between your checkouts.
+LOCK_FILE="${SHEAF_TEST_LOCK:-/tmp/sheaf-test-stack.lock}"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "Another test run holds the stack lock ($LOCK_FILE); waiting..."
+    flock 9
+fi
+echo "Acquired test-stack lock ($LOCK_FILE)."
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/sheaf/api/v1/admin_security.py
+++ b/sheaf/api/v1/admin_security.py
@@ -1,0 +1,250 @@
+"""Admin search over the security-event log.
+
+Three tools, all backed by the `security_events` table:
+
+  - POST /admin/security/ip-lookup    everything from an IP / subnet
+  - GET  /admin/security/stuffing     top failing IPs (credential stuffing)
+  - POST /admin/users/{id}/security-events   one account's auth timeline
+
+The two reads that target a specific IP or account expose user activity
++ IP, so they are write-gated, require a reason, and write an admin audit
+row - same treatment as dossier export. The stuffing view is an
+aggregate over IPs (no single user's data), so it follows the
+non-audited operational-read convention (like the rate-limit history).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_admin_user, get_admin_write_user
+from sheaf.database import get_db
+from sheaf.models.admin_audit_event import AdminAuditAction, AdminAuditTargetType
+from sheaf.models.security_event import SecurityEvent
+from sheaf.models.user import User
+from sheaf.services.admin_audit import log_admin_action
+from sheaf.services.security_events import (
+    accounts_seen_from_ip,
+    events_for_ip,
+    events_for_user,
+    stuffing_offenders,
+)
+
+router = APIRouter(prefix="/admin", tags=["admin security"])
+
+
+class AdminReasonBody(BaseModel):
+    """Required free-form reason captured on the audit row."""
+
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class IpLookupBody(AdminReasonBody):
+    # Exact IP ("203.0.113.7") or CIDR subnet ("203.0.113.0/24").
+    target: str = Field(min_length=1, max_length=64)
+
+
+class SecurityEventRow(BaseModel):
+    id: uuid.UUID
+    created_at: datetime
+    event_type: str
+    outcome: str
+    user_id: uuid.UUID | None
+    ip: str | None
+    user_agent: str | None
+    detail: dict | None
+
+
+def _row(e: SecurityEvent) -> SecurityEventRow:
+    return SecurityEventRow(
+        id=e.id,
+        created_at=e.created_at,
+        event_type=str(e.event_type),
+        outcome=e.outcome,
+        user_id=e.user_id,
+        ip=str(e.ip) if e.ip is not None else None,
+        user_agent=e.user_agent,
+        detail=e.detail,
+    )
+
+
+class IpLookupResponse(BaseModel):
+    query: str
+    is_subnet: bool
+    event_count: int
+    events: list[SecurityEventRow]
+    # Distinct known accounts that appear in events from here - the
+    # ban-evasion / shared-IP signal.
+    distinct_account_ids: list[uuid.UUID]
+    # Accounts whose recorded signup IP is exactly this address. Only
+    # populated for exact-IP queries: signup_ip is a plain string column,
+    # so it can't be subnet-matched.
+    signup_match_ids: list[uuid.UUID]
+    note: str
+
+
+class StuffingRow(BaseModel):
+    ip: str
+    distinct_accounts: int
+    failures: int
+    last_seen: datetime
+
+
+class StuffingResponse(BaseModel):
+    since: datetime
+    window_hours: int
+    min_failures: int
+    offenders: list[StuffingRow]
+
+
+class UserSecurityHistoryResponse(BaseModel):
+    user_id: uuid.UUID
+    event_count: int
+    events: list[SecurityEventRow]
+
+
+def _parse_target(target: str) -> tuple[str, bool]:
+    """Validate the lookup target and report whether it's a subnet.
+
+    Rejecting non-IP input here keeps malformed values from reaching the
+    INET cast (which would 500) and bounds what the query can express.
+    """
+    if "/" in target:
+        try:
+            ipaddress.ip_network(target, strict=False)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid CIDR subnet",
+            ) from exc
+        return target, True
+    try:
+        ipaddress.ip_address(target)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid IP address",
+        ) from exc
+    return target, False
+
+
+@router.post("/security/ip-lookup", response_model=IpLookupResponse)
+async def ip_lookup(
+    body: IpLookupBody,
+    admin: User = Depends(get_admin_write_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Everything the security log knows about an IP or subnet."""
+    target, is_subnet = _parse_target(body.target)
+
+    events = await events_for_ip(db, target)
+    account_ids = await accounts_seen_from_ip(db, target)
+
+    signup_match_ids: list[uuid.UUID] = []
+    if not is_subnet:
+        result = await db.execute(
+            select(User.id).where(User.signup_ip == target)
+        )
+        signup_match_ids = list(result.scalars().all())
+
+    note = (
+        "Live sessions and trusted-device IPs are not searchable by IP "
+        "(session IPs live in Redis without an IP index); this covers the "
+        "security-event log plus exact signup-IP matches."
+    )
+
+    await log_admin_action(
+        db,
+        admin=admin,
+        action=AdminAuditAction.SECURITY_IP_LOOKUP,
+        target_type=AdminAuditTargetType.SYSTEM,
+        reason=body.reason,
+        after={
+            "query": target,
+            "is_subnet": is_subnet,
+            "event_count": len(events),
+            "distinct_accounts": len(account_ids),
+        },
+    )
+    await db.commit()
+
+    return IpLookupResponse(
+        query=target,
+        is_subnet=is_subnet,
+        event_count=len(events),
+        events=[_row(e) for e in events],
+        distinct_account_ids=account_ids,
+        signup_match_ids=signup_match_ids,
+        note=note,
+    )
+
+
+@router.get("/security/stuffing", response_model=StuffingResponse)
+async def stuffing(
+    hours: int = Query(default=24, ge=1, le=720),
+    min_failures: int = Query(default=10, ge=1, le=10_000),
+    limit: int = Query(default=50, ge=1, le=500),
+    _: User = Depends(get_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Top IPs by failed-login volume - the credential-stuffing view.
+
+    Ordered by distinct accounts targeted (the stuffing fingerprint),
+    then raw failures (which surfaces single-account brute force and
+    unknown-user scanning too).
+    """
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    offenders = await stuffing_offenders(
+        db, since=since, min_failures=min_failures, limit=limit
+    )
+    return StuffingResponse(
+        since=since,
+        window_hours=hours,
+        min_failures=min_failures,
+        offenders=[StuffingRow(**o) for o in offenders],
+    )
+
+
+@router.post(
+    "/users/{user_id}/security-events",
+    response_model=UserSecurityHistoryResponse,
+)
+async def user_security_events(
+    user_id: uuid.UUID,
+    body: AdminReasonBody,
+    admin: User = Depends(get_admin_write_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """One account's security timeline, newest first."""
+    target = await db.get(User, user_id)
+    if target is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+
+    events = await events_for_user(db, user_id)
+
+    await log_admin_action(
+        db,
+        admin=admin,
+        action=AdminAuditAction.SECURITY_HISTORY_VIEW,
+        target_type=AdminAuditTargetType.USER,
+        target_id=user_id,
+        target_user_id=user_id,
+        reason=body.reason,
+        after={"event_count": len(events)},
+    )
+    await db.commit()
+
+    return UserSecurityHistoryResponse(
+        user_id=user_id,
+        event_count=len(events),
+        events=[_row(e) for e in events],
+    )

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -66,6 +66,7 @@ from sheaf.database import get_db
 from sheaf.image_processing import animation_allowed
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.api_key import ApiKey
+from sheaf.models.security_event import SecurityEventType
 from sheaf.models.system import DeleteConfirmation, System
 from sheaf.models.trusted_device import TrustedDevice
 from sheaf.models.user import AccountStatus, User, UserTier
@@ -89,6 +90,7 @@ from sheaf.schemas.user import (
     UserUpdate,
 )
 from sheaf.services import captcha
+from sheaf.services.security_events import record_security_event
 
 _VALID_SCOPES = {
     "system:read", "system:write",
@@ -399,6 +401,14 @@ async def register(
 
     await db.commit()
 
+    await record_security_event(
+        event_type=SecurityEventType.REGISTER,
+        outcome="success",
+        user_id=user.id,
+        ip=client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+
     response.set_cookie(
         key="sheaf_session",
         value=session_id,
@@ -610,7 +620,16 @@ async def request_password_reset(
         if user.password_reset_sent_at is not None:
             age = (datetime.now(UTC) - user.password_reset_sent_at).total_seconds()
             if age < settings.password_reset_rate_limit_minutes * 60:
-                # Still return 200 — don't reveal timing info
+                # Still return 200 - don't reveal timing info. Record the
+                # throttle: repeated reset requests for a real account from
+                # one IP are the abuse signal here.
+                await record_security_event(
+                    event_type=SecurityEventType.PASSWORD_RESET_REQUEST,
+                    outcome="throttled",
+                    user_id=user.id,
+                    ip=client_ip(request),
+                    user_agent=request.headers.get("user-agent"),
+                )
                 return {"requested": True}
 
         token = secrets.token_urlsafe(32)
@@ -620,6 +639,13 @@ async def request_password_reset(
 
         background.add_task(
             _deliver_password_reset_email, body.email, token, client_ip(request)
+        )
+        await record_security_event(
+            event_type=SecurityEventType.PASSWORD_RESET_REQUEST,
+            outcome="sent",
+            user_id=user.id,
+            ip=client_ip(request),
+            user_agent=request.headers.get("user-agent"),
         )
     else:
         # Symmetric work on the no-match branch so timing matches the
@@ -631,6 +657,12 @@ async def request_password_reset(
         token = secrets.token_urlsafe(32)
         hash_mail_token(token)
         await db.commit()
+        await record_security_event(
+            event_type=SecurityEventType.PASSWORD_RESET_REQUEST,
+            outcome="user_not_found",
+            ip=client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
 
     # Counted regardless of whether an email actually went out — the rate
     # at which reset is requested is the signal, not the email count
@@ -642,6 +674,7 @@ async def request_password_reset(
 @router.post("/reset-password", dependencies=[rate_limit(5, 60, fail_closed=True)])
 async def reset_password(
     body: PasswordReset,
+    request: Request,
     db: AsyncSession = Depends(get_db),
 ):
     """Reset password using a token from the password reset email."""
@@ -666,6 +699,12 @@ async def reset_password(
         # and purged" from "never existed" here, so both increment the same
         # stage; the requested-vs-completed funnel still tells the story.
         auth_password_reset_total.labels(stage="expired").inc()
+        await record_security_event(
+            event_type=SecurityEventType.PASSWORD_RESET_COMPLETE,
+            outcome="invalid_token",
+            ip=client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired reset token",
@@ -676,6 +715,13 @@ async def reset_password(
         age = (datetime.now(UTC) - user.password_reset_sent_at).total_seconds()
         if age > 3600:
             auth_password_reset_total.labels(stage="expired").inc()
+            await record_security_event(
+                event_type=SecurityEventType.PASSWORD_RESET_COMPLETE,
+                outcome="expired_token",
+                user_id=user.id,
+                ip=client_ip(request),
+                user_agent=request.headers.get("user-agent"),
+            )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Reset token has expired. Please request a new one.",
@@ -698,6 +744,13 @@ async def reset_password(
     await db.commit()
     await delete_all_user_sessions(user.id)
     auth_password_reset_total.labels(stage="completed").inc()
+    await record_security_event(
+        event_type=SecurityEventType.PASSWORD_RESET_COMPLETE,
+        outcome="success",
+        user_id=user.id,
+        ip=client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
     return {"reset": True}
 
 
@@ -707,6 +760,7 @@ async def reset_password(
 )
 async def change_password(
     body: PasswordChange,
+    request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     session_id: str | None = Cookie(default=None, alias="sheaf_session"),
@@ -718,6 +772,15 @@ async def change_password(
     cookie elsewhere can't survive the change; the calling session stays
     alive.
     """
+
+    async def _sec(outcome: str) -> None:
+        await record_security_event(
+            event_type=SecurityEventType.PASSWORD_CHANGE,
+            outcome=outcome,
+            user_id=user.id,
+            ip=client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
     if len(body.new_password) < 8:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -740,6 +803,7 @@ async def change_password(
 
     if not await verify_password(body.current_password, user.password_hash):
         await record_login_failure(db, user)
+        await _sec("password_incorrect")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Current password is incorrect",
@@ -747,6 +811,7 @@ async def change_password(
 
     if user.totp_enabled:
         if not body.totp_code:
+            await _sec("totp_required")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="TOTP code required",
@@ -756,6 +821,7 @@ async def change_password(
         totp_ok = await verify_code_once(user.id, secret, body.totp_code)
         if not totp_ok and not await _check_recovery_code(db, user, body.totp_code):
             await record_login_failure(db, user, reason="totp_failures")
+            await _sec("totp_invalid")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid TOTP code",
@@ -782,6 +848,7 @@ async def change_password(
     if session_id:
         revoked = await delete_other_sessions(user.id, session_id)
 
+    await _sec("success")
     return {"changed": True, "revoked_other_sessions": revoked}
 
 
@@ -897,8 +964,26 @@ async def login(
         default=None, alias=TRUSTED_DEVICE_COOKIE,
     ),
 ):
+    # Security-event origin, captured once. The outcome strings mirror
+    # the auth_logins_total metric labels so the durable log and the
+    # aggregate counter line up. user_id is passed when the account is
+    # known (NULL for unknown-email attempts, which we still want for
+    # the per-IP stuffing signal without storing the attempted address).
+    event_ip = client_ip(request)
+    event_ua = request.headers.get("user-agent")
+
+    async def _sec(outcome: str, user_id=None) -> None:
+        await record_security_event(
+            event_type=SecurityEventType.LOGIN,
+            outcome=outcome,
+            user_id=user_id,
+            ip=event_ip,
+            user_agent=event_ua,
+        )
+
     if captcha.required_for_login() and not captcha.verify(body.captcha):
         auth_logins_total.labels(outcome="captcha_failed").inc()
+        await _sec("captcha_failed")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Captcha verification failed",
@@ -916,18 +1001,21 @@ async def login(
             ensure_not_locked(user)
         except HTTPException:
             auth_logins_total.labels(outcome="locked").inc()
+            await _sec("locked", user.id)
             raise
 
     if user is None or not await verify_password(body.password, user.password_hash):
         if user is not None:
             await record_login_failure(db, user)
             auth_logins_total.labels(outcome="password_incorrect").inc()
+            await _sec("password_incorrect", user.id)
         else:
             # Spend an equivalent Argon2 verify so an unknown email can't
             # be distinguished from a wrong password by response latency.
             # `or` short-circuits, so verify_password never ran here.
             await dummy_verify()
             auth_logins_total.labels(outcome="user_not_found").inc()
+            await _sec("user_not_found")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
@@ -946,12 +1034,14 @@ async def login(
             if until is not None:
                 parts.append(f"until: {until.isoformat()}")
             auth_logins_total.labels(outcome="account_suspended").inc()
+            await _sec("account_suspended", user.id)
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="; ".join(parts),
             )
     if user.account_status == AccountStatus.BANNED:
         auth_logins_total.labels(outcome="account_banned").inc()
+        await _sec("account_banned", user.id)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Account banned",
@@ -971,6 +1061,7 @@ async def login(
         else:
             if not body.totp_code:
                 auth_logins_total.labels(outcome="totp_required").inc()
+                await _sec("totp_required", user.id)
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="TOTP code required",
@@ -987,6 +1078,7 @@ async def login(
                 else:
                     await record_login_failure(db, user, reason="totp_failures")
                     auth_logins_total.labels(outcome="totp_invalid").inc()
+                    await _sec("totp_invalid", user.id)
                     raise HTTPException(
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail="Invalid TOTP code",
@@ -1068,11 +1160,14 @@ async def login(
 
     if bypassed_via_trusted_device:
         auth_logins_total.labels(outcome="trusted_device_bypass").inc()
+        await _sec("trusted_device_bypass", user.id)
     elif recovery_code_used:
         auth_logins_total.labels(outcome="recovery_code_used").inc()
         auth_recovery_codes_used_total.inc()
+        await _sec("recovery_code_used", user.id)
     else:
         auth_logins_total.labels(outcome="success").inc()
+        await _sec("success", user.id)
 
     return TokenResponse(
         access_token=create_token(user.id, TokenType.ACCESS, session_id=session_id),

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -5,6 +5,7 @@ from sheaf.api.v1 import (
     admin,
     admin_audit,
     admin_emergency,
+    admin_security,
     admin_small_actions,
     analytics,
     announcements,
@@ -65,6 +66,11 @@ v1_router.include_router(admin_emergency.router)
 # terminate, force-rotate API keys, bulk-approve. Mix of read +
 # mutation; each endpoint enforces its own admin gate.
 v1_router.include_router(admin_small_actions.router)
+# Admin security-event search: IP/subnet lookup, credential-stuffing
+# view, per-account auth timeline. The per-IP / per-user reads require a
+# reason and are audited; the aggregate stuffing view is an operational
+# read.
+v1_router.include_router(admin_security.router)
 # Account-level (Article 15 etc.) — session/JWT auth only, body-gated
 # step-up. Lives outside the scope-gated section since API key access
 # is refused inline by the endpoint.

--- a/sheaf/auth/dependencies.py
+++ b/sheaf/auth/dependencies.py
@@ -13,6 +13,7 @@ from sheaf.auth.sessions import check_admin_step_up, get_session_user_id, touch_
 from sheaf.database import get_db
 from sheaf.models.user import AccountStatus, User
 from sheaf.request import client_ip
+from sheaf.request_context import set_request_origin
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -269,6 +270,9 @@ async def get_admin_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
         )
+    # Stamp the request origin so log_admin_action can record where this
+    # admin acted from without threading `request` through every caller.
+    set_request_origin(client_ip(request), request.headers.get("user-agent"))
     await _check_admin_step_up(request, user)
     return user
 
@@ -290,6 +294,9 @@ async def get_admin_write_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
         )
+    # Stamp the request origin so log_admin_action can record where this
+    # admin acted from without threading `request` through every caller.
+    set_request_origin(client_ip(request), request.headers.get("user-agent"))
     await _check_admin_step_up(request, user)
     return user
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -396,6 +396,14 @@ class Settings(BaseSettings):
     # single age cutoff covers everything in a done state.
     notification_outbox_retention_days: int = 30
 
+    # How long security-event rows (login attempts, registrations,
+    # password resets/changes, with originating IP) are kept before the
+    # cleanup sweep deletes them. IP is personal data, so a bounded
+    # window does the minimisation: long enough to investigate an abuse
+    # report that lands weeks late, short enough not to hoard. Operators
+    # with a longer legal basis can raise it; self-hosters set their own.
+    security_event_retention_days: int = 30
+
     # A job stuck in `running` longer than this is presumed orphaned by
     # a crashed worker; the recovery sweep resets it to `pending` for a
     # retry. Generous — a large PluralKit API import paginating switch

--- a/sheaf/models/admin_audit_event.py
+++ b/sheaf/models/admin_audit_event.py
@@ -33,6 +33,7 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from sheaf.models.base import Base, UUIDMixin
+from sheaf.models.types import InetStr
 
 
 class AdminAuditAction(enum.StrEnum):
@@ -60,6 +61,8 @@ class AdminAuditAction(enum.StrEnum):
     INVITE_CREATE = "invite_create"
     INVITE_DELETE = "invite_delete"
     JOB_TRIGGER = "job_trigger"                    # manual job / maintenance runs
+    SECURITY_IP_LOOKUP = "security_ip_lookup"      # searched security log by IP/subnet
+    SECURITY_HISTORY_VIEW = "security_history_view"  # viewed one account's security events
 
 
 class AdminAuditTargetType(enum.StrEnum):
@@ -147,3 +150,10 @@ class AdminAuditEvent(UUIDMixin, Base):
     # NOT a privacy regression — admin emails are already exposed via
     # the admin users listing.
     admin_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Where the admin acted from. Populated from the request-scoped
+    # client IP (see request_context) so an action from an unexpected
+    # origin is visible. INET for subnet queries; NULL if unresolved
+    # (e.g. an internal/job-triggered action with no request).
+    ip: Mapped[str | None] = mapped_column(InetStr, nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/sheaf/models/security_event.py
+++ b/sheaf/models/security_event.py
@@ -1,0 +1,110 @@
+"""Append-only security/auth event log.
+
+Records the auth funnel - logins (success + every failure reason),
+registrations, password-reset requests/completions, and self-service
+password changes - with the originating client IP, so an operator can
+answer questions the per-account lockout counter and Prometheus
+aggregates cannot:
+
+  - "Is this IP credential-stuffing?" (many distinct accounts failed
+    from one IP in a short window)
+  - "Show me everything from this IP / subnet"
+  - "What happened on this account before the takeover report came in?"
+
+Append-only by design: no UPDATE/DELETE endpoint. Rows age out via the
+`cleanup_security_events` job (see `security_event_retention_days`), so
+this is bounded PII retention, not an unbounded archive - IP is personal
+data and a short window does the minimisation work.
+
+IP is stored as Postgres INET (NOT the `String(45)` used by
+`User.signup_ip` / `TrustedDevice`). That is a deliberate departure: the
+whole point of this table is IP search *including subnet matching*
+(`ip <<= '203.0.113.0/24'`), which a string column cannot do natively.
+The departure is isolated to this table.
+
+Privacy note: failed logins against a non-existent account record
+`user_id = NULL` and never store the attempted email (plaintext or hash)
+- the IP and the `user_not_found` outcome are enough to spot scanning
+without retaining an identifier we'd then owe under a DSAR.
+"""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sheaf.models.base import Base, UUIDMixin
+from sheaf.models.types import InetStr
+
+
+class SecurityEventType(enum.StrEnum):
+    """Auth-funnel event categories. The fine-grained reason lives in
+    `outcome` (a free string) so new failure modes don't need a migration."""
+
+    LOGIN = "login"
+    REGISTER = "register"
+    PASSWORD_RESET_REQUEST = "password_reset_request"
+    PASSWORD_RESET_COMPLETE = "password_reset_complete"
+    PASSWORD_CHANGE = "password_change"
+
+
+class SecurityEvent(UUIDMixin, Base):
+    __tablename__ = "security_events"
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+    event_type: Mapped[SecurityEventType] = mapped_column(
+        # `name=...` must match the type the migration creates, else
+        # SQLAlchemy autoderives `securityeventtype` and INSERT fails.
+        Enum(
+            SecurityEventType,
+            name="security_event_type",
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+    )
+
+    # Fine-grained result: "success", "password_incorrect",
+    # "user_not_found", "totp_invalid", "locked", "account_suspended",
+    # "account_banned", "captcha_failed", "totp_required", "sent",
+    # "invalid_token", "expired_token". Free string by design.
+    outcome: Mapped[str] = mapped_column(String(40), nullable=False)
+
+    # The account involved, when known. NULL for unknown-user login
+    # attempts and reset requests for non-existent addresses. SET NULL
+    # so account deletion doesn't strand the abuse trail (those rows
+    # stop being the user's personal data the moment the link is cut).
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # Originating client IP as resolved by request.client_ip (trusted-
+    # proxy aware). INET so subnet queries work. Nullable: a malformed
+    # or absent peer address shouldn't drop the event.
+    ip: Mapped[str | None] = mapped_column(InetStr, nullable=True)
+
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Small structured extras (route, session handle, client name).
+    # Never carries member content or plaintext credentials/emails.
+    detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    __table_args__ = (
+        # "everything from this IP/subnet", newest first.
+        Index("ix_security_events_ip_created", "ip", "created_at"),
+        # one account's timeline.
+        Index("ix_security_events_user_created", "user_id", "created_at"),
+        # the stuffing scan: filter to login failures in a window, then
+        # group by IP. event_type + created_at narrows the scan; ip is
+        # carried so the group-by can be index-only-ish.
+        Index(
+            "ix_security_events_type_created", "event_type", "created_at", "ip"
+        ),
+    )

--- a/sheaf/models/types.py
+++ b/sheaf/models/types.py
@@ -1,0 +1,22 @@
+"""Custom SQLAlchemy column types."""
+
+from sqlalchemy.dialects.postgresql import INET
+from sqlalchemy.types import TypeDecorator
+
+
+class InetStr(TypeDecorator):
+    """Postgres ``INET`` that always reads back as a plain string.
+
+    The asyncpg driver decodes ``inet``/``cidr`` columns into Python
+    ``ipaddress`` objects, but the rest of the app (Pydantic response
+    models, ``==`` comparisons against request strings, logging) expects
+    a string. Normalise on the way out so a single integration point
+    handles it instead of every reader remembering to ``str()``. Writes
+    accept a string and let Postgres cast.
+    """
+
+    impl = INET
+    cache_ok = True
+
+    def process_result_value(self, value, dialect):
+        return str(value) if value is not None else None

--- a/sheaf/request_context.py
+++ b/sheaf/request_context.py
@@ -1,0 +1,39 @@
+"""Request-scoped context for cross-cutting metadata.
+
+A small contextvar carrying the resolved client IP for the current
+request. Set once by the admin auth dependencies (which already receive
+the Request and run in the endpoint's async task), then read by
+`log_admin_action` so every admin audit row can record the originating
+IP without threading `request` through ~two dozen call sites.
+
+Deliberately set in a dependency, NOT in a BaseHTTPMiddleware: contextvar
+writes inside Starlette's BaseHTTPMiddleware do not reliably propagate
+down to the endpoint (it runs the handler in a separate anyio task), so
+middleware-set contextvars read back as the default. Dependencies run in
+the same task as the path operation, so the value is visible to the
+endpoint and anything it awaits.
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+_client_ip: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "client_ip", default=None
+)
+_user_agent: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "user_agent", default=None
+)
+
+
+def set_request_origin(ip: str | None, user_agent: str | None) -> None:
+    _client_ip.set(ip)
+    _user_agent.set(user_agent or None)
+
+
+def get_client_ip() -> str | None:
+    return _client_ip.get()
+
+
+def get_user_agent() -> str | None:
+    return _user_agent.get()

--- a/sheaf/schemas/admin_audit.py
+++ b/sheaf/schemas/admin_audit.py
@@ -23,6 +23,11 @@ class AdminAuditEventRead(BaseModel):
     before_json: dict[str, Any] | None
     after_json: dict[str, Any] | None
     created_at: datetime
+    # Where the admin acted from. Admin-surface only - deliberately not
+    # on UserAdminActivityRead, since the admin's origin isn't the
+    # affected user's to see.
+    ip: str | None = None
+    user_agent: str | None = None
 
     model_config = {"from_attributes": True}
 

--- a/sheaf/services/admin_audit.py
+++ b/sheaf/services/admin_audit.py
@@ -22,6 +22,7 @@ from sheaf.models.admin_audit_event import (
     AdminAuditTargetType,
 )
 from sheaf.models.user import User
+from sheaf.request_context import get_client_ip, get_user_agent
 
 
 def _safe_decrypt_email(user: User) -> str | None:
@@ -69,6 +70,11 @@ async def log_admin_action(
         after_json=after,
         created_at=datetime.now(UTC),
         admin_email=_safe_decrypt_email(admin),
+        # Request-scoped origin, set by the admin auth dependency. NULL
+        # for actions with no request context (e.g. the suspension sweep
+        # writing USER_UNSUSPEND from a background job).
+        ip=get_client_ip(),
+        user_agent=get_user_agent(),
     )
     db.add(event)
     return event

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -648,6 +648,24 @@ async def _cleanup_job_logs(db: AsyncSession) -> dict:
     return {"items_processed": result.rowcount}
 
 
+async def _cleanup_security_events(db: AsyncSession) -> dict:
+    """Delete security-event rows past the retention window.
+
+    Bounded retention is the whole point: IP is personal data, so the
+    log is a short investigation window, not a permanent archive.
+    """
+    from sheaf.models.security_event import SecurityEvent
+
+    cutoff = datetime.now(UTC) - timedelta(
+        days=settings.security_event_retention_days
+    )
+    result = await db.execute(
+        delete(SecurityEvent).where(SecurityEvent.created_at < cutoff)
+    )
+    await db.commit()
+    return {"items_processed": result.rowcount or 0}
+
+
 # ---------------------------------------------------------------------------
 # System Safety — finalize pending destructive actions + safety-setting changes
 # ---------------------------------------------------------------------------
@@ -1035,6 +1053,13 @@ def _register_all_jobs() -> None:
         name="cleanup_job_logs",
         description="Delete job run logs older than 30 days",
         func=_cleanup_job_logs,
+        interval_seconds=lambda: 86400,  # daily
+    )
+
+    register_job(
+        name="cleanup_security_events",
+        description="Delete security-event rows past the retention window",
+        func=_cleanup_security_events,
         interval_seconds=lambda: 86400,  # daily
     )
 

--- a/sheaf/services/security_events.py
+++ b/sheaf/services/security_events.py
@@ -1,0 +1,173 @@
+"""Write and query helpers for the security-event log.
+
+Writes go through `record_security_event`, which uses its OWN database
+session (not the request's). That is deliberate: the event is an audit
+side-effect, so it must never roll back with a failed auth transaction
+(a wrong-password login that we WANT recorded) nor be able to break the
+request if the insert fails. Same best-effort contract as the rate-limit
+hit history - wrapped so a DB hiccup can't turn a clean 401 into a 500.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.database import async_session_factory
+from sheaf.models.security_event import SecurityEvent, SecurityEventType
+
+logger = logging.getLogger("sheaf.security_events")
+
+
+async def record_security_event(
+    *,
+    event_type: SecurityEventType,
+    outcome: str,
+    user_id: uuid.UUID | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+    detail: dict | None = None,
+) -> None:
+    """Append one security event. Best-effort, isolated, never raises.
+
+    Runs on a dedicated short-lived session so it is decoupled from the
+    caller's transaction - a login-failure path has already raised by
+    the time this matters, and we still want the row.
+    """
+    try:
+        async with async_session_factory() as session:
+            session.add(
+                SecurityEvent(
+                    id=uuid.uuid4(),
+                    created_at=datetime.now(UTC),
+                    event_type=event_type,
+                    outcome=outcome,
+                    user_id=user_id,
+                    ip=ip,
+                    user_agent=(user_agent or None),
+                    detail=detail,
+                )
+            )
+            await session.commit()
+    except Exception:
+        logger.warning(
+            "security event write failed (%s/%s)",
+            event_type,
+            outcome,
+            exc_info=True,
+        )
+
+
+def _is_cidr(value: str) -> bool:
+    return "/" in value
+
+
+async def events_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    limit: int = 100,
+) -> list[SecurityEvent]:
+    """One account's security events, newest first."""
+    result = await db.execute(
+        select(SecurityEvent)
+        .where(SecurityEvent.user_id == user_id)
+        .order_by(SecurityEvent.created_at.desc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def events_for_ip(
+    db: AsyncSession,
+    ip_or_cidr: str,
+    *,
+    limit: int = 200,
+) -> list[SecurityEvent]:
+    """Security events from an exact IP or a CIDR subnet, newest first.
+
+    `203.0.113.7` matches that address; `203.0.113.0/24` matches the
+    whole block via the Postgres `<<=` (contained-or-equal) operator.
+    """
+    if _is_cidr(ip_or_cidr):
+        condition = SecurityEvent.ip.op("<<=")(ip_or_cidr)
+    else:
+        condition = SecurityEvent.ip == ip_or_cidr
+    result = await db.execute(
+        select(SecurityEvent)
+        .where(condition)
+        .order_by(SecurityEvent.created_at.desc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def accounts_seen_from_ip(
+    db: AsyncSession,
+    ip_or_cidr: str,
+) -> list[uuid.UUID]:
+    """Distinct known accounts that appear in events from this IP/subnet.
+
+    The ban-evasion / shared-IP signal: which accounts have authenticated
+    (or tried to) from here. NULL user_ids (unknown-user attempts) are
+    excluded by the DISTINCT.
+    """
+    if _is_cidr(ip_or_cidr):
+        condition = SecurityEvent.ip.op("<<=")(ip_or_cidr)
+    else:
+        condition = SecurityEvent.ip == ip_or_cidr
+    result = await db.execute(
+        select(SecurityEvent.user_id)
+        .where(condition, SecurityEvent.user_id.is_not(None))
+        .distinct()
+    )
+    return list(result.scalars().all())
+
+
+async def stuffing_offenders(
+    db: AsyncSession,
+    *,
+    since: datetime,
+    min_failures: int = 10,
+    limit: int = 50,
+) -> list[dict]:
+    """Top IPs by failed-login volume since `since`.
+
+    The credential-stuffing fingerprint is one IP failing against MANY
+    distinct accounts, so results are ordered by distinct-accounts first,
+    then raw failure count (which also surfaces single-account brute force
+    and unknown-user scanning, where distinct-accounts stays low).
+    """
+    distinct_accounts = func.count(func.distinct(SecurityEvent.user_id))
+    failures = func.count()
+    result = await db.execute(
+        select(
+            SecurityEvent.ip,
+            distinct_accounts.label("distinct_accounts"),
+            failures.label("failures"),
+            func.max(SecurityEvent.created_at).label("last_seen"),
+        )
+        .where(
+            SecurityEvent.event_type == SecurityEventType.LOGIN,
+            SecurityEvent.outcome != "success",
+            SecurityEvent.created_at >= since,
+            SecurityEvent.ip.is_not(None),
+        )
+        .group_by(SecurityEvent.ip)
+        .having(failures >= min_failures)
+        .order_by(distinct_accounts.desc(), failures.desc())
+        .limit(limit)
+    )
+    return [
+        {
+            "ip": str(row.ip),
+            "distinct_accounts": row.distinct_accounts,
+            "failures": row.failures,
+            "last_seen": row.last_seen,
+        }
+        for row in result.all()
+    ]

--- a/tests/test_security_events.py
+++ b/tests/test_security_events.py
@@ -1,0 +1,251 @@
+"""End-to-end tests for the security-event log and admin search tools.
+
+Covers:
+  - the auth funnel writing events (login success/failure, register,
+    password change) with the originating IP
+  - per-account timeline (isolated by user_id, so robust against the
+    shared test table)
+  - IP / subnet lookup + input validation + admin gate
+  - the credential-stuffing view
+  - admin audit rows capturing the acting admin's IP
+  - the privacy guard: unknown-user attempts store no account, no email
+
+These hit a running server (see conftest); the security-event row is
+committed inline before each auth response returns, so it is queryable
+immediately after.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+from .conftest import BASE_URL
+
+PASSWORD = "correct-horse-battery"
+
+
+def _register(email_prefix: str) -> str:
+    email = f"{email_prefix}-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = httpx.post(
+        f"{BASE_URL}/v1/auth/register",
+        json={"email": email, "password": PASSWORD},
+        timeout=10,
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return email
+
+
+def _find_user_id(admin_client: httpx.Client, email: str) -> str:
+    users = admin_client.get("/v1/admin/users").json()
+    match = next(u for u in users if u["email"] == email)
+    return match["id"]
+
+
+def _login(email: str, password: str) -> httpx.Response:
+    return httpx.post(
+        f"{BASE_URL}/v1/auth/login",
+        json={"email": email, "password": password},
+        timeout=10,
+    )
+
+
+def _timeline(admin_client: httpx.Client, user_id: str) -> list[dict]:
+    resp = admin_client.post(
+        f"/v1/admin/users/{user_id}/security-events",
+        json={"reason": "test"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["events"]
+
+
+# ---------------------------------------------------------------------------
+# Auth funnel -> events (isolated by user_id)
+# ---------------------------------------------------------------------------
+
+def test_failed_then_success_login_recorded(admin_client: httpx.Client):
+    email = _register("sec-login")
+    assert _login(email, "wrong-password").status_code == 401
+    assert _login(email, PASSWORD).status_code == 200
+
+    uid = _find_user_id(admin_client, email)
+    events = _timeline(admin_client, uid)
+
+    outcomes = [e["outcome"] for e in events if e["event_type"] == "login"]
+    assert "password_incorrect" in outcomes
+    assert "success" in outcomes
+    # Every recorded event carries the originating IP and is attributed
+    # to this account.
+    for e in events:
+        assert e["user_id"] == uid
+        assert e["ip"]
+
+
+def test_register_recorded(admin_client: httpx.Client):
+    email = _register("sec-register")
+    uid = _find_user_id(admin_client, email)
+    events = _timeline(admin_client, uid)
+    assert any(
+        e["event_type"] == "register" and e["outcome"] == "success"
+        for e in events
+    )
+
+
+def test_password_change_recorded(admin_client: httpx.Client):
+    # Register through a dedicated client so we hold a live session.
+    email = f"sec-pwchange-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=BASE_URL) as c:
+        reg = c.post(
+            "/v1/auth/register", json={"email": email, "password": PASSWORD}
+        )
+        assert reg.status_code == 201, reg.text
+        c.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+        changed = c.post(
+            "/v1/auth/change-password",
+            json={
+                "current_password": PASSWORD,
+                "new_password": "a-brand-new-password-9",
+            },
+        )
+        assert changed.status_code == 200, changed.text
+
+    uid = _find_user_id(admin_client, email)
+    events = _timeline(admin_client, uid)
+    assert any(
+        e["event_type"] == "password_change" and e["outcome"] == "success"
+        for e in events
+    )
+
+
+# ---------------------------------------------------------------------------
+# Privacy guard: unknown-user attempts
+# ---------------------------------------------------------------------------
+
+def test_unknown_user_login_stores_no_account_or_email(
+    admin_client: httpx.Client,
+):
+    # Learn this client's IP from a known account first.
+    seed_email = _register("sec-seed")
+    assert _login(seed_email, PASSWORD).status_code == 200
+    uid = _find_user_id(admin_client, seed_email)
+    ip = _timeline(admin_client, uid)[0]["ip"]
+
+    # Attempt against an address that was never registered.
+    ghost = f"ghost-{uuid.uuid4().hex}@sheaf.dev"
+    assert _login(ghost, "whatever").status_code == 401
+
+    resp = admin_client.post(
+        "/v1/admin/security/ip-lookup",
+        json={"target": ip, "reason": "test"},
+    )
+    assert resp.status_code == 200, resp.text
+    not_found = [
+        e
+        for e in resp.json()["events"]
+        if e["event_type"] == "login" and e["outcome"] == "user_not_found"
+    ]
+    assert not_found, "expected a recorded user_not_found attempt"
+    for e in not_found:
+        assert e["user_id"] is None
+        # No attempted address is retained anywhere on the row.
+        assert e["detail"] is None
+        assert ghost not in (str(e.get("detail")) or "")
+
+
+# ---------------------------------------------------------------------------
+# IP / subnet lookup
+# ---------------------------------------------------------------------------
+
+def test_ip_lookup_subnet_and_exact(admin_client: httpx.Client):
+    for target in ("10.1.2.3", "10.1.2.0/24"):
+        resp = admin_client.post(
+            "/v1/admin/security/ip-lookup",
+            json={"target": target, "reason": "test"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["query"] == target
+        assert body["is_subnet"] is ("/" in target)
+
+
+def test_ip_lookup_rejects_garbage(admin_client: httpx.Client):
+    for bad in ("not-an-ip", "999.999.999.999", "10.0.0.0/99"):
+        resp = admin_client.post(
+            "/v1/admin/security/ip-lookup",
+            json={"target": bad, "reason": "test"},
+        )
+        assert resp.status_code == 400, f"{bad}: {resp.text}"
+
+
+def test_security_endpoints_require_admin(auth_client: httpx.Client):
+    # auth_client is a normal authenticated (non-admin) user.
+    assert (
+        auth_client.post(
+            "/v1/admin/security/ip-lookup",
+            json={"target": "10.0.0.1", "reason": "x"},
+        ).status_code
+        == 403
+    )
+    assert auth_client.get("/v1/admin/security/stuffing").status_code == 403
+    assert (
+        auth_client.post(
+            f"/v1/admin/users/{uuid.uuid4()}/security-events",
+            json={"reason": "x"},
+        ).status_code
+        == 403
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stuffing view
+# ---------------------------------------------------------------------------
+
+def test_stuffing_view_surfaces_failing_ip(admin_client: httpx.Client):
+    # Generate failures against several distinct accounts from this IP.
+    for _ in range(3):
+        email = _register("sec-stuff")
+        _login(email, "wrong-password")
+
+    resp = admin_client.get(
+        "/v1/admin/security/stuffing?hours=1&min_failures=1"
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["window_hours"] == 1
+    assert body["offenders"], "expected at least one failing IP"
+    top = body["offenders"][0]
+    assert top["ip"]
+    assert top["failures"] >= 1
+    assert top["distinct_accounts"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Admin audit captures origin
+# ---------------------------------------------------------------------------
+
+def test_ip_lookup_is_audited_with_ip(admin_client: httpx.Client):
+    admin_client.post(
+        "/v1/admin/security/ip-lookup",
+        json={"target": "192.0.2.1", "reason": "audit-ip-check"},
+    )
+    rows = admin_client.get(
+        "/v1/admin/audit-events?action=security_ip_lookup"
+    ).json()
+    assert rows, "expected an audit row for the lookup"
+    latest = rows[0]
+    assert latest["action"] == "security_ip_lookup"
+    assert latest["reason"] == "audit-ip-check"
+    # The acting admin's origin is captured on the audit row.
+    assert latest["ip"]
+
+
+def test_user_security_events_is_audited(admin_client: httpx.Client):
+    email = _register("sec-audit")
+    uid = _find_user_id(admin_client, email)
+    _timeline(admin_client, uid)
+
+    rows = admin_client.get(
+        f"/v1/admin/audit-events?action=security_history_view&target_user_id={uid}"
+    ).json()
+    assert any(r["target_user_id"] == uid and r["ip"] for r in rows)


### PR DESCRIPTION
## What

Records the auth funnel - logins (success and every failure outcome), registrations, password-reset requests/completions, and self-service password changes - to a new append-only `security_events` table with the originating client IP. Three admin tools sit on top of it.

## Why

Today the only IP you can search by is `signup_ip`. Login failures and password-reset attempts record no IP at all, and session / rate-limit IPs are ephemeral and keyed only by user. So an operator cannot answer the questions that matter during an incident:

- **Is this IP credential-stuffing?** One IP failing against many distinct accounts is invisible - per-account lockout doesn't fire (each account sees one failure) and the per-IP login-limit blocks are anonymous, so they only bump a Prometheus counter with no searchable trace.
- **Show me everything from this IP / subnet.**
- **What happened on this account before the takeover report came in?**

## Endpoints

- `POST /v1/admin/security/ip-lookup` - exact IP or CIDR subnet, with the distinct accounts seen from there (and exact `signup_ip` matches).
- `GET /v1/admin/security/stuffing` - top failing IPs in a window, ranked by distinct accounts targeted (the stuffing fingerprint), then raw failures (which also surfaces single-account brute force and unknown-user scanning).
- `POST /v1/admin/users/{id}/security-events` - one account's auth timeline.

The two reads that target a specific IP or account require a reason and write an admin audit row, like dossier export. The aggregate stuffing view is an operational read. Admin audit rows now also capture the acting admin's IP and user-agent (via a request-scoped contextvar set in the admin dependencies, so no caller threading), surfaced on the admin-facing audit read only.

## Design notes

- **Events write on their own DB session**, best-effort and exception-isolated, so an audit write can never roll back with a failed auth transaction (a wrong-password login we *want* recorded) nor turn a clean 401 into a 500. Same contract as the rate-limit hit history.
- **Bounded retention.** A daily cleanup job deletes rows past `SECURITY_EVENT_RETENTION_DAYS` (default 30). IP is personal data, so retention is a short investigation window, not an archive. Operators with a longer basis can raise it.
- **Privacy guard.** Failed logins against a non-existent account record `user_id = NULL` and never store the attempted address (plaintext or hash) - the IP and `user_not_found` outcome are enough to spot scanning without retaining an identifier we'd then owe under a DSAR.
- **New `InetStr` column type** - Postgres `INET` that reads back as a plain string (asyncpg otherwise hands back `ipaddress` objects). Used so subnet matching (`ip <<= '203.0.113.0/24'`) works while readers still get strings. Applied to both the new table and the new admin-audit IP column.

## Migration

Two migrations chained off the current head: `security_events` table + enum and the admin-audit `ip`/`user_agent` columns (`l3m4n5o6p7q8`), then the two new `admin_audit_action` enum values in their own migration per the established `ALTER TYPE ... ADD VALUE` pattern (`m4n5o6p7q8r9`).

## Testing

`tests/test_security_events.py` adds 12 behavioral tests: the auth funnel writing events (login success/failure, register, password change, isolated by `user_id`), the privacy guard (unknown-user attempts store no account and no email), IP/subnet lookup + input validation + admin gate, the stuffing view, and admin audit rows capturing the acting admin's IP.

## Also

`run_tests.sh` now takes a system-wide `flock` so concurrent runs of the singleton test stack queue instead of wedging each other.
