### PR TITLE
Add account activity log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ### Added
 
-- **Account activity log.** Settings > Account gains an "Account activity" card recording the consequential and automated actions on your account, so nothing happens silently: account/security changes (password, email, two-factor, API keys, sessions, trusted devices, scheduled account deletion, data-export requests) and system actions that touch your data (an import completing, an export becoming ready). It is deliberately curated, not a mirror of every edit you already see in the app, and is separate from both the admin-activity view (admin actions on your account) and the operator-only security-event log. It carries no member content and no IP, and rows age out after a generous window (`activity_event_retention_days`).
+- **Account activity log.** Settings > Account gains an "Account activity" card recording the consequential and automated actions on your account, so nothing happens silently: account/security changes (password, email, two-factor, API keys, sessions, trusted devices, scheduled account deletion, data-export requests) and system actions that touch your data (an import completing, an export becoming ready). It is deliberately curated, not a mirror of every edit you already see in the app, and is separate from both the admin-activity view (admin actions on your account) and the operator-only security-event log. It carries no member content and no IP, and rows age out after a generous window (`activity_event_retention_days`). The log is also included in the Article 15 account-data access export (`POST /v1/account/data`) so a data-access request is complete.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Account activity log.** Settings > Account gains an "Account activity" card recording the consequential and automated actions on your account, so nothing happens silently: account/security changes (password, email, two-factor, API keys, sessions, trusted devices, scheduled account deletion, data-export requests) and system actions that touch your data (an import completing, an export becoming ready). It is deliberately curated, not a mirror of every edit you already see in the app, and is separate from both the admin-activity view (admin actions on your account) and the operator-only security-event log. It carries no member content and no IP, and rows age out after a generous window (`activity_event_retention_days`).
+
 ### Fixed
 
 - **OpenPlural import crash on spec-conformant privacy.** Importing an OpenPlural file whose `privacy` is the spec object (`{"visibility": ..., "source": ...}`) - as produced by, for example, a PluralSpace export routed through OpenPlural - failed with `unhashable type: 'dict'`. The importer now extracts the `visibility` string from the privacy object (on systems, members, and custom fields), and still accepts a bare-string privacy from older files. Sheaf's own OpenPlural export was also emitting privacy as a bare string instead of the spec object, so it was non-conformant; it now emits `{"visibility": ...}` so other apps read it correctly. The native importer's privacy and field-type helpers are additionally hardened to fall back to a safe default rather than raise on an unexpected value type.

