### PR TITLE
Add front-history volume metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ### Added
 
+- **Front-history volume metrics.** New Prometheus metrics to ground the front-history retention decision in real usage: `sheaf_fronts_total` (global count), `sheaf_systems_by_front_count` (a per-system distribution, exposed as a label-less snapshot of "systems with at most N fronts" so it carries no system id), `sheaf_system_front_count_max` (the single largest system, the direct outlier signal), and `sheaf_fronts_created_total` (switch velocity). Operator-facing only; documented in `docs/METRICS.md`.
+
 - **Standalone front-history export.** You can now export just your fronting history, separate from the full account export, in the format that suits what you want to do with it: **CSV** (one row per front, with duration and co-fronting members, for spreadsheets and analysis), **JSON** (structured and self-describing), or **ICS** (an iCalendar file, one event per front, to drop into a calendar app and see your history on a timeline). It runs through the same async export-job flow as the full export (same step-up auth, the same "your export is ready" email, and the same expiring download), and produces a single file rather than a zip. Member names and per-front notes are decrypted on the way out exactly as the account export does.
 
 ## [1.1.0] - 2026-06-24

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -309,6 +309,22 @@ detect non-zero from the first scrape.
 | `sheaf_systems_total` | gauge | - |
 | `sheaf_members_total` | gauge | - |
 | `sheaf_members_custom_front` | gauge | - |
