### PR TITLE
Journal/edit-history volume metrics + active-poll nav badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ### Added
 
+- **Active-poll badge.** The Polls nav item now shows a count badge when one or more polls are open, so an active poll is something every headmate notices (it is a system decision worth seeing).
+
+- **Journal + edit-history volume metrics.** New operator-facing Prometheus metrics applying the same preserve-by-count lens as the front-volume metrics, to ground the journal-revision retention decision in real usage: `sheaf_journal_entries_total` + a per-system distribution, and `sheaf_content_revisions_total` with a per-target distribution and `sheaf_target_revision_count_max` (the most-revised single journal entry / member bio / message - the save-spam outlier signal), plus `sheaf_content_revisions_created_total` for live edit velocity. Documented in `docs/METRICS.md`.
+
 - **Account activity log.** Settings > Account gains an "Account activity" card recording the consequential and automated actions on your account, so nothing happens silently: account/security changes (password, email, two-factor, API keys, sessions, trusted devices, scheduled account deletion, data-export requests) and system actions that touch your data (an import completing, an export becoming ready). It is deliberately curated, not a mirror of every edit you already see in the app, and is separate from both the admin-activity view (admin actions on your account) and the operator-only security-event log. It carries no member content and no IP, and rows age out after a generous window (`activity_event_retention_days`). The log is also included in the Article 15 account-data access export (`POST /v1/account/data`) so a data-access request is complete.
 
 ### Fixed

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -313,6 +313,13 @@ detect non-zero from the first scrape.
 | `sheaf_systems_by_front_count` | gauge | `le` (front-count threshold; `+Inf` = all systems) |
 | `sheaf_system_front_count_max` | gauge | - |
 | `sheaf_fronts_created_total` | counter | - |
+| `sheaf_journal_entries_total` | gauge | - |
+| `sheaf_systems_by_journal_entry_count` | gauge | `le` (entry-count threshold; `+Inf` = all systems) |
+| `sheaf_system_journal_entry_count_max` | gauge | - |
+| `sheaf_content_revisions_total` | gauge | - |
+| `sheaf_targets_by_revision_count` | gauge | `le` (revisions-per-target threshold; `+Inf` = all targets) |
+| `sheaf_target_revision_count_max` | gauge | - |
+| `sheaf_content_revisions_created_total` | counter | - |
 
 `sheaf_systems_by_front_count` is a point-in-time cumulative distribution of
 per-system front-history size, re-set each gauge refresh: each `le` series is
@@ -325,6 +332,18 @@ than 1000 fronts, and `sheaf_system_front_count_max` is the single largest.
 the HTTP request counter on `POST /v1/fronts`. These exist to ground the
 front-history retention decision in real usage data (see
 `../sheaf-design-docs/front-history-retention-and-limits.md`).
+
+The `sheaf_journal_entries_total` / `sheaf_systems_by_journal_entry_count` /
+`sheaf_system_journal_entry_count_max` set and the
+`sheaf_content_revisions_total` / `sheaf_targets_by_revision_count` /
+`sheaf_target_revision_count_max` / `sheaf_content_revisions_created_total`
+set apply the same lens to journal entries and to content-revision (edit
+history) volume. `sheaf_targets_by_revision_count` is the key one for the
+journal-revision cap decision: a "target" is one journal entry / member bio /
+message, and `sheaf_target_revision_count_max` is the most-revised single
+target (the save-spam outlier signal). `sheaf_content_revisions_created_total`
+is edit velocity on the live edit path (imports excluded). See
+`../sheaf-design-docs/usage-limits-and-tiers.md`.
 
 ### Infra
 

--- a/sheaf/observability/gauges.py
+++ b/sheaf/observability/gauges.py
@@ -27,10 +27,12 @@ from sheaf.observability.metrics import (
     auth_totp_enabled,
     auth_trusted_devices_active,
     cf_shield_active,
+    content_revisions_total,
     db_pool_connections,
     fronts_total,
     imports_in_progress,
     imports_oldest_pending_seconds,
+    journal_entries_total,
     members_custom_front,
     members_total,
     notifications_outbox_depth,
@@ -41,8 +43,12 @@ from sheaf.observability.metrics import (
     requests_per_account_per_minute,
     requests_per_ip_per_minute,
     system_front_count_max,
+    system_journal_entry_count_max,
     systems_by_front_count,
+    systems_by_journal_entry_count,
     systems_total,
+    target_revision_count_max,
+    targets_by_revision_count,
     users_pending_delete,
     users_total,
 )
@@ -165,6 +171,60 @@ async def _refresh_db_counts(db: AsyncSession) -> None:
             sum(1 for c in counts if c <= threshold)
         )
     systems_by_front_count.labels(le="+Inf").set(len(counts))