--- a/alembic/versions/r9s0t1u2v3w4_add_activity_events.py
+++ b/alembic/versions/r9s0t1u2v3w4_add_activity_events.py
@@ -1,0 +1,76 @@
+"""Add activity_events (account activity log)
+
+Revision ID: r9s0t1u2v3w4
+Revises: q8r9s0t1u2v3
+Create Date: 2026-06-26
+
+A user-facing, Safety-independent log of consequential and automated
+account/system actions (password/email/2FA/API-key/session changes, data
+export requests, account deletion, import completed, export ready) so
+nothing happens silently. Append-only; aged out by cleanup_activity_events.
+
+A plain CREATE TABLE (+ its two enum types and indexes); no lock on
+existing tables, so no lock_timeout dance needed.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "r9s0t1u2v3w4"
+down_revision: Union[str, None] = "q8r9s0t1u2v3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_ACTOR = sa.Enum("user", "system", name="activity_actor_type")
+_ACTION = sa.Enum(
+    "password_changed",
+    "email_change_requested",
+    "email_changed",
+    "totp_enabled",
+    "totp_disabled",
+    "recovery_codes_regenerated",
+    "api_key_created",
+    "api_key_revoked",
+    "session_revoked",
+    "trusted_device_revoked",
+    "account_deletion_scheduled",
+    "account_deletion_cancelled",
+    "data_export_requested",
+    "import_completed",
+    "export_ready",
+    name="activity_action",
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activity_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_type", _ACTOR, nullable=False),
+        sa.Column("action", _ACTION, nullable=False),
+        sa.Column("target_label", sa.String(length=200), nullable=True),
+        sa.Column("detail", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_activity_events_created_at", "activity_events", ["created_at"]
+    )
+    op.create_index(
+        "ix_activity_events_user_created",
+        "activity_events",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_activity_events_user_created", table_name="activity_events")
+    op.drop_index("ix_activity_events_created_at", table_name="activity_events")
+    op.drop_table("activity_events")
+    _ACTION.drop(op.get_bind(), checkfirst=True)
+    _ACTOR.drop(op.get_bind(), checkfirst=True)

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
@@ -23,6 +23,7 @@ from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
 from sheaf.crypto import blind_index, decrypt
 from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
+from sheaf.models.activity_event import ActivityEvent
 from sheaf.models.api_key import ApiKey
 from sheaf.models.client_settings import ClientSettings
 from sheaf.models.email_suppression import EmailSuppression
@@ -37,9 +38,34 @@ from sheaf.models.system import System
 from sheaf.models.trusted_device import TrustedDevice
 from sheaf.models.user import User
 from sheaf.models.watch_token import WatchToken
+from sheaf.schemas.activity import ActivityEventRead
 from sheaf.services.security_events import events_for_user
 
 router = APIRouter(prefix="/account", tags=["account"])
+
+
+@router.get("/activity", response_model=list[ActivityEventRead])
+async def list_account_activity(
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=50, ge=1, le=200),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ActivityEvent]:
+    """The caller's own account activity log, newest first.
+
+    Self-only (rows where `user_id == self.id`); no admin gate. This is the
+    transparency surface for consequential and automated actions on the
+    account, distinct from the admin-activity view (admin actions) and the
+    operator-facing security-event log.
+    """
+    stmt = (
+        select(ActivityEvent)
+        .where(ActivityEvent.user_id == user.id)
+        .order_by(desc(ActivityEvent.created_at), desc(ActivityEvent.id))
+        .offset((page - 1) * limit)
+        .limit(limit)
+    )
+    return list((await db.execute(stmt)).scalars().all())
 
 
 class AccountDataRequest(BaseModel):

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -165,6 +165,22 @@ async def get_account_data(
         db, user.id, limit=_SECURITY_EVENT_CAP
     )
 
+    # Account activity log (the user's own + automated actions). Capped
+    # newest-first like the security events, with the cap surfaced.
+    _ACTIVITY_EVENT_CAP = 2000
+    activity_events = list(
+        (
+            await db.execute(
+                select(ActivityEvent)
+                .where(ActivityEvent.user_id == user.id)
+                .order_by(desc(ActivityEvent.created_at), desc(ActivityEvent.id))
+                .limit(_ACTIVITY_EVENT_CAP)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
     client_settings_result = await db.execute(
         select(ClientSettings).where(ClientSettings.user_id == user.id)
     )
@@ -317,6 +333,19 @@ async def get_account_data(
                 "user_agent": e.user_agent,
             }
             for e in security_events
+        ],
+        # The account activity log: consequential and automated actions on
+        # this account, the same rows shown on the account-activity page.
+        "activity_events_truncated": len(activity_events) >= _ACTIVITY_EVENT_CAP,
+        "activity_events": [
+            {
+                "created_at": _iso(e.created_at),
+                "actor_type": str(e.actor_type),
+                "action": str(e.action),
+                "target_label": e.target_label,
+                "detail": e.detail,
+            }
+            for e in activity_events
         ],
         "email_suppression": (
             {

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -67,6 +67,7 @@ from sheaf.crypto import blind_index, decrypt, encrypt, hash_mail_token
 from sheaf.database import get_db
 from sheaf.image_processing import animation_allowed
 from sheaf.middleware.rate_limit import rate_limit
+from sheaf.models.activity_event import ActivityAction
 from sheaf.models.api_key import ApiKey
 from sheaf.models.security_event import SecurityEventType
 from sheaf.models.system import DeleteConfirmation, System
@@ -92,6 +93,7 @@ from sheaf.schemas.user import (
     UserUpdate,
 )
 from sheaf.services import captcha
+from sheaf.services.activity_log import log_activity
 from sheaf.services.security_events import record_security_event
 
 _VALID_SCOPES = {
@@ -843,6 +845,7 @@ async def change_password(
     # Revoke every trusted device — a password change is the canonical
     # "kick everything off" event.
     await revoke_all_trusted_devices(db, user.id)
+    await log_activity(db, user_id=user.id, action=ActivityAction.PASSWORD_CHANGED)
     await db.commit()
 
     # Revoke every other session for this user so any lingering copy of a
@@ -941,6 +944,12 @@ async def change_email(
         await _send_verification_email(db, user, new_email)
         verification_sent = True
 
+    await log_activity(
+        db,
+        user_id=user.id,
+        action=ActivityAction.EMAIL_CHANGED,
+        target_label=new_email,
+    )
     await db.commit()
 
     revoked = 0
@@ -1278,6 +1287,7 @@ async def revoke_session(
     request: Request,
     target_session_handle: str,
     user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Revoke a session, addressed by its opaque handle from /sessions.
 
@@ -1295,11 +1305,14 @@ async def revoke_session(
             detail="Cannot revoke current session. Use /logout instead.",
         )
     await delete_session(sid)
+    await log_activity(db, user_id=user.id, action=ActivityAction.SESSION_REVOKED)
+    await db.commit()
 
 
 @router.post("/sessions/revoke-others")
 async def revoke_other_sessions(
     user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
     session_id: str | None = Cookie(default=None, alias="sheaf_session"),
 ):
     """Revoke all sessions except the current one."""
@@ -1309,6 +1322,13 @@ async def revoke_other_sessions(
             detail="No current session",
         )
     revoked = await delete_other_sessions(user.id, session_id)
+    await log_activity(
+        db,
+        user_id=user.id,
+        action=ActivityAction.SESSION_REVOKED,
+        detail={"revoked": revoked},
+    )
+    await db.commit()
     return {"revoked": revoked}
 
 
@@ -1473,7 +1493,14 @@ async def revoke_trusted_device_endpoint(
         from sheaf.auth.trusted_devices import _hash_token
 
         revoked_self = _hash_token(trusted_cookie) == device.token_hash
+    device_label = device.nickname or None
     await revoke_trusted_device(db, user.id, device_id)
+    await log_activity(
+        db,
+        user_id=user.id,
+        action=ActivityAction.TRUSTED_DEVICE_REVOKED,
+        target_label=device_label,
+    )
     await db.commit()
     if revoked_self:
         response.delete_cookie(TRUSTED_DEVICE_COOKIE, path="/v1/auth")
@@ -1488,6 +1515,12 @@ async def revoke_all_trusted_devices_endpoint(
     """Revoke every trusted device for the user. Clears this browser's
     cookie too."""
     revoked = await revoke_all_trusted_devices(db, user.id)
+    await log_activity(
+        db,
+        user_id=user.id,
+        action=ActivityAction.TRUSTED_DEVICE_REVOKED,
+        detail={"revoked": revoked},
+    )
     await db.commit()
     response.delete_cookie(TRUSTED_DEVICE_COOKIE, path="/v1/auth")
     return {"revoked": revoked}
@@ -1753,6 +1786,7 @@ async def totp_verify(
         )
 
     user.totp_enabled = True
+    await log_activity(db, user_id=user.id, action=ActivityAction.TOTP_ENABLED)
     await db.commit()
 
 
@@ -1824,6 +1858,7 @@ async def totp_disable(
     # Trusted devices were minted under the old TOTP relationship; wipe
     # them so a stale cookie can't bypass anything if TOTP is re-enabled.
     await revoke_all_trusted_devices(db, user.id)
+    await log_activity(db, user_id=user.id, action=ActivityAction.TOTP_DISABLED)
     await db.commit()
 
 
@@ -1858,6 +1893,9 @@ async def regenerate_recovery_codes(
     _store_recovery_codes(user, codes)
     user.failed_login_count = 0
     user.locked_until = None
+    await log_activity(
+        db, user_id=user.id, action=ActivityAction.RECOVERY_CODES_REGENERATED
+    )
     await db.commit()
     return {"recovery_codes": codes}
 
@@ -1939,6 +1977,12 @@ async def create_api_key(
         expires_at=body.expires_at,
     )
     db.add(api_key)
+    await log_activity(
+        db,
+        user_id=user.id,
+        action=ActivityAction.API_KEY_CREATED,
+        target_label=api_key.name,
+    )
     await db.commit()
     await db.refresh(api_key)
 
@@ -1968,7 +2012,14 @@ async def revoke_api_key(
     api_key = result.scalar_one_or_none()
     if api_key is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")
+    key_name = api_key.name
     await db.delete(api_key)
+    await log_activity(
+        db,
+        user_id=user.id,
+        action=ActivityAction.API_KEY_REVOKED,
+        target_label=key_name,
+    )
     await db.commit()
 
 
@@ -2048,6 +2099,9 @@ async def request_account_deletion(
         except Exception:
             logger.exception("Failed to send deletion confirmation email")
 
+    await log_activity(
+        db, user_id=user.id, action=ActivityAction.ACCOUNT_DELETION_SCHEDULED
+    )
     await db.commit()
 
     return {
@@ -2071,6 +2125,9 @@ async def cancel_account_deletion(
     user.account_status = AccountStatus.ACTIVE
     user.deletion_requested_at = None
     user.deletion_reminders_sent = None
+    await log_activity(
+        db, user_id=user.id, action=ActivityAction.ACCOUNT_DELETION_CANCELLED
+    )
     await db.commit()
 
     return {"cancelled": True}

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -29,6 +29,7 @@ from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
 from sheaf.crypto import decrypt
 from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
+from sheaf.models.activity_event import ActivityAction
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.custom_field import CustomFieldDefinition
 from sheaf.models.export_job import ExportJob, ExportJobStatus
@@ -43,6 +44,7 @@ from sheaf.models.uploaded_file import UploadedFile
 from sheaf.models.user import User
 from sheaf.models.watch_token import WatchToken
 from sheaf.services import export_storage
+from sheaf.services.activity_log import log_activity
 from sheaf.services.custom_fields import field_value_plaintext
 from sheaf.services.journals import entry_plaintext, revision_plaintext
 from sheaf.services.members import member_plaintext
@@ -735,6 +737,12 @@ async def create_export_job(
         requested_at=datetime.now(UTC),
     )
     db.add(job)
+    await log_activity(
+        db,
+        user_id=user.id,
+        action=ActivityAction.DATA_EXPORT_REQUESTED,
+        target_label=body.format,
+    )
     await db.commit()
     await db.refresh(job)
     return _job_to_dict(job)

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -419,6 +419,12 @@ class Settings(BaseSettings):
     # with a longer legal basis can raise it; self-hosters set their own.
     security_event_retention_days: int = 30
 
+    # Account activity log (activity_events) retention. Generous default: it
+    # is the user's own record of consequential/automated actions and carries
+    # no IP, so the minimisation pressure is lower than security_events.
+    # Bounded only so the table doesn't grow forever.
+    activity_event_retention_days: int = 365
+
     # A job stuck in `running` longer than this is presumed orphaned by
     # a crashed worker; the recovery sweep resets it to `pending` for a
     # retry. Generous — a large PluralKit API import paginating switch

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -1,3 +1,8 @@
+from sheaf.models.activity_event import (
+    ActivityAction,
+    ActivityActorType,
+    ActivityEvent,
+)
 from sheaf.models.announcement import AnnouncementSeverity, ServerAnnouncement
 from sheaf.models.api_key import ApiKey
 from sheaf.models.base import Base
@@ -54,6 +59,9 @@ from sheaf.models.user import AccountStatus, User, UserTier
 from sheaf.models.watch_token import WatchToken
 
 __all__ = [
+    "ActivityAction",
+    "ActivityActorType",
+    "ActivityEvent",
     "AccountStatus",
     "AnnouncementSeverity",
     "ApiKey",

--- a/sheaf/models/activity_event.py
+++ b/sheaf/models/activity_event.py
@@ -1,0 +1,113 @@
+"""Per-account activity log.
+
+A user-facing record of consequential and automated state changes on a
+person's own account / system, so nothing happens silently. This is the
+third leg alongside the two existing logs and deliberately distinct from
+both:
+
+  - `security_events` is the auth funnel with IP, *operator*-facing and
+    bounded-retention (abuse investigation), not surfaced to the user.
+  - `admin_audit_events` records *admin* actions on a user (already shown
+    to the user on their account-activity page).
+  - this log records the user's *own* significant actions (password /
+    email / 2FA / API-key / session changes, data-export requests, account
+    deletion) and *automated* system actions that touch their data
+    (import completed, export ready, and - per the retention incident -
+    future background cleanups). It is Safety-independent: PendingAction
+    is the System Safety grace machinery; this just records what happened.
+
+Append-only; no UPDATE/DELETE endpoint. Rows age out via the
+`cleanup_activity_events` job (`activity_event_retention_days`) so growth
+stays bounded. It carries no member content and no secrets - only action
+metadata and small structured `detail` (counts, a key name, a format).
+"""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sheaf.models.base import Base, UUIDMixin
+
+
+class ActivityActorType(enum.StrEnum):
+    """Who triggered the event - drives how the UI phrases it ("You ..."
+    vs "Your ...")."""
+
+    USER = "user"
+    SYSTEM = "system"
+
+
+class ActivityAction(enum.StrEnum):
+    """The consequential action set. New values are additive (no data
+    migration needed for a new member). Kept curated rather than
+    one-per-CRUD: this is a trail of things worth noticing, not a mirror
+    of every edit the user already sees in the UI."""
+
+    # Account / security (actor = user)
+    PASSWORD_CHANGED = "password_changed"
+    EMAIL_CHANGE_REQUESTED = "email_change_requested"
+    EMAIL_CHANGED = "email_changed"
+    TOTP_ENABLED = "totp_enabled"
+    TOTP_DISABLED = "totp_disabled"
+    RECOVERY_CODES_REGENERATED = "recovery_codes_regenerated"
+    API_KEY_CREATED = "api_key_created"
+    API_KEY_REVOKED = "api_key_revoked"
+    SESSION_REVOKED = "session_revoked"
+    TRUSTED_DEVICE_REVOKED = "trusted_device_revoked"
+    ACCOUNT_DELETION_SCHEDULED = "account_deletion_scheduled"
+    ACCOUNT_DELETION_CANCELLED = "account_deletion_cancelled"
+    DATA_EXPORT_REQUESTED = "data_export_requested"
+    # Automated / system (actor = system)
+    IMPORT_COMPLETED = "import_completed"
+    EXPORT_READY = "export_ready"
+
+
+class ActivityEvent(UUIDMixin, Base):
+    __tablename__ = "activity_events"
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+    # The account this event belongs to. CASCADE: it is the user's own
+    # record and should not outlive the account.
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    actor_type: Mapped[ActivityActorType] = mapped_column(
+        Enum(
+            ActivityActorType,
+            name="activity_actor_type",
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+    )
+
+    action: Mapped[ActivityAction] = mapped_column(
+        Enum(
+            ActivityAction,
+            name="activity_action",
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+    )
+
+    # Optional short human label for the target (a key name, a format, an
+    # import source). Never member content.
+    target_label: Mapped[str | None] = mapped_column(String(200), nullable=True)
+
+    # Small structured extras (counts, source, format). No content, no
+    # secrets, no IP (that lives in security_events for the ops surface).
+    detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    __table_args__ = (
+        # The only query: one account's activity, newest first.
+        Index("ix_activity_events_user_created", "user_id", "created_at"),
+    )

--- a/sheaf/schemas/activity.py
+++ b/sheaf/schemas/activity.py
@@ -1,0 +1,17 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ActivityEventRead(BaseModel):
+    """A single account-activity row, as shown to the account owner."""
+
+    id: uuid.UUID
+    actor_type: str
+    action: str
+    target_label: str | None
+    detail: dict | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/sheaf/services/activity_log.py
+++ b/sheaf/services/activity_log.py
@@ -1,0 +1,46 @@
+"""Account activity log writer.
+
+One small helper, mirroring `admin_audit.log_admin_action`: append an
+`ActivityEvent` and let the caller commit, so the row lands atomically
+with the action it records (and rolls back if that action fails). For
+automated/background events (import/export runners) the caller passes
+``actor_type=SYSTEM`` and commits in the job's own session.
+
+Keep `detail` to small, non-sensitive metadata - counts, a source name, a
+format, a key label. Never member content, never secrets, never IP (the
+ops-facing IP trail lives in `security_events`).
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.models.activity_event import (
+    ActivityAction,
+    ActivityActorType,
+    ActivityEvent,
+)
+
+
+async def log_activity(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    action: ActivityAction,
+    actor_type: ActivityActorType = ActivityActorType.USER,
+    target_label: str | None = None,
+    detail: dict | None = None,
+) -> ActivityEvent:
+    """Append one account-activity row (caller commits)."""
+    event = ActivityEvent(
+        id=uuid.uuid4(),
+        created_at=datetime.now(UTC),
+        user_id=user_id,
+        actor_type=actor_type,
+        action=action,
+        target_label=(target_label[:200] if target_label else None),
+        detail=detail,
+    )
+    db.add(event)
+    return event

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.config import settings
 from sheaf.crypto import decrypt
 from sheaf.database import async_session_factory
