### PR TITLE
OpenPlural v0.1 import and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 `v1.0.0` is the first stable release. The `v0.x.y` releases were betas; from 1.0 on, the v1 API and database schema carry semver compatibility guarantees.
 
+## [Unreleased]
+
+### Added
+
+- **OpenPlural v0.1 import and export.** Sheaf is a founding adopter of the [OpenPlural](https://github.com/skylartaylor/openplural) data standard, and now exports to and imports from it. Export comes in two shapes: a single JSON document (sync `GET /v1/export?format=openplural`, with uri-only assets) and an `.openplural.zip` bundle (async export job with `format=openplural`, carrying the image bytes under `assets/`). Import accepts either shape (`POST /v1/imports/file` with `source=openplural_file`, sniffed by content) and a preview endpoint (`POST /v1/import/openplural/preview`) summarises a file before committing. Systems, members, fronts, groups, tags, custom fields, and journals map to OpenPlural core records; everything Sheaf has that the draft spec does not yet model (notes, polls, reminders, board messages, revision history, notification config, System Safety settings, member emoji/quick-switch, and more) is preserved losslessly under the namespaced `extensions.sheaf.*` key, so a Sheaf-to-OpenPlural-to-Sheaf round-trip is complete. Every export stamps the producing app and version (`producer.app` / `app_version` / `exporter_version`) and appends a forward-compatible `extensions.sheaf.lineage[]` entry; `pluralkit_id` is emitted as an OpenPlural `source_ref`. The importer reuses the existing native importer underneath, so the member-cap, decompression-size, avatar-policy, and dedup guards all apply unchanged, and it rejects any unfamiliar `openplural_version`. So Sheaf is not a lossy hop for files from other apps, data Sheaf cannot model (other apps' `extensions` namespaces, the chat and relationships modules, switch-style front events/comments, and non-tag taxonomy) is preserved on import (encrypted, compressed, and bounded by `OPENPLURAL_MAX_PRESERVED_MB`) and re-merged into the next OpenPlural export; per-record foreign extensions are the one remaining follow-up and are reported rather than silently dropped. A new format-coverage test fails CI if a future user-data field is added to the export without being given an OpenPlural disposition. The full field-by-field mapping, the `extensions.sheaf.*` table, the edge cases, and the open upstream spec issues are documented in `docs/OPENPLURAL.md`.
+
 ## [1.0.3] - 2026-06-19
 
 ### Added

--- a/alembic/versions/n5o6p7q8r9s0_add_export_jobs_format.py
+++ b/alembic/versions/n5o6p7q8r9s0_add_export_jobs_format.py
@@ -1,0 +1,43 @@
+"""Add format column to export_jobs
+
+Revision ID: n5o6p7q8r9s0
+Revises: m4n5o6p7q8r9
+Create Date: 2026-06-19
+
+Async exports can now be built in two shapes: the native Sheaf zip
+(export.json + images/) or an OpenPlural v0.1 bundle (openplural.json +
+assets/). The chosen format is persisted on the job row so the build
+worker knows which artefact to assemble.
+
+ADD COLUMN with a constant server_default is a metadata-only change on
+modern Postgres (no table rewrite), but it still briefly takes
+ACCESS EXCLUSIVE, so fail fast rather than queue behind a long lock.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "n5o6p7q8r9s0"
+down_revision: Union[str, None] = "m4n5o6p7q8r9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.add_column(
+        "export_jobs",
+        sa.Column(
+            "format",
+            sa.String(length=32),
+            nullable=False,
+            server_default="sheaf_native",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.drop_column("export_jobs", "format")

--- a/alembic/versions/o6p7q8r9s0t1_add_systems_openplural_archive.py
+++ b/alembic/versions/o6p7q8r9s0t1_add_systems_openplural_archive.py
@@ -1,0 +1,39 @@
+"""Add openplural_archive column to systems
+
+Revision ID: o6p7q8r9s0t1
+Revises: n5o6p7q8r9s0
+Create Date: 2026-06-20
+
+Holds the OpenPlural import residual: foreign data Sheaf cannot model
+(other apps' `extensions` namespaces, the chat/relationships modules,
+front_events/front_comments, non-tag taxonomy), preserved on import and
+re-merged into the next OpenPlural export. Stored encrypted + zlib
+compressed, so a plain nullable Text column. NULL when nothing was
+preserved.
+
+ADD COLUMN with no default is metadata-only on modern Postgres, but it
+still briefly takes ACCESS EXCLUSIVE, so fail fast rather than queue.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "o6p7q8r9s0t1"
+down_revision: Union[str, None] = "n5o6p7q8r9s0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.add_column(
+        "systems",
+        sa.Column("openplural_archive", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.drop_column("systems", "openplural_archive")

--- a/docs/IMPORT.md
+++ b/docs/IMPORT.md
@@ -171,6 +171,23 @@ bucket. The async `/v1/export/jobs` endpoint produces a zip with image bytes
 included; the import side that consumes those zips is on the roadmap (see
 [CHANGELOG.md](../CHANGELOG.md)).
 
+## OpenPlural import
+
+For moving data in from any app that speaks the
+[OpenPlural](https://github.com/skylartaylor/openplural) v0.1 standard, including
+a Sheaf OpenPlural export. Accepts either a bare `.json` document or an
+`.openplural.zip` bundle (`openplural.json` + `assets/`); the runner detects
+which by content. The envelope is translated back to the native shape and run
+through the same importer as a Sheaf re-import, so dedup, the member cap, the
+image-restore pipeline (for bundles), and the avatar-policy gate all apply. A
+file whose `openplural_version` this build does not understand is rejected
+rather than partially imported.
+
+Sheaf round-trips its own OpenPlural exports losslessly: anything the v0.1 spec
+cannot model rides under `extensions.sheaf.*` and is restored on import. See
+[OPENPLURAL.md](OPENPLURAL.md) for the full mapping, the per-version
+implementation log, and the known gaps.
+
 ---
 
 ## API surface

--- a/docs/OPENPLURAL.md
+++ b/docs/OPENPLURAL.md
@@ -274,6 +274,14 @@ lifted directly into the native dict.
 - **Front status is free text.** `fronts[].custom_status` becomes
   `FrontPeriod.status` verbatim; there is no controlled vocabulary on the Sheaf
   side, so none is imposed.
+- **Fronting accepts both shapes.** Sheaf stores fronting as intervals
+  (`FrontPeriod`). On import it reads `front_periods` directly and also derives
+  intervals from `front_events` (a point-in-time switch log): each event sets
+  who is fronting until the next event, an empty-assignment event is a gap, and
+  the last event stays open-ended (same conversion as the PluralKit switch log).
+  A file carrying both representations is de-duplicated by interval + member set.
+  Sheaf only ever *emits* `front_periods`, so a re-export normalises events to
+  intervals (the fronting information is preserved; the event shape is not).
 - **Tags are taxonomy.** Sheaf tags become `TaxonomyTerm` with `kind: "tag"`;
   the importer only lifts terms whose `kind` is `tag` back into Sheaf tags, so a
   future taxonomy of another kind round-trips through extensions rather than
@@ -303,7 +311,7 @@ What is preserved (`services/openplural_archive.py`, `extract_residual`):
 | Foreign `extensions` namespaces | File-level `extensions` keys other than `sheaf` (e.g. `extensions.prism`). |
 | `chat` module | Whole object, re-advertised in `capabilities.modules` on export. |
 | `relationships` module | Whole object, re-advertised in `capabilities.modules` on export. |
-| `front_events` / `front_comments` | Fronting shapes Sheaf has no model for (intervals only; `front_events` conversion is tracked as a separate follow-up). |
+| `front_comments` | Time-anchored comments on fronting; Sheaf fronts have a free-text status but no per-comment model. (`front_events` are NOT preserved here - they are imported as intervals, see the fronting edge case below.) |
 | Non-tag `taxonomy_terms` + their assignments | Sheaf models only `kind: "tag"`; roles and other kinds are preserved. |
 
 Storage: the residual is JSON, zlib-compressed, then encrypted at rest (it can

--- a/docs/OPENPLURAL.md
+++ b/docs/OPENPLURAL.md
@@ -1,0 +1,379 @@
+# Sheaf OpenPlural support: implementation log
+
+[OpenPlural](https://github.com/skylartaylor/openplural) is a draft (v0.1)
+interchange format for plural-system data: systems, members, fronting history,
+groups, taxonomy, custom fields, notes, and assets, with a registered
+`extensions.<app>` namespace for anything an app models that the core spec does
+not yet cover. The point of it is that one good exporter beats N pairwise
+converters: map your records to the OpenPlural core once and every other adopter
+can read them.
+
+Sheaf is a founding adopter. Its exporter lives in
+`sheaf/services/openplural_export.py` and the inverse importer in
+`sheaf/services/openplural_import.py`; the import runner that wires them to the
+async job system is `sheaf/services/openplural_import_runner.py`.
+
+## How to use this file
+
+Every Sheaf OpenPlural export stamps two versions in its `producer` block:
+
+- `producer.app_version` - the Sheaf release that produced the file (e.g.
+  `1.1.0`), taken from package metadata.
+- `producer.exporter_version` - the version of the *mapping logic* itself
+  (`OPENPLURAL_IMPL_VERSION`, currently `0.1.0`). This moves independently of
+  the Sheaf release whenever the field mapping changes in a way worth tracking.
+
+When you are handed an export and need to know exactly how that build mapped its
+data - which fields went to core records, what got parked under
+`extensions.sheaf.*`, and what the known limitations were - read the producer
+stamp, then find the matching `## Sheaf X.Y.Z` section in the implementation log
+below. The mapping is intentionally diagnosable from the file alone.
+
+This document is the per-field rationale and running changelog; the code
+comments point back here rather than duplicating it.
+
+## Producer and version stamping
+
+The envelope carries a `producer` object describing what wrote it:
+
+| Field | Value | Source |
+|---|---|---|
+| `producer.app` | `"Sheaf"` | `APP_NAME` |
+| `producer.app_id` | `"sheaf"` | `APP_ID`, the registered namespace key |
+| `producer.app_version` | the Sheaf release, e.g. `"1.1.0"` | package metadata (`sheaf.__version__`) |
+| `producer.exporter_version` | `"0.1.0"` | `OPENPLURAL_IMPL_VERSION` |
+
+Separately, the top-level `openplural_version` field records the *spec* version
+the file targets, currently `"0.1"` (`OPENPLURAL_VERSION`). This is not the
+Sheaf version and not the exporter version - it is the contract the document
+claims to satisfy.
+
+The importer is strict about it. `SUPPORTED_VERSIONS = {"0.1"}`, and
+`_check_version` raises an `ImportPayloadError` for any other
+`openplural_version` rather than silently part-importing a document it does not
+understand. A file stamped, say, `openplural_version: "0.2"` will be rejected by
+a build that only knows `0.1`; this is deliberate per the spec.
+
+## Provenance and lineage
+
+Sheaf records where data came from at two levels.
+
+### Per-record `source_refs`
+
+A record that originated in another app carries a `source_refs[]` entry so a
+later sync or reconciliation pass can match it back to its origin. Today the
+only producer of these is the PluralKit importer: a member that was imported
+from PluralKit keeps its PK HID, and on export that becomes
+
+```json
+"source_refs": [
+  {"app": "pluralkit", "collection": "members", "id": "wyyetr"}
+]
+```
+
+On the way back in, `_pluralkit_id` pulls the `pluralkit` ref out of
+`source_refs` and restores it to the member's `pluralkit_id` field, so the
+cross-reference survives a round-trip.
+
+### File-level `extensions.sheaf.lineage[]`
+
+The envelope also carries a forward-compatible lineage chain under
+`extensions.sheaf.lineage`. Each export appends one entry describing the hop:
+
+```json
+"extensions": {
+  "sheaf": {
+    "lineage": [
+      {
+        "app": "sheaf",
+        "app_version": "1.1.0",
+        "exporter_version": "0.1.0",
+        "exported_at": "2026-06-18T12:00:00Z"
+      }
+    ]
+  }
+}
+```
+
+**Limitation, stated honestly:** Sheaf does not yet *persist* inherited lineage
+across a database round-trip. There is no column for it, so when you import a
+file and then re-export, the new file starts a fresh, Sheaf-only lineage chain
+rather than accumulating the prior hops. The structure is emitted now purely for
+forward-compatibility; full accumulation across round-trips is tracked against
+upstream issue #7. On import, `_note_lineage` surfaces any incoming lineage as
+an `info` event on the import job ("file carries lineage from N prior
+export(s)") but does not store it. `build_envelope` does accept an
+`inherited_lineage` argument and will prepend it when given - the gap is purely
+that nothing in the DB layer can hand it back on the next export yet.
+
+## Delivery shapes
+
+The same `build_envelope` builder backs two delivery shapes, which differ only
+in how assets travel.
+
+### Sync JSON: `GET /v1/export?format=openplural`
+
+A single JSON document. Assets are **uri-only**: each `Asset` carries its avatar
+or image URL but no bytes. Because there are no blobs, the export emits a
+top-level `info` warning with code `asset_uri_only`:
+
+```json
+{"level": "info", "code": "asset_uri_only",
+ "message": "Assets are referenced by URL only; export with images (the .openplural.zip bundle) to include the binary blobs."}
+```
+
+Use this for a quick portable copy of structured data (systems, members, fronts,
+groups, tags, custom fields, journals); the images themselves only resolve if
+the destination can reach those URLs.
+
+### Async bundle: `.openplural.zip`
+
+Produced by the async export job path. The zip contains `openplural.json` plus
+an `assets/<storage_key>` entry for every internal image blob. In this shape each
+bundled asset additionally carries pointers under its own namespace:
+
+```json
+{
+  "id": "…",
+  "kind": "avatar",
+  "uri": "/v1/files/<key>",
+  "extensions": {
+    "sheaf": {
+      "bundle_path": "assets/<storage_key>",
+      "storage_key": "<storage_key>"
+    }
+  }
+}
+```
+
+Only Sheaf-internal references get a `bundle_path`; external CDN URLs (Gravatar,
+DiceBear, a user-typed link) stay uri-only in both shapes because Sheaf has no
+bytes to bundle for them. The bare storage key is recoverable from the unchanged
+`uri` via `_to_internal_key`, which is how the importer's `_AssetMap` lines the
+in-zip blob back up with its asset.
+
+Note that the official bundle-path convention is still pending upstream issue #9.
+Until that lands, the pointer lives in Sheaf's namespace and `uri` is always kept
+present so the document stays spec-valid for an app that does not understand
+`extensions.sheaf.bundle_path`.
+
+---
+
+## Sheaf 1.1.0 - initial OpenPlural v0.1 support
+
+First release with OpenPlural import/export. `OPENPLURAL_IMPL_VERSION = 0.1.0`,
+targeting spec `openplural_version 0.1`. The exporter is a pure transform over
+the native Article-20 export dict (version `"2"`); the importer is its inverse
+and translates back to that same native dict before delegating to the native
+importer, so all the import guards (member cap, safe-JSON, decompressed-size
+bound, avatar normalisation, business caps, fresh UUIDs, tenant scoping) live in
+one place and cannot drift per-format.
+
+### Direct mappings
+
+Sheaf fields that land in OpenPlural core records.
+
+| Sheaf (native export) | OpenPlural core record / field |
+|---|---|
+| `system.id` / `name` / `description` / `tag` / `color` | `System.id` / `name` / `description` / `tag` / `color` |
+| `system.avatar_url` | `Asset` (kind `avatar`) + `System.avatar_asset_id` |
+| `system.privacy` | `System.privacy` (visibility bucket; see edge cases) |
+| `members[].id` / `name` / `display_name` / `description` / `pronouns` / `color` | `Member.id` / `name` / `display_name` / `description` / `pronouns` / `color` |
+| `members[].avatar_url` | `Asset` (kind `avatar`) + `Member.avatar_asset_id` |
+| `members[].banner_url` | `Asset` (kind `banner`) + `Member.banner_asset_id` |
+| `members[].is_custom_front` | `Member.is_custom_front` |
+| `members[].created_at` | `Member.created_at` |
+| `members[].privacy` | `Member.privacy` (visibility bucket) |
+| `members[].birthday` | `Member.birthday` precision sub-record (see below) |
+| `members[].pluralkit_id` | `Member.source_refs[]` (app `pluralkit`; see provenance) |
+| `groups[].id` / `name` / `description` / `color` | `Group.id` / `name` / `description` / `color` |
+| `groups[].parent_id` | `Group.parent_group_id` |
+| `groups[].member_ids` | `GroupMembership[]` (one row per id) |
+| `tags[].id` / `name` / `color` | `TaxonomyTerm` (kind `tag`) `.id` / `name` / `color` |
+| `tags[].member_ids` | `TaxonomyAssignment[]` (subject_type `member`) |
+| `custom_fields[].id` / `name` / `field_type` / `options` | `CustomFieldDefinition.id` / `name` / `field_type` / `options` |
+| `custom_fields[].order` | `CustomFieldDefinition.sort_order` |
+| `custom_fields[].privacy` | `CustomFieldDefinition.privacy` (visibility bucket) |
+| `custom_fields[].values[]` (`member_id`, `value`) | `CustomFieldValue` (subject_type `member`, `field_id`, `subject_id`, `value`) |
+| `fronts[].id` / `started_at` / `ended_at` | `FrontPeriod.id` / `started_at` / `ended_at` |
+| `fronts[].member_ids` | `FrontPeriod.assignments[]` (one per id, `front_role: "member"`) |
+| `fronts[].custom_status` | `FrontPeriod.status` (free text) |
+| `journals[].id` / `title` / `body` / `created_at` / `updated_at` | `Note.id` / `title` / `body` / `created_at` / `updated_at` |
+| `journals[].visibility` | `Note.visibility` (visibility bucket) |
+| `journals[].author_member_ids` | `Note.author_member_ids` |
+| `journals[].image_keys` | `Asset` (kind `image`) + `Note.attachment_asset_ids` |
+| `images` / internal blobs | `assets[]` (deduplicated by storage key / URL) |
+
+#### Birthday precision mapping
+
+Sheaf stores a birthday as a flat string, either with or without a year, and the
+exporter (`_birthday`) derives an OpenPlural precision-aware sub-record from its
+shape:
+
+| Sheaf stored value | OpenPlural `birthday` |
+|---|---|
+| `"YYYY-MM-DD"` (3 parts) | `{"value": "YYYY-MM-DD", "precision": "day", "year_visible": true}` |
+| `"MM-DD"` (2 parts, year-less) | `{"value": "MM-DD", "precision": "month_day", "year_visible": false}` |
+| anything else | `{"value": <raw>, "precision": "unknown", "year_visible": false}` (handed across opaquely rather than dropped) |
+
+On import, `_birthday_to_native` simply reads `birthday.value` back into the flat
+Sheaf string (and tolerates a plain string too).
+
+### `extensions.sheaf.*` (platform-specific data)
+
+Everything Sheaf models that OpenPlural v0.1 has no core record for is preserved
+losslessly under the registered `sheaf` namespace, so a round-trip restores it
+and another app can at least carry it forward. None of this is lost; it is just
+opaque to apps that do not speak Sheaf.
+
+#### Record-level extensions
+
+| Record | `extensions.sheaf` key(s) | Why it is not core (yet) |
+|---|---|---|
+| System | `note` | Sheaf's system note is separate from `description` and encrypted at rest; no distinct core field for it. |
+| System | `date_format`, `replace_fronts_default`, `coalesce_contiguous_fronts`, `delete_confirmation` | App-specific display/behaviour preferences with no spec home. |
+| System | `safety`, `retention` | System Safety and retention config; awaits a v0.2 safety module. |
+| Member | `note` | Encrypted-at-rest member note, distinct from `description`. |
+| Member | `emoji` | No core member-emoji field yet; a candidate shared optional in a later spec (Prism has an analogue). |
+| Member | `quick_switch_pin` | Sheaf quick-switch convenience field, app-specific. |
+| Member | `notify_on_front_global`, `notify_on_front_self`, `notify_on_front_member_ids` | Front-notification preferences; await a notifications module. |
+| Note (journal) | `member_id` | Sheaf journals can be scoped to one member; the core `Note` has no owning-member field. |
+| Note (journal) | `author_member_names` | Denormalised author names retained alongside `author_member_ids` for display fidelity. |
+| Board post | `board_kind` | Distinguishes system board vs per-member wall; no core distinction yet. |
+| Board post | `parent_message_id` | Single-level reply pointer; parks here until `BoardPost.parent_post_id` lands (issue #2). |
+
+#### File-level extensions
+
+These are the native sub-sections with no OpenPlural v0.1 core representation,
+carried verbatim under `extensions.sheaf.<key>` (the `_EXT_PASSTHROUGH_SECTIONS`
+tuple), plus the lineage chain.
+
+| Key | Why it is parked here |
+|---|---|
+| `polls` | Polls (options/votes/events) await the v0.2 polls module. |
+| `reminders` | Reminders await the v0.2 reminders module. |
+| `messages` | Board posts also surface in the `boards` module, but the full native message shape is retained here for lossless round-trip. |
+| `revisions` | Journal / member-bio edit history; awaits a spec revision-history shape. |
+| `watch_tokens` | Notification watch tokens / channels; await a notifications/export module. |
+| `uploaded_files` | The sync JSON's file inventory (no bytes); meaningless without the async zip but kept so nothing is silently dropped. |
+| `lineage` | Provenance chain (see Provenance and lineage above). |
+
+On import these are read straight back: messages prefer the `boards` module shape
+when present and fall back to the passthrough section otherwise; the rest are
+lifted directly into the native dict.
+
+### Edge cases and decisions
+
+- **Privacy / visibility buckets.** Sheaf's `PrivacyLevel`
+  (`public` / `friends` / `private`) maps 1:1 onto the OpenPlural visibility
+  vocabulary. `_privacy` passes through any value in
+  `{public, friends, private, trusted, unknown}` and rounds anything
+  unrecognised to the strictest-safe `"unknown"` rather than guessing. This
+  applies uniformly to system, member, custom-field, and note (journal)
+  visibility.
+- **Front status is free text.** `fronts[].custom_status` becomes
+  `FrontPeriod.status` verbatim; there is no controlled vocabulary on the Sheaf
+  side, so none is imposed.
+- **Tags are taxonomy.** Sheaf tags become `TaxonomyTerm` with `kind: "tag"`;
+  the importer only lifts terms whose `kind` is `tag` back into Sheaf tags, so a
+  future taxonomy of another kind round-trips through extensions rather than
+  being mistaken for a tag.
+- **PluralKit IDs are source refs.** `pluralkit_id` becomes a
+  `source_refs[]` entry with `app: "pluralkit"` and back again (see Provenance).
+- **Custom-field options pass through as-is.** Sheaf stores `options` as JSONB
+  (`dict | None`); it is emitted and re-read unchanged, so both the array-style
+  and object-style option shapes survive.
+- **Lineage is not persisted.** A Sheaf re-export does not carry forward the
+  lineage of a file it imported; see the limitation under
+  [Provenance and lineage](#provenance-and-lineage) and issue #7.
+
+### Preserving data Sheaf cannot model (incoming)
+
+Sheaf maps the subset of OpenPlural it models; without preservation, a file from
+another app would lose everything Sheaf has no home for. To avoid being a lossy
+hop, the importer captures that residual on import and re-merges it into the next
+OpenPlural export. This is the **baseline tier** of the preservation contract
+Sheaf proposed upstream ([skylartaylor/openplural#11](https://github.com/skylartaylor/openplural/issues/11)):
+file-level and whole-section passthrough.
+
+What is preserved (`services/openplural_archive.py`, `extract_residual`):
+
+| Residual | Source |
+| --- | --- |
+| Foreign `extensions` namespaces | File-level `extensions` keys other than `sheaf` (e.g. `extensions.prism`). |
+| `chat` module | Whole object, re-advertised in `capabilities.modules` on export. |
+| `relationships` module | Whole object, re-advertised in `capabilities.modules` on export. |
+| `front_events` / `front_comments` | Fronting shapes Sheaf has no model for (intervals only; `front_events` conversion is tracked as a separate follow-up). |
+| Non-tag `taxonomy_terms` + their assignments | Sheaf models only `kind: "tag"`; roles and other kinds are preserved. |
+
+Storage: the residual is JSON, zlib-compressed, then encrypted at rest (it can
+carry message bodies and other content Sheaf treats as sensitive), and parked on
+`System.openplural_archive`. It is bounded by `OPENPLURAL_MAX_PRESERVED_MB`
+(default 8, measured on the raw JSON); a file over that has its residual dropped
+with a warning rather than stored unbounded. The residual rides the native
+Article-20 export (decrypted) and is deleted with the account, so it is the
+user's data with the usual export and erasure coverage. Re-importing from a
+second app merges namespaces rather than clobbering the first.
+
+**Not yet preserved (the "full passthrough" follow-up):** per-record foreign
+`extensions` (e.g. `extensions.prism` on one member). Re-attaching those on
+export needs stable per-record identity (via `source_refs`), which Sheaf does
+not yet track for arbitrary imported records. When an incoming file carries
+per-record foreign extensions, the importer emits a one-off warning rather than
+silently dropping them.
+
+### Known gaps and open spec issues
+
+Much of what currently round-trips via `extensions.sheaf.*` should move to core
+records or dedicated modules if the matching upstream work lands. Sheaf filed
+issues #2 through #9 against
+[skylartaylor/openplural](https://github.com/skylartaylor/openplural) toward
+that (drafts live in `../sheaf-design-docs/openplural-adoption/`):
+
+- **#2 - Add nullable `parent_post_id` to `BoardPost`.** Board posts carry a
+  single-level reply pointer (`parent_message_id`) with no core field today; it
+  parks under `extensions.sheaf.parent_message_id`.
+- **#3 - Preserve author display names on `Note` / `BoardPost`.** Snapshot the
+  author name so a record stays legible after the authoring member is deleted;
+  Sheaf carries `author_member_names` under `extensions.sheaf` meanwhile.
+- **#4 - A `revisions` module for edit history.** Journal/bio/message edit
+  history has no core shape, so it parks under `extensions.sheaf.revisions`.
+- **#5 - `SourceRef` per-instance disambiguation for self-hosted apps.** Two
+  self-hosted Sheaf instances are indistinguishable as a `SourceRef` `app`
+  today.
+- **#6 - Importers must preserve and append `source_refs`, not replace.** So a
+  record's full cross-app pedigree survives each hop. Sheaf appends from day one.
+- **#7 - Envelope-level `lineage[]` for file provenance.** Define how the
+  file-journey chain accumulates across round-trips; Sheaf emits
+  `extensions.sheaf.lineage` now but cannot persist an inherited chain yet (see
+  the limitation above).
+- **#8 - Specify markdown flavour and in-body image embed syntax.** Pin how
+  `description` / `body` markdown and embedded image references are written so
+  bodies render identically across apps.
+- **#9 - Standardise the `.openplural` zip bundle format.** Where bundled asset
+  bytes live in the archive, so the `bundle_path` pointer can move out of the
+  Sheaf namespace into the core asset shape.
+
+The data forced into `extensions.sheaf.*` until those land: the polls and
+reminders payloads (await the v0.2 modules), System Safety / retention config,
+journal-and-bio revision history (#4), and the notification config
+(`watch_tokens` plus the member `notify_on_front_*` preferences and
+`quick_switch_pin`).
+
+---
+
+## Updating this log
+
+When the mapping logic changes - a field moves from `extensions.sheaf.*` into a
+new core record, a new section is mapped, an enum is remapped, an upstream issue
+lands - do two things:
+
+1. Bump `OPENPLURAL_IMPL_VERSION` in `sheaf/services/openplural_export.py` (and
+   add the new value to the importer's `SUPPORTED_VERSIONS` if the change is not
+   backward-compatible for reading older files).
+2. Add a new dated `## Sheaf X.Y.Z` section here describing exactly what changed.
+
+The goal is that an export stamped with any past `app_version` /
+`exporter_version` remains diagnosable from this file alone: someone holding an
+old file should be able to look up the matching section and know precisely how
+that build mapped their data.

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -907,6 +907,14 @@ MAX_IMPORT_RESTORED_IMAGES=20000 # per-import image-restore cap (archive import)
 
 The last knob bounds how many images one export-with-images archive import will restore. The storage quota already bounds the restored bytes; this bounds the number of normalization passes a single job can demand, so a crafted zip full of tiny images can't monopolise the import runner. An import that hits the cap completes with a warning and strips the remaining image references. Raise it if your system genuinely has more images than the default.
 
+OpenPlural imports additionally preserve data Sheaf cannot model (other apps' `extensions` namespaces, the chat/relationships modules, non-tag taxonomy) so a Sheaf-in-the-middle round-trip is not lossy: that residual is compressed and encrypted on the system and re-emitted on the next OpenPlural export. Its size is bounded by:
+
+```env
+OPENPLURAL_MAX_PRESERVED_MB=8    # max preserved unsupported-data per system; 0 = unlimited
+```
+
+Measured on the raw (pre-compression) JSON. A file whose unsupported data exceeds this has its residual dropped with a warning rather than stored unbounded. `0` disables the cap (unlimited), matching the storage-quota convention. See `docs/OPENPLURAL.md` for what gets preserved.
+
 ### Animated avatars
 
 Animated GIF / animated WebP uploads are **flattened to their first frame by default**, regardless of how they were uploaded. To allow animation:

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -2,7 +2,7 @@
 
 Returns the user's plural-system content in a structured, re-importable
 JSON format. Account/identity data + server-derived telemetry (sessions,
-API key audit, IPs) live in the Article 15 endpoint instead — they
+API key audit, IPs) live in the Article 15 endpoint instead - they
 shouldn't ride along when someone shares their export with another
 person or imports it into a different Sheaf instance.
 
@@ -13,8 +13,9 @@ delivered as a zip via S3-presigned download or filesystem stream.
 
 import uuid
 from datetime import UTC, datetime
+from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -45,6 +46,7 @@ from sheaf.services import export_storage
 from sheaf.services.custom_fields import field_value_plaintext
 from sheaf.services.journals import entry_plaintext, revision_plaintext
 from sheaf.services.members import member_plaintext
+from sheaf.services.openplural_archive import unpack_residual
 
 router = APIRouter(prefix="/export", tags=["export"])
 
@@ -53,11 +55,19 @@ router = APIRouter(prefix="/export", tags=["export"])
 async def export_all(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    format: Literal["sheaf", "openplural"] = Query(
+        "sheaf",
+        description=(
+            "Output format. 'sheaf' is the native re-importable JSON; "
+            "'openplural' wraps it in an OpenPlural v0.1 envelope "
+            "(uri-only assets; use the async zip export for image bytes)."
+        ),
+    ),
 ):
-    """Export the user's plural-system content as JSON. Article 20 — data
+    """Export the user's plural-system content as JSON. Article 20 - data
     portability. Re-importable into another Sheaf instance.
 
-    Excludes account-identity data (email, sessions, API keys, IPs) — that
+    Excludes account-identity data (email, sessions, API keys, IPs) - that
     lives in the separate /v1/account/data endpoint (Article 15).
     """
 
@@ -65,10 +75,10 @@ async def export_all(
     result = await db.execute(select(System).where(System.user_id == user.id))
     system = result.scalar_one_or_none()
     if system is None:
-        return _empty_export()
+        return _maybe_openplural(_empty_export(), format)
 
     # Members. Member.name is encrypted ciphertext, so DB-side ORDER BY on
-    # it is meaningless — sort in Python after decrypting names below.
+    # it is meaningless - sort in Python after decrypting names below.
     members_result = await db.execute(
         select(Member).where(Member.system_id == system.id)
     )
@@ -120,7 +130,7 @@ async def export_all(
 
     # Content revisions: bio (member.id) + journal-entry (entry.id) edit
     # history. Polymorphic, so we filter by target_id IN ({member_ids,
-    # journal_ids}) — much cheaper than a per-row lookup.
+    # journal_ids}) - much cheaper than a per-row lookup.
     member_id_set = {m.id for m, *_ in members_with_plaintext}
     journal_id_set = {e.id for e in journal_entries}
     targets = list(member_id_set | journal_id_set)
@@ -142,7 +152,7 @@ async def export_all(
     else:
         revisions = []
 
-    # Watch tokens + their channels — owner-side notification config the
+    # Watch tokens + their channels - owner-side notification config the
     # user explicitly built up. Re-importable in the sense that the
     # filter/trigger/payload/delivery shaping config carries over to
     # another instance; per-channel destination state (recipient
@@ -164,7 +174,7 @@ async def export_all(
     )
     watch_tokens = list(tokens_result.scalars().all())
 
-    # File inventory — image bytes themselves don't ride along with the
+    # File inventory - image bytes themselves don't ride along with the
     # sync export (use the async with-images job for that), but the
     # metadata IS portable user data and should be in the Article 20
     # dump so re-import can know "you had these files" even if it
@@ -176,7 +186,7 @@ async def export_all(
     )
     uploaded_files = list(files_result.scalars().all())
 
-    # Reminders — config the user explicitly set up. Title and body are
+    # Reminders - config the user explicitly set up. Title and body are
     # encrypted at rest; we decrypt for the export so the user has the
     # plaintext. Pending queue rows are runtime state and not exported.
     from sheaf.models.reminder import Reminder
@@ -189,7 +199,7 @@ async def export_all(
     )
     reminders = list(reminders_result.scalars().all())
 
-    # Polls — same encryption discipline as reminders. We export both
+    # Polls - same encryption discipline as reminders. We export both
     # current vote rows and the audit log, since the audit is part of
     # what makes the poll legible after the fact.
     from sheaf.models.poll import Poll
@@ -206,7 +216,7 @@ async def export_all(
     )
     polls = list(polls_result.scalars().all())
 
-    # Messages — boards + threads. Body is decrypted; deleted messages
+    # Messages - boards + threads. Body is decrypted; deleted messages
     # excluded (those carry no remaining content). Revisions ride the
     # existing content_revisions surface and aren't dumped here per the
     # same shape as journals.
@@ -219,7 +229,7 @@ async def export_all(
     )
     messages_rows = list(msgs_result.scalars().all())
 
-    return {
+    native = {
         "version": "2",
         "system": _system_dict(system),
         "members": [
@@ -304,6 +314,22 @@ async def export_all(
         "polls": [_poll_dict(p) for p in polls],
         "messages": [_message_dict(m) for m in messages_rows],
     }
+    return _maybe_openplural(native, format)
+
+
+def _maybe_openplural(native: dict, format: str) -> dict:
+    """Return the native dict unchanged, or wrap it in an OpenPlural v0.1
+    envelope when `format == "openplural"`.
+
+    The sync path produces uri-only assets (no image bytes); the async
+    zip builder calls `openplural_export.build_envelope` directly with
+    `include_asset_bytes=True` for the bundle.
+    """
+    if format != "openplural":
+        return native
+    from sheaf.services.openplural_export import build_envelope
+
+    return build_envelope(native, exported_at=datetime.now(UTC).isoformat())
 
 
 def _empty_export() -> dict:
@@ -362,6 +388,10 @@ def _system_dict(system: System) -> dict:
             "journal_max_revision_days": system.journal_max_revision_days,
             "pinned_revision_max_per_target": system.pinned_revision_max_per_target,
         },
+        # OpenPlural import residual (foreign data Sheaf cannot model),
+        # decrypted to a plain dict so it rides the portability export and
+        # is re-merged on a Sheaf OpenPlural export. None when empty.
+        "openplural_archive": unpack_residual(system.openplural_archive) or None,
     }
 
 
@@ -421,7 +451,7 @@ def _channel_dict(channel: NotificationChannel) -> dict:
     - webhook_secret_encrypted (lives in a separate column; would need
       to be re-entered by the owner on a new instance anyway)
 
-    destination_config is included verbatim — it may carry a recipient's
+    destination_config is included verbatim - it may carry a recipient's
     push endpoint or a webhook URL, all of which the owner already has
     in some external system; the secret bits (BYO Pushover app_token,
     ntfy auth header) are user-set credentials that the owner controls
@@ -593,6 +623,9 @@ def _poll_dict(poll) -> dict:
 
 class ExportJobRequest(BaseModel):
     include_images: bool = False
+    # Artefact format: "sheaf_native" (export.json + images/) or
+    # "openplural" (openplural.json + assets/, an .openplural.zip bundle).
+    format: Literal["sheaf_native", "openplural"] = "sheaf_native"
     # Step-up auth: same shape and rules as POST /v1/account/data. Always
     # required; mirrors the Article 15 lock since this is the broader read
     # (everything the user has, including binary blobs).
@@ -615,7 +648,7 @@ async def create_export_job(
     background; the user polls or waits for the email/banner.
 
     Step-up requires password (and TOTP if enrolled) regardless of the
-    system's `delete_confirmation` setting — async export is the highest-
+    system's `delete_confirmation` setting - async export is the highest-
     volume read endpoint we have, and the build worker delivers the file
     to whatever session ends up downloading it. Refuses API-key auth so
     a leaked key can't trigger an unattended bulk extraction.
@@ -683,6 +716,7 @@ async def create_export_job(
         id=uuid.uuid4(),
         user_id=user.id,
         include_images=body.include_images,
+        format=body.format,
         status=ExportJobStatus.PENDING,
         requested_at=datetime.now(UTC),
     )
@@ -726,7 +760,7 @@ async def download_export_job(
     """Stream the export artefact (filesystem) or 302 to a presigned URL
     (S3). Job must belong to the caller and be DONE + not yet expired.
 
-    Download is gated by the normal session/JWT auth — the step-up at
+    Download is gated by the normal session/JWT auth - the step-up at
     enqueue time is what protects against drive-by extraction; the
     download itself is just retrieving an already-built artefact.
     """
@@ -741,7 +775,10 @@ async def download_export_job(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Export file no longer available",
         )
-    filename = f"sheaf-export-{job.id}.zip"
+    if job.format == "openplural":
+        filename = f"sheaf-export-{job.id}.openplural.zip"
+    else:
+        filename = f"sheaf-export-{job.id}.zip"
     return await export_storage.download_response(job.file_location, filename)
 
 
@@ -760,6 +797,7 @@ def _job_to_dict(job: ExportJob) -> dict:
     return {
         "id": str(job.id),
         "include_images": job.include_images,
+        "format": job.format,
         "status": job.status,
         "requested_at": job.requested_at.isoformat(),
         "started_at": job.started_at.isoformat() if job.started_at else None,

--- a/sheaf/api/v1/openplural_import.py
+++ b/sheaf/api/v1/openplural_import.py
@@ -1,0 +1,94 @@
+"""OpenPlural import - preview endpoint.
+
+The actual import runs asynchronously through the unified job runner
+(POST /v1/imports/file with source=openplural_file). This is the
+synchronous preview: parse an OpenPlural v0.1 export, translate it to
+the native shape, and summarise the importable data. Preview writes
+nothing.
+
+Accepts both shapes the exporter produces: a bare OpenPlural JSON
+document and an `.openplural.zip` bundle (`openplural.json` +
+`assets/`), distinguished by the zip magic bytes. The response carries
+`archive` / `image_count` so the client knows which flavour it
+previewed, and `lineage_length` so it can surface the file's prior
+journey.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+
+from sheaf.auth.dependencies import get_current_user
+from sheaf.models.user import User
+from sheaf.services.import_parsing import ImportPayloadError
+from sheaf.services.openplural_import import (
+    inherited_lineage,
+    looks_like_zip,
+    parse_bundle_async,
+    parse_json,
+    to_native,
+)
+from sheaf.services.sheaf_import import SheafPreviewSummary, preview
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+MAX_IMPORT_SIZE = 100 * 1024 * 1024  # 100MB
+
+
+def _summary_dict(p: SheafPreviewSummary) -> dict:
+    return {
+        "system_name": p.system_name,
+        "member_count": p.member_count,
+        "members": p.members,
+        "front_count": p.front_count,
+        "group_count": p.group_count,
+        "tag_count": p.tag_count,
+        "custom_field_count": p.custom_field_count,
+        "journal_count": p.journal_count,
+        "message_count": p.message_count,
+        "poll_count": p.poll_count,
+        "reminder_count": p.reminder_count,
+        "channel_count": p.channel_count,
+    }
+
+
+@router.post("/openplural/preview")
+async def preview_openplural_import(
+    file: UploadFile,
+    _user: User = Depends(get_current_user),
+):
+    """Parse an OpenPlural export (JSON or .openplural.zip) and summarise it."""
+    data = await file.read()
+    if len(data) > MAX_IMPORT_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Import file too large. Max 100MB.",
+        )
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Import file is empty.",
+        )
+
+    try:
+        if looks_like_zip(data):
+            parsed, envelope = await parse_bundle_async(data)
+            summary = preview(parsed.data)
+            return {
+                **_summary_dict(summary),
+                "archive": True,
+                "image_count": len(parsed.image_keys),
+                "lineage_length": len(inherited_lineage(envelope)),
+            }
+        envelope = parse_json(data)
+        summary = preview(to_native(envelope))
+        return {
+            **_summary_dict(summary),
+            "archive": False,
+            "image_count": 0,
+            "lineage_length": len(inherited_lineage(envelope)),
+        }
+    except ImportPayloadError as exc:
+        # User-facing parse/version failures (bad JSON, bad zip, unknown
+        # openplural_version) map to a 400 with the short message.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -23,6 +23,7 @@ from sheaf.api.v1 import (
     messages,
     notification_channels,
     notifications_public,
+    openplural_import,
     pk_import,
     pluralspace_import,
     polls,
@@ -148,6 +149,10 @@ v1_router.include_router(
 )
 v1_router.include_router(
     pluralspace_import.router,
+    dependencies=[Depends(require_scope("import:write"))],
+)
+v1_router.include_router(
+    openplural_import.router,
     dependencies=[Depends(require_scope("import:write"))],
 )
 v1_router.include_router(

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -83,6 +83,14 @@ class Settings(BaseSettings):
     # the body is buffered anywhere. Must be >= the largest per-endpoint cap
     # (currently the 100MB import endpoint) plus a little multipart overhead.
     max_request_body_size_mb: int = 110
+    # OpenPlural import: max size (MB) of foreign data Sheaf cannot model
+    # (other apps' `extensions` namespaces, the chat/relationships modules,
+    # front_events/front_comments, non-tag taxonomy) that gets preserved as
+    # an opaque archive on the system and re-emitted on the next OpenPlural
+    # export. Measured on the raw (pre-compression) JSON; over this, the
+    # residual is dropped with a warning rather than stored unbounded.
+    openplural_max_preserved_mb: int = 8
+
     # Storage quotas per tier (MB). 0 = unlimited.
     storage_quota_free_mb: int = 50
     storage_quota_plus_mb: int = 500

--- a/sheaf/models/export_job.py
+++ b/sheaf/models/export_job.py
@@ -48,6 +48,15 @@ class ExportJob(UUIDMixin, Base):
         Boolean, nullable=False, default=False, server_default="false"
     )
 
+    # Output format: "sheaf_native" (export.json + images/) or
+    # "openplural" (openplural.json + assets/, an .openplural.zip bundle).
+    format: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="sheaf_native",
+        server_default="sheaf_native",
+    )
+
     # State machine: pending -> running -> done | failed; done -> expired
     # after the file is cleaned up. EXPIRED rows stick around so the user
     # can see the historical request even after the file is gone.

--- a/sheaf/models/import_job.py
+++ b/sheaf/models/import_job.py
@@ -34,6 +34,11 @@ class ImportJobSource(enum.StrEnum):
     SHEAF_ARCHIVE = "sheaf_archive"
     PLURALSPACE_FILE = "pluralspace_file"
     PRISM_FILE = "prism_file"
+    # OpenPlural v0.1 envelope: a bare .json document or an .openplural.zip
+    # bundle (openplural.json + assets/). The runner sniffs which by the
+    # zip magic; both translate to the native shape and reuse the Sheaf
+    # JSON / archive importers underneath.
+    OPENPLURAL_FILE = "openplural_file"
 
 
 class ImportJobStatus(enum.StrEnum):

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -139,6 +139,15 @@ class System(UUIDMixin, TimestampMixin, Base):
         Integer, nullable=True
     )
 
+    # OpenPlural import residual: foreign data Sheaf does not model (other
+    # apps' `extensions` namespaces, the chat/relationships modules,
+    # front_events/front_comments, non-tag taxonomy) preserved verbatim on
+    # import and re-merged into the next OpenPlural export, so a
+    # Sheaf-in-the-middle round-trip does not silently drop it. Stored
+    # encrypted (it can carry message bodies) and zlib-compressed; see
+    # services/openplural_archive.py. NULL when nothing was preserved.
+    openplural_archive: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Relationships
     user: Mapped["User"] = relationship(back_populates="system")
     members: Mapped[list["Member"]] = relationship(

--- a/sheaf/schemas/imports.py
+++ b/sheaf/schemas/imports.py
@@ -44,6 +44,7 @@ class ImportFileCreateRequest(BaseModel):
         ImportJobSource.SHEAF_ARCHIVE,
         ImportJobSource.PLURALSPACE_FILE,
         ImportJobSource.PRISM_FILE,
+        ImportJobSource.OPENPLURAL_FILE,
     ]
     idempotency_key: uuid.UUID
     # Source-specific options as JSON string in the form field. Parsed

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -51,6 +51,24 @@ image references removed.
 """
 
 
+_OPENPLURAL_README = """\
+This zip is an OpenPlural v0.1 bundle export of your Sheaf data.
+
+Contents:
+- openplural.json -- your plural-system content mapped to the OpenPlural
+  v0.1 data standard (https://github.com/skylartaylor/openplural).
+  Systems, members, groups, tags, custom fields, front history, and
+  journals map to OpenPlural core records; everything Sheaf has that
+  the spec does not yet model is preserved under extensions.sheaf.*
+- assets/ -- the binary blobs (avatars, banners, journal images)
+  referenced by the assets[] entries via their bundle_path.
+
+Re-importable into Sheaf (Settings -> Import) and into any other app
+that supports OpenPlural v0.1. See docs/OPENPLURAL.md in the Sheaf
+source for the field-by-field mapping and known gaps.
+"""
+
+
 async def run_build_tick() -> int:
     """Process one batch of pending export jobs. Returns count handled.
 
@@ -113,7 +131,7 @@ async def _build(job_id: uuid.UUID) -> None:
         try:
             try:
                 tmp_path, size_bytes = await _assemble_zip_to_tempfile(
-                    db, user, include_images=job.include_images
+                    db, user, include_images=job.include_images, fmt=job.format
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.exception("Export build failed for job %s", job_id)
@@ -186,44 +204,94 @@ async def _mark_failed(db: AsyncSession, job: ExportJob, reason: str) -> None:
 
 
 async def _assemble_zip_to_tempfile(
-    db: AsyncSession, user: User, *, include_images: bool
+    db: AsyncSession, user: User, *, include_images: bool, fmt: str = "sheaf_native"
 ) -> tuple[str, int]:
     """Build the zip artefact on disk and return (path, size_bytes).
 
-    Layout:
+    Native layout (`fmt="sheaf_native"`):
         export.json   -- same shape as the sync /v1/export endpoint
         README.txt    -- explains the asymmetry around image re-import
         images/<key>  -- (when include_images) the binary blobs
 
+    OpenPlural bundle (`fmt="openplural"`):
+        openplural.json   -- OpenPlural v0.1 envelope
+        README.txt        -- bundle notes
+        assets/<key>      -- (when include_images) the referenced blobs
+
     Streams images through `zipfile.open(..., 'w')` so each blob lives
-    in RAM only while it's actively being written — never accumulates.
+    in RAM only while it's actively being written, never accumulating.
     The JSON payload is built in-memory because the sync /v1/export
     endpoint already returns the whole dict; refactoring that to
     stream would be a much bigger change.
     """
-    # Build the JSON payload by calling the same code path the sync
+    # Build the native payload by calling the same code path the sync
     # endpoint uses, so we don't drift between the two.
     from sheaf.api.v1.export import export_all  # late import to avoid cycle
 
-    json_payload = await export_all(user=user, db=db)
-    json_bytes = json.dumps(json_payload, indent=2, default=str).encode("utf-8")
+    native_payload = await export_all(user=user, db=db)
 
     tmp_dir = settings.export_build_tmp_dir or None
     fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="sheaf-export-", dir=tmp_dir)
     os.close(fd)  # zipfile reopens the path; we just needed exclusive creation
     try:
         with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            zf.writestr("export.json", json_bytes)
-            zf.writestr("README.txt", _README)
+            if fmt == "openplural":
+                from sheaf.services.openplural_export import build_envelope
 
-            if include_images:
-                await _add_images(zf, db, user)
+                envelope = build_envelope(
+                    native_payload,
+                    exported_at=datetime.now(UTC).isoformat(),
+                    include_asset_bytes=include_images,
+                )
+                zf.writestr(
+                    "openplural.json",
+                    json.dumps(envelope, indent=2, default=str).encode("utf-8"),
+                )
+                zf.writestr("README.txt", _OPENPLURAL_README)
+                if include_images:
+                    await _add_openplural_assets(zf, envelope)
+            else:
+                zf.writestr(
+                    "export.json",
+                    json.dumps(native_payload, indent=2, default=str).encode("utf-8"),
+                )
+                zf.writestr("README.txt", _README)
+                if include_images:
+                    await _add_images(zf, db, user)
         size_bytes = os.path.getsize(tmp_path)
     except Exception:
         with contextlib.suppress(FileNotFoundError):
             os.unlink(tmp_path)
         raise
     return tmp_path, size_bytes
+
+
+async def _add_openplural_assets(zf: zipfile.ZipFile, envelope: dict) -> None:
+    """Pack the blobs the OpenPlural envelope references under assets/<key>.
+
+    Only assets carrying an `extensions.sheaf.storage_key` (Sheaf-internal
+    references) have bytes to bundle; external CDN URLs stay uri-only.
+    Each blob is fetched and written one at a time so per-asset memory is
+    bounded by the largest single blob, mirroring `_add_images`.
+    """
+    storage = get_storage()
+    seen: set[str] = set()
+    for asset in envelope.get("assets", []) or []:
+        ext = (asset.get("extensions") or {}).get("sheaf") or {}
+        key = ext.get("storage_key")
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        try:
+            blob = await storage.get(key)
+        except Exception:  # noqa: BLE001
+            logger.warning("Skipping unreadable asset %s in OpenPlural export", key)
+            continue
+        if blob is None:
+            continue
+        with zf.open(f"assets/{key}", "w") as dest:
+            dest.write(blob)
+        del blob
 
 
 async def _add_images(

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -432,6 +432,7 @@ def _register_builtin_handlers() -> None:
     """
     # pk_import_runner registers both pluralkit_file and pluralkit_api.
     from sheaf.services import (
+        openplural_import_runner,  # noqa: F401
         pk_import_runner,  # noqa: F401
         pluralspace_import_runner,  # noqa: F401
         prism_import_runner,  # noqa: F401

--- a/sheaf/services/openplural_archive.py
+++ b/sheaf/services/openplural_archive.py
@@ -34,10 +34,12 @@ from sheaf.crypto import decrypt, encrypt
 _OWN_NS = "sheaf"
 
 # Whole top-level objects/sections Sheaf does not translate. Captured
-# verbatim. `chat` / `relationships` are spec modules; `front_events` /
-# `front_comments` are fronting shapes Sheaf has no model for (it stores
-# intervals only - front_events conversion is tracked separately).
-_PASSTHROUGH_TOP_LEVEL = ("chat", "relationships", "front_events", "front_comments")
+# verbatim. `chat` / `relationships` are spec modules Sheaf has no feature
+# for; `front_comments` are time-anchored comments on fronting that Sheaf
+# has no model for. NB `front_events` are NOT here: the importer converts
+# them to interval fronts (see openplural_import._fronts_from_events), so
+# they are consumed, not preserved.
+_PASSTHROUGH_TOP_LEVEL = ("chat", "relationships", "front_comments")
 
 
 def extract_residual(envelope: dict) -> dict:

--- a/sheaf/services/openplural_archive.py
+++ b/sheaf/services/openplural_archive.py
@@ -1,0 +1,180 @@
+"""OpenPlural import-residual preservation.
+
+Sheaf's OpenPlural importer maps the subset of the format it models and,
+without this module, drops the rest. That makes Sheaf a lossy hop: a
+file from another app loses that app's `extensions` namespaces, its chat
+and relationships modules, switch-style `front_events` / `front_comments`,
+and non-tag taxonomy on the way through.
+
+This module captures that residual on import and re-merges it into the
+next OpenPlural export, so a Sheaf-in-the-middle round-trip preserves it.
+This is the "baseline" tier of the preservation contract Sheaf proposed
+upstream (skylartaylor/openplural#11): file-level and whole-section
+passthrough. Per-record foreign `extensions` (which need stable record
+identity to re-attach) are not preserved yet and are reported with a
+warning; that is the follow-up "full passthrough" tier.
+
+Storage: the residual is JSON, zlib-compressed (it can be large), then
+encrypted at rest (it can carry message bodies and other content Sheaf
+treats as sensitive), and parked on `System.openplural_archive`. It is
+bounded by `settings.openplural_max_preserved_mb` (measured on the raw
+JSON) so a hostile or huge file cannot grow the row without limit.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import zlib
+
+from sheaf.crypto import decrypt, encrypt
+
+# The reserved namespace Sheaf owns; everything else under file-level
+# `extensions` is foreign and gets preserved.
+_OWN_NS = "sheaf"
+
+# Whole top-level objects/sections Sheaf does not translate. Captured
+# verbatim. `chat` / `relationships` are spec modules; `front_events` /
+# `front_comments` are fronting shapes Sheaf has no model for (it stores
+# intervals only - front_events conversion is tracked separately).
+_PASSTHROUGH_TOP_LEVEL = ("chat", "relationships", "front_events", "front_comments")
+
+
+def extract_residual(envelope: dict) -> dict:
+    """Return the parts of an OpenPlural envelope Sheaf does not model.
+
+    Empty dict when there is nothing to preserve. Pure: no IO.
+    """
+    residual: dict = {}
+
+    # Foreign file-level extensions namespaces (everything but our own).
+    ext = envelope.get("extensions")
+    if isinstance(ext, dict):
+        foreign = {k: v for k, v in ext.items() if k != _OWN_NS}
+        if foreign:
+            residual["extensions"] = foreign
+
+    # Whole un-consumed top-level sections / modules.
+    for key in _PASSTHROUGH_TOP_LEVEL:
+        val = envelope.get(key)
+        if val:
+            residual[key] = val
+
+    # Non-tag taxonomy: Sheaf only models tag-kind terms. Preserve the rest
+    # (roles, sources, custom kinds) and their assignments.
+    terms = envelope.get("taxonomy_terms")
+    if isinstance(terms, list):
+        non_tag = [
+            t for t in terms if isinstance(t, dict) and t.get("kind") != "tag"
+        ]
+        if non_tag:
+            residual["taxonomy_terms"] = non_tag
+            non_tag_ids = {t.get("id") for t in non_tag}
+            assignments = envelope.get("taxonomy_assignments")
+            if isinstance(assignments, list):
+                kept = [
+                    a
+                    for a in assignments
+                    if isinstance(a, dict) and a.get("term_id") in non_tag_ids
+                ]
+                if kept:
+                    residual["taxonomy_assignments"] = kept
+
+    return residual
+
+
+# Record arrays whose per-record `extensions` could carry a foreign
+# namespace. Used only to decide whether to warn that per-record
+# preservation is not done yet (the full-passthrough follow-up).
+_RECORD_ARRAYS = (
+    "systems",
+    "members",
+    "groups",
+    "taxonomy_terms",
+    "custom_fields",
+    "front_periods",
+    "notes",
+)
+
+
+def has_per_record_foreign_extensions(envelope: dict) -> bool:
+    """True if any record carries a per-record `extensions` namespace other
+    than Sheaf's own. Sheaf preserves file-level residual but not per-record
+    foreign extensions yet, so this drives a one-off warning."""
+    for key in _RECORD_ARRAYS:
+        for rec in envelope.get(key) or []:
+            if not isinstance(rec, dict):
+                continue
+            ext = rec.get("extensions")
+            if isinstance(ext, dict) and any(ns != _OWN_NS for ns in ext):
+                return True
+    boards = envelope.get("boards")
+    if isinstance(boards, dict):
+        for post in boards.get("posts") or []:
+            if isinstance(post, dict):
+                ext = post.get("extensions")
+                if isinstance(ext, dict) and any(ns != _OWN_NS for ns in ext):
+                    return True
+    return False
+
+
+def merge_residual(existing: dict, incoming: dict) -> dict:
+    """Combine a previously-preserved residual with a new one.
+
+    Re-importing from a second foreign app must not wipe the first app's
+    preserved data. Merge at top-level-key granularity; for `extensions`
+    merge namespaces (incoming wins on a clash); for the list sections
+    the incoming file replaces (it is the fresher snapshot of that
+    section). Empty inputs are tolerated.
+    """
+    if not existing:
+        return dict(incoming)
+    if not incoming:
+        return dict(existing)
+    merged = dict(existing)
+    for key, val in incoming.items():
+        if key == "extensions" and isinstance(val, dict):
+            base = dict(merged.get("extensions") or {})
+            base.update(val)
+            merged["extensions"] = base
+        else:
+            merged[key] = val
+    return merged
+
+
+def pack_residual(residual: dict, *, max_bytes: int) -> tuple[str | None, str | None]:
+    """Compress + encrypt a residual for storage.
+
+    Returns ``(token, warning)``. ``token`` is None when there is nothing
+    to store or when the raw JSON exceeds ``max_bytes`` (in which case
+    ``warning`` explains the drop). The size check is on the uncompressed
+    JSON: it bounds what we are willing to retain, not the on-disk size.
+    """
+    if not residual:
+        return None, None
+    raw = json.dumps(residual, separators=(",", ":")).encode("utf-8")
+    if max_bytes and len(raw) > max_bytes:
+        return None, (
+            f"preserved {len(raw)} bytes of unsupported OpenPlural data exceeds "
+            f"the {max_bytes // (1024 * 1024)}MB limit "
+            "(OPENPLURAL_MAX_PRESERVED_MB); it was not retained"
+        )
+    compressed = zlib.compress(raw, 9)
+    token = encrypt(base64.b64encode(compressed).decode("ascii"))
+    return token, None
+
+
+def unpack_residual(token: str | None) -> dict:
+    """Inverse of ``pack_residual``. Returns {} for NULL/empty/corrupt.
+
+    Tolerant by design: a residual that fails to decode must never break
+    an export. A corrupt blob yields an empty residual (the export is
+    simply missing the preserved data, not failed)."""
+    if not token:
+        return {}
+    try:
+        compressed = base64.b64decode(decrypt(token))
+        data = json.loads(zlib.decompress(compressed))
+    except Exception:  # noqa: BLE001 - corrupt archive must not break export
+        return {}
+    return data if isinstance(data, dict) else {}

--- a/sheaf/services/openplural_export.py
+++ b/sheaf/services/openplural_export.py
@@ -1,0 +1,484 @@
+"""OpenPlural v0.1 export mapping.
+
+Sheaf is a founding adopter of the OpenPlural data standard
+(https://github.com/skylartaylor/openplural). This module is a *pure*
+transform: it takes the native Article-20 export dict that
+``sheaf/api/v1/export.py::export_all`` already produces (version "2")
+and reshapes it into an OpenPlural v0.1 envelope. It performs no DB
+access and no decryption - everything it needs is already plaintext in
+the native dict.
+
+The mapping follows the Sheaf card in ``../openplural/adopt.md``. Every
+field Sheaf has that OpenPlural v0.1 can model goes into a core record;
+everything else is preserved losslessly under the namespaced
+``extensions.sheaf`` key so a round-trip back into Sheaf restores it and
+another app can at least carry it forward. See ``docs/OPENPLURAL.md``
+for the full per-field rationale and the running implementation log.
+
+Two delivery shapes share this builder:
+
+* The sync ``GET /v1/export?format=openplural`` path emits a single
+  JSON document with *uri-only* assets (avatar URLs, no bytes) and a
+  top-level ``asset_uri_only`` warning.
+* The async ``.openplural.zip`` bundle additionally writes the blobs to
+  ``assets/<key>`` and records the in-zip path under each asset's
+  ``extensions.sheaf.bundle_path`` (the official bundle-path convention
+  is still pending upstream issue #9; until it lands we keep ``uri``
+  present so the document stays spec-valid and stash our pointer in our
+  own namespace).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sheaf import __version__
+
+# What this module targets / advertises.
+OPENPLURAL_VERSION = "0.1"
+# Bumped independently of the Sheaf app version when the *mapping* logic
+# changes in a way worth tracking; surfaces as producer.exporter_version.
+OPENPLURAL_IMPL_VERSION = "0.1.0"
+APP_ID = "sheaf"
+APP_NAME = "Sheaf"
+# The reverse-DNS-free registered namespace key Sheaf owns in the spec.
+EXT_NS = "sheaf"
+
+# Stable namespace for deterministic asset ids derived from storage keys /
+# URLs, so the same blob maps to the same Asset id across exports and a
+# member can reference it by id.
+_ASSET_NS = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
+
+# Native sub-sections with no OpenPlural v0.1 core representation. Carried
+# verbatim under extensions.sheaf.<key> so the round-trip is lossless and
+# the importer can lift them straight back. Each is parked pending the
+# matching upstream module (polls/reminders -> v0.2, etc); see the table
+# in docs/OPENPLURAL.md.
+_EXT_PASSTHROUGH_SECTIONS = (
+    "polls",
+    "reminders",
+    "messages",
+    "revisions",
+    "watch_tokens",
+    "uploaded_files",
+)
+
+
+def _asset_id(key: str) -> str:
+    return str(uuid.uuid5(_ASSET_NS, key))
+
+
+def _internal_key(url: str) -> str | None:
+    """Bare storage key for a Sheaf-internal reference, else None (external).
+
+    Thin wrapper over ``sheaf.files._to_internal_key`` (local import to
+    keep this module's import graph light and DB-free)."""
+    from sheaf.files import _to_internal_key
+
+    return _to_internal_key(url)
+
+
+def _birthday(raw: str | None) -> dict | None:
+    """Map Sheaf's ``"MM-DD"`` / ``"YYYY-MM-DD"`` birthday string to an
+    OpenPlural precision-aware Birthday sub-record."""
+    if not raw:
+        return None
+    parts = raw.split("-")
+    if len(parts) == 3:
+        return {"value": raw, "precision": "day", "year_visible": True}
+    if len(parts) == 2:
+        # Stored without a year - represent as a year-less month/day.
+        return {"value": raw, "precision": "month_day", "year_visible": False}
+    # Anything else: hand it across opaquely rather than dropping it.
+    return {"value": raw, "precision": "unknown", "year_visible": False}
+
+
+class _AssetTable:
+    """Collects unique assets referenced across the export.
+
+    Keyed by storage key / URL so each distinct blob yields one Asset
+    with a deterministic id. ``include_bytes`` only affects whether a
+    ``bundle_path`` pointer is recorded; the builder caller is what
+    actually writes the blob into the zip.
+    """
+
+    def __init__(self, *, include_bytes: bool) -> None:
+        self._by_key: dict[str, dict] = {}
+        self._include_bytes = include_bytes
+        self.uri_only_used = False
+
+    def ref(self, url: str | None, *, kind: str) -> str | None:
+        """Register an asset for ``url`` and return its asset id."""
+        if not url:
+            return None
+        existing = self._by_key.get(url)
+        if existing is not None:
+            return existing["id"]
+        asset: dict = {
+            "id": _asset_id(url),
+            "kind": kind,
+            "uri": url,
+        }
+        # Only Sheaf-internal references have bytes we can bundle; an
+        # external CDN URL (Gravatar, dicebear, a user-typed link) stays
+        # uri-only in both delivery shapes.
+        internal_key = _internal_key(url)
+        if self._include_bytes and internal_key is not None:
+            # The builder writes the blob under this path; until the spec
+            # ratifies a bundle-path convention (issue #9) it lives in our
+            # namespace and the importer reads it from here. The path keys
+            # on the bare storage key so the importer's _to_internal_key
+            # of the (unchanged) uri recovers the same key.
+            asset.setdefault("extensions", {})[EXT_NS] = {
+                "bundle_path": f"assets/{internal_key}",
+                "storage_key": internal_key,
+            }
+        else:
+            self.uri_only_used = True
+        self._by_key[url] = asset
+        return asset["id"]
+
+    def as_list(self) -> list[dict]:
+        return list(self._by_key.values())
+
+
+def build_envelope(
+    native: dict,
+    *,
+    exported_at: str,
+    app_version: str | None = None,
+    inherited_lineage: list | None = None,
+    include_asset_bytes: bool = False,
+) -> dict:
+    """Transform a native export dict into an OpenPlural v0.1 envelope.
+
+    ``exported_at`` is an ISO-8601 UTC timestamp supplied by the caller
+    (this module takes no clock). ``inherited_lineage`` is any
+    ``extensions.sheaf.lineage`` carried in from a prior import, so the
+    file's journey accumulates across round-trips (forward-compat with
+    upstream issue #7). ``include_asset_bytes`` is set by the bundle
+    builder so assets carry an in-zip ``bundle_path``.
+    """
+    app_version = app_version or __version__
+    assets = _AssetTable(include_bytes=include_asset_bytes)
+    warnings: list[dict] = []
+
+    systems: list[dict] = []
+    members: list[dict] = []
+    groups: list[dict] = []
+    group_memberships: list[dict] = []
+    taxonomy_terms: list[dict] = []
+    taxonomy_assignments: list[dict] = []
+    custom_fields: list[dict] = []
+    custom_field_values: list[dict] = []
+    front_periods: list[dict] = []
+    notes: list[dict] = []
+    board_posts: list[dict] = []
+
+    # --- System -----------------------------------------------------------
+    sys_data = native.get("system")
+    if isinstance(sys_data, dict):
+        sys_ext = {
+            "note": sys_data.get("note"),
+            "date_format": sys_data.get("date_format"),
+            "replace_fronts_default": sys_data.get("replace_fronts_default"),
+            "coalesce_contiguous_fronts": sys_data.get("coalesce_contiguous_fronts"),
+            "delete_confirmation": sys_data.get("delete_confirmation"),
+            "safety": sys_data.get("safety"),
+            "retention": sys_data.get("retention"),
+        }
+        systems.append(
+            {
+                "id": sys_data.get("id"),
+                "name": sys_data.get("name"),
+                "description": sys_data.get("description"),
+                "tag": sys_data.get("tag"),
+                "color": sys_data.get("color"),
+                "avatar_asset_id": assets.ref(sys_data.get("avatar_url"), kind="avatar"),
+                "privacy": _privacy(sys_data.get("privacy")),
+                "extensions": {EXT_NS: _prune(sys_ext)},
+            }
+        )
+
+    # --- Members ----------------------------------------------------------
+    for m in native.get("members", []):
+        if not isinstance(m, dict):
+            continue
+        source_refs = []
+        if m.get("pluralkit_id"):
+            source_refs.append(
+                {"app": "pluralkit", "collection": "members", "id": m["pluralkit_id"]}
+            )
+        m_ext = {
+            "note": m.get("note"),
+            "emoji": m.get("emoji"),
+            "quick_switch_pin": m.get("quick_switch_pin"),
+            "notify_on_front_global": m.get("notify_on_front_global"),
+            "notify_on_front_self": m.get("notify_on_front_self"),
+            "notify_on_front_member_ids": m.get("notify_on_front_member_ids"),
+        }
+        members.append(
+            {
+                "id": m.get("id"),
+                "name": m.get("name"),
+                "display_name": m.get("display_name"),
+                "description": m.get("description"),
+                "pronouns": m.get("pronouns"),
+                "color": m.get("color"),
+                "birthday": _birthday(m.get("birthday")),
+                "is_custom_front": bool(m.get("is_custom_front")),
+                "avatar_asset_id": assets.ref(m.get("avatar_url"), kind="avatar"),
+                "banner_asset_id": assets.ref(m.get("banner_url"), kind="banner"),
+                "privacy": _privacy(m.get("privacy")),
+                "created_at": m.get("created_at"),
+                "source_refs": source_refs,
+                "extensions": {EXT_NS: _prune(m_ext)},
+            }
+        )
+
+    # --- Groups (+ normalized memberships) --------------------------------
+    for g in native.get("groups", []):
+        if not isinstance(g, dict):
+            continue
+        groups.append(
+            {
+                "id": g.get("id"),
+                "name": g.get("name"),
+                "description": g.get("description"),
+                "color": g.get("color"),
+                "parent_group_id": g.get("parent_id"),
+            }
+        )
+        for mid in g.get("member_ids", []) or []:
+            group_memberships.append({"group_id": g.get("id"), "member_id": mid})
+
+    # --- Tags -> taxonomy (kind=tag) + assignments ------------------------
+    for t in native.get("tags", []):
+        if not isinstance(t, dict):
+            continue
+        taxonomy_terms.append(
+            {"id": t.get("id"), "kind": "tag", "name": t.get("name"), "color": t.get("color")}
+        )
+        for mid in t.get("member_ids", []) or []:
+            taxonomy_assignments.append(
+                {"term_id": t.get("id"), "subject_type": "member", "subject_id": mid}
+            )
+
+    # --- Custom fields ----------------------------------------------------
+    for fd in native.get("custom_fields", []):
+        if not isinstance(fd, dict):
+            continue
+        custom_fields.append(
+            {
+                "id": fd.get("id"),
+                "name": fd.get("name"),
+                "field_type": fd.get("field_type"),
+                "options": fd.get("options"),
+                "sort_order": fd.get("order"),
+                "privacy": _privacy(fd.get("privacy")),
+            }
+        )
+        for v in fd.get("values", []) or []:
+            if not isinstance(v, dict):
+                continue
+            custom_field_values.append(
+                {
+                    "field_id": fd.get("id"),
+                    "subject_type": "member",
+                    "subject_id": v.get("member_id"),
+                    "value": v.get("value"),
+                }
+            )
+
+    # --- Fronts -> front_periods ------------------------------------------
+    for f in native.get("fronts", []):
+        if not isinstance(f, dict):
+            continue
+        front_periods.append(
+            {
+                "id": f.get("id"),
+                "started_at": f.get("started_at"),
+                "ended_at": f.get("ended_at"),
+                "assignments": [
+                    {"member_id": mid, "front_role": "member"}
+                    for mid in f.get("member_ids", []) or []
+                ],
+                "status": f.get("custom_status"),
+            }
+        )
+
+    # --- Journals -> notes ------------------------------------------------
+    for j in native.get("journals", []):
+        if not isinstance(j, dict):
+            continue
+        attachment_ids = [
+            assets.ref(k, kind="image") for k in (j.get("image_keys") or []) if k
+        ]
+        notes.append(
+            {
+                "id": j.get("id"),
+                "title": j.get("title"),
+                "body": j.get("body"),
+                "visibility": _privacy(j.get("visibility")),
+                "author_member_ids": j.get("author_member_ids") or [],
+                "created_at": j.get("created_at"),
+                "updated_at": j.get("updated_at"),
+                "attachment_asset_ids": [a for a in attachment_ids if a],
+                "extensions": {
+                    EXT_NS: _prune(
+                        {
+                            "member_id": j.get("member_id"),
+                            "author_member_names": j.get("author_member_names"),
+                        }
+                    )
+                },
+            }
+        )
+
+    # --- Messages -> boards.posts module ----------------------------------
+    for msg in native.get("messages", []):
+        if not isinstance(msg, dict):
+            continue
+        board_posts.append(
+            {
+                "id": msg.get("id"),
+                "target_member_id": msg.get("board_member_id"),
+                "author_member_id": msg.get("author_member_id"),
+                "body": msg.get("body"),
+                "created_at": msg.get("created_at"),
+                "updated_at": msg.get("updated_at"),
+                "extensions": {
+                    EXT_NS: _prune(
+                        {
+                            "board_kind": msg.get("board_kind"),
+                            # Reply pointer parks here until BoardPost.parent_post_id
+                            # lands upstream (issue #2).
+                            "parent_message_id": msg.get("parent_message_id"),
+                        }
+                    )
+                },
+            }
+        )
+
+    # --- File-level extensions: passthrough sections + lineage ------------
+    file_ext: dict = {}
+    for section in _EXT_PASSTHROUGH_SECTIONS:
+        rows = native.get(section)
+        if rows:
+            file_ext[section] = rows
+
+    lineage = list(inherited_lineage or [])
+    lineage.append(
+        {
+            "app": APP_ID,
+            "app_version": app_version,
+            "exporter_version": OPENPLURAL_IMPL_VERSION,
+            "exported_at": exported_at,
+        }
+    )
+    file_ext["lineage"] = lineage
+
+    # --- Capabilities -----------------------------------------------------
+    modules: list[str] = []
+    if board_posts:
+        modules.append("boards")
+
+    if assets.uri_only_used:
+        warnings.append(
+            {
+                "level": "info",
+                "code": "asset_uri_only",
+                "message": (
+                    "Assets are referenced by URL only; export with images "
+                    "(the .openplural.zip bundle) to include the binary blobs."
+                ),
+            }
+        )
+
+    envelope: dict = {
+        "openplural_version": OPENPLURAL_VERSION,
+        "exported_at": exported_at,
+        "producer": {
+            "app": APP_NAME,
+            "app_id": APP_ID,
+            "app_version": app_version,
+            "exporter_version": OPENPLURAL_IMPL_VERSION,
+        },
+        "capabilities": {"modules": modules},
+        "systems": systems,
+        "members": members,
+        "groups": groups,
+        "group_memberships": group_memberships,
+        "taxonomy_terms": taxonomy_terms,
+        "taxonomy_assignments": taxonomy_assignments,
+        "custom_fields": custom_fields,
+        "custom_field_values": custom_field_values,
+        "front_periods": front_periods,
+        "notes": notes,
+        "assets": assets.as_list(),
+        "extensions": {EXT_NS: file_ext},
+        "warnings": warnings,
+    }
+    if board_posts:
+        envelope["boards"] = {"posts": board_posts}
+
+    # Re-merge any preserved residual from a prior foreign import (the
+    # baseline passthrough tier: file-level extensions + whole un-consumed
+    # sections). Sheaf stores this encrypted on the system; the native
+    # export decrypts it into `system.openplural_archive` as a plain dict.
+    preserved = sys_data.get("openplural_archive") if isinstance(sys_data, dict) else None
+    if isinstance(preserved, dict) and preserved:
+        _merge_preserved(envelope, preserved)
+    return envelope
+
+
+def _merge_preserved(envelope: dict, preserved: dict) -> None:
+    """Fold a preserved import-residual back into a freshly-built envelope."""
+    foreign_ext = preserved.get("extensions")
+    if isinstance(foreign_ext, dict):
+        # Sheaf's own namespace wins on a clash; foreign namespaces ride alongside.
+        merged = dict(foreign_ext)
+        merged.update(envelope["extensions"])
+        envelope["extensions"] = merged
+
+    modules = envelope["capabilities"]["modules"]
+    for key in ("chat", "relationships"):
+        val = preserved.get(key)
+        if val:
+            envelope[key] = val
+            if key not in modules:
+                modules.append(key)
+
+    for key in ("front_events", "front_comments"):
+        val = preserved.get(key)
+        if val:
+            envelope[key] = val
+
+    extra_terms = preserved.get("taxonomy_terms")
+    if isinstance(extra_terms, list) and extra_terms:
+        envelope["taxonomy_terms"] = list(envelope["taxonomy_terms"]) + extra_terms
+    extra_assignments = preserved.get("taxonomy_assignments")
+    if isinstance(extra_assignments, list) and extra_assignments:
+        envelope["taxonomy_assignments"] = (
+            list(envelope["taxonomy_assignments"]) + extra_assignments
+        )
+
+
+_VALID_VISIBILITY = {"public", "friends", "private", "trusted", "unknown"}
+
+
+def _privacy(val: str | None) -> str:
+    """Sheaf privacy/visibility -> OpenPlural conservative bucket.
+
+    Sheaf's PrivacyLevel (public/friends/private) maps 1:1 onto the
+    OpenPlural visibility vocabulary; anything unrecognised rounds to
+    the strictest-safe ``unknown``.
+    """
+    if val in _VALID_VISIBILITY:
+        return val
+    return "unknown"
+
+
+def _prune(d: dict) -> dict:
+    """Drop None-valued keys so extensions stay tidy (and absent != null)."""
+    return {k: v for k, v in d.items() if v is not None}

--- a/sheaf/services/openplural_import.py
+++ b/sheaf/services/openplural_import.py
@@ -229,8 +229,8 @@ def to_native(envelope: dict) -> dict:
         )
     native["custom_fields"] = fields
 
-    # --- Front periods -> fronts ------------------------------------------
-    fronts: list[dict] = []
+    # --- Fronts: front_periods (intervals) + front_events (switch log) ----
+    period_fronts: list[dict] = []
     for f in envelope.get("front_periods", []) or []:
         if not isinstance(f, dict):
             continue
@@ -239,7 +239,7 @@ def to_native(envelope: dict) -> dict:
             for a in (f.get("assignments") or [])
             if isinstance(a, dict) and a.get("member_id")
         ]
-        fronts.append(
+        period_fronts.append(
             {
                 "id": f.get("id"),
                 "started_at": f.get("started_at"),
@@ -248,6 +248,24 @@ def to_native(envelope: dict) -> dict:
                 "custom_status": f.get("status"),
             }
         )
+    # Some apps record fronting as a switch log rather than intervals;
+    # derive intervals from it. Both shapes can co-exist in one file, so
+    # dedup the union by normalised interval + member set (the importer's
+    # own dedup keys on the same thing, but doing it here keeps a file
+    # carrying both representations from double-importing).
+    event_fronts = _fronts_from_events(envelope.get("front_events") or [])
+    seen: set[tuple] = set()
+    fronts: list[dict] = []
+    for fr in period_fronts + event_fronts:
+        key = (
+            fr["started_at"],
+            fr["ended_at"],
+            tuple(sorted(mid for mid in fr["member_ids"] if mid)),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        fronts.append(fr)
     native["fronts"] = fronts
 
     # --- Notes -> journals ------------------------------------------------
@@ -325,6 +343,48 @@ def _file_extensions(envelope: dict) -> dict:
         return {}
     sheaf = ext.get(EXT_NS)
     return sheaf if isinstance(sheaf, dict) else {}
+
+
+def _fronts_from_events(events: object) -> list[dict]:
+    """Convert OpenPlural point-in-time ``front_events`` (a switch log) into
+    Sheaf interval fronts.
+
+    Each event names who is fronting *from its timestamp onward*; the
+    interval ends at the next event. An event with no assignments is a gap
+    (it closes the previous interval and opens none); the final event stays
+    open-ended (currently fronting). This mirrors the PluralKit switch-log
+    to front-interval conversion - the same model, a different source field.
+    """
+    timed: list[tuple[str, list[str], str]] = []
+    for idx, e in enumerate(events or []):
+        if not isinstance(e, dict):
+            continue
+        at = e.get("at")
+        if not at:
+            continue
+        member_ids = [
+            a.get("member_id")
+            for a in (e.get("assignments") or [])
+            if isinstance(a, dict) and a.get("member_id")
+        ]
+        timed.append((at, member_ids, str(e.get("id") or f"fe{idx}")))
+    timed.sort(key=lambda t: t[0])
+
+    fronts: list[dict] = []
+    for i, (at, member_ids, eid) in enumerate(timed):
+        if not member_ids:
+            continue  # gap: nobody fronting from here, no interval emitted
+        ended_at = timed[i + 1][0] if i + 1 < len(timed) else None
+        fronts.append(
+            {
+                "id": f"event-{eid}",
+                "started_at": at,
+                "ended_at": ended_at,
+                "member_ids": member_ids,
+                "custom_status": None,
+            }
+        )
+    return fronts
 
 
 def _pluralkit_id(source_refs: object) -> str | None:

--- a/sheaf/services/openplural_import.py
+++ b/sheaf/services/openplural_import.py
@@ -1,0 +1,441 @@
+"""OpenPlural v0.1 import: envelope -> native Sheaf shape.
+
+Sheaf's OpenPlural importer is deliberately thin. Rather than re-walk
+every record type, it *translates* an OpenPlural v0.1 envelope back into
+the native Article-20 export dict (version "2") that
+``sheaf_import.run_import`` already consumes, then delegates. Every
+mandatory guard (member cap, safe-JSON, decompressed-size bound, avatar
+normalisation, internal-image stripping, business caps, fresh UUIDs,
+tenant scoping) therefore lives in the native importer and cannot drift
+per-format. This module is the inverse of ``openplural_export`` and is
+verified against it by the round-trip test.
+
+Two payload shapes:
+
+* A bare ``.json`` document -> translate, hand to ``sheaf_import``.
+* An ``.openplural.zip`` bundle (``openplural.json`` + ``assets/<key>``)
+  -> translate, then hand a ``ParsedArchive`` (with ``asset_prefix``
+  ``"assets/"``) to ``sheaf_archive_import`` so the blobs are restored.
+
+See ``docs/OPENPLURAL.md`` for the field-by-field mapping and the list
+of things that round-trip via ``extensions.sheaf.*``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import zipfile
+
+from sheaf.services.import_parsing import ImportPayloadError, expect_dict, safe_json_loads
+from sheaf.services.openplural_export import EXT_NS
+
+# Versions this importer understands. The spec mandates rejecting an
+# unknown openplural_version rather than silently part-importing it.
+SUPPORTED_VERSIONS = {"0.1"}
+
+# Matches the native archive's decompressed-size caps (DEFLATE reaches
+# ~1000:1, so the 100MB compressed upload cap alone does not bound memory).
+_MAX_JSON_DECOMPRESSED = 256 * 1024 * 1024
+_MAX_ASSET_DECOMPRESSED = 100 * 1024 * 1024
+_BUNDLE_JSON_NAME = "openplural.json"
+_ASSET_PREFIX = "assets/"
+
+# zip local-file-header magic; lets the runner sniff bundle vs bare JSON.
+_ZIP_MAGIC = b"PK\x03\x04"
+
+
+def looks_like_zip(blob: bytes) -> bool:
+    return blob[:4] == _ZIP_MAGIC
+
+
+def _check_version(envelope: dict) -> None:
+    ver = envelope.get("openplural_version")
+    if ver not in SUPPORTED_VERSIONS:
+        raise ImportPayloadError(
+            f"unsupported openplural_version {ver!r} "
+            f"(this build understands {sorted(SUPPORTED_VERSIONS)})"
+        )
+
+
+def _ext(obj: dict) -> dict:
+    """The ``extensions.sheaf`` sub-dict of a record, or empty."""
+    if not isinstance(obj, dict):
+        return {}
+    ext = obj.get("extensions")
+    if not isinstance(ext, dict):
+        return {}
+    sheaf = ext.get(EXT_NS)
+    return sheaf if isinstance(sheaf, dict) else {}
+
+
+def _birthday_to_native(b: object) -> str | None:
+    """OpenPlural Birthday sub-record -> Sheaf's flat ``MM-DD`` / ``YYYY-MM-DD``."""
+    if isinstance(b, str):
+        return b
+    if isinstance(b, dict):
+        val = b.get("value")
+        return val if isinstance(val, str) else None
+    return None
+
+
+class _AssetMap:
+    """asset id -> native image reference, built from the envelope's assets.
+
+    For a bare-JSON import the reference is the asset's ``uri`` (an
+    external URL the native importer treats like any other). For a bundle
+    it is still the ``uri`` (a ``/v1/files/<key>`` form), and the bare
+    storage key parsed from ``bundle_path`` is what the archive restore
+    keys its blobs by.
+    """
+
+    def __init__(self, envelope: dict) -> None:
+        self.by_id: dict[str, str] = {}
+        self.bundle_keys: set[str] = set()
+        for a in envelope.get("assets", []) or []:
+            if not isinstance(a, dict):
+                continue
+            aid = a.get("id")
+            if not aid:
+                continue
+            uri = a.get("uri")
+            bundle_path = _ext(a).get("bundle_path")
+            if isinstance(uri, str) and uri:
+                self.by_id[aid] = uri
+            if isinstance(bundle_path, str) and bundle_path.startswith(_ASSET_PREFIX):
+                self.bundle_keys.add(bundle_path[len(_ASSET_PREFIX):])
+
+    def url(self, asset_id: object) -> str | None:
+        if isinstance(asset_id, str):
+            return self.by_id.get(asset_id)
+        return None
+
+
+def to_native(envelope: dict) -> dict:
+    """Translate an OpenPlural v0.1 envelope into the native export dict.
+
+    Pure transform: no DB, no IO. Mirrors ``openplural_export.build_envelope``.
+    """
+    _check_version(envelope)
+    assets = _AssetMap(envelope)
+
+    native: dict = {"version": "2"}
+
+    # --- System -----------------------------------------------------------
+    systems = envelope.get("systems") or []
+    sys_in = systems[0] if systems and isinstance(systems[0], dict) else None
+    if sys_in is not None:
+        ext = _ext(sys_in)
+        native["system"] = {
+            "id": sys_in.get("id"),
+            "name": sys_in.get("name"),
+            "description": sys_in.get("description"),
+            "note": ext.get("note"),
+            "tag": sys_in.get("tag"),
+            "avatar_url": assets.url(sys_in.get("avatar_asset_id")),
+            "color": sys_in.get("color"),
+            "privacy": sys_in.get("privacy"),
+            "date_format": ext.get("date_format"),
+            "replace_fronts_default": ext.get("replace_fronts_default"),
+            "coalesce_contiguous_fronts": ext.get("coalesce_contiguous_fronts"),
+            "delete_confirmation": ext.get("delete_confirmation"),
+            "safety": ext.get("safety"),
+            "retention": ext.get("retention"),
+        }
+    else:
+        native["system"] = None
+
+    # --- Members ----------------------------------------------------------
+    members: list[dict] = []
+    for m in envelope.get("members", []) or []:
+        if not isinstance(m, dict):
+            continue
+        ext = _ext(m)
+        members.append(
+            {
+                "id": m.get("id"),
+                "name": m.get("name"),
+                "display_name": m.get("display_name"),
+                "description": m.get("description"),
+                "pronouns": m.get("pronouns"),
+                "avatar_url": assets.url(m.get("avatar_asset_id")),
+                "banner_url": assets.url(m.get("banner_asset_id")),
+                "color": m.get("color"),
+                "birthday": _birthday_to_native(m.get("birthday")),
+                "pluralkit_id": _pluralkit_id(m.get("source_refs")),
+                "emoji": ext.get("emoji"),
+                "is_custom_front": bool(m.get("is_custom_front")),
+                "privacy": m.get("privacy"),
+                "note": ext.get("note"),
+                "quick_switch_pin": ext.get("quick_switch_pin"),
+                "notify_on_front_global": ext.get("notify_on_front_global"),
+                "notify_on_front_self": ext.get("notify_on_front_self"),
+                "notify_on_front_member_ids": ext.get("notify_on_front_member_ids"),
+                "created_at": m.get("created_at"),
+            }
+        )
+    native["members"] = members
+
+    # --- Groups (+ denormalize memberships) -------------------------------
+    group_members = _group_index(envelope.get("group_memberships"))
+    groups: list[dict] = []
+    for g in envelope.get("groups", []) or []:
+        if not isinstance(g, dict):
+            continue
+        groups.append(
+            {
+                "id": g.get("id"),
+                "name": g.get("name"),
+                "description": g.get("description"),
+                "color": g.get("color"),
+                "parent_id": g.get("parent_group_id"),
+                "member_ids": group_members.get(g.get("id"), []),
+            }
+        )
+    native["groups"] = groups
+
+    # --- Taxonomy(kind=tag) -> tags (+ denormalize assignments) -----------
+    tag_members = _assignment_index(envelope.get("taxonomy_assignments"))
+    tags: list[dict] = []
+    for t in envelope.get("taxonomy_terms", []) or []:
+        if not isinstance(t, dict) or t.get("kind") != "tag":
+            continue
+        tags.append(
+            {
+                "id": t.get("id"),
+                "name": t.get("name"),
+                "color": t.get("color"),
+                "member_ids": tag_members.get(t.get("id"), []),
+            }
+        )
+    native["tags"] = tags
+
+    # --- Custom fields (+ values) -----------------------------------------
+    field_values = _field_value_index(envelope.get("custom_field_values"))
+    fields: list[dict] = []
+    for fd in envelope.get("custom_fields", []) or []:
+        if not isinstance(fd, dict):
+            continue
+        fields.append(
+            {
+                "id": fd.get("id"),
+                "name": fd.get("name"),
+                "field_type": fd.get("field_type"),
+                "options": fd.get("options"),
+                "order": fd.get("sort_order"),
+                "privacy": fd.get("privacy"),
+                "values": field_values.get(fd.get("id"), []),
+            }
+        )
+    native["custom_fields"] = fields
+
+    # --- Front periods -> fronts ------------------------------------------
+    fronts: list[dict] = []
+    for f in envelope.get("front_periods", []) or []:
+        if not isinstance(f, dict):
+            continue
+        member_ids = [
+            a.get("member_id")
+            for a in (f.get("assignments") or [])
+            if isinstance(a, dict) and a.get("member_id")
+        ]
+        fronts.append(
+            {
+                "id": f.get("id"),
+                "started_at": f.get("started_at"),
+                "ended_at": f.get("ended_at"),
+                "member_ids": member_ids,
+                "custom_status": f.get("status"),
+            }
+        )
+    native["fronts"] = fronts
+
+    # --- Notes -> journals ------------------------------------------------
+    journals: list[dict] = []
+    for n in envelope.get("notes", []) or []:
+        if not isinstance(n, dict):
+            continue
+        ext = _ext(n)
+        image_keys = [
+            assets.url(aid) for aid in (n.get("attachment_asset_ids") or [])
+        ]
+        journals.append(
+            {
+                "id": n.get("id"),
+                "member_id": ext.get("member_id"),
+                "title": n.get("title"),
+                "body": n.get("body"),
+                "visibility": n.get("visibility"),
+                "author_member_ids": n.get("author_member_ids") or [],
+                "author_member_names": ext.get("author_member_names"),
+                "image_keys": [k for k in image_keys if k],
+                "created_at": n.get("created_at"),
+                "updated_at": n.get("updated_at"),
+            }
+        )
+    native["journals"] = journals
+
+    # --- boards.posts -> messages -----------------------------------------
+    messages: list[dict] = []
+    boards = envelope.get("boards")
+    if isinstance(boards, dict):
+        for p in boards.get("posts", []) or []:
+            if not isinstance(p, dict):
+                continue
+            ext = _ext(p)
+            messages.append(
+                {
+                    "id": p.get("id"),
+                    "board_kind": ext.get("board_kind"),
+                    "board_member_id": p.get("target_member_id"),
+                    "author_member_id": p.get("author_member_id"),
+                    "parent_message_id": ext.get("parent_message_id"),
+                    "body": p.get("body"),
+                    "created_at": p.get("created_at"),
+                    "updated_at": p.get("updated_at"),
+                }
+            )
+
+    # --- File-level passthrough sections ----------------------------------
+    file_ext = _file_extensions(envelope)
+    # messages may come from boards module OR the passthrough section; the
+    # boards module wins when present, else fall back to the passthrough.
+    native["messages"] = messages or (file_ext.get("messages") or [])
+    native["revisions"] = file_ext.get("revisions") or []
+    native["watch_tokens"] = file_ext.get("watch_tokens") or []
+    native["uploaded_files"] = file_ext.get("uploaded_files") or []
+    native["reminders"] = file_ext.get("reminders") or []
+    native["polls"] = file_ext.get("polls") or []
+
+    return native
+
+
+def inherited_lineage(envelope: dict) -> list:
+    """The ``extensions.sheaf.lineage`` array carried in, or empty."""
+    lineage = _file_extensions(envelope).get("lineage")
+    return lineage if isinstance(lineage, list) else []
+
+
+# --- index helpers -----------------------------------------------------------
+
+
+def _file_extensions(envelope: dict) -> dict:
+    ext = envelope.get("extensions")
+    if not isinstance(ext, dict):
+        return {}
+    sheaf = ext.get(EXT_NS)
+    return sheaf if isinstance(sheaf, dict) else {}
+
+
+def _pluralkit_id(source_refs: object) -> str | None:
+    if not isinstance(source_refs, list):
+        return None
+    for ref in source_refs:
+        if isinstance(ref, dict) and ref.get("app") == "pluralkit" and ref.get("id"):
+            return ref["id"]
+    return None
+
+
+def _group_index(memberships: object) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for row in memberships or []:
+        if isinstance(row, dict) and row.get("group_id") and row.get("member_id"):
+            out.setdefault(row["group_id"], []).append(row["member_id"])
+    return out
+
+
+def _assignment_index(assignments: object) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for row in assignments or []:
+        if (
+            isinstance(row, dict)
+            and row.get("subject_type") == "member"
+            and row.get("term_id")
+            and row.get("subject_id")
+        ):
+            out.setdefault(row["term_id"], []).append(row["subject_id"])
+    return out
+
+
+def _field_value_index(values: object) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for row in values or []:
+        if (
+            isinstance(row, dict)
+            and row.get("subject_type") == "member"
+            and row.get("field_id")
+            and row.get("subject_id")
+        ):
+            out.setdefault(row["field_id"], []).append(
+                {"member_id": row["subject_id"], "value": row.get("value")}
+            )
+    return out
+
+
+# --- parse entrypoints -------------------------------------------------------
+
+
+def parse_json(blob: bytes) -> dict:
+    """Parse + version-check a bare OpenPlural JSON document."""
+    envelope = expect_dict(safe_json_loads(blob), descriptor="OpenPlural export")
+    _check_version(envelope)
+    return envelope
+
+
+def parse_bundle(blob: bytes):
+    """Open an .openplural.zip, validate, and return a translated
+    ``ParsedArchive`` ready for ``sheaf_archive_import.run_import``.
+
+    Returns ``(ParsedArchive, envelope)``: the archive carries the
+    native-translated ``data`` and an ``assets/`` ``asset_prefix``; the
+    envelope is handed back for lineage extraction.
+    """
+    from sheaf.services.sheaf_archive_import import ParsedArchive
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(blob))
+    except zipfile.BadZipFile as exc:
+        raise ImportPayloadError("file is not a valid zip archive") from exc
+
+    names = set(zf.namelist())
+    if _BUNDLE_JSON_NAME not in names:
+        raise ImportPayloadError(
+            f"OpenPlural bundle must contain {_BUNDLE_JSON_NAME} "
+            "(is this an .openplural.zip export?)"
+        )
+    if zf.getinfo(_BUNDLE_JSON_NAME).file_size > _MAX_JSON_DECOMPRESSED:
+        raise ImportPayloadError(
+            f"{_BUNDLE_JSON_NAME} decompresses to more than "
+            f"{_MAX_JSON_DECOMPRESSED // (1024 * 1024)}MB; refusing to parse"
+        )
+
+    envelope = expect_dict(
+        safe_json_loads(zf.read(_BUNDLE_JSON_NAME)), descriptor="OpenPlural bundle"
+    )
+    _check_version(envelope)
+
+    native = to_native(envelope)
+    bundle_keys = {
+        n.removeprefix(_ASSET_PREFIX)
+        for n in names
+        if n.startswith(_ASSET_PREFIX) and not n.endswith("/")
+    }
+    parsed = ParsedArchive(
+        data=native, zf=zf, image_keys=bundle_keys, asset_prefix=_ASSET_PREFIX
+    )
+    return parsed, envelope
+
+
+_parse_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_parse_semaphore() -> asyncio.Semaphore:
+    global _parse_semaphore
+    if _parse_semaphore is None:
+        _parse_semaphore = asyncio.Semaphore(2)
+    return _parse_semaphore
+
+
+async def parse_bundle_async(blob: bytes):
+    async with _get_parse_semaphore():
+        return await asyncio.to_thread(parse_bundle, blob)

--- a/sheaf/services/openplural_import_runner.py
+++ b/sheaf/services/openplural_import_runner.py
@@ -1,0 +1,275 @@
+"""Async runner handler for OpenPlural v0.1 imports.
+
+Wrap-pattern handler. Sniffs whether the payload is a bare JSON document
+or an ``.openplural.zip`` bundle, translates the envelope to the native
+shape (``openplural_import.to_native``), and delegates to the existing
+native importer: ``sheaf_import.run_import`` for JSON,
+``sheaf_archive_import.run_import`` for the bundle (which restores the
+``assets/`` blobs). All the import guards therefore live in one place.
+
+Lineage: any ``extensions.sheaf.lineage`` carried in is surfaced as an
+info event. v0.1 Sheaf does not yet persist inherited lineage across a
+DB round-trip (there is no column for it), so a re-export starts a fresh
+Sheaf-only chain - see the limitation noted in docs/OPENPLURAL.md and
+upstream issue #7.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.config import settings
+from sheaf.models.import_job import ImportJob, ImportJobSource
+from sheaf.models.user import User
+from sheaf.schemas.sheaf_import import SheafArchiveImportOptions, SheafImportOptions
+from sheaf.services.import_parsing import ImportPayloadError, parse_options
+from sheaf.services.import_runner import (
+    append_event,
+    load_user_system,
+    register_handler,
+    update_counts,
+)
+from sheaf.services.import_storage import get_payload
+from sheaf.services.openplural_archive import (
+    extract_residual,
+    has_per_record_foreign_extensions,
+    merge_residual,
+    pack_residual,
+    unpack_residual,
+)
+from sheaf.services.openplural_import import (
+    inherited_lineage,
+    looks_like_zip,
+    parse_bundle_async,
+    parse_json,
+    to_native,
+)
+
+logger = logging.getLogger("sheaf.imports.openplural")
+
+
+def _note_lineage(job: ImportJob, envelope: dict) -> None:
+    lineage = inherited_lineage(envelope)
+    if not lineage:
+        return
+    apps = ", ".join(
+        str(e.get("app", "?")) for e in lineage if isinstance(e, dict)
+    )
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=(
+            f"file carries lineage from {len(lineage)} prior export(s) "
+            f"[{apps}]; not persisted in this release (see docs/OPENPLURAL.md)"
+        ),
+    )
+
+
+def _preserve_residual(job: ImportJob, system, envelope: dict) -> None:
+    """Capture the parts of the envelope Sheaf cannot model and park them
+    (encrypted, compressed, size-capped) on the system so the next
+    OpenPlural export re-emits them. Baseline (file-level + whole-section)
+    passthrough; per-record foreign extensions are warned, not stored."""
+    if has_per_record_foreign_extensions(envelope):
+        append_event(
+            job,
+            level="warning",
+            stage="preserve",
+            message=(
+                "per-record extensions from other apps were not preserved "
+                "(file-level passthrough only in this release); see docs/OPENPLURAL.md"
+            ),
+        )
+    residual = extract_residual(envelope)
+    if not residual:
+        return
+    existing = unpack_residual(system.openplural_archive)
+    merged = merge_residual(existing, residual)
+    max_bytes = settings.openplural_max_preserved_mb * 1024 * 1024
+    token, warning = pack_residual(merged, max_bytes=max_bytes)
+    if warning:
+        append_event(job, level="warning", stage="preserve", message=warning)
+        return
+    system.openplural_archive = token
+    append_event(
+        job,
+        level="info",
+        stage="preserve",
+        message=(
+            f"preserved {len(residual)} unsupported section(s) for round-trip: "
+            f"{', '.join(sorted(residual))}"
+        ),
+    )
+
+
+def _base_counts(job: ImportJob, base) -> None:
+    update_counts(
+        job,
+        members_imported=base.members_imported,
+        members_skipped=base.members_skipped,
+        members_updated=base.members_updated,
+        fronts_imported=base.fronts_imported,
+        fronts_skipped=base.fronts_skipped,
+        groups_imported=base.groups_imported,
+        groups_skipped=base.groups_skipped,
+        tags_imported=base.tags_imported,
+        tags_skipped=base.tags_skipped,
+        custom_fields_imported=base.custom_fields_imported,
+        custom_fields_skipped=base.custom_fields_skipped,
+        journals_imported=base.journals_imported,
+        journals_skipped=base.journals_skipped,
+        revisions_imported=base.revisions_imported,
+        revisions_skipped=base.revisions_skipped,
+        messages_imported=base.messages_imported,
+        messages_skipped=base.messages_skipped,
+        polls_imported=base.polls_imported,
+        polls_skipped=base.polls_skipped,
+        reminders_imported=base.reminders_imported,
+        reminders_skipped=base.reminders_skipped,
+        channels_imported=base.channels_imported,
+        channels_skipped=base.channels_skipped,
+    )
+
+
+async def handle_openplural_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run an OpenPlural import (bare JSON or .openplural.zip) for a job."""
+    if job.payload_storage_key is None:
+        raise ImportPayloadError(
+            "OpenPlural job has no payload - was the upload step skipped?"
+        )
+    blob = await get_payload(job.payload_storage_key)
+    if blob is None:
+        raise ImportPayloadError(
+            "OpenPlural payload missing from storage - "
+            "the blob may have been swept by orphan cleanup"
+        )
+
+    if looks_like_zip(blob):
+        await _run_bundle(job, db, blob)
+    else:
+        await _run_json(job, db, blob)
+
+
+async def _run_json(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
+    from sheaf.services.sheaf_import import run_import as sheaf_run_import
+
+    envelope = parse_json(blob)
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=f"parsed {len(blob)} bytes of OpenPlural JSON",
+    )
+    _note_lineage(job, envelope)
+    native = to_native(envelope)
+    options = parse_options(job.payload_metadata, SheafImportOptions)
+    system = await load_user_system(db, job.user_id)
+
+    result = await sheaf_run_import(
+        native,
+        system,
+        db,
+        conflict_strategy=options.conflict_strategy,
+        system_profile=options.system_profile,
+        member_ids=options.member_ids,
+        fronts=options.fronts,
+        groups=options.groups,
+        tags=options.tags,
+        custom_fields=options.custom_fields,
+        journals=options.journals,
+        messages=options.messages,
+        polls=options.polls,
+        reminders=options.reminders,
+        notifications=options.notifications,
+    )
+    _base_counts(job, result)
+    for warning in result.warnings:
+        append_event(job, level="warning", stage="import", message=warning)
+    _preserve_residual(job, system, envelope)
+    append_event(
+        job,
+        level="info",
+        stage="import",
+        message=(
+            f"imported {result.members_imported} members, "
+            f"{result.fronts_imported} fronts, "
+            f"{result.groups_imported} groups, "
+            f"{result.tags_imported} tags, "
+            f"{result.journals_imported} journals"
+        ),
+    )
+
+
+async def _run_bundle(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
+    from sheaf.services.sheaf_archive_import import run_import as archive_run_import
+
+    parsed, envelope = await parse_bundle_async(blob)
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=(
+            f"parsed {len(blob)} bytes of OpenPlural bundle "
+            f"({len(parsed.image_keys)} bundled asset(s))"
+        ),
+    )
+    _note_lineage(job, envelope)
+    options = parse_options(job.payload_metadata, SheafArchiveImportOptions)
+    system = await load_user_system(db, job.user_id)
+    user = await db.get(User, job.user_id)
+    if user is None:
+        raise ImportPayloadError("user vanished mid-import")
+
+    result = await archive_run_import(
+        parsed,
+        system,
+        user,
+        db,
+        images=options.images,
+        conflict_strategy=options.conflict_strategy,
+        system_profile=options.system_profile,
+        member_ids=options.member_ids,
+        fronts=options.fronts,
+        groups=options.groups,
+        tags=options.tags,
+        custom_fields=options.custom_fields,
+        journals=options.journals,
+        messages=options.messages,
+        polls=options.polls,
+        reminders=options.reminders,
+        notifications=options.notifications,
+    )
+    base = result.base
+    _base_counts(job, base)
+    update_counts(job, images_imported=result.images_imported)
+    for warning in result.warnings:
+        append_event(job, level="warning", stage="import", message=warning)
+    for key, sites in result.missing_images:
+        append_event(
+            job,
+            level="warning",
+            stage="images",
+            message=(
+                "asset missing from the bundle (or over the per-asset size "
+                f"limit); reference removed from: {sites}"[:500]
+            ),
+            record_ref=key[:200],
+        )
+    _preserve_residual(job, system, envelope)
+    append_event(
+        job,
+        level="info",
+        stage="import",
+        message=(
+            f"imported {base.members_imported} members, "
+            f"{base.fronts_imported} fronts, "
+            f"{base.journals_imported} journals, "
+            f"{result.images_imported} assets"
+        ),
+    )
+
+
+register_handler(ImportJobSource.OPENPLURAL_FILE.value, handle_openplural_file)

--- a/sheaf/services/sheaf_archive_import.py
+++ b/sheaf/services/sheaf_archive_import.py
@@ -82,15 +82,20 @@ class ParsedArchive:
 
     The zip handle stays open as long as this struct exists so image
     bytes can be fetched lazily by storage key.
+
+    `asset_prefix` is the in-zip directory blobs live under. The native
+    Sheaf archive uses ``images/``; the OpenPlural bundle reuses this
+    same struct with ``assets/`` (see ``openplural_import``).
     """
 
     data: dict
     zf: zipfile.ZipFile
     image_keys: set[str] = field(default_factory=set)
+    asset_prefix: str = "images/"
 
     def read_image(self, key: str) -> bytes | None:
-        """Bytes for `images/<key>`, or None when absent / over-cap."""
-        path = f"images/{key}"
+        """Bytes for `<asset_prefix><key>`, or None when absent / over-cap."""
+        path = f"{self.asset_prefix}{key}"
         if key not in self.image_keys:
             return None
         try:

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -414,6 +414,30 @@ async def run_import(
                             _coerce_int(retention[key], default=0, minimum=0),
                         )
 
+            # OpenPlural import residual: a native export carries it as a
+            # plain dict (decrypted in export.py). Re-pack (compress +
+            # encrypt) and merge onto the column so a Sheaf backup/restore
+            # preserves another app's data the same way the OpenPlural
+            # importer does. See services/openplural_archive.py.
+            op_archive = sys_data.get("openplural_archive")
+            if isinstance(op_archive, dict) and op_archive:
+                from sheaf.config import settings
+                from sheaf.services.openplural_archive import (
+                    merge_residual,
+                    pack_residual,
+                    unpack_residual,
+                )
+
+                merged = merge_residual(
+                    unpack_residual(system.openplural_archive), op_archive
+                )
+                token, _warn = pack_residual(
+                    merged,
+                    max_bytes=settings.openplural_max_preserved_mb * 1024 * 1024,
+                )
+                if token is not None:
+                    system.openplural_archive = token
+
     # --- Members ---
     export_members = data.get("members", [])
     if member_ids is not None:

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -83,7 +83,7 @@ CLASSIFICATION: dict[type, dict] = {
             "safety_applies_to_notifications", "safety_applies_to_reminders",
             "safety_applies_to_polls", "safety_applies_to_messages",
             "journal_max_revisions", "journal_max_revision_days",
-            "pinned_revision_max_per_target",
+            "pinned_revision_max_per_target", "openplural_archive",
         },
         "excluded": {
             "id": _SURROGATE_PK,

--- a/tests/test_imports_openplural_runner.py
+++ b/tests/test_imports_openplural_runner.py
@@ -1,0 +1,284 @@
+"""End-to-end tests for the OpenPlural import runner.
+
+The OpenPlural importer translates an envelope back to the native shape
+and delegates to the Sheaf JSON / archive importers, so these tests
+build real OpenPlural payloads with ``build_envelope`` (the exporter)
+and drive them through ``POST /v1/imports/file`` with
+``source=openplural_file``. That makes each happy-path test a genuine
+export->import round-trip. Failure paths cover the version guard, the
+member-cap precheck, and the zip guards inherited from the archive path.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+import zipfile
+
+import httpx
+
+from sheaf.services.openplural_export import build_envelope
+from tests._import_runner_helpers import (
+    drive_import_runner,
+    set_member_limit,
+    wait_for_terminal,
+)
+
+_EXPORTED_AT = "2026-06-20T00:00:00+00:00"
+
+# 4x4 RGBA PNG that survives a real normalize_image decode pass.
+_TINY_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x04\x00\x00\x00\x04"
+    b"\x08\x06\x00\x00\x00\xa9\xf1\x9e~\x00\x00\x00\x15IDATx\x9cc\xfc\xcf"
+    b"\xc0\xf0\x9f\x01\t01\xa0\x01\xc2\x02\x00\x83\xd1\x02\x06\x02\x90\xef"
+    b"X\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_AVATAR_KEY = "avatars/00000000-0000-0000-0000-00000000bbbb/op_avatar.png"
+
+
+def _native(*, avatar: bool = False) -> dict:
+    return {
+        "version": "2",
+        "system": {"name": "OP System", "privacy": "public"},
+        "members": [
+            {
+                "id": "m1",
+                "name": "OpIris",
+                "pronouns": "they/them",
+                "birthday": "1991-04-02",
+                "pluralkit_id": "opabc",
+                "is_custom_front": False,
+                "privacy": "private",
+                "avatar_url": f"/v1/files/{_AVATAR_KEY}" if avatar else None,
+            },
+            {"id": "m2", "name": "OpJay"},
+        ],
+        "fronts": [
+            {
+                "id": "f1",
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "ended_at": None,
+                "member_ids": ["m1"],
+                "custom_status": "co-fronting",
+            }
+        ],
+        "groups": [{"id": "g1", "name": "Inner", "member_ids": ["m1", "m2"]}],
+        "tags": [{"id": "t1", "name": "host", "color": "#abc", "member_ids": ["m1"]}],
+        "custom_fields": [],
+        "journals": [],
+    }
+
+
+def _envelope_bytes(native: dict) -> bytes:
+    env = build_envelope(native, exported_at=_EXPORTED_AT)
+    return json.dumps(env).encode("utf-8")
+
+
+def _bundle_bytes(native: dict, images: dict[str, bytes]) -> bytes:
+    env = build_envelope(native, exported_at=_EXPORTED_AT, include_asset_bytes=True)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("openplural.json", json.dumps(env))
+        zf.writestr("README.txt", "test bundle")
+        for key, blob in images.items():
+            zf.writestr(f"assets/{key}", blob)
+    return buf.getvalue()
+
+
+def _post(
+    client: httpx.Client,
+    payload: bytes,
+    *,
+    filename: str = "export.openplural.json",
+    options: dict | None = None,
+) -> dict:
+    form: dict[str, str] = {
+        "source": "openplural_file",
+        "idempotency_key": str(uuid.uuid4()),
+    }
+    if options is not None:
+        form["options"] = json.dumps(options)
+    resp = client.post(
+        "/v1/imports/file",
+        files={"file": (filename, payload, "application/json")},
+        data=form,
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+def _files_list(client: httpx.Client) -> list[dict]:
+    resp = client.get("/v1/files/list")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# --- Happy paths -------------------------------------------------------------
+
+
+def test_json_round_trip_imports_core_records(auth_client: httpx.Client):
+    """A Sheaf-produced OpenPlural JSON re-imports its members, fronts,
+    groups, and tags."""
+    job = _post(auth_client, _envelope_bytes(_native()))
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 2, final["counts"]
+    assert final["counts"]["fronts_imported"] == 1, final["counts"]
+    assert final["counts"]["groups_imported"] == 1, final["counts"]
+    assert final["counts"]["tags_imported"] == 1, final["counts"]
+
+    members = {m["name"]: m for m in auth_client.get("/v1/members").json()}
+    assert set(members) == {"OpIris", "OpJay"}
+    # pluralkit_id survives the source_ref round-trip.
+    assert members["OpIris"]["pluralkit_id"] == "opabc", members["OpIris"]
+
+
+def test_bundle_round_trip_restores_avatar(auth_client: httpx.Client):
+    """An .openplural.zip bundle restores the avatar blob under a fresh
+    key owned by the importing user."""
+    payload = _bundle_bytes(_native(avatar=True), {_AVATAR_KEY: _TINY_PNG})
+    job = _post(auth_client, payload, filename="export.openplural.zip")
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"].get("images_imported", 0) == 1, final["counts"]
+
+    files = {f["key"] for f in _files_list(auth_client)}
+    assert _AVATAR_KEY not in files  # foreign key never reused
+    iris = next(m for m in auth_client.get("/v1/members").json() if m["name"] == "OpIris")
+    avatar_key = (iris["avatar_url"] or "").removeprefix("/v1/files/")
+    assert avatar_key in files, iris["avatar_url"]
+
+
+def test_preview_reports_counts_and_lineage(auth_client: httpx.Client):
+    """The preview endpoint summarises without writing, and surfaces the
+    lineage length of the file."""
+    resp = auth_client.post(
+        "/v1/import/openplural/preview",
+        files={"file": ("e.json", _envelope_bytes(_native()), "application/json")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["system_name"] == "OP System"
+    assert body["member_count"] == 2
+    assert body["front_count"] == 1
+    assert body["archive"] is False
+    # Sheaf stamped one lineage entry on export.
+    assert body["lineage_length"] == 1
+    # Preview must not have created anything.
+    assert auth_client.get("/v1/members").json() == []
+
+
+def _foreign_envelope_bytes() -> bytes:
+    """An envelope as if from another app, carrying data Sheaf cannot model."""
+    env = {
+        "openplural_version": "0.1",
+        "producer": {"app": "Prism", "app_id": "prism"},
+        "systems": [{"id": "s1", "name": "Foreign Sys", "privacy": "public"}],
+        "members": [{"id": "m1", "name": "ForeignIris", "privacy": "private"}],
+        "taxonomy_terms": [
+            {"id": "t1", "kind": "tag", "name": "host"},
+            {"id": "r1", "kind": "role", "name": "protector"},
+        ],
+        "taxonomy_assignments": [
+            {"term_id": "r1", "subject_type": "member", "subject_id": "m1"},
+        ],
+        "chat": {"messages": [{"id": "x1", "body": "secret chat"}]},
+        "relationships": {"edges": [{"a": "m1", "b": "m1", "type": "self"}]},
+        "extensions": {"prism": {"theme": "dark"}},
+    }
+    return json.dumps(env).encode("utf-8")
+
+
+def test_foreign_data_preserved_and_re_exported(auth_client: httpx.Client):
+    """Data Sheaf cannot model (foreign extensions, chat/relationships,
+    non-tag taxonomy) survives an import and comes back out on a Sheaf
+    OpenPlural export, instead of being dropped."""
+    job = _post(auth_client, _foreign_envelope_bytes())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 1, final["counts"]
+    # The preserve stage recorded what it kept.
+    assert any(
+        e["stage"] == "preserve" and "preserved" in e["message"]
+        for e in final["events"]
+    ), final["events"]
+
+    # Re-export as OpenPlural: the foreign residual is merged back in.
+    resp = auth_client.get("/v1/export", params={"format": "openplural"})
+    assert resp.status_code == 200, resp.text
+    env = resp.json()
+    assert env["extensions"]["prism"] == {"theme": "dark"}
+    assert "sheaf" in env["extensions"]
+    assert env["chat"]["messages"][0]["body"] == "secret chat"
+    assert env["relationships"]["edges"][0]["type"] == "self"
+    assert "chat" in env["capabilities"]["modules"]
+    assert any(t.get("id") == "r1" for t in env["taxonomy_terms"]), env["taxonomy_terms"]
+
+
+# --- Failure paths -----------------------------------------------------------
+
+
+def test_unknown_version_fails(auth_client: httpx.Client):
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    env["openplural_version"] = "0.2"
+    job = _post(auth_client, json.dumps(env).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any(
+        "unsupported openplural_version" in e["message"] for e in final["events"]
+    ), final["events"]
+
+
+def test_member_cap_fails_before_writes(auth_client: httpx.Client):
+    set_member_limit(auth_client, 1)
+    job = _post(auth_client, _envelope_bytes(_native()))
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any("limited to" in e["message"] for e in final["events"]), final["events"]
+    assert auth_client.get("/v1/members").json() == []
+
+
+def test_garbage_json_fails(auth_client: httpx.Client):
+    job = _post(auth_client, b"this is not json at all {{{")
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "failed", final
+
+
+def test_bundle_rejects_missing_openplural_json(auth_client: httpx.Client):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("data.json", "{}")
+    job = _post(auth_client, buf.getvalue(), filename="x.openplural.zip")
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any(
+        "must contain openplural.json" in e["message"] for e in final["events"]
+    ), final["events"]
+
+
+def test_bundle_rejects_decompression_bomb(auth_client: httpx.Client):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("openplural.json", b" " * (260 * 1024 * 1024))
+    job = _post(auth_client, buf.getvalue(), filename="x.openplural.zip")
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any(
+        "decompresses to more than" in e["message"] for e in final["events"]
+    ), final["events"]

--- a/tests/test_imports_openplural_runner.py
+++ b/tests/test_imports_openplural_runner.py
@@ -173,6 +173,33 @@ def test_preview_reports_counts_and_lineage(auth_client: httpx.Client):
     assert auth_client.get("/v1/members").json() == []
 
 
+def test_front_events_imported_as_fronts(auth_client: httpx.Client):
+    """A switch-log style file (front_events, no front_periods) imports its
+    fronting history as intervals instead of dropping it."""
+    env = {
+        "openplural_version": "0.1",
+        "producer": {"app": "PluralKit", "app_id": "pluralkit"},
+        "systems": [{"id": "s1", "name": "SwitchLog Sys", "privacy": "public"}],
+        "members": [
+            {"id": "m1", "name": "EventIris", "privacy": "private"},
+            {"id": "m2", "name": "EventJay", "privacy": "private"},
+        ],
+        "front_events": [
+            {"id": "e1", "at": "2026-01-01T00:00:00+00:00",
+             "assignments": [{"member_id": "m1"}]},
+            {"id": "e2", "at": "2026-01-02T00:00:00+00:00",
+             "assignments": [{"member_id": "m1"}, {"member_id": "m2"}]},
+        ],
+    }
+    job = _post(auth_client, json.dumps(env).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 2, final["counts"]
+    assert final["counts"]["fronts_imported"] == 2, final["counts"]
+
+
 def _foreign_envelope_bytes() -> bytes:
     """An envelope as if from another app, carrying data Sheaf cannot model."""
     env = {

--- a/tests/test_openplural_archive.py
+++ b/tests/test_openplural_archive.py
@@ -1,0 +1,125 @@
+"""Unit tests for OpenPlural import-residual preservation (the baseline
+passthrough tier). Pure functions: extraction, compress+encrypt pack/unpack,
+size cap, merge, per-record detection, and re-merge on export.
+"""
+
+from __future__ import annotations
+
+from sheaf.services.openplural_archive import (
+    extract_residual,
+    has_per_record_foreign_extensions,
+    merge_residual,
+    pack_residual,
+    unpack_residual,
+)
+from sheaf.services.openplural_export import build_envelope
+from sheaf.services.openplural_import import to_native
+
+_EXPORTED_AT = "2026-06-20T00:00:00+00:00"
+
+
+def _foreign_envelope() -> dict:
+    """An envelope as if produced by another app: carries data Sheaf does
+    not model (foreign extensions, chat + relationships modules,
+    front_comments, non-tag taxonomy)."""
+    return {
+        "openplural_version": "0.1",
+        "producer": {"app": "Prism", "app_id": "prism"},
+        "systems": [{"id": "s1", "name": "Foreign", "privacy": "public"}],
+        "members": [{"id": "m1", "name": "Iris", "privacy": "private"}],
+        "taxonomy_terms": [
+            {"id": "t1", "kind": "tag", "name": "host"},
+            {"id": "r1", "kind": "role", "name": "protector"},
+        ],
+        "taxonomy_assignments": [
+            {"term_id": "t1", "subject_type": "member", "subject_id": "m1"},
+            {"term_id": "r1", "subject_type": "member", "subject_id": "m1"},
+        ],
+        "chat": {"conversations": [{"id": "c1"}], "messages": [{"id": "x1", "body": "hi"}]},
+        "relationships": {"edges": [{"a": "m1", "b": "m1", "type": "self"}]},
+        "front_comments": [{"id": "fc1", "body": "comment"}],
+        "extensions": {
+            "sheaf": {"lineage": []},
+            "prism": {"theme": "dark", "legacyCoFronters": [1, 2]},
+        },
+    }
+
+
+def test_extract_residual_captures_unsupported():
+    res = extract_residual(_foreign_envelope())
+    assert res["extensions"] == {"prism": {"theme": "dark", "legacyCoFronters": [1, 2]}}
+    assert "sheaf" not in res["extensions"]
+    assert res["chat"]["messages"][0]["body"] == "hi"
+    assert res["relationships"]["edges"][0]["type"] == "self"
+    assert res["front_comments"][0]["body"] == "comment"
+    # Only the non-tag term + its assignment are preserved.
+    assert [t["id"] for t in res["taxonomy_terms"]] == ["r1"]
+    assert [a["term_id"] for a in res["taxonomy_assignments"]] == ["r1"]
+
+
+def test_extract_residual_empty_for_native_file():
+    # A Sheaf-produced envelope has only our own extensions namespace.
+    native_env = build_envelope(
+        {"version": "2", "system": {"name": "S"}, "members": []},
+        exported_at=_EXPORTED_AT,
+    )
+    assert extract_residual(native_env) == {}
+
+
+def test_pack_unpack_round_trip():
+    res = extract_residual(_foreign_envelope())
+    token, warning = pack_residual(res, max_bytes=8 * 1024 * 1024)
+    assert warning is None
+    assert isinstance(token, str) and token
+    assert unpack_residual(token) == res
+
+
+def test_pack_respects_size_cap():
+    big = {"extensions": {"prism": {"blob": "x" * 5000}}}
+    token, warning = pack_residual(big, max_bytes=1024)
+    assert token is None
+    assert warning is not None and "exceeds" in warning
+
+
+def test_pack_empty_is_noop():
+    assert pack_residual({}, max_bytes=1024) == (None, None)
+    assert unpack_residual(None) == {}
+    assert unpack_residual("not-a-real-token") == {}  # corrupt -> empty, no raise
+
+
+def test_merge_residual_unions_namespaces():
+    a = {"extensions": {"prism": {"x": 1}}, "chat": {"messages": []}}
+    b = {"extensions": {"pluralkit": {"y": 2}}, "relationships": {"edges": []}}
+    merged = merge_residual(a, b)
+    assert merged["extensions"] == {"prism": {"x": 1}, "pluralkit": {"y": 2}}
+    assert "chat" in merged and "relationships" in merged
+
+
+def test_has_per_record_foreign_extensions():
+    env = {"members": [{"id": "m1", "extensions": {"prism": {"color": "#f00"}}}]}
+    assert has_per_record_foreign_extensions(env) is True
+    env_own = {"members": [{"id": "m1", "extensions": {"sheaf": {"emoji": "X"}}}]}
+    assert has_per_record_foreign_extensions(env_own) is False
+
+
+def test_preserved_residual_re_merges_on_export():
+    """The full round-trip: residual extracted from a foreign file, carried
+    on the (native) system as a plain dict, comes back out in the envelope."""
+    residual = extract_residual(_foreign_envelope())
+    native = to_native(
+        {"openplural_version": "0.1", "systems": [{"id": "s1", "name": "S"}], "members": []}
+    )
+    native["system"]["openplural_archive"] = residual
+    env = build_envelope(native, exported_at=_EXPORTED_AT)
+    # Foreign extensions ride alongside Sheaf's namespace.
+    assert env["extensions"]["prism"] == {"theme": "dark", "legacyCoFronters": [1, 2]}
+    assert "sheaf" in env["extensions"]
+    # Whole modules restored + advertised in capabilities.
+    assert env["chat"]["messages"][0]["body"] == "hi"
+    assert env["relationships"]["edges"][0]["type"] == "self"
+    assert "chat" in env["capabilities"]["modules"]
+    assert "relationships" in env["capabilities"]["modules"]
+    # front_comments + non-tag taxonomy folded back in.
+    assert env["front_comments"][0]["body"] == "comment"
+    assert any(t["id"] == "r1" for t in env["taxonomy_terms"])
+    assert any(a["term_id"] == "r1" for a in env["taxonomy_assignments"])

--- a/tests/test_openplural_export.py
+++ b/tests/test_openplural_export.py
@@ -218,6 +218,51 @@ def test_parse_json_rejects_non_dict_and_bad_version():
         parse_json(json.dumps({"openplural_version": "9.9"}).encode())
 
 
+def test_front_events_convert_to_intervals():
+    """A switch-log file (front_events) becomes Sheaf interval fronts: each
+    event runs until the next, an empty-assignment event is a gap, and the
+    last event stays open-ended."""
+    env = {
+        "openplural_version": "0.1",
+        "members": [{"id": "m1", "name": "A"}, {"id": "m2", "name": "B"}],
+        "front_events": [
+            {"id": "e1", "at": "2026-01-01T00:00:00+00:00",
+             "assignments": [{"member_id": "m1"}]},
+            {"id": "e2", "at": "2026-01-02T00:00:00+00:00",
+             "assignments": [{"member_id": "m1"}, {"member_id": "m2"}]},
+            {"id": "e3", "at": "2026-01-03T00:00:00+00:00", "assignments": []},
+        ],
+    }
+    fronts = to_native(env)["fronts"]
+    assert len(fronts) == 2  # e3 is a gap, emits no interval
+    assert fronts[0]["member_ids"] == ["m1"]
+    assert fronts[0]["started_at"] == "2026-01-01T00:00:00+00:00"
+    assert fronts[0]["ended_at"] == "2026-01-02T00:00:00+00:00"
+    assert sorted(fronts[1]["member_ids"]) == ["m1", "m2"]
+    # The gap event closes the second interval.
+    assert fronts[1]["ended_at"] == "2026-01-03T00:00:00+00:00"
+
+
+def test_front_events_dedup_against_periods():
+    """A file carrying both a period and an identical event collapses to one
+    front (no double-import); the open-ended period is preserved."""
+    env = {
+        "openplural_version": "0.1",
+        "members": [{"id": "m1", "name": "A"}],
+        "front_periods": [
+            {"id": "p1", "started_at": "2026-01-01T00:00:00+00:00", "ended_at": None,
+             "assignments": [{"member_id": "m1"}]},
+        ],
+        "front_events": [
+            {"id": "e1", "at": "2026-01-01T00:00:00+00:00",
+             "assignments": [{"member_id": "m1"}]},
+        ],
+    }
+    fronts = to_native(env)["fronts"]
+    assert len(fronts) == 1
+    assert fronts[0]["ended_at"] is None
+
+
 def test_privacy_buckets_round_to_known():
     native = _native()
     native["members"][0]["privacy"] = "weird-value"

--- a/tests/test_openplural_export.py
+++ b/tests/test_openplural_export.py
@@ -1,0 +1,226 @@
+"""Unit tests for the OpenPlural exporter / inverse-importer transforms.
+
+These are pure-function tests (no DB, no HTTP): they exercise
+``openplural_export.build_envelope`` and ``openplural_import.to_native``
+directly, plus the version guard and lineage handling. The end-to-end
+job-runner behaviour (guards, dedup, image restore) is covered by
+``test_imports_openplural_runner.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sheaf.services.import_parsing import ImportPayloadError
+from sheaf.services.openplural_export import (
+    OPENPLURAL_IMPL_VERSION,
+    OPENPLURAL_VERSION,
+    build_envelope,
+)
+from sheaf.services.openplural_import import inherited_lineage, parse_json, to_native
+
+_EXPORTED_AT = "2026-06-20T00:00:00+00:00"
+
+
+def _native() -> dict:
+    return {
+        "version": "2",
+        "system": {
+            "id": "s1", "name": "Sys", "description": "d", "note": "sysnote",
+            "tag": "|S|", "avatar_url": "/v1/files/avatars/u/a.png",
+            "color": "#fff", "privacy": "public", "date_format": "ymd",
+            "replace_fronts_default": True, "coalesce_contiguous_fronts": False,
+            "delete_confirmation": "password",
+            "safety": {"grace_period_days": 7},
+            "retention": {"journal_max_revisions": 10},
+        },
+        "members": [
+            {
+                "id": "m1", "name": "Alex", "display_name": "A",
+                "description": "bio", "pronouns": "they",
+                "avatar_url": "/v1/files/avatars/u/m.png", "banner_url": None,
+                "color": "#000", "birthday": "1990-03-19", "pluralkit_id": "abcde",
+                "emoji": "X", "is_custom_front": False, "privacy": "private",
+                "note": "mn", "quick_switch_pin": "1",
+                "notify_on_front_global": True, "notify_on_front_self": False,
+                "notify_on_front_member_ids": ["m2"],
+                "created_at": "2026-01-01T00:00:00+00:00",
+            },
+            {"id": "m2", "name": "Jay", "is_custom_front": True, "birthday": "03-19"},
+        ],
+        "fronts": [
+            {
+                "id": "f1", "started_at": "2026-01-01T00:00:00+00:00",
+                "ended_at": None, "member_ids": ["m1", "m2"],
+                "custom_status": "busy",
+            }
+        ],
+        "groups": [
+            {"id": "g1", "name": "G", "description": None, "color": None,
+             "parent_id": None, "member_ids": ["m1"]}
+        ],
+        "tags": [{"id": "t1", "name": "tag", "color": "#f00", "member_ids": ["m1"]}],
+        "custom_fields": [
+            {"id": "c1", "name": "CF", "field_type": "text", "options": None,
+             "order": 0, "privacy": "public",
+             "values": [{"member_id": "m1", "value": "v"}]}
+        ],
+        "journals": [
+            {"id": "j1", "member_id": "m1", "title": "T", "body": "B",
+             "visibility": "private", "author_user_id": "u",
+             "author_member_ids": ["m1"], "author_member_names": ["Alex"],
+             "image_keys": ["/v1/files/journals/u/x.png"],
+             "created_at": "2026-01-01T00:00:00+00:00",
+             "updated_at": "2026-01-01T00:00:00+00:00"}
+        ],
+        "revisions": [{"id": "r1", "target_type": "member_bio"}],
+        "watch_tokens": [{"id": "w1", "label": "L"}],
+        "uploaded_files": [{"key": "k", "size_bytes": 1}],
+        "reminders": [{"id": "rm1", "name": "R"}],
+        "polls": [{"id": "p1", "question": "Q?"}],
+        "messages": [
+            {"id": "msg1", "board_kind": "system", "board_member_id": None,
+             "author_member_id": "m1", "parent_message_id": None, "body": "hi",
+             "created_at": "2026-01-01T00:00:00+00:00",
+             "updated_at": "2026-01-01T00:00:00+00:00"}
+        ],
+    }
+
+
+def test_envelope_producer_and_version_stamp():
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT, app_version="1.1.0")
+    assert env["openplural_version"] == OPENPLURAL_VERSION == "0.1"
+    p = env["producer"]
+    assert p["app"] == "Sheaf"
+    assert p["app_id"] == "sheaf"
+    assert p["app_version"] == "1.1.0"
+    assert p["exporter_version"] == OPENPLURAL_IMPL_VERSION
+    assert env["exported_at"] == _EXPORTED_AT
+
+
+def test_core_records_mapped():
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    assert env["systems"][0]["name"] == "Sys"
+    assert env["systems"][0]["privacy"] == "public"
+    # pluralkit_id becomes a source_ref, not a core member field.
+    m1 = next(m for m in env["members"] if m["id"] == "m1")
+    assert {"app": "pluralkit", "collection": "members", "id": "abcde"} in m1["source_refs"]
+    # birthday precision derivation.
+    assert m1["birthday"] == {"value": "1990-03-19", "precision": "day", "year_visible": True}
+    m2 = next(m for m in env["members"] if m["id"] == "m2")
+    assert m2["birthday"]["precision"] == "month_day"
+    assert m2["birthday"]["year_visible"] is False
+    # normalized memberships / assignments.
+    assert {"group_id": "g1", "member_id": "m1"} in env["group_memberships"]
+    assert env["taxonomy_terms"][0]["kind"] == "tag"
+    assert {"term_id": "t1", "subject_type": "member", "subject_id": "m1"} in env[
+        "taxonomy_assignments"
+    ]
+    # front assignments.
+    fp = env["front_periods"][0]
+    assert {a["member_id"] for a in fp["assignments"]} == {"m1", "m2"}
+    assert fp["status"] == "busy"
+    # boards module.
+    assert env["boards"]["posts"][0]["body"] == "hi"
+    assert "boards" in env["capabilities"]["modules"]
+
+
+def test_extensions_passthrough_and_uri_only_warning():
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    sheaf_ext = env["extensions"]["sheaf"]
+    for section in ("polls", "reminders", "revisions", "watch_tokens", "uploaded_files"):
+        assert sheaf_ext[section], section
+    # uri-only assets warn (sync path, no bundle bytes).
+    assert any(w["code"] == "asset_uri_only" for w in env["warnings"])
+    # assets are uri-only: no bundle_path recorded.
+    for a in env["assets"]:
+        assert "bundle_path" not in (a.get("extensions", {}).get("sheaf", {}))
+
+
+def test_bundle_mode_records_bundle_path():
+    env = build_envelope(
+        _native(), exported_at=_EXPORTED_AT, include_asset_bytes=True
+    )
+    # Internal refs carry a bundle_path + storage_key; no uri-only warning.
+    avatars = [
+        a for a in env["assets"]
+        if a.get("extensions", {}).get("sheaf", {}).get("bundle_path")
+    ]
+    assert avatars, env["assets"]
+    sk = avatars[0]["extensions"]["sheaf"]["storage_key"]
+    assert avatars[0]["extensions"]["sheaf"]["bundle_path"] == f"assets/{sk}"
+    assert not any(w["code"] == "asset_uri_only" for w in env["warnings"])
+
+
+def test_lineage_appends_and_accumulates():
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT, app_version="1.1.0")
+    lineage = env["extensions"]["sheaf"]["lineage"]
+    assert lineage[-1] == {
+        "app": "sheaf", "app_version": "1.1.0",
+        "exporter_version": OPENPLURAL_IMPL_VERSION, "exported_at": _EXPORTED_AT,
+    }
+    # A prior hop carried in is preserved ahead of Sheaf's entry.
+    prior = [{"app": "simply_plural", "exported_at": "2023-01-01T00:00:00+00:00"}]
+    env2 = build_envelope(
+        _native(), exported_at=_EXPORTED_AT, inherited_lineage=prior
+    )
+    chain = env2["extensions"]["sheaf"]["lineage"]
+    assert chain[0]["app"] == "simply_plural"
+    assert chain[-1]["app"] == "sheaf"
+    assert inherited_lineage(env2) == chain
+
+
+def test_round_trip_to_native_restores_fields():
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    back = to_native(env)
+    assert back["version"] == "2"
+    assert back["system"]["name"] == "Sys"
+    assert back["system"]["note"] == "sysnote"
+    assert back["system"]["date_format"] == "ymd"
+    assert back["system"]["safety"] == {"grace_period_days": 7}
+    m1 = next(m for m in back["members"] if m["id"] == "m1")
+    assert m1["name"] == "Alex"
+    assert m1["pluralkit_id"] == "abcde"
+    assert m1["emoji"] == "X"
+    assert m1["note"] == "mn"
+    assert m1["notify_on_front_member_ids"] == ["m2"]
+    assert back["groups"][0]["member_ids"] == ["m1"]
+    assert back["tags"][0]["member_ids"] == ["m1"]
+    assert back["custom_fields"][0]["values"] == [{"member_id": "m1", "value": "v"}]
+    front = back["fronts"][0]
+    assert set(front["member_ids"]) == {"m1", "m2"}
+    assert front["custom_status"] == "busy"
+    j = back["journals"][0]
+    assert j["title"] == "T" and j["member_id"] == "m1"
+    assert j["author_member_names"] == ["Alex"]
+    assert back["messages"][0]["body"] == "hi"
+    assert back["messages"][0]["board_kind"] == "system"
+    # passthrough sections restored verbatim.
+    assert back["polls"][0]["question"] == "Q?"
+    assert back["reminders"][0]["name"] == "R"
+    assert back["watch_tokens"][0]["label"] == "L"
+    assert back["revisions"][0]["target_type"] == "member_bio"
+
+
+def test_import_rejects_unknown_version():
+    bad = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    bad["openplural_version"] = "0.2"
+    with pytest.raises(ImportPayloadError, match="unsupported openplural_version"):
+        to_native(bad)
+
+
+def test_parse_json_rejects_non_dict_and_bad_version():
+    import json
+
+    with pytest.raises(ImportPayloadError):
+        parse_json(json.dumps([1, 2, 3]).encode())
+    with pytest.raises(ImportPayloadError, match="unsupported openplural_version"):
+        parse_json(json.dumps({"openplural_version": "9.9"}).encode())
+
+
+def test_privacy_buckets_round_to_known():
+    native = _native()
+    native["members"][0]["privacy"] = "weird-value"
+    env = build_envelope(native, exported_at=_EXPORTED_AT)
+    m1 = next(m for m in env["members"] if m["id"] == "m1")
+    assert m1["privacy"] == "unknown"

--- a/tests/test_openplural_parity.py
+++ b/tests/test_openplural_parity.py
@@ -1,0 +1,177 @@
+"""OpenPlural export-coverage guard.
+
+``test_export_import_parity.py`` proves every user-data column is either
+*exported* in the native Article-20 dump or deliberately *excluded*. This
+test extends that to the OpenPlural exporter: every column the native
+export carries (each model's ``exported`` set) must have a stated
+disposition in the OpenPlural envelope, one of:
+
+* ``core``  - mapped to an OpenPlural v0.1 core record/field,
+* ``ext``   - preserved under ``extensions.sheaf.*`` (lossless, opaque),
+* ``gap``   - intentionally not carried, with a reason.
+
+The dispositions below are read against ``CLASSIFICATION`` live, so a
+newly-added *exported* column fails here until someone decides how the
+OpenPlural exporter should treat it (and wires it into
+``openplural_export.build_envelope``). That is the whole point: it stops
+a new field silently falling out of the OpenPlural format the same way
+the native parity guard stops it falling out of the native one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_export_import_parity import CLASSIFICATION
+
+# Per model: every column in that model's `exported` set maps to exactly
+# one disposition. `gap` carries a reason string; `core`/`ext`/`residual`
+# are bare markers. Keep in sync with openplural_export.build_envelope.
+CORE = "core"
+EXT = "ext"
+# The preservation channel itself: it does not map to one envelope field,
+# it carries the FOREIGN residual (other apps' extensions/modules) that is
+# re-merged into the envelope on export. See openplural_archive.py.
+RESIDUAL = "residual"
+
+DISPOSITION: dict[str, dict[str, object]] = {
+    "System": {
+        # Core OpenPlural System fields.
+        "name": CORE, "description": CORE, "tag": CORE, "color": CORE,
+        "privacy": CORE, "avatar_url": CORE,
+        # extensions.sheaf.* (note + prefs + the safety/retention blocks).
+        "note": EXT, "date_format": EXT, "replace_fronts_default": EXT,
+        "coalesce_contiguous_fronts": EXT, "delete_confirmation": EXT,
+        "auto_pin_first_revision": EXT,
+        "safety_grace_period_days": EXT, "safety_applies_to_members": EXT,
+        "safety_applies_to_groups": EXT, "safety_applies_to_tags": EXT,
+        "safety_applies_to_fields": EXT, "safety_applies_to_fronts": EXT,
+        "safety_applies_to_journals": EXT, "safety_applies_to_images": EXT,
+        "safety_applies_to_revisions": EXT,
+        "safety_applies_to_notifications": EXT,
+        "safety_applies_to_reminders": EXT, "safety_applies_to_polls": EXT,
+        "safety_applies_to_messages": EXT,
+        "journal_max_revisions": EXT, "journal_max_revision_days": EXT,
+        "pinned_revision_max_per_target": EXT,
+        "openplural_archive": RESIDUAL,
+    },
+    "Member": {
+        "name": CORE, "display_name": CORE, "description": CORE,
+        "pronouns": CORE, "avatar_url": CORE, "banner_url": CORE,
+        "color": CORE, "birthday": CORE, "is_custom_front": CORE,
+        "privacy": CORE, "created_at": CORE,
+        # pluralkit_id becomes a SourceRef(app="pluralkit").
+        "pluralkit_id": CORE,
+        # extensions.sheaf.* on the member record.
+        "emoji": EXT, "note": EXT, "quick_switch_pin": EXT,
+        "notify_on_front_global": EXT, "notify_on_front_self": EXT,
+        "notify_on_front_member_ids": EXT,
+    },
+    "Front": {
+        "started_at": CORE, "ended_at": CORE, "custom_status": CORE,
+    },
+    "Group": {
+        "name": CORE, "description": CORE, "color": CORE, "parent_id": CORE,
+    },
+    "Tag": {
+        "name": CORE, "color": CORE,
+    },
+    "CustomFieldDefinition": {
+        "name": CORE, "field_type": CORE, "options": CORE, "order": CORE,
+        "privacy": CORE,
+    },
+    "CustomFieldValue": {
+        "member_id": CORE, "value": CORE,
+    },
+    "JournalEntry": {
+        "title": CORE, "body": CORE, "visibility": CORE,
+        "author_member_ids": CORE, "image_keys": CORE,
+        "created_at": CORE, "updated_at": CORE,
+        "member_id": EXT, "author_member_names": EXT,
+        "author_user_id": (
+            "GAP: journal author account id is re-pointed to the importing "
+            "user by the native importer, so it is not portable content"
+        ),
+    },
+    "Message": {
+        # Mapped to boards.posts[] ...
+        "board_member_id": CORE, "author_member_id": CORE, "body": CORE,
+        "created_at": CORE, "updated_at": CORE,
+        # ... with these in the post's extensions.sheaf.
+        "board_kind": EXT, "parent_message_id": EXT,
+    },
+    # Everything below is carried verbatim under a file-level
+    # extensions.sheaf.<section> passthrough (polls / reminders /
+    # revisions / watch_tokens / uploaded_files), so every exported
+    # column is `ext`.
+    "ContentRevision": "_all_ext",
+    "WatchToken": "_all_ext",
+    "NotificationChannel": "_all_ext",
+    "NotificationChannelGroupRule": "_all_ext",
+    "NotificationChannelMemberRule": "_all_ext",
+    "UploadedFile": "_all_ext",
+    "Reminder": "_all_ext",
+    "Poll": "_all_ext",
+    "PollOption": "_all_ext",
+    "PollVote": "_all_ext",
+    "PollVoteEvent": "_all_ext",
+}
+
+
+def _disposition_for(model_name: str, exported: set[str]) -> dict[str, object]:
+    entry = DISPOSITION.get(model_name)
+    if entry == "_all_ext":
+        return {col: EXT for col in exported}
+    assert isinstance(entry, dict), (
+        f"{model_name} has no OpenPlural disposition. Add it to "
+        f"tests/test_openplural_parity.py (core / ext / gap per column)."
+    )
+    return entry
+
+
+@pytest.mark.parametrize(
+    "model", list(CLASSIFICATION), ids=lambda m: m.__name__
+)
+def test_every_exported_column_has_an_openplural_disposition(model: type):
+    """Every natively-exported column must have an OpenPlural disposition.
+
+    A new column added to a model's `exported` set in the native parity
+    guard fails here until it is given a disposition and (if core/ext)
+    threaded into openplural_export.build_envelope.
+    """
+    name = model.__name__
+    exported: set[str] = set(CLASSIFICATION[model]["exported"])
+    disposition = _disposition_for(name, exported)
+
+    missing = exported - set(disposition)
+    assert not missing, (
+        f"{name}: exported column(s) {sorted(missing)} have no OpenPlural "
+        f"disposition. Decide core / ext / gap in "
+        f"tests/test_openplural_parity.py and wire core/ext fields into "
+        f"openplural_export.build_envelope."
+    )
+
+    phantom = set(disposition) - exported
+    assert not phantom, (
+        f"{name}: disposition names column(s) {sorted(phantom)} that are no "
+        f"longer in the native `exported` set. Remove them."
+    )
+
+    for col, disp in disposition.items():
+        if disp in (CORE, EXT, RESIDUAL):
+            continue
+        assert isinstance(disp, str) and disp.startswith("GAP:"), (
+            f"{name}.{col}: disposition must be 'core', 'ext', or a "
+            f"'GAP: <reason>' string (got {disp!r})"
+        )
+
+
+def test_disposition_has_no_unknown_models():
+    """Every model named in DISPOSITION is a real classified model - a
+    rename in the native guard must not leave a stale entry here."""
+    classified = {m.__name__ for m in CLASSIFICATION}
+    stale = set(DISPOSITION) - classified
+    assert not stale, (
+        f"DISPOSITION names model(s) {sorted(stale)} not in the native "
+        f"CLASSIFICATION. Renamed or dropped? Update this file."
+    )

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -27,6 +27,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 type ExportMode = "with_images" | "account_data";
+type ExportFormat = "sheaf_native" | "openplural";
 
 function formatBytes(n: number | null): string {
   if (n === null) return "—";
@@ -138,6 +139,7 @@ export function DataExportCard() {
   const qc = useQueryClient();
   const [syncing, setSyncing] = useState(false);
   const [mode, setMode] = useState<ExportMode | null>(null);
+  const [format, setFormat] = useState<ExportFormat>("sheaf_native");
   const [searchParams, setSearchParams] = useSearchParams();
   const highlightJobId = searchParams.get("job");
   // Row refs so we can scroll the highlighted backup into view once
@@ -236,6 +238,7 @@ export function DataExportCard() {
     if (mode === "with_images") {
       createJob.mutate({
         include_images: true,
+        format,
         password,
         totp_code: totp || undefined,
       });
@@ -286,6 +289,41 @@ export function DataExportCard() {
               need to be re-uploaded by hand. The image bytes are present
               for your records.
             </p>
+            <fieldset className="space-y-2 mb-3">
+              <legend className="text-sm font-medium mb-1">Format</legend>
+              <label className="flex items-start gap-2 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="export-format"
+                  className="mt-0.5 h-4 w-4 border-input"
+                  checked={format === "sheaf_native"}
+                  onChange={() => setFormat("sheaf_native")}
+                />
+                <span>
+                  Sheaf (native)
+                  <span className="block text-xs text-muted-foreground">
+                    Re-importable into another Sheaf instance with full
+                    fidelity.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="export-format"
+                  className="mt-0.5 h-4 w-4 border-input"
+                  checked={format === "openplural"}
+                  onChange={() => setFormat("openplural")}
+                />
+                <span>
+                  OpenPlural
+                  <span className="block text-xs text-muted-foreground">
+                    An OpenPlural v0.1 bundle (.openplural.zip) for
+                    interchange with other OpenPlural-compatible apps.
+                  </span>
+                </span>
+              </label>
+            </fieldset>
             <Button onClick={() => setMode("with_images")} variant="outline">
               Build full backup (with images)
             </Button>

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -213,14 +213,16 @@ export function DataExportCard() {
   async function handleSyncJsonExport() {
     setSyncing(true);
     try {
-      const data = await exportData();
+      const data = await exportData(format);
       const blob = new Blob([JSON.stringify(data, null, 2)], {
         type: "application/json",
       });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `sheaf-export-${new Date().toISOString().slice(0, 10)}.json`;
+      const date = new Date().toISOString().slice(0, 10);
+      const ext = format === "openplural" ? "openplural.json" : "json";
+      a.download = `sheaf-export-${date}.${ext}`;
       a.click();
       URL.revokeObjectURL(url);
       toast.success("Data exported");
@@ -267,30 +269,11 @@ export function DataExportCard() {
               Re-importable into another Sheaf instance via{" "}
               <strong>Data import</strong> below.
             </p>
-            <Button
-              onClick={handleSyncJsonExport}
-              variant="outline"
-              disabled={syncing}
-            >
-              {syncing ? "Exporting..." : "Export (JSON only)"}
-            </Button>
-          </div>
-
-          <div className="border-t pt-4">
-            <p className="text-sm text-muted-foreground mb-2 max-w-prose">
-              Full backup including image bytes (avatars, journal embeds,
-              bio history). Builds in the background — typically a few
-              minutes — then we'll email you and show a download button
-              here. The file is available for 72 hours.
-            </p>
-            <p className="text-xs text-muted-foreground mb-3 max-w-prose">
-              Note: importing this zip into another Sheaf instance brings
-              text content (members, journals, etc.) but image attachments
-              need to be re-uploaded by hand. The image bytes are present
-              for your records.
-            </p>
             <fieldset className="space-y-2 mb-3">
               <legend className="text-sm font-medium mb-1">Format</legend>
+              <p className="text-xs text-muted-foreground mb-2 max-w-prose">
+                Applies to both the JSON export here and the full backup below.
+              </p>
               <label className="flex items-start gap-2 text-sm cursor-pointer">
                 <input
                   type="radio"
@@ -318,12 +301,41 @@ export function DataExportCard() {
                 <span>
                   OpenPlural
                   <span className="block text-xs text-muted-foreground">
-                    An OpenPlural v0.1 bundle (.openplural.zip) for
-                    interchange with other OpenPlural-compatible apps.
+                    OpenPlural v0.1, for interchange with other
+                    OpenPlural-compatible apps. JSON export here is uri-only;
+                    the full backup is a .openplural.zip with image bytes.
                   </span>
                 </span>
               </label>
             </fieldset>
+            <Button
+              onClick={handleSyncJsonExport}
+              variant="outline"
+              disabled={syncing}
+            >
+              {syncing ? "Exporting..." : "Export (JSON only)"}
+            </Button>
+          </div>
+
+          <div className="border-t pt-4">
+            <p className="text-sm text-muted-foreground mb-2 max-w-prose">
+              Full backup including image bytes (avatars, journal embeds,
+              bio history). Builds in the background — typically a few
+              minutes — then we'll email you and show a download button
+              here. The file is available for 72 hours.
+            </p>
+            <p className="text-xs text-muted-foreground mb-3 max-w-prose">
+              Note: importing this zip into another Sheaf instance brings
+              text content (members, journals, etc.) but image attachments
+              need to be re-uploaded by hand. The image bytes are present
+              for your records.
+            </p>
+            <p className="text-xs text-muted-foreground mb-3 max-w-prose">
+              Uses the <strong>format</strong> selected above
+              {format === "openplural"
+                ? " (OpenPlural .openplural.zip)."
+                : " (Sheaf native zip)."}
+            </p>
             <Button onClick={() => setMode("with_images")} variant="outline">
               Build full backup (with images)
             </Button>

--- a/web/src/lib/imports.ts
+++ b/web/src/lib/imports.ts
@@ -16,7 +16,8 @@ export type ImportJobSource =
   | "sheaf_file"
   | "sheaf_archive"
   | "pluralspace_file"
-  | "prism_file";
+  | "prism_file"
+  | "openplural_file";
 
 export type ImportJobStatus =
   | "pending"
@@ -78,6 +79,7 @@ export const SOURCE_LABELS: Record<ImportJobSource, string> = {
   sheaf_archive: "Sheaf (with images)",
   pluralspace_file: "PluralSpace",
   prism_file: "Prism",
+  openplural_file: "OpenPlural",
 };
 
 const TERMINAL = new Set<ImportJobStatus>(["complete", "failed", "cancelled"]);

--- a/web/src/lib/openplural-import.ts
+++ b/web/src/lib/openplural-import.ts
@@ -1,0 +1,31 @@
+/**
+ * OpenPlural import - preview call.
+ *
+ * Mirrors the Sheaf native re-import: a synchronous preview step counts
+ * the sections in the uploaded file (a bare openplural.json document or
+ * an .openplural.zip bundle, sniffed server-side) so the card can show
+ * per-section counts and a member selector before the user commits. The
+ * actual import is enqueued via lib/imports.ts under source
+ * "openplural_file".
+ */
+import { apiFetch } from "./api-client";
+import type { SheafPreviewSummary } from "./sheaf-import";
+
+// OpenPlural carries the same section counts as the Sheaf preview, plus
+// the length of the export lineage (how many prior exports this file has
+// passed through).
+export interface OpenpluralPreviewSummary extends SheafPreviewSummary {
+  lineage_length: number;
+}
+
+export async function previewOpenpluralImport(
+  file: File,
+): Promise<OpenpluralPreviewSummary> {
+  const form = new FormData();
+  form.append("file", file);
+  return apiFetch<OpenpluralPreviewSummary>("/v1/import/openplural/preview", {
+    method: "POST",
+    headers: {},
+    body: form,
+  });
+}

--- a/web/src/lib/systems.ts
+++ b/web/src/lib/systems.ts
@@ -12,8 +12,9 @@ export function updateMySystem(data: SystemUpdate) {
   });
 }
 
-export function exportData() {
-  return apiFetch<Record<string, unknown>>("/v1/export");
+export function exportData(format: "sheaf_native" | "openplural" = "sheaf_native") {
+  const q = format === "openplural" ? "?format=openplural" : "";
+  return apiFetch<Record<string, unknown>>(`/v1/export${q}`);
 }
 
 // --- Article 15 + async export jobs ---------------------------------------

--- a/web/src/lib/systems.ts
+++ b/web/src/lib/systems.ts
@@ -36,6 +36,10 @@ export function listExportJobs() {
 
 export function createExportJob(body: {
   include_images: boolean;
+  // Artefact format: "sheaf_native" (export.json + images/) or
+  // "openplural" (an .openplural.zip bundle). Defaults server-side to
+  // "sheaf_native" when omitted.
+  format?: "sheaf_native" | "openplural";
   password: string;
   totp_code?: string;
 }) {

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -35,13 +35,17 @@ import {
   previewImport as previewPrism,
 } from "@/lib/prism-import";
 import {
+  type OpenpluralPreviewSummary,
+  previewOpenpluralImport,
+} from "@/lib/openplural-import";
+import {
   createApiImport,
   createFileImport,
   newIdempotencyKey,
 } from "@/lib/imports";
 import { Input } from "@/components/ui/input";
 
-type Source = "choose" | "sheaf" | "sp" | "pk" | "tb" | "ps" | "prism";
+type Source = "choose" | "sheaf" | "sp" | "pk" | "tb" | "ps" | "prism" | "op";
 // "importing" shows a brief spinner while the enqueue POST is in
 // flight; on success the flow navigates to /imports/:id, which owns
 // the running/done UI. There's no "done" step here any more.
@@ -76,6 +80,9 @@ export function ImportPage() {
       )}
       {source === "prism" && (
         <PrismImportFlow onBack={() => setSource("choose")} />
+      )}
+      {source === "op" && (
+        <OPImportFlow onBack={() => setSource("choose")} />
       )}
     </>
   );
@@ -173,6 +180,22 @@ function SourcePicker({ onSelect }: { onSelect: (s: Source) => void }) {
             messages, and member-board posts. Prism's sleep tracking, habits,
             and reminders aren't surfaces Sheaf has yet and are dropped with
             a warning event on the import detail page.
+          </p>
+        </CardContent>
+      </Card>
+      <Card
+        className="cursor-pointer hover:border-primary transition-colors"
+        onClick={() => onSelect("op")}
+      >
+        <CardHeader>
+          <CardTitle className="text-base">Import from OpenPlural</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Import an OpenPlural v0.1 export from Sheaf or another
+            OpenPlural-compatible app. Upload the <code>.json</code>{" "}
+            document, or the <code>.openplural.zip</code> bundle (the
+            bundle restores avatars and embedded images too).
           </p>
         </CardContent>
       </Card>
@@ -1568,6 +1591,270 @@ function PrismImportFlow({ onBack }: { onBack: () => void }) {
                 checked={mediaAttachments}
                 onChange={setMediaAttachments}
               />
+
+              <ConflictStrategyField
+                value={conflictStrategy}
+                onChange={setConflictStrategy}
+              />
+
+              <MemberSelector
+                members={preview.members}
+                totalCount={preview.member_count}
+                allMembers={allMembers}
+                setAllMembers={setAllMembers}
+                selectedMembers={selectedMembers}
+                toggleMember={toggleMember}
+              />
+
+              <ImportSubmit incoming={importIncoming} onImport={handleImport} />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {step === "importing" && <ImportingCard />}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OpenPlural import flow
+// ---------------------------------------------------------------------------
+
+function OPImportFlow({ onBack }: { onBack: () => void }) {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>("upload");
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<OpenpluralPreviewSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // One idempotency key per flow visit - a double-click on Import
+  // reuses it, so the server dedupes instead of enqueueing twice.
+  const [idemKey] = useState(newIdempotencyKey);
+
+  const [systemProfile, setSystemProfile] = useState(true);
+  const [allMembers, setAllMembers] = useState(true);
+  const [conflictStrategy, setConflictStrategy] =
+    useState<ConflictStrategy>("skip");
+  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set());
+  const [importFronts, setImportFronts] = useState(true);
+  const [importGroups, setImportGroups] = useState(true);
+  const [importTags, setImportTags] = useState(true);
+  const [importFields, setImportFields] = useState(true);
+  const [importJournals, setImportJournals] = useState(true);
+  const [importMessages, setImportMessages] = useState(true);
+  const [importPolls, setImportPolls] = useState(true);
+  const [importNotifications, setImportNotifications] = useState(true);
+  const [importReminders, setImportReminders] = useState(true);
+  // Only meaningful for the .openplural.zip bundle (preview.archive).
+  const [restoreImages, setRestoreImages] = useState(true);
+
+  const importIncoming = allMembers
+    ? (preview?.member_count ?? 0)
+    : selectedMembers.size;
+
+  async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+    setError(null);
+    try {
+      const p = await previewOpenpluralImport(f);
+      setPreview(p);
+      setStep("preview");
+    } catch (err) {
+      setError(apiErrorMessage(err, "Failed to parse file"));
+    }
+  }
+
+  async function handleImport() {
+    if (!file) return;
+    setStep("importing");
+    setError(null);
+    try {
+      const isArchive = preview?.archive ?? false;
+      const job = await createFileImport({
+        source: "openplural_file",
+        file,
+        idempotencyKey: idemKey,
+        options: {
+          system_profile: systemProfile,
+          member_ids: allMembers ? null : Array.from(selectedMembers),
+          conflict_strategy: conflictStrategy,
+          fronts: importFronts,
+          groups: importGroups,
+          tags: importTags,
+          custom_fields: importFields,
+          journals: importJournals,
+          messages: importMessages,
+          polls: importPolls,
+          notifications: importNotifications,
+          // Reminders need a channel; without notifications there's nothing
+          // for them to attach to.
+          reminders: importReminders && importNotifications,
+          // The images toggle only applies to the .openplural.zip bundle.
+          ...(isArchive ? { images: restoreImages } : {}),
+        },
+      });
+      navigate(`/imports/${job.id}`);
+    } catch (err) {
+      setError(apiErrorMessage(err, "Import failed"));
+      setStep("preview");
+    }
+  }
+
+  function toggleMember(id: string) {
+    setSelectedMembers((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <>
+      {error && <ErrorBanner message={error} />}
+
+      {step === "upload" && (
+        <Card className="max-w-lg">
+          <CardHeader>
+            <CardTitle className="text-base">Upload OpenPlural export</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Upload an OpenPlural v0.1 export from Sheaf or another
+              OpenPlural-compatible app. Either the bare{" "}
+              <code>.json</code> document, or the full{" "}
+              <code>.openplural.zip</code> bundle (the bundle restores
+              avatars and embedded images too).
+            </p>
+            <input
+              type="file"
+              accept=".json,.zip,.openplural.zip,application/json,application/zip"
+              onChange={handleFileSelect}
+              className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+            />
+            <Button variant="outline" size="sm" onClick={onBack}>
+              Back
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "preview" && preview && (
+        <div className="grid gap-4 max-w-2xl">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Export summary
+                {preview.system_name && (
+                  <span className="ml-2 font-normal text-muted-foreground">
+                    - {preview.system_name}
+                  </span>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-3 text-sm">
+              <div>Members: <strong>{preview.member_count}</strong></div>
+              <div>Fronts: <strong>{preview.front_count}</strong></div>
+              <div>Groups: <strong>{preview.group_count}</strong></div>
+              <div>Tags: <strong>{preview.tag_count}</strong></div>
+              <div>Custom fields: <strong>{preview.custom_field_count}</strong></div>
+              <div>Journals: <strong>{preview.journal_count}</strong></div>
+              <div>Messages: <strong>{preview.message_count}</strong></div>
+              <div>Polls: <strong>{preview.poll_count}</strong></div>
+              <div>Reminders: <strong>{preview.reminder_count}</strong></div>
+              <div>Notification channels: <strong>{preview.channel_count}</strong></div>
+              {preview.archive && (
+                <div>Images: <strong>{preview.image_count}</strong></div>
+              )}
+            </CardContent>
+          </Card>
+
+          {preview.lineage_length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              This file carries history from{" "}
+              {preview.lineage_length.toLocaleString()} prior export(s).
+            </p>
+          )}
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Import options</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Checkbox
+                label="System profile (name, description, color, tag, safety + retention settings)"
+                checked={systemProfile}
+                onChange={setSystemProfile}
+              />
+              <Checkbox
+                label={`Fronts (${preview.front_count.toLocaleString()} entries)`}
+                checked={importFronts}
+                onChange={setImportFronts}
+              />
+              <Checkbox
+                label="Groups"
+                checked={importGroups}
+                onChange={setImportGroups}
+              />
+              <Checkbox
+                label="Tags"
+                checked={importTags}
+                onChange={setImportTags}
+              />
+              <Checkbox
+                label="Custom fields (definitions + values)"
+                checked={importFields}
+                onChange={setImportFields}
+              />
+              <Checkbox
+                label={`Journals (${preview.journal_count.toLocaleString()} entries, with edit history)`}
+                checked={importJournals}
+                onChange={setImportJournals}
+              />
+              <Checkbox
+                label={`Messages (${preview.message_count.toLocaleString()} board posts)`}
+                checked={importMessages}
+                onChange={setImportMessages}
+              />
+              <Checkbox
+                label={`Polls (${preview.poll_count.toLocaleString()}, with votes + audit log)`}
+                checked={importPolls}
+                onChange={setImportPolls}
+              />
+              <Checkbox
+                label={`Notification setup (${preview.channel_count.toLocaleString()} channels - recipients re-activate on this instance)`}
+                checked={importNotifications}
+                onChange={setImportNotifications}
+              />
+              <div>
+                <Checkbox
+                  label={`Reminders (${preview.reminder_count.toLocaleString()})`}
+                  checked={importReminders && importNotifications}
+                  onChange={setImportReminders}
+                />
+                {!importNotifications && (
+                  <p className="ml-6 text-xs text-muted-foreground">
+                    Reminders attach to a notification channel, so they need
+                    Notification setup enabled to come across.
+                  </p>
+                )}
+              </div>
+              {preview.archive && (
+                <div>
+                  <Checkbox
+                    label={`Restore images (${preview.image_count.toLocaleString()} bundled)`}
+                    checked={restoreImages}
+                    onChange={setRestoreImages}
+                  />
+                  <p className="ml-6 text-xs text-muted-foreground">
+                    Avatars and embedded images are re-uploaded to this
+                    account (they count toward your storage quota). Unticked,
+                    image references are removed like a plain JSON import.
+                  </p>
+                </div>
+              )}
 
               <ConflictStrategyField
                 value={conflictStrategy}


### PR DESCRIPTION
Sheaf is a founding adopter of the [OpenPlural](https://github.com/skylartaylor/openplural) data standard; this adds bidirectional OpenPlural v0.1 support.

Export comes in two shapes: a single JSON document (sync `GET /v1/export?format=openplural`, with uri-only assets) and an `.openplural.zip` bundle (async export job with `format=openplural`, carrying the image bytes under `assets/`). The data-export settings card exposes both via a format selector that governs the JSON-only download and the full backup. Every export stamps the producing app and version (`producer.app` / `app_id` / `app_version` / `exporter_version`) and appends a forward-compatible `extensions.sheaf.lineage[]` entry; `pluralkit_id` is emitted as an OpenPlural `source_ref`.

Import accepts either shape (`POST /v1/imports/file` with `source=openplural_file`, sniffed by content) plus a preview endpoint (`POST /v1/import/openplural/preview`) that drives the import card's per-section counts and member selector. The importer translates the envelope to Sheaf's native shape and reuses the existing native importer underneath, so the member-cap, decompression-size, avatar-policy, dedup, and tenant-scoping guards all apply unchanged, and it rejects any unfamiliar `openplural_version`. It reads `front_periods` and also derives intervals from `front_events` (the PluralKit-style switch log), so an event-log file does not lose its fronting history.

Systems, members, fronts, groups, tags, custom fields, and journals map to OpenPlural core records; everything Sheaf has that the draft spec has no core record for (notes, polls, reminders, board messages, revision history, notification config, System Safety settings, member emoji / quick-switch, and more) is preserved losslessly under the namespaced `extensions.sheaf` key, so a Sheaf round-trip is complete. So Sheaf is not a lossy hop for files from other apps either, data it cannot model (other apps' `extensions` namespaces, the chat and relationships modules, front comments, non-tag taxonomy) is preserved on import (compressed, encrypted, and bounded by `OPENPLURAL_MAX_PRESERVED_MB`) and re-merged into the next OpenPlural export. Per-record foreign extensions are the one remaining follow-up and are reported rather than silently dropped.

Two migrations (`export_jobs.format`, `systems.openplural_archive`, both fast-failing on lock). A new format-coverage test fails CI if a future user-data field is added to the export without being given an OpenPlural disposition, alongside pure-mapping, parity, and end-to-end round-trip tests (JSON + bundle, preview, version-reject, member-cap, zip guards, switch-log import, and foreign-data preservation). The full field-by-field mapping, the `extensions.sheaf.*` table, the edge cases, and the open upstream spec issues are documented in `docs/OPENPLURAL.md`; `docs/IMPORT.md` and `docs/SELFHOSTING.md` are updated too.

The CHANGELOG entry sits under `[Unreleased]`; the version bump to v1.1.0 is a separate release step.
