### PR TITLE
Add standalone front-history export (CSV / JSON / ICS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Standalone front-history export.** You can now export just your fronting history, separate from the full account export, in the format that suits what you want to do with it: **CSV** (one row per front, with duration and co-fronting members, for spreadsheets and analysis), **JSON** (structured and self-describing), or **ICS** (an iCalendar file, one event per front, to drop into a calendar app and see your history on a timeline). It runs through the same async export-job flow as the full export (same step-up auth, the same "your export is ready" email, and the same expiring download), and produces a single file rather than a zip. Member names and per-front notes are decrypted on the way out exactly as the account export does.
+
 ## [1.1.0] - 2026-06-24
 
 ### Added

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -628,8 +628,17 @@ def _poll_dict(poll) -> dict:
 class ExportJobRequest(BaseModel):
     include_images: bool = False
     # Artefact format: "sheaf_native" (export.json + images/) or
-    # "openplural" (openplural.json + assets/, an .openplural.zip bundle).
-    format: Literal["sheaf_native", "openplural"] = "sheaf_native"
+    # "openplural" (openplural.json + assets/, an .openplural.zip bundle), or
+    # a standalone front-history file ("fronts_csv" / "fronts_json" /
+    # "fronts_ics") - a single file of just the fronting history, no zip.
+    # include_images is ignored for the fronts_* formats.
+    format: Literal[
+        "sheaf_native",
+        "openplural",
+        "fronts_csv",
+        "fronts_json",
+        "fronts_ics",
+    ] = "sheaf_native"
     # Step-up auth: same shape and rules as POST /v1/account/data. Always
     # required; mirrors the Article 15 lock since this is the broader read
     # (everything the user has, including binary blobs).
@@ -780,8 +789,17 @@ async def download_export_job(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Export file no longer available",
         )
+    from sheaf.services.front_history_export import (
+        FRONT_HISTORY_FORMATS,
+        format_extension,
+    )
+
     if job.format == "openplural":
         filename = f"sheaf-export-{job.id}.openplural.zip"
+    elif job.format in FRONT_HISTORY_FORMATS:
+        filename = (
+            f"sheaf-front-history-{job.id}.{format_extension(job.format)}"
+        )
     else:
         filename = f"sheaf-export-{job.id}.zip"
     return await export_storage.download_response(job.file_location, filename)

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -130,9 +130,18 @@ async def _build(job_id: uuid.UUID) -> None:
         tmp_path: str | None = None
         try:
             try:
-                tmp_path, size_bytes = await _assemble_zip_to_tempfile(
-                    db, user, include_images=job.include_images, fmt=job.format
+                from sheaf.services.front_history_export import (
+                    FRONT_HISTORY_FORMATS,
                 )
+
+                if job.format in FRONT_HISTORY_FORMATS:
+                    tmp_path, size_bytes = await _assemble_fronts_to_tempfile(
+                        db, user, fmt=job.format
+                    )
+                else:
+                    tmp_path, size_bytes = await _assemble_zip_to_tempfile(
+                        db, user, include_images=job.include_images, fmt=job.format
+                    )
             except Exception as exc:  # noqa: BLE001
                 logger.exception("Export build failed for job %s", job_id)
                 await _mark_failed(db, job, f"build failed: {exc}")
@@ -258,6 +267,47 @@ async def _assemble_zip_to_tempfile(
                 zf.writestr("README.txt", _README)
                 if include_images:
                     await _add_images(zf, db, user)
+        size_bytes = os.path.getsize(tmp_path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_path)
+        raise
+    return tmp_path, size_bytes
+
+
+async def _assemble_fronts_to_tempfile(
+    db: AsyncSession, user: User, *, fmt: str
+) -> tuple[str, int]:
+    """Build a standalone front-history file (CSV / JSON / ICS) on disk and
+    return (path, size_bytes). Unlike the account export this is a single
+    file, not a zip - the front history is small relative to a full
+    account dump and the formats are flat.
+    """
+    from sqlalchemy import select
+
+    from sheaf.models.system import System
+    from sheaf.services.front_history_export import (
+        format_extension,
+        load_front_history,
+        serialize_front_history,
+    )
+
+    system = (
+        await db.execute(select(System).where(System.user_id == user.id))
+    ).scalar_one_or_none()
+    exported_at = datetime.now(UTC)
+    rows = await load_front_history(db, system) if system is not None else []
+    data = serialize_front_history(
+        rows, system.name if system is not None else None, fmt, exported_at
+    )
+
+    tmp_dir = settings.export_build_tmp_dir or None
+    fd, tmp_path = tempfile.mkstemp(
+        suffix=f".{format_extension(fmt)}", prefix="sheaf-fronts-", dir=tmp_dir
+    )
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
         size_bytes = os.path.getsize(tmp_path)
     except Exception:
         with contextlib.suppress(FileNotFoundError):

--- a/sheaf/services/front_history_export.py
+++ b/sheaf/services/front_history_export.py
@@ -1,0 +1,257 @@
+"""Standalone front-history export: CSV / JSON / ICS.
+
+A lighter-weight companion to the full account export. Where the native /
+OpenPlural exports produce a whole-account zip, this produces a single
+file containing only the system's front history, in a format the user
+picks:
+
+* ``fronts_csv``  - one row per front, for spreadsheets / analysis.
+* ``fronts_json`` - structured, self-describing, machine-readable.
+* ``fronts_ics``  - an iCalendar feed (one VEVENT per front) to drop into
+  a calendar app and see fronting history on a timeline.
+
+These run through the same async export-job machinery as the full export
+(``ExportJob.format`` carries the value), so the step-up auth gate, rate
+limit, completion email, download, and cleanup all apply unchanged. The
+only difference is the artefact is a single file, not a zip.
+
+Encryption discipline matches the full export: ``custom_status`` and
+member names are decrypted only here, on the way out, via the same
+helpers the account export uses.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from sheaf.crypto import decrypt
+from sheaf.models.front import Front
+from sheaf.models.system import System
+from sheaf.services.members import member_plaintext
+
+# The ExportJob.format values handled here. Kept as a tuple so callers can
+# branch with `job.format in FRONT_HISTORY_FORMATS`.
+FRONT_HISTORY_FORMATS = ("fronts_csv", "fronts_json", "fronts_ics")
+
+_FORMAT_EXT = {"fronts_csv": "csv", "fronts_json": "json", "fronts_ics": "ics"}
+
+
+def format_extension(fmt: str) -> str:
+    """File extension for a front-history format (no leading dot)."""
+    return _FORMAT_EXT[fmt]
+
+
+async def load_front_history(db: AsyncSession, system: System) -> list[dict[str, Any]]:
+    """Load and decrypt a system's fronts in chronological order.
+
+    Member names and custom_status are decrypted here (owner's own data).
+    Members are eager-loaded to avoid an N+1, and their names are sorted
+    so a co-fronting summary is stable.
+    """
+    result = await db.execute(
+        select(Front)
+        .options(selectinload(Front.members))
+        .where(Front.system_id == system.id)
+        .order_by(Front.started_at.asc())
+    )
+    rows: list[dict[str, Any]] = []
+    for f in result.scalars().all():
+        names = sorted(
+            (member_plaintext(m)[0] for m in f.members), key=str.casefold
+        )
+        rows.append(
+            {
+                "id": str(f.id),
+                "started_at": f.started_at,
+                "ended_at": f.ended_at,
+                "members": names,
+                "custom_status": decrypt(f.custom_status) if f.custom_status else None,
+            }
+        )
+    return rows
+
+
+def serialize_front_history(
+    rows: list[dict[str, Any]],
+    system_name: str | None,
+    fmt: str,
+    exported_at: datetime,
+) -> bytes:
+    """Render already-loaded/decrypted front rows to the requested format."""
+    if fmt == "fronts_csv":
+        return _build_csv(rows)
+    if fmt == "fronts_json":
+        return _build_json(rows, system_name, exported_at)
+    if fmt == "fronts_ics":
+        return _build_ics(rows, system_name, exported_at)
+    raise ValueError(f"unknown front-history format: {fmt!r}")
+
+
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _csv_safe(value: str) -> str:
+    """Neutralise spreadsheet formula injection.
+
+    A CSV cell beginning with =, +, -, @ (or a leading control char) can be
+    executed as a formula by Excel / Sheets when the file is opened. Since a
+    front-history export is meant to be shared, the recipient's spreadsheet
+    must be safe even though the content (member names, custom_status) is the
+    user's own free text. Prefixing with a single quote makes the cell render
+    as literal text. Numeric / ISO-timestamp columns are never user free text,
+    so only the text columns are guarded.
+    """
+    if value and value[0] in _CSV_FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
+
+def _hms(seconds: int) -> str:
+    """Hours:MM:SS, with hours unbounded (a front can span days)."""
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}"
+
+
+def _build_csv(rows: list[dict[str, Any]]) -> bytes:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "started_at",
+            "ended_at",
+            "duration_seconds",
+            "duration",
+            "member_count",
+            "members",
+            "custom_status",
+        ]
+    )
+    for r in rows:
+        started = r["started_at"]
+        ended = r["ended_at"]
+        if ended is not None:
+            secs = int((ended - started).total_seconds())
+            duration_seconds: int | str = secs
+            duration = _hms(secs)
+        else:
+            # Ongoing front: leave duration blank rather than guess an end.
+            duration_seconds = ""
+            duration = ""
+        writer.writerow(
+            [
+                started.isoformat(),
+                ended.isoformat() if ended else "",
+                duration_seconds,
+                duration,
+                len(r["members"]),
+                _csv_safe("; ".join(r["members"])),
+                _csv_safe(r["custom_status"] or ""),
+            ]
+        )
+    # Prepend a UTF-8 BOM so spreadsheet apps (Excel) read non-ASCII member
+    # names correctly. The csv module handles quoting of embedded commas /
+    # newlines / quotes in custom_status.
+    return ("﻿" + buf.getvalue()).encode("utf-8")
+
+
+def _build_json(
+    rows: list[dict[str, Any]], system_name: str | None, exported_at: datetime
+) -> bytes:
+    payload = {
+        "sheaf_front_history_version": "1",
+        "exported_at": exported_at.isoformat(),
+        "system_name": system_name,
+        "front_count": len(rows),
+        "fronts": [
+            {
+                "id": r["id"],
+                "started_at": r["started_at"].isoformat(),
+                "ended_at": r["ended_at"].isoformat() if r["ended_at"] else None,
+                "members": r["members"],
+                "custom_status": r["custom_status"],
+            }
+            for r in rows
+        ],
+    }
+    return json.dumps(payload, indent=2).encode("utf-8")
+
+
+def _ics_escape(text: str) -> str:
+    """Escape a TEXT value per RFC 5545 (backslash, newline, comma, semicolon)."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace(",", "\\,")
+        .replace(";", "\\;")
+    )
+
+
+def _ics_fold(line: str) -> str:
+    """Fold a content line to <=75 octets per RFC 5545, on UTF-8 char
+    boundaries (continuation lines begin with a single space)."""
+    if len(line.encode("utf-8")) <= 75:
+        return line
+    chunks: list[bytes] = []
+    cur = b""
+    for ch in line:
+        b = ch.encode("utf-8")
+        # Leave room for the leading space that continuation lines carry.
+        if len(cur) + len(b) > 74 and cur:
+            chunks.append(cur)
+            cur = b" " + b
+        else:
+            cur += b
+    chunks.append(cur)
+    return "\r\n".join(c.decode("utf-8") for c in chunks)
+
+
+def _dt_utc(dt: datetime) -> str:
+    """An aware datetime as a UTC iCalendar timestamp (YYYYMMDDTHHMMSSZ)."""
+    return dt.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _build_ics(
+    rows: list[dict[str, Any]], system_name: str | None, exported_at: datetime
+) -> bytes:
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Sheaf//Front History//EN",
+        "CALSCALE:GREGORIAN",
+    ]
+    if system_name:
+        lines.append(
+            _ics_fold("X-WR-CALNAME:" + _ics_escape(f"{system_name} front history"))
+        )
+    stamp = _dt_utc(exported_at)
+    for r in rows:
+        summary = "; ".join(r["members"]) or "(no member)"
+        ended = r["ended_at"]
+        if ended is None:
+            # iCalendar needs a DTEND; mark the open front as ongoing and
+            # span it to the export time so it renders as a real interval.
+            summary += " (ongoing)"
+            end_dt = exported_at
+        else:
+            end_dt = ended
+        lines.append("BEGIN:VEVENT")
+        lines.append(f"UID:{r['id']}@sheaf")
+        lines.append(f"DTSTAMP:{stamp}")
+        lines.append(f"DTSTART:{_dt_utc(r['started_at'])}")
+        lines.append(f"DTEND:{_dt_utc(end_dt)}")
+        lines.append(_ics_fold("SUMMARY:" + _ics_escape(summary)))
+        if r["custom_status"]:
+            lines.append(_ics_fold("DESCRIPTION:" + _ics_escape(r["custom_status"])))
+        lines.append("END:VEVENT")
+    lines.append("END:VCALENDAR")
+    # iCalendar mandates CRLF line endings.
+    return ("\r\n".join(lines) + "\r\n").encode("utf-8")

--- a/tests/test_account_export_completeness.py
+++ b/tests/test_account_export_completeness.py
@@ -202,6 +202,23 @@ def test_export_job_refuses_api_key_auth(auth_client: httpx.Client):
     assert r.status_code == 403
 
 
+def test_export_job_accepts_fronts_format(auth_client: httpx.Client):
+    """The standalone front-history formats are accepted by the same
+    enqueue endpoint and round-trip through the job record. Building is the
+    60s-interval worker's job; the serializers are unit-tested in
+    test_front_history_export.py, so this just covers the format plumbing."""
+    r = auth_client.post(
+        "/v1/export/jobs",
+        json={"format": "fronts_csv", "password": "testpassword123"},
+    )
+    assert r.status_code == 202, r.text
+    job = r.json()
+    assert job["format"] == "fronts_csv"
+    assert job["status"] == "pending"
+    listed = auth_client.get("/v1/export/jobs").json()
+    assert any(j["id"] == job["id"] and j["format"] == "fronts_csv" for j in listed)
+
+
 # ---------------------------------------------------------------------------
 # Builder unit-style — assemble the zip directly
 # ---------------------------------------------------------------------------

--- a/tests/test_front_history_export.py
+++ b/tests/test_front_history_export.py
@@ -1,0 +1,122 @@
+"""Unit tests for the standalone front-history serializers (CSV/JSON/ICS).
+
+These exercise the pure serialization layer directly with synthetic rows -
+no DB or running stack needed. The DB load + decrypt path is covered by
+the export job e2e tests.
+"""
+
+import csv
+import io
+import json
+from datetime import UTC, datetime
+
+from sheaf.services.front_history_export import serialize_front_history
+
+_EXPORTED_AT = datetime(2026, 6, 24, 12, 0, 0, tzinfo=UTC)
+
+
+def _rows():
+    return [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "started_at": datetime(2026, 6, 1, 9, 0, 0, tzinfo=UTC),
+            "ended_at": datetime(2026, 6, 1, 11, 30, 0, tzinfo=UTC),
+            "members": ["Alice", "Bob"],
+            "custom_status": "interview, then lunch",  # comma -> must quote
+        },
+        {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "started_at": datetime(2026, 6, 2, 14, 0, 0, tzinfo=UTC),
+            "ended_at": None,  # ongoing
+            "members": ["Carol"],
+            "custom_status": None,
+        },
+    ]
+
+
+def test_csv_shape_and_quoting():
+    raw = serialize_front_history(_rows(), "Test System", "fronts_csv", _EXPORTED_AT)
+    text = raw.decode("utf-8")
+    assert text.startswith("﻿")  # UTF-8 BOM for spreadsheets
+    reader = list(csv.reader(io.StringIO(text.lstrip("﻿"))))
+    header = reader[0]
+    assert header == [
+        "started_at",
+        "ended_at",
+        "duration_seconds",
+        "duration",
+        "member_count",
+        "members",
+        "custom_status",
+    ]
+    closed = reader[1]
+    assert closed[2] == "9000"  # 2.5h in seconds
+    assert closed[3] == "2:30:00"
+    assert closed[4] == "2"
+    assert closed[5] == "Alice; Bob"
+    assert closed[6] == "interview, then lunch"  # csv module quoted the comma
+    ongoing = reader[2]
+    assert ongoing[1] == ""  # no ended_at
+    assert ongoing[2] == "" and ongoing[3] == ""  # blank duration
+    assert ongoing[4] == "1"
+
+
+def test_csv_neutralises_formula_injection():
+    rows = [
+        {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "started_at": datetime(2026, 6, 3, 8, 0, 0, tzinfo=UTC),
+            "ended_at": datetime(2026, 6, 3, 9, 0, 0, tzinfo=UTC),
+            "members": ["=cmd|' /c calc'!A1"],  # malicious member name
+            "custom_status": "+1+2",  # malicious status
+        },
+    ]
+    raw = serialize_front_history(rows, None, "fronts_csv", _EXPORTED_AT)
+    reader = list(csv.reader(io.StringIO(raw.decode("utf-8").lstrip("﻿"))))
+    row = reader[1]
+    # A leading =, +, -, @ is prefixed with ' so a spreadsheet treats the
+    # shared file's cell as literal text, not a formula.
+    assert row[5].startswith("'=")  # members cell
+    assert row[6].startswith("'+")  # custom_status cell
+
+
+def test_json_shape():
+    raw = serialize_front_history(_rows(), "Test System", "fronts_json", _EXPORTED_AT)
+    doc = json.loads(raw)
+    assert doc["sheaf_front_history_version"] == "1"
+    assert doc["system_name"] == "Test System"
+    assert doc["front_count"] == 2
+    assert doc["exported_at"] == _EXPORTED_AT.isoformat()
+    first, second = doc["fronts"]
+    assert first["members"] == ["Alice", "Bob"]
+    assert first["ended_at"] is not None
+    assert second["ended_at"] is None
+    assert second["custom_status"] is None
+
+
+def test_ics_structure_and_escaping():
+    raw = serialize_front_history(_rows(), "Test; System", "fronts_ics", _EXPORTED_AT)
+    text = raw.decode("utf-8")
+    assert "\r\n" in text  # CRLF line endings
+    assert text.startswith("BEGIN:VCALENDAR\r\n")
+    assert text.rstrip().endswith("END:VCALENDAR")
+    assert text.count("BEGIN:VEVENT") == 2
+    # UTC timestamps in iCalendar basic format.
+    assert "DTSTART:20260601T090000Z" in text
+    assert "DTEND:20260601T113000Z" in text
+    # Comma in the custom_status DESCRIPTION is escaped.
+    assert "DESCRIPTION:interview\\, then lunch" in text
+    # The ongoing front has no real end: it is marked and spans to export time.
+    assert "SUMMARY:Carol (ongoing)" in text
+    assert "DTEND:20260624T120000Z" in text  # == exported_at
+    # Semicolon in the calendar name is escaped, not a property separator.
+    assert "X-WR-CALNAME:Test\\; System front history" in text
+
+
+def test_unknown_format_raises():
+    try:
+        serialize_front_history([], None, "fronts_xml", _EXPORTED_AT)
+    except ValueError as exc:
+        assert "fronts_xml" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError for unknown format")

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -12,6 +12,7 @@ import {
   listExportJobs,
   requestAccountData,
   type ExportJob,
+  type ExportJobFormat,
 } from "@/lib/systems";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,9 +26,32 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-type ExportMode = "with_images" | "account_data";
+type ExportMode = "with_images" | "account_data" | "front_history";
 type ExportFormat = "sheaf_native" | "openplural";
+type FrontHistoryFormat = "fronts_csv" | "fronts_json" | "fronts_ics";
+
+// Friendly labels for every artefact format a job row can carry.
+const FORMAT_LABELS: Record<ExportJobFormat, string> = {
+  sheaf_native: "Sheaf native",
+  openplural: "OpenPlural",
+  fronts_csv: "Front history (CSV)",
+  fronts_json: "Front history (JSON)",
+  fronts_ics: "Front history (Calendar)",
+};
+
+const FRONT_HISTORY_OPTIONS: { value: FrontHistoryFormat; label: string }[] = [
+  { value: "fronts_csv", label: "CSV" },
+  { value: "fronts_json", label: "JSON" },
+  { value: "fronts_ics", label: "Calendar (.ics)" },
+];
 
 function formatBytes(n: number | null): string {
   if (n === null) return "—";
@@ -140,6 +164,7 @@ export function DataExportCard() {
   const [syncing, setSyncing] = useState(false);
   const [mode, setMode] = useState<ExportMode | null>(null);
   const [format, setFormat] = useState<ExportFormat>("sheaf_native");
+  const [frontFormat, setFrontFormat] = useState<FrontHistoryFormat>("fronts_csv");
   const [searchParams, setSearchParams] = useSearchParams();
   const highlightJobId = searchParams.get("job");
   // Row refs so we can scroll the highlighted backup into view once
@@ -241,6 +266,14 @@ export function DataExportCard() {
       createJob.mutate({
         include_images: true,
         format,
+        password,
+        totp_code: totp || undefined,
+      });
+    } else if (mode === "front_history") {
+      createJob.mutate({
+        // include_images is ignored server-side for the fronts_* formats.
+        include_images: false,
+        format: frontFormat,
         password,
         totp_code: totp || undefined,
       });
@@ -354,6 +387,43 @@ export function DataExportCard() {
             </Button>
           </div>
 
+          <div className="border-t pt-4">
+            <p className="text-sm text-muted-foreground mb-1 max-w-prose">
+              <strong>Export front history.</strong> Just your fronting
+              history (CSV for spreadsheets, JSON, or a calendar file). Member
+              names and notes are included. Builds in the background and shows
+              up in the list below, same as a full backup.
+            </p>
+            <div className="flex items-end gap-2 mt-3">
+              <div className="space-y-1">
+                <Label htmlFor="front-history-format" className="text-xs">
+                  Format
+                </Label>
+                <Select
+                  value={frontFormat}
+                  onValueChange={(v) => setFrontFormat(v as FrontHistoryFormat)}
+                >
+                  <SelectTrigger id="front-history-format" className="w-44">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {FRONT_HISTORY_OPTIONS.map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button
+                onClick={() => setMode("front_history")}
+                variant="outline"
+              >
+                Export front history
+              </Button>
+            </div>
+          </div>
+
           {jobs && jobs.length > 0 && (
             <div className="border-t pt-4">
               <p className="text-sm font-medium mb-2">Recent backups</p>
@@ -372,6 +442,8 @@ export function DataExportCard() {
                   >
                     <div className="flex flex-col">
                       <span className="text-xs text-muted-foreground">
+                        {FORMAT_LABELS[j.format] ?? j.format}
+                        {" · "}
                         {new Date(j.requested_at).toLocaleString()}
                       </span>
                       <span className="text-xs">
@@ -408,6 +480,16 @@ export function DataExportCard() {
         onOpenChange={(o) => !o && setMode(null)}
         title="Confirm full backup"
         description="Re-enter your password to queue a full backup including all your image bytes. This is the highest-value export, so we always require step-up auth."
+        totpEnabled={totpEnabled}
+        busy={busy}
+        onConfirm={handleStepUpConfirm}
+        confirmLabel="Queue export"
+      />
+      <StepUpDialog
+        open={mode === "front_history"}
+        onOpenChange={(o) => !o && setMode(null)}
+        title="Confirm front-history export"
+        description="Re-enter your password to queue an export of your fronting history (member names and notes included). Step-up gated like the other exports."
         totpEnabled={totpEnabled}
         busy={busy}
         onConfirm={handleStepUpConfirm}

--- a/web/src/lib/systems.ts
+++ b/web/src/lib/systems.ts
@@ -19,9 +19,20 @@ export function exportData(format: "sheaf_native" | "openplural" = "sheaf_native
 
 // --- Article 15 + async export jobs ---------------------------------------
 
+// Artefact format for an export job. "sheaf_native" / "openplural" are the
+// full-system exports; the fronts_* values are standalone front-history files
+// (a single CSV / JSON / iCalendar file, no zip).
+export type ExportJobFormat =
+  | "sheaf_native"
+  | "openplural"
+  | "fronts_csv"
+  | "fronts_json"
+  | "fronts_ics";
+
 export interface ExportJob {
   id: string;
   include_images: boolean;
+  format: ExportJobFormat;
   status: "pending" | "running" | "done" | "failed" | "expired";
   requested_at: string;
   started_at: string | null;
@@ -37,10 +48,11 @@ export function listExportJobs() {
 
 export function createExportJob(body: {
   include_images: boolean;
-  // Artefact format: "sheaf_native" (export.json + images/) or
-  // "openplural" (an .openplural.zip bundle). Defaults server-side to
-  // "sheaf_native" when omitted.
-  format?: "sheaf_native" | "openplural";
+  // Artefact format: "sheaf_native" (export.json + images/), "openplural"
+  // (an .openplural.zip bundle), or a standalone front-history file
+  // (fronts_csv / fronts_json / fronts_ics). Defaults server-side to
+  // "sheaf_native" when omitted. include_images is ignored for fronts_*.
+  format?: ExportJobFormat;
   password: string;
   totp_code?: string;
 }) {


### PR DESCRIPTION
A lighter companion to the full account export, and part of the post-incident commitment to let people keep a portable copy of their history: export just the fronting history as a single file, in the format that fits what you want to do with it.

- **CSV** - one row per front (started/ended, duration, co-fronting members, custom_status). UTF-8 BOM so spreadsheets read non-ASCII names, a precomputed duration column, and formula-injection neutralisation (a leading `=`/`+`/`-`/`@` is escaped) so a shared CSV can't execute in the recipient's spreadsheet.
- **JSON** - structured and self-describing (version, exported_at, system name, fronts with member names).
- **ICS** - an iCalendar file, one VEVENT per front, to drop into a calendar app and see fronting history on a timeline. RFC 5545 (CRLF, TEXT escaping, line folding, UTC timestamps); ongoing fronts are marked and span to export time.

It reuses the async export-job machinery wholesale via three new `ExportJob.format` values (`fronts_csv` / `fronts_json` / `fronts_ics`): the same step-up auth gate, rate limit, no-API-key rule, owner-only download, "your export is ready" email, and expiry/cleanup. The only difference is the artefact is a single file rather than a zip. Member names and `custom_status` are decrypted on the way out exactly as the account export does, and the data is loaded owner-scoped (no cross-tenant surface). No new endpoint, no migration.

Frontend: a "front history" export section on the existing data/export settings card with a CSV / JSON / Calendar picker, reusing the existing step-up dialog and job list (with friendly labels like "Front history (CSV)").

No client/mobile impact (the only API change is three new accepted `format` values on an existing endpoint).

Verification: ruff clean; serializer unit tests (CSV quoting/BOM/duration/ongoing, JSON shape, ICS structure/escaping, formula-injection guard, unknown-format) and the enqueue-plumbing test plus the existing export/builder suites pass against a rebuilt stack; frontend tsc + eslint + build clean.

Scoping note: no full enqueue-build-download e2e, because exports build on a 60s poll (no LISTEN/NOTIFY) - the existing export suite stops at the API gate + in-process smoke for the same reason, and the serializers carry the output-correctness coverage.