### PR TITLE
Format member birthday with the date format setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Member birthdays now honour the date format setting.** A member's birthday was always shown as `YYYY-MM-DD`, ignoring the system's configured date format. It now renders in the chosen order (e.g. `DD/MM/YYYY`), and year-less birthdays (the "no birth year" option) format as month and day in the same order rather than as a raw string.
+
 ### Changed
 
 - **Import previews parse off the event loop.** The synchronous import preview endpoints (PluralKit, Tupperbox, SimplyPlural, Sheaf native JSON, OpenPlural JSON) now decode the uploaded file on a worker thread under a small concurrency cap, instead of parsing it on the asyncio event loop. A large export no longer makes the server briefly unresponsive to other requests while it parses. The zip-based previews already did this; this brings the plain-JSON ones in line. As part of the move, the PluralKit/Tupperbox/SimplyPlural previews now also apply the same JSON element-count guard the importers themselves use, so a preview is not a cheaper way to stress the server than the real import. No API change: request and response shapes are identical.

--- a/web/src/lib/date-format.ts
+++ b/web/src/lib/date-format.ts
@@ -1,10 +1,18 @@
-import { format, parseISO } from "date-fns";
+import { format, isValid, parse, parseISO } from "date-fns";
 import type { DateFormat } from "@/types/api";
 
 const formatStrings: Record<DateFormat, string> = {
   dmy: "dd/MM/yyyy",
   mdy: "MM/dd/yyyy",
   ymd: "yyyy-MM-dd",
+};
+
+// Year-less birthdays (the "no birth year" option) render month + day only,
+// in the same order as the user's full-date format.
+const monthDayFormatStrings: Record<DateFormat, string> = {
+  dmy: "dd/MM",
+  mdy: "MM/dd",
+  ymd: "MM-dd",
 };
 
 const formatStringsWithTime: Record<DateFormat, string> = {
@@ -32,6 +40,33 @@ export function formatDateTime(
   if (!dateStr) return "";
   try {
     return format(parseISO(dateStr), formatStringsWithTime[dateFormat]);
+  } catch {
+    return dateStr;
+  }
+}
+
+/**
+ * Format a member birthday in the user's configured date order.
+ *
+ * Birthdays come in two shapes: a full `YYYY-MM-DD` date, or a year-less
+ * `MM-DD` (when the member opted out of a birth year). Each is rendered in
+ * the user's chosen order - with the year for a full date, month/day only
+ * for a year-less one. Falls back to the raw string if it does not parse.
+ */
+export function formatBirthday(
+  dateStr: string | null | undefined,
+  dateFormat: DateFormat = "ymd",
+): string {
+  if (!dateStr) return "";
+  try {
+    // A year-less birthday is `MM-DD` (two parts); a full date is
+    // `YYYY-MM-DD` (three).
+    if (dateStr.split("-").length === 2) {
+      const parsed = parse(dateStr, "MM-dd", new Date(2000, 0, 1));
+      if (!isValid(parsed)) return dateStr;
+      return format(parsed, monthDayFormatStrings[dateFormat]);
+    }
+    return format(parseISO(dateStr), formatStrings[dateFormat]);
   } catch {
     return dateStr;
   }

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks/use-members";
 import { useCustomFields, useMemberFieldValues, useSetMemberFieldValues } from "@/hooks/use-custom-fields";
 import { getMySystem } from "@/lib/systems";
+import { formatBirthday } from "@/lib/date-format";
 import { cn } from "@/lib/utils";
 import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import {
@@ -1031,7 +1032,9 @@ function MemberView({
                 <p className="text-sm text-muted-foreground">{member.pronouns}</p>
               )}
               {member.birthday && (
-                <p className="text-sm text-muted-foreground">{member.birthday}</p>
+                <p className="text-sm text-muted-foreground">
+                  {formatBirthday(member.birthday, dateFormat)}
+                </p>
               )}
               {member.pluralkit_id && (
                 <p className="text-xs text-muted-foreground font-mono">


### PR DESCRIPTION
A member's birthday was always shown as `YYYY-MM-DD`, ignoring the system's configured date format. The member view rendered `member.birthday` as the raw API string, even though the date format was already in scope and applied to the revision history just below it.

Adds a `formatBirthday` helper that renders a birthday in the user's chosen order. It handles both shapes a birthday can take: a full `YYYY-MM-DD` date (formatted with the year, e.g. `DD/MM/YYYY`) and a year-less `MM-DD` from the "no birth year" option (formatted as month and day in the same order). The existing `formatDate` helper could not be reused as-is because it falls back to the raw string for the year-less case, which is the same class of bug.

This is the only birthday display site (the other references are the edit-form date picker input and form state). The native mobile apps format dates themselves, so no client change is needed here.

Verification: tsc, eslint, and the web build are all clean. (No frontend test runner is configured in the repo, so no unit test was added; a vitest harness for the date helpers would be a good future backstop.)