### PR TITLE
Fix OpenPlural import crash on spec-conformant privacy objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenPlural import crash on spec-conformant privacy.** Importing an OpenPlural file whose `privacy` is the spec object (`{"visibility": ..., "source": ...}`) - as produced by, for example, a PluralSpace export routed through OpenPlural - failed with `unhashable type: 'dict'`. The importer now extracts the `visibility` string from the privacy object (on systems, members, and custom fields), and still accepts a bare-string privacy from older files. Sheaf's own OpenPlural export was also emitting privacy as a bare string instead of the spec object, so it was non-conformant; it now emits `{"visibility": ...}` so other apps read it correctly. The native importer's privacy and field-type helpers are additionally hardened to fall back to a safe default rather than raise on an unexpected value type.
+
 ### Added
 
 - **Front-history volume metrics.** New Prometheus metrics to ground the front-history retention decision in real usage: `sheaf_fronts_total` (global count), `sheaf_systems_by_front_count` (a per-system distribution, exposed as a label-less snapshot of "systems with at most N fronts" so it carries no system id), `sheaf_system_front_count_max` (the single largest system, the direct outlier signal), and `sheaf_fronts_created_total` (switch velocity). Operator-facing only; documented in `docs/METRICS.md`.

--- a/docs/OPENPLURAL.md
+++ b/docs/OPENPLURAL.md
@@ -266,11 +266,17 @@ lifted directly into the native dict.
 
 - **Privacy / visibility buckets.** Sheaf's `PrivacyLevel`
   (`public` / `friends` / `private`) maps 1:1 onto the OpenPlural visibility
-  vocabulary. `_privacy` passes through any value in
-  `{public, friends, private, trusted, unknown}` and rounds anything
-  unrecognised to the strictest-safe `"unknown"` rather than guessing. This
-  applies uniformly to system, member, custom-field, and note (journal)
-  visibility.
+  vocabulary (`{public, friends, private, trusted, unknown}`), rounding
+  anything unrecognised to the strictest-safe `"unknown"` rather than
+  guessing. Note the *shape*: on **system / member / custom-field** the spec
+  models privacy as a Privacy **object** `{"visibility": ..., "source": ...}`,
+  so the exporter emits `{"visibility": <bucket>}` (Sheaf has no raw `source`
+  detail to carry) and the importer reads the `visibility` field back out. A
+  bare-string privacy is still accepted on import for older/lenient files.
+  **Note (journal) `visibility`** is a plain string in the spec, not the
+  object, and stays a string both directions. (Treating the privacy object as
+  a bare string was the cause of the `unhashable type: 'dict'` import crash on
+  spec-conformant files, e.g. a PluralSpace export routed through OpenPlural.)
 - **Front status is free text.** `fronts[].custom_status` becomes
   `FrontPeriod.status` verbatim; there is no controlled vocabulary on the Sheaf
   side, so none is imposed.

--- a/sheaf/services/openplural_export.py
+++ b/sheaf/services/openplural_export.py
@@ -195,7 +195,7 @@ def build_envelope(
                 "tag": sys_data.get("tag"),
                 "color": sys_data.get("color"),
                 "avatar_asset_id": assets.ref(sys_data.get("avatar_url"), kind="avatar"),
-                "privacy": _privacy(sys_data.get("privacy")),
+                "privacy": _privacy_obj(sys_data.get("privacy")),
                 "extensions": {EXT_NS: _prune(sys_ext)},
             }
         )
@@ -230,7 +230,7 @@ def build_envelope(
                 "archived": bool(m.get("archived_at")),
                 "avatar_asset_id": assets.ref(m.get("avatar_url"), kind="avatar"),
                 "banner_asset_id": assets.ref(m.get("banner_url"), kind="banner"),
-                "privacy": _privacy(m.get("privacy")),
+                "privacy": _privacy_obj(m.get("privacy")),
                 "created_at": m.get("created_at"),
                 "source_refs": source_refs,
                 "extensions": {EXT_NS: _prune(m_ext)},
@@ -276,7 +276,7 @@ def build_envelope(
                 "field_type": fd.get("field_type"),
                 "options": fd.get("options"),
                 "sort_order": fd.get("order"),
-                "privacy": _privacy(fd.get("privacy")),
+                "privacy": _privacy_obj(fd.get("privacy")),
             }
         )
         for v in fd.get("values", []) or []:
@@ -478,6 +478,16 @@ def _privacy(val: str | None) -> str:
     if val in _VALID_VISIBILITY:
         return val
     return "unknown"
