### PR TITLE
Admin web UI for security-event / IP search

### DIFF
--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -51,6 +51,7 @@ const adminItems = [
   { to: "/admin/announcements", label: "Announcements" },
   { to: "/admin/jobs", label: "Jobs" },
   { to: "/admin/audit", label: "Audit log" },
+  { to: "/admin/security", label: "Security" },
 ];
 
 export function AppSidebar({

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -213,6 +213,75 @@ export function viewImportJobDetail(jobId: string, reason: string) {
   });
 }
 
+// --- Security-event search ---
+
+export interface SecurityEventRow {
+  id: string;
+  created_at: string;
+  event_type: string;
+  outcome: string;
+  user_id: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  detail: Record<string, unknown> | null;
+}
+
+export interface IpLookupResult {
+  query: string;
+  is_subnet: boolean;
+  event_count: number;
+  events: SecurityEventRow[];
+  distinct_account_ids: string[];
+  signup_match_ids: string[];
+  note: string;
+}
+
+// Privileged read: audited, so it takes a reason and is a POST.
+export function securityIpLookup(target: string, reason: string) {
+  return apiFetch<IpLookupResult>("/v1/admin/security/ip-lookup", {
+    method: "POST",
+    body: JSON.stringify({ target, reason }),
+  });
+}
+
+export interface StuffingOffender {
+  ip: string;
+  distinct_accounts: number;
+  failures: number;
+  last_seen: string;
+}
+
+export interface StuffingResult {
+  since: string;
+  window_hours: number;
+  min_failures: number;
+  offenders: StuffingOffender[];
+}
+
+export function securityStuffingView(
+  opts: { hours?: number; min_failures?: number; limit?: number } = {},
+) {
+  const params = new URLSearchParams();
+  params.set("hours", String(opts.hours ?? 24));
+  params.set("min_failures", String(opts.min_failures ?? 10));
+  params.set("limit", String(opts.limit ?? 50));
+  return apiFetch<StuffingResult>(`/v1/admin/security/stuffing?${params}`);
+}
+
+export interface UserSecurityHistory {
+  user_id: string;
+  event_count: number;
+  events: SecurityEventRow[];
+}
+
+// Audited per-account timeline; POST + reason like the import-log view.
+export function userSecurityEvents(userId: string, reason: string) {
+  return apiFetch<UserSecurityHistory>(
+    `/v1/admin/users/${userId}/security-events`,
+    { method: "POST", body: JSON.stringify({ reason }) },
+  );
+}
+
 export function getPendingApprovals() {
   return apiFetch<PendingUser[]>("/v1/admin/approvals");
 }

