### PR TITLE
Announcement links and settable expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Server announcements support links and a settable expiry.** An announcement body now renders inline markdown, so an admin can include a link (e.g. to a full incident write-up); it stays a one-line banner, with any block markdown degrading to plain text and links opening in a new tab. The admin form also gains an optional "Expires" datetime, after which the announcement stops showing to users (the field already existed on the backend but was not settable in the UI).
+
 ### Fixed
 
 - **Member birthdays now honour the date format setting.** A member's birthday was always shown as `YYYY-MM-DD`, ignoring the system's configured date format. It now renders in the chosen order (e.g. `DD/MM/YYYY`), and year-less birthdays (the "no birth year" option) format as month and day in the same order rather than as a raw string.

--- a/web/src/components/announcement-banners.tsx
+++ b/web/src/components/announcement-banners.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import {
   getActiveAnnouncements,
   getLoggedOutAnnouncements,
@@ -122,6 +124,37 @@ export function LoggedOutAnnouncementBanners() {
   );
 }
 
+// Announcement bodies support inline markdown, mainly so an admin can
+// include a link (e.g. to a full incident write-up). This is a one-line
+// banner, so only inline elements are allowed - any block markdown
+// (headings, images, lists, code blocks) is unwrapped to its plain text so
+// it can never break the banner layout. react-markdown sanitises link URLs
+// by default (javascript:/data: are dropped); links open in a new tab.
+function AnnouncementBody({ body }: { body: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      allowedElements={["p", "a", "em", "strong", "del", "code", "br"]}
+      unwrapDisallowed
+      components={{
+        p: ({ children }) => <>{children}</>,
+        a: ({ href, children }) => (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:opacity-80"
+          >
+            {children}
+          </a>
+        ),
+      }}
+    >
+      {body}
+    </ReactMarkdown>
+  );
+}
+
 function AnnouncementBanner({
   announcement,
   onDismiss,
@@ -152,7 +185,9 @@ function AnnouncementBanner({
             <span className="mx-2 opacity-50" aria-hidden="true">
               ·
             </span>
-            <span className="opacity-90">{announcement.body}</span>
+            <span className="opacity-90">
+              <AnnouncementBody body={announcement.body} />
+            </span>
           </>
         )}
       </div>

--- a/web/src/routes/admin/announcements.tsx
+++ b/web/src/routes/admin/announcements.tsx
@@ -34,6 +34,25 @@ import {
   AlertOctagon,
 } from "lucide-react";
 
+// A datetime-local <input> works in the browser's local zone; the API
+// stores/returns ISO (UTC) strings. Convert between the two.
+function isoToLocalInput(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+function localInputToIso(local: string): string | null {
+  if (!local) return null;
+  const d = new Date(local);
+  if (isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
 const severityIcons = {
   info: Info,
   warning: AlertTriangle,
@@ -119,7 +138,7 @@ function AnnouncementRow({ announcement }: { announcement: Announcement }) {
           )}
           {announcement.expires_at && (
             <span>
-              Expires: {new Date(announcement.expires_at).toLocaleDateString()}
+              Expires: {new Date(announcement.expires_at).toLocaleString()}
             </span>
           )}
         </div>
@@ -199,6 +218,9 @@ function EditAnnouncementForm({
   const [visibleWhileLoggedOut, setVisibleWhileLoggedOut] = useState(
     announcement.visible_while_logged_out,
   );
+  const [expiresAt, setExpiresAt] = useState(
+    isoToLocalInput(announcement.expires_at),
+  );
 
   const save = useMutation({
     mutationFn: () =>
@@ -208,6 +230,9 @@ function EditAnnouncementForm({
         severity,
         dismissible,
         visible_while_logged_out: visibleWhileLoggedOut,
+        ...(expiresAt
+          ? { expires_at: localInputToIso(expiresAt) }
+          : { clear_expires_at: true }),
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "announcements"] });
@@ -250,6 +275,25 @@ function EditAnnouncementForm({
           onChange={(e) => setBody(e.target.value)}
           maxLength={2000}
         />
+        <p className="text-xs text-muted-foreground">
+          Supports markdown links, e.g. [read more](https://example.com)
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="edit-expires" className="text-xs">
+          Expires (optional)
+        </Label>
+        <Input
+          id="edit-expires"
+          type="datetime-local"
+          value={expiresAt}
+          onChange={(e) => setExpiresAt(e.target.value)}
+          className="w-60"
+        />
+        <p className="text-xs text-muted-foreground">
+          Stops showing to users after this time. Leave blank to show until
+          manually deactivated.
+        </p>
       </div>
       <div className="flex items-center gap-2">
         <Checkbox
@@ -293,6 +337,7 @@ function CreateAnnouncementForm({ onCreated }: { onCreated: () => void }) {
   const [severity, setSeverity] = useState("info");
   const [dismissible, setDismissible] = useState(true);
   const [visibleWhileLoggedOut, setVisibleWhileLoggedOut] = useState(false);
+  const [expiresAt, setExpiresAt] = useState("");
 
   const create = useMutation({
     mutationFn: () =>
@@ -302,6 +347,7 @@ function CreateAnnouncementForm({ onCreated }: { onCreated: () => void }) {
         severity,
         dismissible,
         visible_while_logged_out: visibleWhileLoggedOut,
+        expires_at: localInputToIso(expiresAt),
       }),
     onSuccess: () => {
       setTitle("");
@@ -309,6 +355,7 @@ function CreateAnnouncementForm({ onCreated }: { onCreated: () => void }) {
       setSeverity("info");
       setDismissible(true);
       setVisibleWhileLoggedOut(false);
+      setExpiresAt("");
       onCreated();
       toast.success("Announcement created");
     },
@@ -357,6 +404,25 @@ function CreateAnnouncementForm({ onCreated }: { onCreated: () => void }) {
             onChange={(e) => setBody(e.target.value)}
             maxLength={2000}
           />
+          <p className="text-xs text-muted-foreground">
+            Supports markdown links, e.g. [read more](https://example.com)
+          </p>
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="ann-expires" className="text-xs">
+            Expires (optional)
+          </Label>
+          <Input
+            id="ann-expires"
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            className="w-60"
+          />
+          <p className="text-xs text-muted-foreground">
+            Stops showing to users after this time. Leave blank to show until
+            manually deactivated.
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <Checkbox


### PR DESCRIPTION
Two small improvements to server announcements, prompted by needing to link an incident notice to its full write-up.

**Inline links.** Announcement bodies now render inline markdown, so an admin can include a link (e.g. `[read the full report](https://...)`) or a bare URL and have it be clickable. It stays a one-line banner: only inline elements are allowed and any block markdown (headings, images, lists, code blocks) is unwrapped to its plain text, so the layout can't break. Links open in a new tab with `rel="noopener noreferrer"`, and react-markdown sanitises link URLs by default (javascript:/data: are dropped). The admin body fields gained a short "supports markdown links" hint. Authoring is admin-only, so this is not user-controlled input.

**Settable expiry.** The admin create and edit forms gain an optional "Expires" datetime. The `expires_at` field already existed on the model, schema, and API - the active-announcements query already hides an announcement once it is past - but there was no way to set it from the UI. This exposes it (with clear-on-empty handling on edit), and the admin list now shows the expiry with its time.

Frontend only: no backend, schema, or migration changes, and no client/mobile impact (the API is unchanged).

Verification: tsc, eslint, and the web build are all clean.