### PR TITLE
Add fronts.created_at row-creation timestamp

### DIFF
--- a/alembic/versions/q8r9s0t1u2v3_add_front_created_at.py
+++ b/alembic/versions/q8r9s0t1u2v3_add_front_created_at.py
@@ -1,0 +1,46 @@
+"""Add fronts.created_at
+
+Revision ID: q8r9s0t1u2v3
+Revises: p7q8r9s0t1u2
+Create Date: 2026-06-24
+
+The fronts table never had a row-creation timestamp, only the front's
+real-world started_at / ended_at. That gap is what let the retention job
+key off started_at and delete just-imported historical fronts. This adds
+created_at as the correct "when did this row land here" timestamp.
+
+ADD COLUMN with a non-volatile server_default (now() is stable within the
+statement) is metadata-only on modern Postgres: existing rows get the
+migration-time value without a table rewrite, which is exactly the safe
+backfill we want (imported/old history is treated as created now, never
+retroactively eligible for anything). It still briefly takes ACCESS
+EXCLUSIVE, so fail fast rather than queue behind a long-running session.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "q8r9s0t1u2v3"
+down_revision: Union[str, None] = "p7q8r9s0t1u2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.add_column(
+        "fronts",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.drop_column("fronts", "created_at")

--- a/sheaf/models/front.py
+++ b/sheaf/models/front.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Text
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -32,6 +32,18 @@ class Front(UUIDMixin, Base):
     # encryption model is meant to protect, matching the precedent set by
     # bios and journal entries.
     custom_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Row-creation timestamp, distinct from the front's real-world `started_at`.
+    # This is *when the row landed in this database* (created or imported), so
+    # it is the correct key for any age-based handling: an imported historical
+    # front gets a fresh created_at, not its old start date. The prior retention
+    # job keyed off `started_at` and so deleted just-imported history; see
+    # ../sheaf-design-docs/front-history-retention-and-limits.md.
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
 
     # Relationships
     system: Mapped["System"] = relationship(back_populates="fronts")

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -114,6 +114,10 @@ CLASSIFICATION: dict[type, dict] = {
         "excluded": {
             "id": _SURROGATE_PK,
             "system_id": _TENANT_FK,
+            # created_at is local row-provenance: a re-imported front is a new
+            # row and gets a fresh created_at (the server default), so it is
+            # deliberately not carried in the export.
+            "created_at": _ROW_CREATED,
             # member_ids ride the front_members association, exported as a list.
         },
     },


### PR DESCRIPTION
Foundational prerequisite for the front-history retention rework (see `../sheaf-design-docs/front-history-retention-and-limits.md`).

`Front` carried only the front's real-world `started_at` / `ended_at` and had no row-creation timestamp - it was the one core model with no creation time. That gap is what let the retention job key off `started_at` and delete just-imported historical fronts (the 2026-06-23 incident). This adds `created_at` as the correct "when did this row land in this database" timestamp, so an imported backdated front gets a fresh `created_at` rather than inheriting its old start date.

- **Model:** `created_at` on `Front`, `server_default = now()`, NOT NULL.
- **Migration (`q8r9s0t1u2v3`):** a single `add_column` with a non-volatile `now()` default - metadata-only on modern Postgres, so existing rows are backfilled to migration time without a table rewrite, behind the `lock_timeout` fail-fast guard. Reversible downgrade.
- **Parity guard:** `Front.created_at` is classified excluded (`_ROW_CREATED`) - a re-imported front is a new row and gets a fresh timestamp, so it is intentionally not carried in the export. No export/import or OpenPlural changes.

No API or export change, so no client/mobile impact, and nothing user-visible yet (the column is plumbing the retention rework will query directly).

Verification: ruff clean; export/import + OpenPlural parity guards green; rebuilt the test stack to apply the migration; fronts + audit + coalesce + top-fronters + native import round-trip all pass (61 tests).

Note: the behavioural assertion that a backdated front keeps a recent `created_at` lands with the retention test fixture (#377), its natural home, rather than as a DB-introspection test here.