+| `sheaf_fronts_total` | gauge | - |
+| `sheaf_systems_by_front_count` | gauge | `le` (front-count threshold; `+Inf` = all systems) |
+| `sheaf_system_front_count_max` | gauge | - |
+| `sheaf_fronts_created_total` | counter | - |
+
+`sheaf_systems_by_front_count` is a point-in-time cumulative distribution of
+per-system front-history size, re-set each gauge refresh: each `le` series is
+the number of systems whose front count is at or below that threshold. It
+carries no system id by design. Read it to answer "what does a typical
+system's front history look like, and is anyone an outlier?" - e.g. the gap
+between the `le="1000"` series and `le="+Inf"` is how many systems have more
+than 1000 fronts, and `sheaf_system_front_count_max` is the single largest.
+`sheaf_fronts_created_total` is switch velocity (rows created), distinct from
+the HTTP request counter on `POST /v1/fronts`. These exist to ground the
+front-history retention decision in real usage data (see
+`../sheaf-design-docs/front-history-retention-and-limits.md`).
 
 ### Infra
 

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -16,6 +16,7 @@ from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.observability.metrics import fronts_created_total
 from sheaf.schemas.front import (
     FrontAuditEventRead,
     FrontCreate,
@@ -430,6 +431,7 @@ async def create_front(
     )
 
     await db.commit()
+    fronts_created_total.inc()
     await db.refresh(front, ["members"])
     return _front_to_read(front)
 

--- a/sheaf/observability/gauges.py
+++ b/sheaf/observability/gauges.py
@@ -21,12 +21,14 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.observability.metrics import (
+    FRONT_COUNT_BUCKETS,
     auth_lockouts_active,
     auth_sessions_active,
     auth_totp_enabled,
     auth_trusted_devices_active,
     cf_shield_active,
     db_pool_connections,
+    fronts_total,
     imports_in_progress,
     imports_oldest_pending_seconds,
     members_custom_front,
@@ -38,6 +40,8 @@ from sheaf.observability.metrics import (
     redis_up,
     requests_per_account_per_minute,
     requests_per_ip_per_minute,
+    system_front_count_max,
+    systems_by_front_count,
     systems_total,
     users_pending_delete,
     users_total,
@@ -131,6 +135,36 @@ async def _refresh_db_counts(db: AsyncSession) -> None:
         select(func.count(Member.id)).where(Member.is_custom_front.is_(True))
     )
     members_custom_front.set(int(custom_fronts or 0))
+
+    from sheaf.models.front import Front
+
+    total_fronts = await db.scalar(select(func.count(Front.id)))
+    fronts_total.set(int(total_fronts or 0))
+
+    # Per-system front-count distribution. One grouped query; the outer join
+    # keeps systems with zero fronts in the picture so the distribution
+    # covers every system. We never label by system_id - we set a snapshot
+    # cumulative gauge (count of systems at/under each threshold) plus the
+    # single max, which is enough to spot an outlier without naming it.
+    per_system = (
+        (
+            await db.execute(
+                select(func.count(Front.id))
+                .select_from(System)
+                .outerjoin(Front, Front.system_id == System.id)
+                .group_by(System.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    counts = [int(c or 0) for c in per_system]
+    system_front_count_max.set(max(counts) if counts else 0)
+    for threshold in FRONT_COUNT_BUCKETS:
+        systems_by_front_count.labels(le=str(threshold)).set(
+            sum(1 for c in counts if c <= threshold)
+        )
+    systems_by_front_count.labels(le="+Inf").set(len(counts))
 
 
 async def _refresh_outbox(db: AsyncSession) -> None:

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -484,6 +484,42 @@ members_custom_front = _G(
     "sheaf_members_custom_front",
     "Members flagged as custom-front entities (non-counting fronters).",
 )
+fronts_total = _G(
+    "sheaf_fronts_total",
+    "All front-history rows across all systems (global volume baseline).",
+)
+
+# Per-system front counts as a point-in-time DISTRIBUTION, without ever
+# labelling by system_id (that would blow up cardinality and leak which
+# system is which). `systems_by_front_count` is a snapshot cumulative
+# histogram expressed as a gauge: each refresh sets, per `le` threshold, the
+# number of systems whose front-history row count is <= that threshold.
+# Read across the buckets to see the distribution; `system_front_count_max`
+# is the single biggest system, the direct "is anyone an outlier?" signal.
+# A gauge (re-set each refresh) rather than a real Histogram because the
+# quantity changes slowly and we want a current snapshot, not an all-time
+# accumulation. Thresholds are front *counts*, not seconds.
+FRONT_COUNT_BUCKETS = (
+    1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000,
+    100000,
+)
+systems_by_front_count = _G(
+    "sheaf_systems_by_front_count",
+    "Number of systems whose front-history row count is <= the `le` bucket "
+    "(a point-in-time cumulative distribution, re-set each refresh). Read "
+    "across buckets to see the per-system distribution. See docs/METRICS.md.",
+    ["le"],
+)
+system_front_count_max = _G(
+    "sheaf_system_front_count_max",
+    "Largest single system's front-history row count - the direct outlier "
+    "signal for the retention decision.",
+)
+fronts_created_total = _C(
+    "sheaf_fronts_created_total",
+    "Front-history rows created via the API. Switch velocity: counts row "
+    "creation, distinct from the HTTP request counter on POST /v1/fronts.",
+)
 
 # ---------------------------------------------------------------------------
 # Infra

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -211,6 +211,22 @@ def test_webhook_signature_failures_total_prewarmed():
         assert val is not None, f"missing prewarmed series for endpoint={endpoint}"
 
 
+def test_front_volume_metrics_present():
+    """The front-history volume metrics (for the retention decision) are
+    label-less and so are exposed from the first scrape: fronts_total and
+    system_front_count_max as gauges, fronts_created_total as a counter.
+    The per-system distribution gauge (sheaf_systems_by_front_count) is
+    labelled by `le` and only appears once the gauge refresher has run, so
+    it is not asserted here."""
+    body = _scrape()
+    for name in (
+        "sheaf_fronts_total",
+        "sheaf_system_front_count_max",
+        "sheaf_fronts_created_total",
+    ):
+        assert _series_value(body, name) is not None, f"missing series: {name}"
+
+
 # ---------------------------------------------------------------------------
 # Leader election
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Instrumentation to ground the front-history retention decision in real usage data, rather than the assumption that bit us in the 2026-06-23 incident (see `../sheaf-design-docs/front-history-retention-and-limits.md`, the "instrument first" step). Today we have HTTP-route traffic on the front endpoints but no actual volume or distribution, so we can't yet answer "is any system an outlier, or is preserve-everything simply fine?".

New metrics (all in the existing gauge/metric machinery):

- `sheaf_fronts_total` (gauge) - global front-row count: baseline and growth trend.
- `sheaf_systems_by_front_count` (gauge, label `le`) - the per-system front-count distribution, exposed as a point-in-time snapshot cumulative histogram: each `le` series is the number of systems with at most that many fronts, re-set each refresh. Deliberately a labelled snapshot gauge rather than a real Histogram - a histogram observed every refresh accumulates an all-time average and grows unbounded, whereas we want a current snapshot. It carries no `system_id`, so no cardinality blowup and no leaking which system is which.
- `sheaf_system_front_count_max` (gauge) - the single largest system's front count: the direct outlier signal.
- `sheaf_fronts_created_total` (counter) - switch velocity (rows created), distinct from the HTTP request counter on `POST /v1/fronts`.

The distribution + counts are computed in one grouped query in the existing background gauge refresher (`observability/gauges.py`); the counter increments on successful front creation. Documented in `docs/METRICS.md` with how to read the distribution.

Operator-facing only: no API, schema, migration, or client change.

Verification: ruff clean; import smoke clean; the front suites pass against a rebuilt stack (the new counter path on front-create works). The scrape-presence test lives in `tests/test_metrics.py`, which runs in the dedicated metrics CI config (the gauge refresher is disabled when metrics are off, as with the rest of that suite).