+
+
+def _privacy_obj(val: str | None) -> dict:
+    """Wrap a Sheaf privacy bucket in the OpenPlural Privacy *object*
+    (``{"visibility": ...}``), which is the spec shape for system / member /
+    custom-field privacy. Sheaf has no richer raw source detail to carry, so
+    the optional ``source`` key is omitted. (Note/journal ``visibility`` is a
+    plain string in the spec, not this object - those keep using ``_privacy``
+    directly.)"""
+    return {"visibility": _privacy(val)}
 
 
 def _prune(d: dict) -> dict:

--- a/sheaf/services/openplural_import.py
+++ b/sheaf/services/openplural_import.py
@@ -69,6 +69,25 @@ def _ext(obj: dict) -> dict:
     return sheaf if isinstance(sheaf, dict) else {}
 
 
+def _op_privacy(val: object) -> str | None:
+    """Extract the visibility bucket from an OpenPlural privacy value.
+
+    Per the spec, `privacy` is an object: ``{"visibility": "...", "source":
+    {...}}`` (on systems, members, and custom fields). We carry just the
+    `visibility` string into the native shape. Older / lenient files that put
+    a bare string there are accepted as-is; anything else becomes None and
+    the native importer applies its default. This is the conformant inverse
+    of the wrapping the exporter does - and it stops a spec-conformant file's
+    privacy object reaching the native importer as an unhashable dict.
+    """
+    if isinstance(val, dict):
+        v = val.get("visibility")
+        return v if isinstance(v, str) else None
+    if isinstance(val, str):
+        return val
+    return None
+
+
 def _birthday_to_native(b: object) -> str | None:
     """OpenPlural Birthday sub-record -> Sheaf's flat ``MM-DD`` / ``YYYY-MM-DD``."""
     if isinstance(b, str):
@@ -134,7 +153,7 @@ def to_native(envelope: dict) -> dict:
             "tag": sys_in.get("tag"),
             "avatar_url": assets.url(sys_in.get("avatar_asset_id")),
             "color": sys_in.get("color"),
-            "privacy": sys_in.get("privacy"),
+            "privacy": _op_privacy(sys_in.get("privacy")),
             "date_format": ext.get("date_format"),
             "replace_fronts_default": ext.get("replace_fronts_default"),
             "coalesce_contiguous_fronts": ext.get("coalesce_contiguous_fronts"),
@@ -171,7 +190,7 @@ def to_native(envelope: dict) -> dict:
                 "archived_at": (
                     envelope.get("exported_at") if m.get("archived") else None
                 ),
-                "privacy": m.get("privacy"),
+                "privacy": _op_privacy(m.get("privacy")),
                 "note": ext.get("note"),
                 "quick_switch_pin": ext.get("quick_switch_pin"),
                 "notify_on_front_global": ext.get("notify_on_front_global"),
@@ -229,7 +248,7 @@ def to_native(envelope: dict) -> dict:
                 "field_type": fd.get("field_type"),
                 "options": fd.get("options"),
                 "order": fd.get("sort_order"),
-                "privacy": fd.get("privacy"),
+                "privacy": _op_privacy(fd.get("privacy")),
                 "values": field_values.get(fd.get("id"), []),
             }
         )

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -111,14 +111,18 @@ _VALID_PRIVACY = {e.value for e in PrivacyLevel}
 _VALID_FIELD_TYPE = {e.value for e in FieldType}
 
 
-def _privacy(val: str | None) -> str:
-    if val and val in _VALID_PRIVACY:
+def _privacy(val: object) -> str:
+    # `val` is untrusted/translated import data: guard the type before the
+    # set membership test. A non-string (e.g. an OpenPlural `{visibility:
+    # ...}` privacy object that reached here un-extracted) must default
+    # rather than raise `TypeError: unhashable type` mid-import.
+    if isinstance(val, str) and val in _VALID_PRIVACY:
         return val
     return PrivacyLevel.PRIVATE
 
 
-def _field_type(val: str | None) -> FieldType:
-    if val and val in _VALID_FIELD_TYPE:
+def _field_type(val: object) -> FieldType:
+    if isinstance(val, str) and val in _VALID_FIELD_TYPE:
         return FieldType(val)
     return FieldType.TEXT
 

--- a/tests/test_openplural_export.py
+++ b/tests/test_openplural_export.py
@@ -101,7 +101,8 @@ def test_envelope_producer_and_version_stamp():
 def test_core_records_mapped():
     env = build_envelope(_native(), exported_at=_EXPORTED_AT)
     assert env["systems"][0]["name"] == "Sys"