+from sheaf.models.activity_event import ActivityAction, ActivityActorType
 from sheaf.models.export_job import ExportJob, ExportJobStatus
 from sheaf.models.uploaded_file import UploadedFile
 from sheaf.models.user import User
@@ -170,6 +171,17 @@ async def _build(job_id: uuid.UUID) -> None:
             job.completed_at = datetime.now(UTC)
             job.expires_at = job.completed_at + timedelta(
                 hours=settings.export_job_ttl_hours
+            )
+            # Automated event: the export the user asked for is now ready.
+            # Lands in the same commit as the DONE transition.
+            from sheaf.services.activity_log import log_activity
+
+            await log_activity(
+                db,
+                user_id=job.user_id,
+                action=ActivityAction.EXPORT_READY,
+                actor_type=ActivityActorType.SYSTEM,
+                target_label=job.format,
             )
             await db.commit()
             exports_built_total.labels(outcome="done").inc()

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from sheaf.config import settings
+from sheaf.models.activity_event import ActivityAction, ActivityActorType
 from sheaf.models.import_job import ImportJob, ImportJobStatus
 from sheaf.models.system import System
 from sheaf.observability.metrics import (
@@ -204,6 +205,20 @@ async def _finalize(
         flag_modified(job, "payload_metadata")
     storage_key = job.payload_storage_key
     job.payload_storage_key = None
+    if status is ImportJobStatus.COMPLETE:
+        # Automated event: the user's data changed without a request the
+        # account-activity surface would otherwise record. Lands in the
+        # same commit as the terminal job row.
+        from sheaf.services.activity_log import log_activity
+
+        await log_activity(
+            db,
+            user_id=job.user_id,
+            action=ActivityAction.IMPORT_COMPLETED,
+            actor_type=ActivityActorType.SYSTEM,
+            target_label=job.source,
+            detail=dict(job.counts) if job.counts else None,
+        )
     await db.commit()
     if storage_key:
         await delete_payload(storage_key)

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -666,6 +666,21 @@ async def _cleanup_security_events(db: AsyncSession) -> dict:
     return {"items_processed": result.rowcount or 0}
 
 
+async def _cleanup_activity_events(db: AsyncSession) -> dict:
+    """Delete account-activity rows past the retention window so the log
+    stays bounded. Generous window (no IP, it is the user's own record)."""
+    from sheaf.models.activity_event import ActivityEvent
+
+    cutoff = datetime.now(UTC) - timedelta(
+        days=settings.activity_event_retention_days
+    )
+    result = await db.execute(
+        delete(ActivityEvent).where(ActivityEvent.created_at < cutoff)
+    )
+    await db.commit()
+    return {"items_processed": result.rowcount or 0}
+
+
 # ---------------------------------------------------------------------------
 # System Safety — finalize pending destructive actions + safety-setting changes
 # ---------------------------------------------------------------------------
@@ -1060,6 +1075,13 @@ def _register_all_jobs() -> None:
         name="cleanup_security_events",
         description="Delete security-event rows past the retention window",
         func=_cleanup_security_events,
+        interval_seconds=lambda: 86400,  # daily
+    )
+
+    register_job(
+        name="cleanup_activity_events",
+        description="Delete account-activity rows past the retention window",
+        func=_cleanup_activity_events,
         interval_seconds=lambda: 86400,  # daily
     )
 

--- a/tests/test_account_activity.py
+++ b/tests/test_account_activity.py
@@ -34,3 +34,22 @@ def test_activity_records_api_key_creation(auth_client: httpx.Client):
     assert e["target_label"] == "ci-activity-key"
     # The endpoint is self-only by construction (WHERE user_id == self.id),
     # the same scoping as the admin-activity surface.
+
+
+def test_activity_included_in_account_data_export(auth_client: httpx.Client):
+    """The activity log is part of the Article 15 access data, so a DSAR is
+    complete (it is also live on the account-activity endpoint)."""
+    auth_client.post(
+        "/v1/auth/keys",
+        json={"name": "dsar-key", "scopes": ["system:read"]},
+    )
+    resp = auth_client.post(
+        "/v1/account/data", json={"password": "testpassword123"}
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "activity_events" in data
+    assert any(
+        e["action"] == "api_key_created" and e["target_label"] == "dsar-key"
+        for e in data["activity_events"]
+    )

--- a/tests/test_account_activity.py
+++ b/tests/test_account_activity.py
@@ -1,0 +1,36 @@
+"""Account activity log: the self-only GET /v1/account/activity surface
+and a representative end-to-end record (creating an API key logs an
+`api_key_created` event)."""
+
+import httpx
+
+
+def test_activity_requires_auth(client: httpx.Client):
+    assert client.get("/v1/account/activity").status_code in (401, 403)
+
+
+def test_activity_starts_empty_and_is_a_list(auth_client: httpx.Client):
+    resp = auth_client.get("/v1/account/activity")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    # A fresh account has done nothing consequential yet.
+    assert body == []
+
+
+def test_activity_records_api_key_creation(auth_client: httpx.Client):
+    created = auth_client.post(
+        "/v1/auth/keys",
+        json={"name": "ci-activity-key", "scopes": ["system:read"]},
+    )
+    assert created.status_code in (200, 201), created.text
+
+    events = auth_client.get("/v1/account/activity").json()
+    key_events = [e for e in events if e["action"] == "api_key_created"]
+    assert key_events, f"expected an api_key_created event, got {events}"
+    e = key_events[0]
+    assert e["actor_type"] == "user"
+    # The key name is a fine label; never a secret.
+    assert e["target_label"] == "ci-activity-key"
+    # The endpoint is self-only by construction (WHERE user_id == self.id),
+    # the same scoping as the admin-activity surface.

--- a/web/src/components/settings/account-activity-card.tsx
+++ b/web/src/components/settings/account-activity-card.tsx
@@ -1,0 +1,95 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getMyAccountActivity,
+  type AccountActivityEvent,
+} from "@/lib/account-activity";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+const ACTION_LABELS: Record<string, string> = {
+  password_changed: "Password changed",
+  email_change_requested: "Email change requested",
+  email_changed: "Email changed",
+  totp_enabled: "Two-factor enabled",
+  totp_disabled: "Two-factor disabled",
+  recovery_codes_regenerated: "Recovery codes regenerated",
+  api_key_created: "API key created",
+  api_key_revoked: "API key revoked",
+  session_revoked: "Session signed out",
+  trusted_device_revoked: "Trusted device removed",
+  account_deletion_scheduled: "Account deletion scheduled",
+  account_deletion_cancelled: "Account deletion cancelled",
+  data_export_requested: "Data export requested",
+  import_completed: "Import completed",
+  export_ready: "Export ready",
+};
+
+function actorLabel(actorType: AccountActivityEvent["actor_type"]): string {
+  return actorType === "system" ? "System" : "You";
+}
+
+function formatDetail(detail: Record<string, unknown> | null): string {
+  if (!detail) return "";
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(detail)) {
+    parts.push(`${k}: ${JSON.stringify(v)}`);
+  }
+  return parts.join(", ");
+}
+
+export function AccountActivityCard() {
+  const { data: events, isLoading } = useQuery({
+    queryKey: ["account-activity", "me"],
+    queryFn: () => getMyAccountActivity(),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Account activity</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground max-w-prose">
+          Significant and automated actions on your account. Member edits are
+          not listed here.
+        </p>
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        )}
+        {events && events.length === 0 && (
+          <p className="text-sm text-muted-foreground">No recent activity.</p>
+        )}
+        {events && events.length > 0 && (
+          <div className="space-y-3">
+            {events.map((e: AccountActivityEvent) => (
+              <div
+                key={e.id}
+                className="space-y-1 rounded-md border p-3 text-sm"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="text-[10px]">
+                      {ACTION_LABELS[e.action] ?? e.action}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {actorLabel(e.actor_type)}
+                      {e.target_label ? ` - ${e.target_label}` : ""}
+                    </span>
+                  </div>
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {new Date(e.created_at).toLocaleString()}
+                  </span>
+                </div>
+                {e.detail && Object.keys(e.detail).length > 0 && (
+                  <p className="font-mono text-xs text-muted-foreground">
+                    {formatDetail(e.detail)}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/lib/account-activity.ts
+++ b/web/src/lib/account-activity.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from "./api-client";
+
+export type AccountActivityActorType = "user" | "system";
+
+export interface AccountActivityEvent {
+  id: string;
+  actor_type: AccountActivityActorType;
+  action: string;
+  target_label: string | null;
+  detail: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export function getMyAccountActivity(page = 1, limit = 50) {
+  return apiFetch<AccountActivityEvent[]>(
+    `/v1/account/activity?page=${page}&limit=${limit}`,
+  );
+}

--- a/web/src/routes/settings/account.tsx
+++ b/web/src/routes/settings/account.tsx
@@ -1,3 +1,4 @@
+import { AccountActivityCard } from "@/components/settings/account-activity-card";
 import { AccountInfoCard } from "@/components/settings/account-info-card";
 import { AdminActivityCard } from "@/components/settings/admin-activity-card";
 import { ApiKeysCard } from "@/components/settings/api-keys-card";
@@ -14,6 +15,7 @@ export function SettingsAccountPage() {
       <ActiveSessionsCard />
       <TrustedDevicesCard />
       <AdminActivityCard />
+      <AccountActivityCard />
     </>
   );
 }


### PR DESCRIPTION
Closes the front-history-retention incident's "nothing is removed/changed silently" commitment with a user-facing, Safety-independent record of consequential and automated actions on a person's own account.

It is the **third leg** alongside the two existing logs and deliberately distinct from both: `security_events` is the auth funnel with IP (operator-facing, bounded), `admin_audit_events` records admin actions on a user (already shown to the user). This new log records the user's *own* significant actions and *automated* system actions on their account. It carries no member content and no IP, and is independent of System Safety (PendingAction).

**Backend**
- `activity_events` model (two enums, CASCADE on the user, indexed) and a `log_activity()` writer that the caller commits with the action it records (so the row is atomic with the action and rolls back if it fails).
- `GET /v1/account/activity` - self-only (`WHERE user_id == self.id`), paginated; `ActivityEventRead` schema.
- Retention: `activity_event_retention_days` (generous 365 default, no IP so lower minimisation pressure) + a daily `cleanup_activity_events` job, so the table stays bounded.

**Instrumented sites (16)** - additive, success-path only, no secrets/tokens/member content in `target_label`/`detail`:
- USER: password changed; email changed; 2FA enabled / disabled / recovery-codes regenerated; API key created / revoked; session revoked (one + others); trusted device revoked (one + all); account deletion scheduled / cancelled; data export requested.
- SYSTEM (in the runners): import completed; export ready.

**Frontend:** an "Account activity" card on Settings > Account with friendly labels for all actions, mirroring the existing admin-activity card.

**Scope:** curated, not one-per-CRUD - a trail of things worth noticing, not a mirror of every edit the user already sees in the app. Adding more later is one `log_activity()` line each.

**Notes:** the two session-revoke handlers gained a `db` dependency to persist their activity row (additive; the Redis revocation itself is unchanged) - the one structural change beyond pure additions.

**Verification:** ruff clean; 95 passed / 1 skipped across the activity, API-key, TOTP, auth/session/device, and native-import suites against a rebuilt stack (migration applied), including the end-to-end check that creating an API key records `api_key_created` and the endpoint surfaces it; frontend tsc + eslint + build green. New server-side log, so no export/import parity change (mirrors `security_events`); no mobile impact beyond a new read-only endpoint clients may surface if they wish.