+
+    # Journal entries + content-revision (edit-history) volume, same
+    # preserve-by-count lens. One grouped query each; the snapshot CDF +
+    # max are set the same way as the front distribution above.
+    from sheaf.models.content_revision import ContentRevision
+    from sheaf.models.journal_entry import JournalEntry
+
+    def _set_distribution(cdf_gauge, max_gauge, values: list[int]) -> None:
+        max_gauge.set(max(values) if values else 0)
+        for threshold in FRONT_COUNT_BUCKETS:
+            cdf_gauge.labels(le=str(threshold)).set(
+                sum(1 for v in values if v <= threshold)
+            )
+        cdf_gauge.labels(le="+Inf").set(len(values))
+
+    je_total = await db.scalar(select(func.count(JournalEntry.id)))
+    journal_entries_total.set(int(je_total or 0))
+    je_per_system = [
+        int(c or 0)
+        for c in (
+            await db.execute(
+                select(func.count(JournalEntry.id))
+                .select_from(System)
+                .outerjoin(JournalEntry, JournalEntry.system_id == System.id)
+                .group_by(System.id)
+            )
+        )
+        .scalars()
+        .all()
+    ]
+    _set_distribution(
+        systems_by_journal_entry_count,
+        system_journal_entry_count_max,
+        je_per_system,
+    )
+
+    cr_total = await db.scalar(select(func.count(ContentRevision.id)))
+    content_revisions_total.set(int(cr_total or 0))
+    # Revisions per target (one journal entry / member bio / message).
+    rev_per_target = [
+        int(c or 0)
+        for c in (
+            await db.execute(
+                select(func.count(ContentRevision.id)).group_by(
+                    ContentRevision.target_type, ContentRevision.target_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    ]
+    _set_distribution(
+        targets_by_revision_count, target_revision_count_max, rev_per_target
+    )
 
 
 async def _refresh_outbox(db: AsyncSession) -> None:

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -521,6 +521,53 @@ fronts_created_total = _C(
     "creation, distinct from the HTTP request counter on POST /v1/fronts.",
 )
 
+# Journal entries + content-revision (edit-history) volume - the same
+# preserve-by-count lens as front history, feeding the journal-revision
+# count-cap decision (../sheaf-design-docs/usage-limits-and-tiers.md). The
+# generic FRONT_COUNT_BUCKETS thresholds are reused (they are plain counts).
+journal_entries_total = _G(
+    "sheaf_journal_entries_total",
+    "All journal entries across all systems (global volume baseline).",
+)
+systems_by_journal_entry_count = _G(
+    "sheaf_systems_by_journal_entry_count",
+    "Number of systems whose journal-entry count is <= the `le` bucket (a "
+    "point-in-time cumulative distribution, re-set each refresh).",
+    ["le"],
+)
+system_journal_entry_count_max = _G(
+    "sheaf_system_journal_entry_count_max",
+    "Largest single system's journal-entry count.",
+)
+
+# Content revisions are the edit history for journal entries, member bios,
+# and messages (one polymorphic table). The pathological case is a single
+# target with a huge revision count (a save-spamming client / bug); these
+# answer "is any single target an outlier?" without naming it - the input to
+# shifting journal revisions from age-based to count-based retention.
+content_revisions_total = _G(
+    "sheaf_content_revisions_total",
+    "All content-revision (edit-history) rows across journal entries, member "
+    "bios, and messages.",
+)
+targets_by_revision_count = _G(
+    "sheaf_targets_by_revision_count",
+    "Number of revision targets (one journal entry / member bio / message) "
+    "whose revision count is <= the `le` bucket (point-in-time cumulative "
+    "distribution, re-set each refresh). See docs/METRICS.md.",
+    ["le"],
+)
+target_revision_count_max = _G(
+    "sheaf_target_revision_count_max",
+    "Most revisions on any single target - the direct outlier signal for the "
+    "journal-revision count-cap decision.",
+)
+content_revisions_created_total = _C(
+    "sheaf_content_revisions_created_total",
+    "Content revisions created via the live edit path (not imports). Edit "
+    "velocity; the save-spam signal.",
+)
+
 # ---------------------------------------------------------------------------
 # Infra
 # ---------------------------------------------------------------------------

--- a/sheaf/services/journals.py
+++ b/sheaf/services/journals.py
@@ -20,6 +20,7 @@ from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
 from sheaf.models.system import System
 from sheaf.models.user import User, UserTier
+from sheaf.observability.metrics import content_revisions_created_total
 from sheaf.services.markdown import extract_image_keys
 from sheaf.services.system_safety import snapshot_current_fronts
 
@@ -128,6 +129,7 @@ async def capture_revision(
         pinned_at=pinned_at,
     )
     db.add(revision)
+    content_revisions_created_total.inc()
     return revision
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -227,6 +227,22 @@ def test_front_volume_metrics_present():
         assert _series_value(body, name) is not None, f"missing series: {name}"
 
 
+def test_journal_revision_volume_metrics_present():
+    """The journal-entry and content-revision volume metrics (for the
+    journal-revision cap decision) are label-less and exposed from the
+    first scrape. The per-system / per-target distribution gauges are `le`-
+    labelled and only appear once the refresher has run, so not asserted."""
+    body = _scrape()
+    for name in (
+        "sheaf_journal_entries_total",
+        "sheaf_system_journal_entry_count_max",
+        "sheaf_content_revisions_total",
+        "sheaf_target_revision_count_max",
+        "sheaf_content_revisions_created_total",
+    ):
+        assert _series_value(body, name) is not None, f"missing series: {name}"
+
+
 # ---------------------------------------------------------------------------
 # Leader election
 # ---------------------------------------------------------------------------

--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
 import { useCurrentFronts } from "@/hooks/use-fronts";
 import { getUnread } from "@/lib/messages";
+import { listPolls } from "@/lib/polls";
 import { Button } from "@/components/ui/button";
 import { Logo } from "@/components/logo";
 import { ThemeModeToggle } from "@/components/theme-mode-toggle";
@@ -79,6 +80,18 @@ export function AppSidebar({
   });
   const messagesUnread = unread?.total ?? 0;
 
+  // Open-poll count for the Polls nav badge. Shares the ["polls"] cache with
+  // the polls page so it's free when that page is mounted and deduped
+  // otherwise. "Open" mirrors the polls page: the server-computed is_closed
+  // flag, not a local clock comparison. Everyone should notice an active poll,
+  // so it's worth a periodic refetch.
+  const { data: polls } = useQuery({
+    queryKey: ["polls"],
+    queryFn: listPolls,
+    refetchInterval: 60_000,
+  });
+  const openPolls = (polls ?? []).filter((p) => !p.is_closed).length;
+
   // Collapsed-icons-only is a desktop-only convenience. On mobile the
   // sidebar is shown as a drawer overlay where horizontal space is plentiful,
   // so always render the full label set there. Forcing isCollapsed=false
@@ -143,7 +156,13 @@ export function AppSidebar({
             icon={item.icon}
             collapsed={isCollapsed}
             onClick={onMobileClose}
-            badge={item.to === "/messages" ? messagesUnread : undefined}
+            badge={
+              item.to === "/messages"
+                ? messagesUnread
+                : item.to === "/polls"
+                  ? openPolls
+                  : undefined
+            }
           />
         ))}
         {user?.is_admin &&


### PR DESCRIPTION
Two pieces of the usage-limits rework (see `../sheaf-design-docs/usage-limits-and-tiers.md`), bundled to save a PR cycle.

**Journal + edit-history volume metrics** - the same preserve-by-count lens as the front-volume metrics, to ground the journal-revision retention decision (shifting it from age-based to count-based) in real usage instead of assumption:
- `sheaf_journal_entries_total` + `sheaf_systems_by_journal_entry_count{le}` + `sheaf_system_journal_entry_count_max` (journal entries per system).
- `sheaf_content_revisions_total` + `sheaf_targets_by_revision_count{le}` + `sheaf_target_revision_count_max` (revisions per target - the most-revised single journal entry / member bio / message, i.e. the save-spam outlier signal that the count cap will key on).
- `sheaf_content_revisions_created_total` (live edit velocity; imports excluded).

The distributions are label-less snapshot cumulative gauges set in the existing background gauge refresher (one grouped query each), carrying no per-account id - same shape and rationale as `sheaf_systems_by_front_count`. The counter increments on the live `journals.create_revision` path only.

**Active-poll nav badge** - a count bubble on the Polls nav item when one or more polls are open, so an active poll (a system decision) is something every headmate notices. Reuses the existing messages-unread nav-badge component; "open" is `!is_closed`, matching the polls page exactly (server's notion of closed), with a 60s refetch.

Operator-facing only on the backend (no API/schema/migration change); the badge is the only user-visible change. Closes #381; advances the limits rework.

Verification: ruff clean; import smoke clean; journals + revision-pinning + revision-retention + fronts suites pass (61) against a rebuilt stack (exercises the revision-create counter path); `docs/METRICS.md` updated with a scrape-presence test (runs in the metrics CI config). Frontend tsc + eslint + build green.