-    assert env["systems"][0]["privacy"] == "public"
+    # privacy is the OpenPlural Privacy object, not a bare string.
+    assert env["systems"][0]["privacy"] == {"visibility": "public"}
     # pluralkit_id becomes a source_ref, not a core member field.
     m1 = next(m for m in env["members"] if m["id"] == "m1")
     assert {"app": "pluralkit", "collection": "members", "id": "abcde"} in m1["source_refs"]
@@ -268,4 +269,47 @@ def test_privacy_buckets_round_to_known():
     native["members"][0]["privacy"] = "weird-value"
     env = build_envelope(native, exported_at=_EXPORTED_AT)
     m1 = next(m for m in env["members"] if m["id"] == "m1")
-    assert m1["privacy"] == "unknown"
+    assert m1["privacy"] == {"visibility": "unknown"}
+
+
+def test_privacy_object_extracted_on_import():
+    """Spec-conformant OpenPlural privacy is an object {visibility, source};
+    to_native must extract the visibility string rather than pass the dict
+    through (which crashed the native importer: unhashable type 'dict').
+    Repro of the reported PluralSpace-via-OpenPlural import failure."""
+    env = {
+        "openplural_version": "0.1",
+        "systems": [
+            {
+                "id": "s1",
+                "name": "S",
+                "privacy": {"visibility": "public", "source": {"pluralspace": "public"}},
+            }
+        ],
+        "members": [
+            {"id": "m1", "name": "M", "privacy": {"visibility": "private", "source": {}}}
+        ],
+        "custom_fields": [
+            {"id": "f1", "name": "F", "privacy": {"visibility": "friends"}}
+        ],
+    }
+    native = to_native(env)
+    assert native["system"]["privacy"] == "public"
+    assert native["members"][0]["privacy"] == "private"
+    assert native["custom_fields"][0]["privacy"] == "friends"
+
+
+def test_privacy_bare_string_still_accepted_on_import():
+    """Older / lenient files with a bare-string privacy still read."""
+    env = {
+        "openplural_version": "0.1",
+        "systems": [{"id": "s1", "name": "S", "privacy": "public"}],
+    }
+    assert to_native(env)["system"]["privacy"] == "public"
+
+
+def test_privacy_round_trips_object_to_string():
+    """Export emits the privacy object; import reads it back to a string."""
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    assert env["systems"][0]["privacy"] == {"visibility": "public"}
+    assert to_native(env)["system"]["privacy"] == "public"


### PR DESCRIPTION
**Reported by nocturnal:** a PluralSpace-origin OpenPlural import failed with `unhashable type: 'dict'`. Found and fixed without needing the file, then validated against the actual file once provided.

**Root cause.** The OpenPlural spec models `privacy` as an object - `{"visibility": "...", "source": {...}}` - on systems, members, and custom fields. Sheaf treated it as a bare string in both directions:
- **Import:** `to_native` passed the whole privacy object straight to the native importer, which did `<dict> in _VALID_PRIVACY` and crashed with `TypeError: unhashable type: 'dict'`.
- **Export:** Sheaf emitted a bare string, so Sheaf's own OpenPlural output was non-conformant (other apps would hit the mirror bug).

The reported file was a PluralSpace export routed through OpenPlural (its privacy carried `source: {"pluralspace": ...}`), which is why it was described as a PluralSpace import. Any spec-conformant OpenPlural file would have hit this.

**Fix.**
- Import (`openplural_import.py`): new `_op_privacy` extracts the `visibility` string from the privacy object on system / member / custom-field; a bare-string privacy is still accepted for older / lenient files.
- Export (`openplural_export.py`): emit the spec object `{"visibility": ...}` so Sheaf's output is conformant. Note/journal `visibility` is a plain string per spec and is unchanged.
- Harden the native `_privacy` / `_field_type` helpers to `isinstance`-guard and fall back to a safe default rather than ever raising on an unexpected value type (house importer pattern: never crash on translated/untrusted input).

**Verification.** Ran the reported `openplural.json` through `to_native`: it now extracts the visibility bucket cleanly for the system and all members, no crash. ruff clean; pure transform + parity suites pass with 3 new privacy regression tests (object shape, bare-string back-compat, export round-trip) and the updated export assertions; the OpenPlural + native import e2e runners pass against a rebuilt stack. `docs/OPENPLURAL.md` updated. No migration, no API/mobile change.