--- a/web/src/routes/admin/security.tsx
+++ b/web/src/routes/admin/security.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  securityIpLookup,
+  securityStuffingView,
+  type SecurityEventRow,
+} from "@/lib/admin";
+import { PageHeader } from "@/components/page-header";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+function outcomeBadge(outcome: string) {
+  const ok = outcome === "success" || outcome === "sent";
+  return (
+    <Badge
+      variant={ok ? "outline" : "destructive"}
+      className="text-[10px] font-mono"
+    >
+      {outcome}
+    </Badge>
+  );
+}
+
+function EventsTable({ events }: { events: SecurityEventRow[] }) {
+  return (
+    <Card>
+      <CardContent className="p-0">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b text-xs text-muted-foreground">
+              <th className="py-2 px-3 text-left font-medium">When</th>
+              <th className="py-2 px-3 text-left font-medium">Type</th>
+              <th className="py-2 px-3 text-left font-medium">Outcome</th>
+              <th className="py-2 px-3 text-left font-medium">Account</th>
+              <th className="py-2 px-3 text-left font-medium">IP</th>
+              <th className="py-2 px-3 text-left font-medium">Client</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((e) => (
+              <tr key={e.id} className="border-b text-sm last:border-0">
+                <td className="py-2 px-3 align-top whitespace-nowrap">
+                  {new Date(e.created_at).toLocaleString()}
+                </td>
+                <td className="py-2 px-3 align-top">{e.event_type}</td>
+                <td className="py-2 px-3 align-top">
+                  {outcomeBadge(e.outcome)}
+                </td>
+                <td className="py-2 px-3 align-top font-mono text-xs text-muted-foreground">
+                  {e.user_id ?? (
+                    <span className="italic">unknown</span>
+                  )}
+                </td>
+                <td className="py-2 px-3 align-top font-mono text-xs">
+                  {e.ip ?? ""}
+                </td>
+                <td className="py-2 px-3 align-top text-xs text-muted-foreground max-w-[16rem] truncate">
+                  {e.user_agent ?? ""}
+                </td>
+              </tr>
+            ))}
+            {events.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="py-6 px-3 text-center text-sm text-muted-foreground"
+                >
+                  No security events for this query.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function IpLookup({
+  target,
+  setTarget,
+}: {
+  target: string;
+  setTarget: (v: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+
+  const lookup = useMutation({
+    mutationFn: () => securityIpLookup(target.trim(), reason.trim()),
+  });
+  const result = lookup.data;
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-sm font-medium mb-2">IP / subnet lookup</h2>
+      <p className="text-sm text-muted-foreground max-w-prose mb-3">
+        Everything the security log has seen from an exact address
+        (<span className="font-mono">203.0.113.7</span>) or a CIDR subnet
+        (<span className="font-mono">203.0.113.0/24</span>). This is an audited
+        read of account-linked data, so a reason is recorded.
+      </p>
+      <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto] sm:items-end mb-4">
+        <div className="space-y-1">
+          <Label htmlFor="ip-target" className="text-xs">
+            IP or subnet
+          </Label>
+          <Input
+            id="ip-target"
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            placeholder="203.0.113.7 or 203.0.113.0/24"
+            className="font-mono text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="ip-reason" className="text-xs">
+            Reason
+          </Label>
+          <Input
+            id="ip-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Why are you looking this up?"
+            className="text-xs"
+          />
+        </div>
+        <Button
+          size="sm"
+          disabled={!target.trim() || !reason.trim() || lookup.isPending}
+          onClick={() => lookup.mutate()}
+        >
+          {lookup.isPending ? "Looking up..." : "Look up"}
+        </Button>
+      </div>
+
+      {lookup.isError && (
+        <p className="text-sm text-destructive mb-3">
+          Lookup failed. Check the address or subnet is valid.
+        </p>
+      )}
+
+      {result && (
+        <>
+          <div className="flex flex-wrap gap-2 mb-3 text-xs text-muted-foreground">
+            <Badge variant="outline" className="text-[10px]">
+              {result.event_count} events
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {result.distinct_account_ids.length} distinct accounts
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {result.signup_match_ids.length} signup-IP matches
+            </Badge>
+            {result.is_subnet && (
+              <Badge variant="outline" className="text-[10px]">
+                subnet query
+              </Badge>
+            )}
+          </div>
+          <EventsTable events={result.events} />
+          <p className="text-xs text-muted-foreground max-w-prose mt-2">
+            {result.note}
+          </p>
+        </>
+      )}
+    </section>
+  );
+}
+
+function StuffingWatch({
+  onPickIp,
+}: {
+  onPickIp: (ip: string) => void;
+}) {
+  const [hours, setHours] = useState(24);
+  const [minFailures, setMinFailures] = useState(10);
+
+  const opts = useMemo(
+    () => ({ hours, min_failures: minFailures, limit: 50 }),
+    [hours, minFailures],
+  );
+  const { data } = useQuery({
+    queryKey: ["admin", "security", "stuffing", opts],
+    queryFn: () => securityStuffingView(opts),
+  });
+
+  return (
+    <section>
+      <h2 className="text-sm font-medium mb-2">Credential-stuffing watch</h2>
+      <p className="text-sm text-muted-foreground max-w-prose mb-3">
+        IPs with the most failed logins in the window, ranked by how many
+        distinct accounts each one targeted - the stuffing fingerprint. A high
+        failure count against few accounts is brute force or scanning instead.
+      </p>
+      <div className="grid gap-3 sm:grid-cols-2 max-w-md mb-4">
+        <div className="space-y-1">
+          <Label htmlFor="stuff-hours" className="text-xs">
+            Window (hours)
+          </Label>
+          <Input
+            id="stuff-hours"
+            type="number"
+            min={1}
+            max={720}
+            value={hours}
+            onChange={(e) => setHours(Number(e.target.value) || 1)}
+            className="text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="stuff-min" className="text-xs">
+            Min failures
+          </Label>
+          <Input
+            id="stuff-min"
+            type="number"
+            min={1}
+            value={minFailures}
+            onChange={(e) => setMinFailures(Number(e.target.value) || 1)}
+            className="text-xs"
+          />
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b text-xs text-muted-foreground">
+                <th className="py-2 px-3 text-left font-medium">IP</th>
+                <th className="py-2 px-3 text-right font-medium">
+                  Distinct accounts
+                </th>
+                <th className="py-2 px-3 text-right font-medium">Failures</th>
+                <th className="py-2 px-3 text-left font-medium">Last seen</th>
+                <th className="py-2 px-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {data?.offenders.map((o) => (
+                <tr key={o.ip} className="border-b text-sm last:border-0">
+                  <td className="py-2 px-3 align-top font-mono text-xs">
+                    {o.ip}
+                  </td>
+                  <td className="py-2 px-3 align-top text-right tabular-nums">
+                    {o.distinct_accounts}
+                  </td>
+                  <td className="py-2 px-3 align-top text-right tabular-nums">
+                    {o.failures}
+                  </td>
+                  <td className="py-2 px-3 align-top whitespace-nowrap text-xs text-muted-foreground">
+                    {new Date(o.last_seen).toLocaleString()}
+                  </td>
+                  <td className="py-2 px-3 align-top text-right">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-[10px] h-6"
+                      onClick={() => onPickIp(o.ip)}
+                    >
+                      Look up
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {data?.offenders.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="py-6 px-3 text-center text-sm text-muted-foreground"
+                  >
+                    No IPs over the failure threshold in this window.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+export function AdminSecurityPage() {
+  // Shared so "Look up" on a stuffing row prefills the lookup field.
+  const [target, setTarget] = useState("");
+
+  return (
+    <>
+      <PageHeader title="Security" />
+      <p className="text-sm text-muted-foreground max-w-prose mb-6">
+        Search the authentication event log by IP, and watch for
+        credential-stuffing. Per-account timelines live on each user's detail
+        view.
+      </p>
+      <IpLookup target={target} setTarget={setTarget} />
+      <StuffingWatch onPickIp={setTarget} />
+    </>
+  );
+}

--- a/web/src/routes/admin/users.tsx
+++ b/web/src/routes/admin/users.tsx
@@ -25,6 +25,7 @@ import {
   listUserSessionsAdmin,
   listUserImportJobs,
   viewImportJobDetail,
+  userSecurityEvents,
   suspendUser,
   terminateUserSession,
   unbanUser,
@@ -279,6 +280,94 @@ function ImportLogsSection({ userId }: { userId: string }) {
   );
 }
 
+function SecurityEventsSection({ userId }: { userId: string }) {
+  const qc = useQueryClient();
+  const [reason, setReason] = useState("");
+  const [confirming, setConfirming] = useState(false);
+
+  // Viewing the timeline writes a `security_history_view` audit row, so the
+  // reason is required and the audit list is refreshed on success.
+  const view = useMutation({
+    mutationFn: (why: string) => userSecurityEvents(userId, why),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "audit"] });
+      qc.invalidateQueries({ queryKey: ["admin", "explain", userId] });
+      setConfirming(false);
+      setReason("");
+    },
+  });
+  const data = view.data;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2">
+        <span className="text-muted-foreground">Security events:</span>
+        {confirming ? (
+          <div className="flex items-center gap-1">
+            <Input
+              className="h-6 w-44 text-[10px]"
+              placeholder="Reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+            />
+            <Button
+              size="sm"
+              variant="default"
+              className="h-6 text-[10px]"
+              disabled={!reason.trim() || view.isPending}
+              onClick={() => view.mutate(reason)}
+            >
+              View
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-6 text-[10px]"
+              onClick={() => {
+                setConfirming(false);
+                setReason("");
+              }}
+            >
+              X
+            </Button>
+          </div>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-6 text-[10px]"
+            onClick={() => setConfirming(true)}
+          >
+            {data ? "Refresh" : "View timeline"}
+          </Button>
+        )}
+      </div>
+      {data && (
+        <ul className="space-y-0.5 font-mono">
+          {data.events.map((e) => (
+            <li key={e.id}>
+              {new Date(e.created_at).toLocaleString()} · {e.event_type} ·{" "}
+              <span
+                className={
+                  e.outcome === "success" || e.outcome === "sent"
+                    ? "text-muted-foreground"
+                    : "text-destructive"
+                }
+              >
+                {e.outcome}
+              </span>
+              {e.ip ? ` · ${e.ip}` : ""}
+            </li>
+          ))}
+          {data.events.length === 0 && (
+            <li className="text-muted-foreground">(none)</li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function RateLimitSection({ userId }: { userId: string }) {
   const [showAll, setShowAll] = useState(false);
   const { data } = useQuery<RateLimitHistoryResponse>({
@@ -405,6 +494,7 @@ function ExplainPanel({ userId }: { userId: string }) {
               )}
               <SessionsSection userId={userId} />
               <RateLimitSection userId={userId} />
+              <SecurityEventsSection userId={userId} />
               <ImportLogsSection userId={userId} />
               {data.recent_admin_audit.length > 0 && (
                 <div>

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -42,6 +42,7 @@ import { AdminInvitesPage } from "./admin/invites";
 import { AdminAnnouncementsPage } from "./admin/announcements";
 import { AdminJobsPage } from "./admin/jobs";
 import { AdminAuditPage } from "./admin/audit";
+import { AdminSecurityPage } from "./admin/security";
 
 export const router = createBrowserRouter([
   {
@@ -114,6 +115,7 @@ export const router = createBrowserRouter([
           { path: "announcements", element: <AdminAnnouncementsPage /> },
           { path: "jobs", element: <AdminJobsPage /> },
           { path: "audit", element: <AdminAuditPage /> },
+          { path: "security", element: <AdminSecurityPage /> },
         ],
       },
       // Catch-all under AppLayout: unknown paths render the 404 inside the


### PR DESCRIPTION
Follow-up to #157 (backend) - the web UI for the security-event search tools.

## New "Security" admin page (`/admin/security`)

- **IP / subnet lookup** - enter an exact IP (`203.0.113.7`) or CIDR subnet (`203.0.113.0/24`) plus a reason (the read is audited server-side), and see every authentication event from there, with the distinct accounts seen and signup-IP matches summarised. Failure outcomes are flagged.
- **Credential-stuffing watch** - the top failing IPs in a configurable window, ranked by how many distinct accounts each targeted (the stuffing fingerprint). Each row has a one-click hand-off that prefills the lookup field.

## Per-account timeline

Added to the user detail panel (Explain account) as a reason-gated "View timeline" action, sitting next to the rate-limit history it mirrors - same pattern as the import-log view. Writes a `security_history_view` audit row.

## Plumbing

`securityIpLookup`, `securityStuffingView`, and `userSecurityEvents` added to the admin API client with matching types, following the existing POST-with-reason / GET-with-params conventions.

## Validation

`tsc -b`, `eslint`, and a production build all pass. Not yet click-tested against a live backend (same environment constraint as the backend test run); the endpoints are live on main via #157.
