### PR TITLE
Clamp imported data to schema limits, warn before truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Security
+
+- **Importers clamp imported data to the same limits the API enforces.** Importers build database rows directly and so used to bypass the length and count limits the normal create/update endpoints apply, letting a crafted (or just messy) export land an over-length member name, a 50k-character note, or a custom field with thousands of choices. Every importer (Sheaf native and the export-with-images archive, OpenPlural, PluralKit/Octocon, Tupperbox, SimplyPlural, PluralSpace, Prism) now routes user-content fields through one shared clamp that truncates to the schema cap and bounds list counts (poll options, custom-field choices). This also fixed a latent crash in the Prism importer, where a member birthday longer than 10 characters would error the whole import on the database write, and an uncapped poll-option list in the PluralSpace importer.
+
 ### Added
+
+- **Import preview warns before anything is shortened.** The import preview now tells you up front when imported data exceeds Sheaf's limits (for example "3 member names will be shortened to 100 characters" or "1 poll's option list will be trimmed to 20 entries"), so you can continue or cancel and adjust the source first rather than discovering the truncation after the fact. The same shortening is also recorded in the import job's event log.
 
 - **Active-poll badge.** The Polls nav item now shows a count badge when one or more polls are open, so an active poll is something every headmate notices (it is a system decision worth seeing).
 

--- a/sheaf/api/v1/openplural_import.py
+++ b/sheaf/api/v1/openplural_import.py
@@ -46,6 +46,7 @@ def _summary_dict(p: SheafPreviewSummary) -> dict:
         "poll_count": p.poll_count,
         "reminder_count": p.reminder_count,
         "channel_count": p.channel_count,
+        "limit_warnings": p.limit_warnings,
     }
 
 

--- a/sheaf/api/v1/sheaf_import.py
+++ b/sheaf/api/v1/sheaf_import.py
@@ -72,6 +72,7 @@ def _summary_dict(p: SheafPreviewSummary) -> dict:
         "poll_count": p.poll_count,
         "reminder_count": p.reminder_count,
         "channel_count": p.channel_count,
+        "limit_warnings": p.limit_warnings,
     }
 
 

--- a/sheaf/schemas/pk_import.py
+++ b/sheaf/schemas/pk_import.py
@@ -66,6 +66,7 @@ class PKPreviewSummary(BaseModel):
     switch_count: int = 0
     earliest_switch: datetime | None = None
     latest_switch: datetime | None = None
+    limit_warnings: list[str] = []
 
 
 class PKImportResult(BaseModel):

--- a/sheaf/schemas/pluralspace_import.py
+++ b/sheaf/schemas/pluralspace_import.py
@@ -75,6 +75,10 @@ class PluralspacePreviewSummary(BaseModel):
     thought_count: int = 0
     media_file_count: int = 0
 
+    # Business-cap predictions: fields the import would shorten/trim to the
+    # schema limits, surfaced so the user can decide before enqueueing.
+    limit_warnings: list[str] = Field(default_factory=list)
+
 
 class PluralspaceImportResult(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/sheaf/schemas/prism_import.py
+++ b/sheaf/schemas/prism_import.py
@@ -80,6 +80,8 @@ class PrismPreviewSummary(BaseModel):
     media_attachment_count: int = 0
     media_blob_count: int = 0
 
+    limit_warnings: list[str] = Field(default_factory=list)
+
 
 class PrismImportResult(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/sheaf/schemas/sp_import.py
+++ b/sheaf/schemas/sp_import.py
@@ -46,6 +46,7 @@ class SPPreviewSummary(BaseModel):
     custom_field_count: int = 0
     note_count: int = 0
     message_count: int = 0
+    limit_warnings: list[str] = []
 
 
 class SPImportResult(BaseModel):

--- a/sheaf/schemas/tb_import.py
+++ b/sheaf/schemas/tb_import.py
@@ -40,6 +40,10 @@ class TBPreviewSummary(BaseModel):
     member_count: int = 0
     members: list[TBPreviewMember] = []
     group_count: int = 0
+    # Fields that exceed the schema caps and would be shortened on import
+    # (so the user can cancel or continue). Mirrors what run_import's clamp
+    # pass would record.
+    limit_warnings: list[str] = []
 
 
 class TBImportResult(BaseModel):

--- a/sheaf/services/import_limits.py
+++ b/sheaf/services/import_limits.py
@@ -1,0 +1,164 @@
+"""Business-cap clamping for importers.
+
+Importers build ORM rows directly from uploaded files, so they bypass the
+Pydantic ``max_length`` / count validation the create API enforces. Without a
+guard, a crafted (or just messy) export can land a 50k-char member note or a
+custom field with 10,000 choices straight in the DB. Every importer routes its
+user-content fields through the helpers here so over-cap values can never be
+stored - the clamp is unconditional, a security backstop that holds even if the
+preview warning below is missed.
+
+The two functions also tally what they touched into a :class:`ClampReport`. The
+preview endpoints run the *same* helpers over the parsed payload (discarding the
+returned values) to predict, before the import runs, exactly what would be
+shortened - so the user gets a "3 member names will be shortened" warning and
+can cancel or continue. Because preview and the real import call the identical
+helper with the identical :class:`Cap`, the warning matches the clamp.
+
+The caps mirror ``sheaf/schemas/*.py``. When a schema cap changes, change the
+matching :class:`Cap` here too. (A model/schema/import cap-parity test is
+planned as the mechanical backstop; until it lands, keep these in sync by hand.)
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import NamedTuple
+
+
+class Cap(NamedTuple):
+    """A named length/count limit. Pairing the user-facing label with the
+    numeric limit means a call site can't accidentally apply one field's limit
+    under another's label - the two always travel together."""
+
+    label: str
+    limit: int
+
+
+# --- Member -----------------------------------------------------------------
+# Mirrors sheaf/schemas/member.py.
+M_NAME = Cap("member name", 100)
+M_DISPLAY_NAME = Cap("member display name", 100)
+M_PRONOUNS = Cap("member pronouns", 100)
+M_NOTE = Cap("member note", 5000)
+M_AVATAR_URL = Cap("member avatar URL", 500)
+M_BANNER_URL = Cap("member banner URL", 500)
+M_COLOR = Cap("member color", 7)
+M_BIRTHDAY = Cap("member birthday", 10)
+M_PLURALKIT_ID = Cap("member PluralKit ID", 8)
+M_EMOJI = Cap("member emoji", 8)
+
+# --- System -----------------------------------------------------------------
+# Mirrors sheaf/schemas/system.py.
+SYS_NAME = Cap("system name", 100)
+SYS_NOTE = Cap("system note", 5000)
+SYS_TAG = Cap("system tag", 8)
+SYS_AVATAR_URL = Cap("system avatar URL", 500)
+SYS_COLOR = Cap("system color", 7)
+
+# --- Group / tag ------------------------------------------------------------
+# Mirrors sheaf/schemas/group.py and sheaf/schemas/tag.py.
+GROUP_NAME = Cap("group name", 100)
+GROUP_COLOR = Cap("group color", 7)
+TAG_NAME = Cap("tag name", 50)
+TAG_COLOR = Cap("tag color", 7)
+
+# --- Custom fields ----------------------------------------------------------
+# Mirrors sheaf/schemas/custom_field.py (_MAX_CHOICES_PER_FIELD /
+# _MAX_CHOICE_LENGTH).
+CF_NAME = Cap("custom field name", 100)
+CF_CHOICE = Cap("custom field choice", 100)
+CF_CHOICES_COUNT = Cap("custom field's choice list", 100)
+
+# --- Journal / message / poll / reminder ------------------------------------
+JOURNAL_TITLE = Cap("journal title", 200)
+MESSAGE_BODY = Cap("message", 5000)
+POLL_QUESTION = Cap("poll question", 500)
+POLL_DESCRIPTION = Cap("poll description", 2000)
+POLL_OPTION = Cap("poll option", 200)
+POLL_OPTIONS_COUNT = Cap("poll's option list", 20)
+REMINDER_NAME = Cap("reminder name", 120)
+REMINDER_TITLE = Cap("reminder title", 500)
+REMINDER_BODY = Cap("reminder body", 2000)
+
+
+@dataclass
+class ClampReport:
+    """Accumulates which caps a clamp pass actually hit.
+
+    Shared currency between the import run (where it feeds the job's warning
+    events) and the preview (where :meth:`to_warnings` becomes the
+    ``limit_warnings`` the user sees before deciding to proceed). A report with
+    nothing recorded is :attr:`empty` and produces no warnings.
+    """
+
+    _str_hits: Counter[Cap] = field(default_factory=Counter)
+    _list_hits: Counter[Cap] = field(default_factory=Counter)
+
+    def record_str(self, cap: Cap) -> None:
+        self._str_hits[cap] += 1
+
+    def record_list(self, cap: Cap) -> None:
+        self._list_hits[cap] += 1
+
+    @property
+    def empty(self) -> bool:
+        return not self._str_hits and not self._list_hits
+
+    def to_warnings(self) -> list[str]:
+        """Render the tally as user-facing sentences, deterministically ordered.
+
+        One line per distinct field that was clamped, e.g.::
+
+            3 member names will be shortened to 100 characters
+            1 custom field's choice list will be trimmed to 100 entries
+        """
+        lines: list[str] = []
+        for cap, n in sorted(self._str_hits.items(), key=lambda kv: kv[0].label):
+            noun = cap.label if n == 1 else f"{cap.label}s"
+            lines.append(
+                f"{n} {noun} will be shortened to {cap.limit} characters"
+            )
+        for cap, n in sorted(self._list_hits.items(), key=lambda kv: kv[0].label):
+            noun = cap.label if n == 1 else f"{cap.label}s"
+            lines.append(
+                f"{n} {noun} will be trimmed to {cap.limit} entries"
+            )
+        return lines
+
+
+def clamp_str(
+    value: str | None, cap: Cap, *, report: ClampReport | None = None
+) -> str | None:
+    """Truncate ``value`` to ``cap.limit`` characters, tallying if it had to.
+
+    ``None`` passes through untouched. Pass a ``report`` to record the hit (the
+    import run and the preview both do); omit it for a silent clamp of a field
+    that isn't worth surfacing to the user.
+    """
+    if value is None:
+        return None
+    if len(value) > cap.limit:
+        if report is not None:
+            report.record_str(cap)
+        return value[: cap.limit]
+    return value
+
+
+def clamp_list[T](
+    items: list[T] | None, cap: Cap, *, report: ClampReport | None = None
+) -> list[T] | None:
+    """Cap ``items`` to ``cap.limit`` entries, tallying if it had to.
+
+    ``None`` passes through. Keeps the leading ``cap.limit`` entries (the
+    create API rejects the whole over-cap list; for an import we keep what fits
+    rather than drop the record entirely).
+    """
+    if items is None:
+        return None
+    if len(items) > cap.limit:
+        if report is not None:
+            report.record_list(cap)
+        return items[: cap.limit]
+    return items

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -42,6 +42,7 @@ from sheaf.schemas.pk_import import (
     PKPreviewMember,
     PKPreviewSummary,
 )
+from sheaf.services import import_limits as il
 from sheaf.services.import_content_dedup import (
     ContentMatchIndex,
     PairGuard,
@@ -52,6 +53,7 @@ from sheaf.services.import_content_dedup import (
     normalize_front_interval,
 )
 from sheaf.services.import_dedup import ImportConflictStrategy
+from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_parsing import sanitize_external_avatar_url
 
 logger = logging.getLogger("sheaf.import.pk")
@@ -78,6 +80,39 @@ def _parse_iso(value: Any) -> datetime | None:
         return None
 
 
+def measure_pk_payload(data: dict, report: ClampReport) -> None:
+    """Tally which PK-shaped fields exceed the schema caps, into ``report``.
+
+    Reads the same PK keys the import path clamps, calling the same
+    ``clamp_str`` helpers, so the preview's warnings match what the import
+    would shorten. Octocon exports route through this importer too, so they
+    inherit this prediction. Defensive: only string values are measured, so a
+    malformed upload can't raise here.
+    """
+
+    def s(value: object, cap: il.Cap) -> None:
+        if isinstance(value, str):
+            clamp_str(value, cap, report=report)
+
+    # System profile (only filled in when the Sheaf-side field is empty, but
+    # we measure unconditionally - the user can't tell from the preview which
+    # fields are already set, and over-measuring is harmless here).
+    s(data.get("name"), il.SYS_NAME)
+    s(data.get("tag"), il.SYS_TAG)
+
+    for m in get_list(data, "members"):
+        if not isinstance(m, dict):
+            continue
+        s(m.get("name"), il.M_NAME)
+        s(m.get("display_name"), il.M_DISPLAY_NAME)
+        s(m.get("pronouns"), il.M_PRONOUNS)
+        s(m.get("id"), il.M_PLURALKIT_ID)
+
+    for g in get_list(data, "groups"):
+        if isinstance(g, dict):
+            s(g.get("name"), il.GROUP_NAME)
+
+
 def preview(data: dict, *, switch_count_override: int | None = None) -> PKPreviewSummary:
     """Summarise a PK export for the user before they confirm the import.
 
@@ -91,6 +126,9 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
 
     timestamps = [_parse_iso(s.get("timestamp")) for s in switches]
     timestamps = [t for t in timestamps if t is not None]
+
+    report = ClampReport()
+    measure_pk_payload(data, report)
 
     return PKPreviewSummary(
         system_name=_clean_str(data.get("name")),
@@ -107,6 +145,7 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
         switch_count=switch_count_override if switch_count_override is not None else len(switches),
         earliest_switch=min(timestamps) if timestamps else None,
         latest_switch=max(timestamps) if timestamps else None,
+        limit_warnings=report.to_warnings(),
     )
 
 
@@ -120,7 +159,7 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
 # --- System profile ----------------------------------------------------------
 
 
-def apply_system_profile(data: dict, system: System) -> None:
+def apply_system_profile(data: dict, system: System, *, report: ClampReport) -> None:
     """Copy a few non-destructive fields from the PK system onto Sheaf's.
 
     We never overwrite a name the user has already set (their Sheaf system
@@ -133,10 +172,10 @@ def apply_system_profile(data: dict, system: System) -> None:
     """
     name = _clean_str(data.get("name"))
     if name and not system.name:
-        system.name = name[:100]
+        system.name = clamp_str(name, il.SYS_NAME, report=report)
     tag = _clean_str(data.get("tag"))
     if tag and not system.tag:
-        system.tag = tag[:8]
+        system.tag = clamp_str(tag, il.SYS_TAG, report=report)
     color = _normalize_color(data.get("color"))
     if color and not system.color:
         system.color = color
@@ -150,16 +189,18 @@ def apply_system_profile(data: dict, system: System) -> None:
 # --- Members -----------------------------------------------------------------
 
 
-def build_member(pk_m: dict, system_id: uuid.UUID) -> Member | None:
+def build_member(
+    pk_m: dict, system_id: uuid.UUID, *, report: ClampReport
+) -> Member | None:
     """Construct a Sheaf Member from a PK member object.
 
     Returns None if the source row lacks a usable name. Encryption,
-    blind-index, length truncation, and HID truncation all live here.
+    blind-index, length clamping, and HID clamping all live here.
     """
     plaintext_name = _clean_str(pk_m.get("name"))
     if not plaintext_name:
         return None
-    plaintext_name = plaintext_name[:100]
+    plaintext_name = clamp_str(plaintext_name, il.M_NAME, report=report)
     plaintext_description = _clean_str(pk_m.get("description"))
 
     pk_hid = _clean_str(pk_m.get("id"))
@@ -169,13 +210,17 @@ def build_member(pk_m: dict, system_id: uuid.UUID) -> Member | None:
         system_id=system_id,
         name=encrypt(plaintext_name),
         name_hash=blind_index(plaintext_name),
-        display_name=_truncate(_clean_str(pk_m.get("display_name")), 100),
+        display_name=clamp_str(
+            _clean_str(pk_m.get("display_name")), il.M_DISPLAY_NAME, report=report
+        ),
         description=encrypt(plaintext_description) if plaintext_description else None,
-        pronouns=_truncate(_clean_str(pk_m.get("pronouns")), 100),
+        pronouns=clamp_str(
+            _clean_str(pk_m.get("pronouns")), il.M_PRONOUNS, report=report
+        ),
         avatar_url=sanitize_external_avatar_url(_clean_str(pk_m.get("avatar_url"))),
         color=_normalize_color(pk_m.get("color")),
         birthday=_normalize_birthday(pk_m.get("birthday")),
-        pluralkit_id=_truncate(pk_hid, _PKID_MAX_LEN),
+        pluralkit_id=clamp_str(pk_hid, il.M_PLURALKIT_ID, report=report),
         privacy=_map_privacy(pk_m.get("privacy")),
     )
 
@@ -190,6 +235,7 @@ async def import_groups(
     db: AsyncSession,
     *,
     conflict_strategy: ImportConflictStrategy = ImportConflictStrategy.CREATE,
+    report: ClampReport,
 ) -> tuple[int, int]:
     """Create Sheaf Groups from PK groups and wire member associations.
 
@@ -213,7 +259,7 @@ async def import_groups(
         name = _clean_str(pk_g.get("name"))
         if not name:
             continue
-        name = name[:100]
+        name = clamp_str(name, il.GROUP_NAME, report=report)
         existing = group_index.get(name) if dedupe else None
         if existing is not None:
             sheaf_groups.append((pk_g, existing))
@@ -392,12 +438,6 @@ def _clean_str(value: Any) -> str | None:
         value = str(value)
     value = value.strip()
     return value or None
-
-
-def _truncate(value: str | None, max_len: int) -> str | None:
-    if value is None:
-        return None
-    return value[:max_len]
 
 
 def _normalize_color(value: Any) -> str | None:

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -30,6 +30,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_limits import ClampReport
 from sheaf.services.import_parsing import (
     ImportPayloadError,
     expect_dict,
@@ -76,8 +77,14 @@ async def _process_pk_export(
     """
     system = await load_user_system(db, job.user_id)
 
+    # Tally any field/list the import clamps to its schema cap, so the user
+    # gets a "N member names were shortened" warning in the job event log
+    # (matching the warn-before-import preview prediction). Threaded through
+    # every section helper that constructs a row.
+    report = ClampReport()
+
     if options.system_profile:
-        apply_system_profile(parsed, system)
+        apply_system_profile(parsed, system, report=report)
         append_event(
             job,
             level="info",
@@ -103,7 +110,7 @@ async def _process_pk_export(
         # with the HID so the user can see what got skipped.
         hid_for_event = pk_m.get("id") if isinstance(pk_m, dict) else None
         try:
-            member = build_member(pk_m, system.id)
+            member = build_member(pk_m, system.id, report=report)
         except Exception as exc:
             update_counts(job, members_failed=1)
             append_event(
@@ -167,6 +174,7 @@ async def _process_pk_export(
                 hid_to_member,
                 db,
                 conflict_strategy=options.conflict_strategy,
+                report=report,
             )
             update_counts(job, groups_imported=count, groups_skipped=group_skipped)
             append_event(
@@ -216,6 +224,13 @@ async def _process_pk_export(
                 message=f"switch import failed: {exc!s}"[:500],
             )
             raise
+
+    # --- Clamp warnings --------------------------------------------------
+
+    # Surface any field/list that hit a schema cap during this run. One event
+    # per distinct clamped field, e.g. "3 member names will be shortened ...".
+    for warning in report.to_warnings():
+        append_event(job, level="warning", stage="limits", message=warning)
 
 
 async def handle_pluralkit_file(job: ImportJob, db: AsyncSession) -> None:

--- a/sheaf/services/pluralspace_import.py
+++ b/sheaf/services/pluralspace_import.py
@@ -96,6 +96,7 @@ from sheaf.schemas.pluralspace_import import (
     PluralspacePreviewMember,
     PluralspacePreviewSummary,
 )
+from sheaf.services import import_limits as il
 from sheaf.services.custom_fields import encrypt_field_value
 from sheaf.services.import_content_dedup import (
     ContentMatchIndex,
@@ -115,6 +116,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_limits import ClampReport, clamp_list, clamp_str
 from sheaf.services.import_media import (
     ImportImageError,
     store_imported_image,
@@ -248,6 +250,59 @@ async def parse_export_async(blob: bytes) -> _ParsedExport:
 # --- Preview ---------------------------------------------------------------
 
 
+def measure_export(data: dict, report: ClampReport) -> None:
+    """Tally which PluralSpace fields exceed the business caps, into ``report``.
+
+    Reads the same keys ``run_import`` clamps, with PluralSpace's own key names,
+    calling the same helpers so the preview's warnings match what the import
+    would shorten. Defensive: only string values are measured, so a malformed
+    upload can't raise here.
+    """
+
+    def s(value: object, cap: il.Cap) -> None:
+        if isinstance(value, str):
+            clamp_str(value, cap, report=report)
+
+    sys_data = data.get("system")
+    if isinstance(sys_data, dict):
+        s(sys_data.get("name"), il.SYS_NAME)
+
+    for m in _list(data.get("members")):
+        if not isinstance(m, dict):
+            continue
+        s(m.get("name"), il.M_NAME)
+        s(m.get("display_name"), il.M_DISPLAY_NAME)
+        s(m.get("pronouns"), il.M_PRONOUNS)
+        for role in _list(m.get("role")):
+            s(role, il.TAG_NAME)
+
+    for g in _list(data.get("member_groups")):
+        if isinstance(g, dict):
+            s(g.get("name"), il.GROUP_NAME)
+
+    for fd in _list(data.get("custom_fields")):
+        if isinstance(fd, dict):
+            s(fd.get("name"), il.CF_NAME)
+
+    for p in _list(data.get("polls")):
+        if not isinstance(p, dict):
+            continue
+        s(p.get("title"), il.POLL_QUESTION)
+        s(p.get("description"), il.POLL_DESCRIPTION)
+        options = _list(p.get("options"))
+        clamp_list(options, il.POLL_OPTIONS_COUNT, report=report)
+        for o in options:
+            if isinstance(o, dict):
+                s(o.get("text"), il.POLL_OPTION)
+
+    for channel in _list(data.get("chat_channels")):
+        if not isinstance(channel, dict):
+            continue
+        for msg in _list(channel.get("messages")):
+            if isinstance(msg, dict):
+                s(msg.get("content"), il.MESSAGE_BODY)
+
+
 def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
     """Walk the parsed export and return a counts + member-list summary.
 
@@ -289,6 +344,9 @@ def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
     sys_block = data.get("system") if isinstance(data.get("system"), dict) else {}
     sys_name = _clean_str(sys_block.get("name")) or _clean_str(manifest.get("system_name"))
 
+    report = ClampReport()
+    measure_export(data, report)
+
     return PluralspacePreviewSummary(
         system_name=sys_name,
         format_version=_clean_str(manifest.get("format_version")),
@@ -305,6 +363,7 @@ def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
         poll_count=len(_list(data.get("polls"))),
         thought_count=len(_list(data.get("thoughts"))),
         media_file_count=len(parsed.media_paths),
+        limit_warnings=report.to_warnings(),
     )
 
 
@@ -338,10 +397,11 @@ async def run_import(
     """
     result = PluralspaceImportResult()
     data = parsed.data
+    report = ClampReport()
 
     # --- System profile ----
     if system_profile:
-        _apply_system_profile(data, system)
+        _apply_system_profile(data, system, report)
 
     # --- Members (regular + custom fronts) ----
     selected = set(member_ids) if member_ids is not None else None
@@ -372,18 +432,29 @@ async def run_import(
         ps_id = _clean_str(m_data.get("id"))
         is_cf = bool(m_data.get("is_custom_front"))
 
-        plaintext_name = (_clean_str(m_data.get("name")) or "unnamed")[:100]
+        plaintext_name = clamp_str(
+            _clean_str(m_data.get("name")) or "unnamed", il.M_NAME, report=report
+        )
+        # member `description` (the bio, encrypted Text) is intentionally
+        # uncapped, matching the create API; only `note` carries M_NOTE and
+        # PluralSpace exports have no note-equivalent field to map.
         plaintext_description = _clean_str(m_data.get("description"))
         member = Member(
             id=uuid.uuid4(),
             system_id=system.id,
             name=encrypt(plaintext_name),
             name_hash=blind_index(plaintext_name),
-            display_name=_truncate(_clean_str(m_data.get("display_name")), 100),
+            display_name=clamp_str(
+                _clean_str(m_data.get("display_name")),
+                il.M_DISPLAY_NAME,
+                report=report,
+            ),
             description=(
                 encrypt(plaintext_description) if plaintext_description else None
             ),
-            pronouns=_truncate(_clean_str(m_data.get("pronouns")), 100),
+            pronouns=clamp_str(
+                _clean_str(m_data.get("pronouns")), il.M_PRONOUNS, report=report
+            ),
             color=_normalize_color(m_data.get("color")),
             is_custom_front=is_cf,
             privacy=PrivacyLevel.PRIVATE,
@@ -466,7 +537,7 @@ async def run_import(
     # --- Roles -> tags ----
     if roles_as_tags:
         result.tags_imported += await _import_roles_as_tags(
-            members_in, ps_id_to_member, system.id, db
+            members_in, ps_id_to_member, system.id, db, report
         )
 
     # --- Groups ----
@@ -478,6 +549,7 @@ async def run_import(
             system.id,
             db,
             result.warnings,
+            report,
         )
 
     # --- Custom fields ----
@@ -489,6 +561,7 @@ async def run_import(
             system.id,
             db,
             result.warnings,
+            report,
         )
 
     # Content dedup is active under skip/update; CREATE keeps the old
@@ -530,6 +603,7 @@ async def run_import(
             system.id,
             db,
             result.warnings,
+            report,
             dedupe=content_dedupe,
         )
         result.messages_imported += m_imported
@@ -544,6 +618,7 @@ async def run_import(
             system.id,
             db,
             result.warnings,
+            report,
             dedupe=content_dedupe,
         )
         result.polls_imported += p_imported
@@ -557,13 +632,14 @@ async def run_import(
             "thoughts-feature equivalent yet."
         )
 
+    result.warnings = result.warnings + report.to_warnings()
     return result
 
 
 # --- Section helpers -------------------------------------------------------
 
 
-def _apply_system_profile(data: dict, system: System) -> None:
+def _apply_system_profile(data: dict, system: System, report: ClampReport) -> None:
     """Copy non-destructive system fields onto Sheaf's system.
 
     Only fills empty Sheaf fields. Never overwrites a user-set name.
@@ -573,9 +649,12 @@ def _apply_system_profile(data: dict, system: System) -> None:
         return
     name = _clean_str(sys_data.get("name"))
     if name and not system.name:
-        system.name = name[:100]
+        system.name = clamp_str(name, il.SYS_NAME, report=report)
     description = _clean_str(sys_data.get("description"))
     if description and not system.description:
+        # System description (the long bio) is intentionally uncapped, like the
+        # create API; only `note` carries the SYS_NOTE business cap and
+        # PluralSpace has no note-equivalent to map here.
         system.description = description
     color = _normalize_color(sys_data.get("color"))
     if color and not system.color:
@@ -587,6 +666,7 @@ async def _import_roles_as_tags(
     ps_id_to_member: dict[str, Member],
     system_id: uuid.UUID,
     db: AsyncSession,
+    report: ClampReport,
 ) -> int:
     """Create one Tag per distinct PluralSpace role and wire memberships.
 
@@ -618,7 +698,7 @@ async def _import_roles_as_tags(
                 tag = Tag(
                     id=uuid.uuid4(),
                     system_id=system_id,
-                    name=role_str[:50],
+                    name=clamp_str(role_str, il.TAG_NAME, report=report),
                 )
                 db.add(tag)
                 tag_by_name[key] = tag
@@ -653,6 +733,7 @@ async def _import_groups(
     system_id: uuid.UUID,
     db: AsyncSession,
     warnings: list[str],
+    report: ClampReport,
 ) -> int:
     """Create Sheaf Groups from PluralSpace member_groups + members[].groups[].
 
@@ -684,7 +765,7 @@ async def _import_groups(
             group = Group(
                 id=uuid.uuid4(),
                 system_id=system_id,
-                name=name[:100],
+                name=clamp_str(name, il.GROUP_NAME, report=report),
                 description=_clean_str(g_data.get("description")),
                 color=_normalize_color(g_data.get("color")),
             )
@@ -718,7 +799,7 @@ async def _import_groups(
                 group = Group(
                     id=uuid.uuid4(),
                     system_id=system_id,
-                    name=name[:100],
+                    name=clamp_str(name, il.GROUP_NAME, report=report),
                 )
                 db.add(group)
                 name_to_group[key] = group
@@ -777,6 +858,7 @@ async def _import_custom_fields(
     system_id: uuid.UUID,
     db: AsyncSession,
     warnings: list[str],
+    report: ClampReport,
 ) -> int:
     """Create Sheaf custom-field definitions + per-member values.
 
@@ -814,7 +896,7 @@ async def _import_custom_fields(
             field_def = CustomFieldDefinition(
                 id=uuid.uuid4(),
                 system_id=system_id,
-                name=name[:100],
+                name=clamp_str(name, il.CF_NAME, report=report),
                 field_type=ftype,
                 privacy=PrivacyLevel.PRIVATE,
             )
@@ -1063,6 +1145,7 @@ async def _import_chat(
     system_id: uuid.UUID,
     db: AsyncSession,
     warnings: list[str],
+    report: ClampReport,
     *,
     dedupe: bool = False,
 ) -> tuple[int, int]:
@@ -1109,6 +1192,7 @@ async def _import_chat(
             body = _clean_str(msg.get("content")) or ""
             if multi_channel:
                 body = f"[{channel_name}] {body}".rstrip()
+            body = clamp_str(body, il.MESSAGE_BODY, report=report)
             author_name = _clean_str(msg.get("member_name"))
             author = member_name_to_member.get(author_name) if author_name else None
             if author_name and author is None:
@@ -1140,6 +1224,7 @@ async def _import_polls(
     system_id: uuid.UUID,
     db: AsyncSession,
     warnings: list[str],
+    report: ClampReport,
     *,
     dedupe: bool = False,
 ) -> tuple[int, int]:
@@ -1164,8 +1249,12 @@ async def _import_polls(
     for p_data in polls_in:
         if not isinstance(p_data, dict):
             continue
-        question = _clean_str(p_data.get("title")) or ""
-        description = _clean_str(p_data.get("description"))
+        question = clamp_str(
+            _clean_str(p_data.get("title")) or "", il.POLL_QUESTION, report=report
+        )
+        description = clamp_str(
+            _clean_str(p_data.get("description")), il.POLL_DESCRIPTION, report=report
+        )
         allow_multi = bool(p_data.get("allows_multiple_votes"))
         created_at = _parse_iso(p_data.get("created_at"))
         if dedupe and created_at is not None:
@@ -1200,13 +1289,22 @@ async def _import_polls(
         # Build options + invert option-keyed votes into voter-keyed.
         option_rows: list[tuple[str, PollOption]] = []
         voter_to_options: dict[uuid.UUID, list[uuid.UUID]] = {}
-        for position, o_data in enumerate(_list(p_data.get("options"))):
+        options_in = clamp_list(
+            _list(p_data.get("options")), il.POLL_OPTIONS_COUNT, report=report
+        )
+        for position, o_data in enumerate(options_in):
             if not isinstance(o_data, dict):
                 continue
             option = PollOption(
                 id=uuid.uuid4(),
                 poll_id=poll.id,
-                text=encrypt(_clean_str(o_data.get("text")) or ""),
+                text=encrypt(
+                    clamp_str(
+                        _clean_str(o_data.get("text")) or "",
+                        il.POLL_OPTION,
+                        report=report,
+                    )
+                ),
                 position=position,
             )
             db.add(option)
@@ -1325,12 +1423,6 @@ def _clean_str(value: Any) -> str | None:
         value = str(value)
     value = value.strip()
     return value or None
-
-
-def _truncate(value: str | None, max_len: int) -> str | None:
-    if value is None:
-        return None
-    return value[:max_len]
 
 
 def _normalize_color(value: Any) -> str | None:

--- a/sheaf/services/prism_import.py
+++ b/sheaf/services/prism_import.py
@@ -100,6 +100,7 @@ from sheaf.schemas.prism_import import (
     PrismPreviewMember,
     PrismPreviewSummary,
 )
+from sheaf.services import import_limits as il
 from sheaf.services.custom_fields import encrypt_field_value
 from sheaf.services.import_content_dedup import (
     ContentMatchIndex,
@@ -120,6 +121,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_media import (
     ImportImageError,
     store_imported_image,
@@ -190,6 +192,45 @@ async def parse_envelope_bytes_async(blob: bytes, passphrase: str) -> ParsedPris
 # --- Preview ---------------------------------------------------------------
 
 
+def _measure_prism_payload(data: dict, report: ClampReport) -> None:
+    """Tally which Prism fields/lists exceed the schema caps, into ``report``.
+
+    Reads the same Prism keys ``run_import`` clamps, calling the same helpers,
+    so the preview's warnings match what the import would shorten. Defensive:
+    only string values are measured and only list shapes are counted, so a
+    malformed upload can't raise here.
+    """
+
+    def s(value: object, cap: il.Cap) -> None:
+        if isinstance(value, str):
+            clamp_str(value, cap, report=report)
+
+    settings_arr = _list(data.get("systemSettings"))
+    if settings_arr and isinstance(settings_arr[0], dict):
+        s(settings_arr[0].get("systemName"), il.SYS_NAME)
+
+    for m in _list(data.get("headmates")):
+        if not isinstance(m, dict):
+            continue
+        s(m.get("name"), il.M_NAME)
+        s(m.get("displayName"), il.M_DISPLAY_NAME)
+        s(m.get("pluralkitDisplayName"), il.M_DISPLAY_NAME)
+        s(m.get("pronouns"), il.M_PRONOUNS)
+        s(m.get("birthday"), il.M_BIRTHDAY)
+        s(m.get("pluralkitId"), il.M_PLURALKIT_ID)
+        s(m.get("emoji"), il.M_EMOJI)
+
+    for g in _list(data.get("memberGroups")):
+        if not isinstance(g, dict):
+            continue
+        s(g.get("name"), il.GROUP_NAME)
+
+    for f in _list(data.get("customFields")):
+        if not isinstance(f, dict):
+            continue
+        s(f.get("name"), il.CF_NAME)
+
+
 def preview(parsed: ParsedPrism) -> PrismPreviewSummary:
     """Walk the decrypted JSON and return counts + member list summary.
 
@@ -219,6 +260,9 @@ def preview(parsed: ParsedPrism) -> PrismPreviewSummary:
     sys_block = sys_block[0] if sys_block and isinstance(sys_block[0], dict) else {}
     sys_name = _clean_str(sys_block.get("systemName"))
 
+    report = ClampReport()
+    _measure_prism_payload(data, report)
+
     return PrismPreviewSummary(
         system_name=sys_name,
         format_version=_clean_str(data.get("formatVersion")),
@@ -240,6 +284,7 @@ def preview(parsed: ParsedPrism) -> PrismPreviewSummary:
         member_board_post_count=len(_list(data.get("memberBoardPosts"))),
         media_attachment_count=len(_list(data.get("mediaAttachments"))),
         media_blob_count=len(parsed.media_blobs),
+        limit_warnings=report.to_warnings(),
     )
 
 
@@ -288,10 +333,11 @@ async def run_import(
     `level=warning, stage=import` event.
     """
     result = PrismImportResult()
+    report = ClampReport()
     data = parsed.data
 
     if system_profile:
-        _apply_system_profile(data, system)
+        _apply_system_profile(data, system, report)
 
     selected = set(member_ids) if member_ids is not None else None
 
@@ -315,7 +361,9 @@ async def run_import(
     candidates: list[tuple[Member, str, str, dict]] = []
     for m in eligible:
         ps_id = _clean_str(m.get("id"))
-        plaintext_name = (_clean_str(m.get("name")) or "unnamed")[:100]
+        plaintext_name = clamp_str(
+            _clean_str(m.get("name")) or "unnamed", il.M_NAME, report=report
+        )
         plaintext_description = _clean_str(m.get("notes"))
         custom_color = _normalize_color(m.get("customColorHex")) if m.get(
             "customColorEnabled"
@@ -328,15 +376,21 @@ async def run_import(
             system_id=system.id,
             name=encrypt(plaintext_name),
             name_hash=blind_index(plaintext_name),
-            display_name=_truncate(display_name, 100),
+            display_name=clamp_str(display_name, il.M_DISPLAY_NAME, report=report),
             description=(
                 encrypt(plaintext_description) if plaintext_description else None
             ),
-            pronouns=_truncate(_clean_str(m.get("pronouns")), 100),
+            pronouns=clamp_str(
+                _clean_str(m.get("pronouns")), il.M_PRONOUNS, report=report
+            ),
             color=custom_color,
-            birthday=_clean_str(m.get("birthday")),
-            pluralkit_id=_truncate(_clean_str(m.get("pluralkitId")), 8),
-            emoji=_truncate(_clean_str(m.get("emoji")), 8),
+            birthday=clamp_str(
+                _clean_str(m.get("birthday")), il.M_BIRTHDAY, report=report
+            ),
+            pluralkit_id=clamp_str(
+                _clean_str(m.get("pluralkitId")), il.M_PLURALKIT_ID, report=report
+            ),
+            emoji=clamp_str(_clean_str(m.get("emoji")), il.M_EMOJI, report=report),
             is_custom_front=False,
             privacy=PrivacyLevel.PRIVATE,
         )
@@ -372,6 +426,7 @@ async def run_import(
         )
 
     if not ps_id_to_handle:
+        result.warnings = result.warnings + report.to_warnings()
         return result
 
     await db.flush()
@@ -419,6 +474,7 @@ async def run_import(
             system.id,
             db,
             result.warnings,
+            report,
         )
 
     if custom_fields:
@@ -429,6 +485,7 @@ async def run_import(
             system.id,
             db,
             result.warnings,
+            report,
         )
         result.custom_fields_imported += cf_imported
         result.custom_field_values_imported += cfv_imported
@@ -545,13 +602,16 @@ async def run_import(
             "equivalent and is preserved when present)."
         )
 
+    result.warnings = result.warnings + report.to_warnings()
     return result
 
 
 # --- Section helpers -------------------------------------------------------
 
 
-def _apply_system_profile(data: dict, system: System) -> None:
+def _apply_system_profile(
+    data: dict, system: System, report: ClampReport
+) -> None:
     """Pull the systemSettings[0] block onto the importing system.
 
     Only fills empty Sheaf fields; never overwrites a name the user
@@ -563,7 +623,7 @@ def _apply_system_profile(data: dict, system: System) -> None:
     block = settings_arr[0]
     name = _clean_str(block.get("systemName"))
     if name and not system.name:
-        system.name = name[:100]
+        system.name = clamp_str(name, il.SYS_NAME, report=report)
     description = _clean_str(block.get("systemDescription"))
     if description and not system.description:
         system.description = description
@@ -581,6 +641,7 @@ async def _import_groups(
     system_id: uuid.UUID,
     db: AsyncSession,
     warnings: list[str],
+    report: ClampReport,
 ) -> int:
     """Create Sheaf Groups + group_members from Prism's two-table model.
 
@@ -603,7 +664,7 @@ async def _import_groups(
             group = Group(
                 id=uuid.uuid4(),
                 system_id=system_id,
-                name=name[:100],
+                name=clamp_str(name, il.GROUP_NAME, report=report),
                 description=_clean_str(g.get("description")),
                 color=_normalize_color(g.get("colorHex")),
             )
@@ -669,6 +730,7 @@ async def _import_custom_fields(
     system_id: uuid.UUID,
     db: AsyncSession,
     warnings: list[str],
+    report: ClampReport,
 ) -> tuple[int, int]:
     """Create Sheaf CustomFieldDefinitions + per-member values.
 
@@ -703,7 +765,7 @@ async def _import_custom_fields(
             field_def = CustomFieldDefinition(
                 id=uuid.uuid4(),
                 system_id=system_id,
-                name=name[:100],
+                name=clamp_str(name, il.CF_NAME, report=report),
                 field_type=ftype,
                 privacy=PrivacyLevel.PRIVATE,
             )
@@ -1373,12 +1435,6 @@ def _clean_str(value: Any) -> str | None:
         value = str(value)
     value = value.strip()
     return value or None
-
-
-def _truncate(value: str | None, max_len: int) -> str | None:
-    if value is None:
-        return None
-    return value[:max_len]
 
 
 def _normalize_color(value: Any) -> str | None:

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -66,6 +66,7 @@ from sheaf.models.reminder import Reminder, reminder_scope_members
 from sheaf.models.system import DateFormat, PrivacyLevel, System
 from sheaf.models.tag import Tag
 from sheaf.models.watch_token import WatchToken
+from sheaf.services import import_limits as il
 from sheaf.services.custom_fields import encrypt_field_value
 from sheaf.services.import_content_dedup import (
     ContentMatchIndex,
@@ -102,6 +103,7 @@ from sheaf.services.import_image_strip import (
     rewrite_internal_image_refs_md,
     rewrite_internal_image_refs_md_to_none,
 )
+from sheaf.services.import_limits import ClampReport, clamp_list, clamp_str
 from sheaf.services.member_limits import enforce_import_member_cap
 
 logger = logging.getLogger("sheaf.import.sheaf")
@@ -181,6 +183,10 @@ class SheafPreviewSummary:
         self.poll_count: int = 0
         self.reminder_count: int = 0
         self.channel_count: int = 0
+        # Fields/lists that exceed the schema caps and would be shortened on
+        # import (so the user can cancel or continue). Mirrors what
+        # run_import's clamp pass would record.
+        self.limit_warnings: list[str] = []
 
 
 class SheafImportResult:
@@ -211,6 +217,99 @@ class SheafImportResult:
         self.warnings: list[str] = []
 
 
+def _as_list(val: object) -> list:
+    return val if isinstance(val, list) else []
+
+
+def measure_native_payload(data: dict, report: ClampReport) -> None:
+    """Tally which fields/lists in a native-shaped payload exceed the schema
+    caps, into ``report`` - the warn-before-import prediction.
+
+    Reads the same keys ``run_import`` clamps, calling the same helpers, so the
+    preview's warnings match what the import would shorten. The archive and
+    OpenPlural importers translate to this shape, so they reuse this for their
+    previews too. Defensive: only string values are measured and only list
+    shapes are counted, so a malformed upload can't raise here.
+    """
+
+    def s(value: object, cap: il.Cap) -> None:
+        if isinstance(value, str):
+            clamp_str(value, cap, report=report)
+
+    sys_data = data.get("system")
+    if isinstance(sys_data, dict):
+        s(sys_data.get("name"), il.SYS_NAME)
+        s(sys_data.get("tag"), il.SYS_TAG)
+        s(sys_data.get("color"), il.SYS_COLOR)
+        s(sys_data.get("avatar_url"), il.SYS_AVATAR_URL)
+        s(sys_data.get("note"), il.SYS_NOTE)
+
+    for m in _as_list(data.get("members")):
+        if not isinstance(m, dict):
+            continue
+        s(m.get("name"), il.M_NAME)
+        s(m.get("display_name"), il.M_DISPLAY_NAME)
+        s(m.get("pronouns"), il.M_PRONOUNS)
+        s(m.get("note"), il.M_NOTE)
+        s(m.get("avatar_url"), il.M_AVATAR_URL)
+        s(m.get("banner_url"), il.M_BANNER_URL)
+        s(m.get("color"), il.M_COLOR)
+        s(m.get("birthday"), il.M_BIRTHDAY)
+        s(m.get("pluralkit_id"), il.M_PLURALKIT_ID)
+        s(m.get("emoji"), il.M_EMOJI)
+
+    for t in _as_list(data.get("tags")):
+        if isinstance(t, dict):
+            s(t.get("name"), il.TAG_NAME)
+            s(t.get("color"), il.TAG_COLOR)
+
+    for g in _as_list(data.get("groups")):
+        if isinstance(g, dict):
+            s(g.get("name"), il.GROUP_NAME)
+            s(g.get("color"), il.GROUP_COLOR)
+
+    for fd in _as_list(data.get("custom_fields")):
+        if not isinstance(fd, dict):
+            continue
+        s(fd.get("name"), il.CF_NAME)
+        options = fd.get("options")
+        if isinstance(options, dict) and isinstance(options.get("choices"), list):
+            choices = options["choices"]
+            clamp_list(choices, il.CF_CHOICES_COUNT, report=report)
+            for c in choices:
+                s(c, il.CF_CHOICE)
+
+    for j in _as_list(data.get("journals")):
+        if isinstance(j, dict):
+            s(j.get("title"), il.JOURNAL_TITLE)
+
+    for r in _as_list(data.get("revisions")):
+        if isinstance(r, dict):
+            s(r.get("title"), il.JOURNAL_TITLE)
+
+    for msg in _as_list(data.get("messages")):
+        if isinstance(msg, dict):
+            s(msg.get("body"), il.MESSAGE_BODY)
+
+    for p in _as_list(data.get("polls")):
+        if not isinstance(p, dict):
+            continue
+        s(p.get("question"), il.POLL_QUESTION)
+        s(p.get("description"), il.POLL_DESCRIPTION)
+        options = p.get("options")
+        if isinstance(options, list):
+            clamp_list(options, il.POLL_OPTIONS_COUNT, report=report)
+            for o in options:
+                if isinstance(o, dict):
+                    s(o.get("text"), il.POLL_OPTION)
+
+    for rm in _as_list(data.get("reminders")):
+        if isinstance(rm, dict):
+            s(rm.get("name"), il.REMINDER_NAME)
+            s(rm.get("title"), il.REMINDER_TITLE)
+            s(rm.get("body"), il.REMINDER_BODY)
+
+
 def preview(data: dict) -> SheafPreviewSummary:
     """Parse Sheaf export JSON and return a summary for user review."""
     summary = SheafPreviewSummary()
@@ -237,6 +336,10 @@ def preview(data: dict) -> SheafPreviewSummary:
     summary.channel_count = sum(
         len(t.get("channels", [])) for t in data.get("watch_tokens", [])
     )
+
+    report = ClampReport()
+    measure_native_payload(data, report)
+    summary.limit_warnings = report.to_warnings()
 
     return summary
 
@@ -306,6 +409,9 @@ async def run_import(
     """
     result = SheafImportResult()
     warnings: list[str] = []
+    # Tally over-cap fields/lists clamped during this run; surfaced as
+    # warnings at the end (the preview shows the same prediction up front).
+    report = ClampReport()
 
     # Image-reference handling, bound once so the call sites below stay
     # one-liners. Empty map == strip mode.
@@ -343,7 +449,7 @@ async def run_import(
         sys_data = data.get("system")
         if sys_data:
             if sys_data.get("name"):
-                system.name = sys_data["name"][:100]
+                system.name = clamp_str(sys_data["name"], il.SYS_NAME, report=report)
             if sys_data.get("description") is not None:
                 # Strip any /v1/files/... image embeds — those keys belong
                 # to the exporting account, not this one.
@@ -351,16 +457,26 @@ async def run_import(
                     sys_data["description"]
                 )
             if sys_data.get("tag") is not None:
-                system.tag = sys_data["tag"][:8] if sys_data["tag"] else None
+                system.tag = (
+                    clamp_str(sys_data["tag"], il.SYS_TAG, report=report)
+                    if sys_data["tag"]
+                    else None
+                )
             if sys_data.get("color") is not None:
-                system.color = sys_data["color"][:7] if sys_data["color"] else None
+                system.color = (
+                    clamp_str(sys_data["color"], il.SYS_COLOR, report=report)
+                    if sys_data["color"]
+                    else None
+                )
             if sys_data.get("privacy"):
                 system.privacy = _privacy(sys_data["privacy"])
             # Notes are encrypted at rest. Empty-string clears (matches the
             # PATCH /systems/me semantics).
             if "note" in sys_data:
-                note_val = _resolve_md_to_none(
-                    sys_data.get("note")
+                note_val = clamp_str(
+                    _resolve_md_to_none(sys_data.get("note")),
+                    il.SYS_NOTE,
+                    report=report,
                 )
                 system.note = encrypt(note_val) if note_val else None
             if sys_data.get("avatar_url") is not None:
@@ -368,8 +484,10 @@ async def run_import(
                 # at the original account's storage; we can't fetch the
                 # bytes, so drop the reference. External URLs (gravatar
                 # etc.) pass through unchanged.
-                system.avatar_url = _trunc(
-                    _resolve_avatar_url(sys_data["avatar_url"]), 500
+                system.avatar_url = clamp_str(
+                    _resolve_avatar_url(sys_data["avatar_url"]),
+                    il.SYS_AVATAR_URL,
+                    report=report,
                 )
             if "replace_fronts_default" in sys_data:
                 system.replace_fronts_default = bool(
@@ -456,7 +574,9 @@ async def run_import(
     candidates: list[tuple[Member, str, set[str]]] = []
     for m_data in export_members:
         old_id = m_data.get("id", "")
-        plaintext_name = (m_data.get("name") or "unnamed")[:100]
+        plaintext_name = clamp_str(
+            m_data.get("name") or "unnamed", il.M_NAME, report=report
+        )
         # Rewrite (or drop) /v1/files/... image refs in the bio + note +
         # avatar. Usage is tracked per-candidate rather than into the
         # shared set: a candidate the dedup pass skips below never
@@ -466,15 +586,21 @@ async def run_import(
         plaintext_description = rewrite_internal_image_refs_md(
             m_data.get("description"), _ikm, member_used
         )
-        plaintext_note = rewrite_internal_image_refs_md_to_none(
-            m_data.get("note"), _ikm, member_used
+        plaintext_note = clamp_str(
+            rewrite_internal_image_refs_md_to_none(
+                m_data.get("note"), _ikm, member_used
+            ),
+            il.M_NOTE,
+            report=report,
         )
         member = Member(
             id=uuid.uuid4(),
             system_id=system.id,
             name=encrypt(plaintext_name),
             name_hash=blind_index(plaintext_name),
-            display_name=_trunc(m_data.get("display_name"), 100),
+            display_name=clamp_str(
+                m_data.get("display_name"), il.M_DISPLAY_NAME, report=report
+            ),
             description=(
                 encrypt(plaintext_description)
                 if plaintext_description is not None
@@ -485,23 +611,31 @@ async def run_import(
                 if plaintext_note
                 else None
             ),
-            pronouns=_trunc(m_data.get("pronouns"), 100),
-            avatar_url=_trunc(
+            pronouns=clamp_str(
+                m_data.get("pronouns"), il.M_PRONOUNS, report=report
+            ),
+            avatar_url=clamp_str(
                 rewrite_internal_avatar_url(
                     m_data.get("avatar_url"), _ikm, member_used
                 ),
-                500,
+                il.M_AVATAR_URL,
+                report=report,
             ),
-            banner_url=_trunc(
+            banner_url=clamp_str(
                 rewrite_internal_avatar_url(
                     m_data.get("banner_url"), _ikm, member_used
                 ),
-                500,
+                il.M_BANNER_URL,
+                report=report,
             ),
-            color=_trunc(m_data.get("color"), 7),
-            birthday=_trunc(m_data.get("birthday"), 10),
-            pluralkit_id=_trunc(m_data.get("pluralkit_id"), 8),
-            emoji=_trunc(m_data.get("emoji"), 8),
+            color=clamp_str(m_data.get("color"), il.M_COLOR, report=report),
+            birthday=clamp_str(
+                m_data.get("birthday"), il.M_BIRTHDAY, report=report
+            ),
+            pluralkit_id=clamp_str(
+                m_data.get("pluralkit_id"), il.M_PLURALKIT_ID, report=report
+            ),
+            emoji=clamp_str(m_data.get("emoji"), il.M_EMOJI, report=report),
             is_custom_front=bool(m_data.get("is_custom_front", False)),
             privacy=_privacy(m_data.get("privacy")),
             quick_switch_pin=_coerce_pin(m_data.get("quick_switch_pin")),
@@ -576,7 +710,7 @@ async def run_import(
         )
         for t_data in data.get("tags", []):
             old_tid = t_data.get("id", "")
-            name = (t_data.get("name") or "unnamed")[:50]
+            name = clamp_str(t_data.get("name") or "unnamed", il.TAG_NAME, report=report)
             existing_tag = tag_index.get(name) if dedupe else None
             if existing_tag is not None:
                 # Same-named tag already in the system: reuse it so the
@@ -588,7 +722,7 @@ async def run_import(
                 id=uuid.uuid4(),
                 system_id=system.id,
                 name=name,
-                color=_trunc(t_data.get("color"), 7),
+                color=clamp_str(t_data.get("color"), il.TAG_COLOR, report=report),
             )
             db.add(tag)
             tag_index.register(name, tag)
@@ -627,7 +761,7 @@ async def run_import(
         field_index = await load_field_def_index(db, system.id)
         for fd_data in data.get("custom_fields", []):
             old_fid = fd_data.get("id", "")
-            name = (fd_data.get("name") or "field")[:100]
+            name = clamp_str(fd_data.get("name") or "field", il.CF_NAME, report=report)
             ftype = _field_type(fd_data.get("field_type"))
             key = (name, ftype.value)
             field_def = field_index.get(key)
@@ -637,7 +771,7 @@ async def run_import(
                     system_id=system.id,
                     name=name,
                     field_type=ftype,
-                    options=fd_data.get("options"),
+                    options=_clamp_field_options(fd_data.get("options"), report),
                     order=fd_data.get("order", 0),
                     privacy=_privacy(fd_data.get("privacy")),
                 )
@@ -686,7 +820,7 @@ async def run_import(
         # First pass: create groups without parent links
         for g_data in export_groups:
             old_gid = g_data.get("id", "")
-            name = (g_data.get("name") or "unnamed")[:100]
+            name = clamp_str(g_data.get("name") or "unnamed", il.GROUP_NAME, report=report)
             existing_group = group_index.get(name) if dedupe else None
             if existing_group is not None:
                 # Reuse the existing same-named group so membership and
@@ -699,7 +833,7 @@ async def run_import(
                 system_id=system.id,
                 name=name,
                 description=_resolve_md(g_data.get("description")),
-                color=_trunc(g_data.get("color"), 7),
+                color=clamp_str(g_data.get("color"), il.GROUP_COLOR, report=report),
             )
             db.add(group)
             group_index.register(name, group)
@@ -839,7 +973,9 @@ async def run_import(
                     old_journal_to_entry[old_jid] = existing_entry
                     result.journals_skipped += 1
                     continue
-            title = j_data.get("title")
+            title = clamp_str(
+                j_data.get("title"), il.JOURNAL_TITLE, report=report
+            )
             entry = JournalEntry(
                 id=uuid.uuid4(),
                 system_id=system.id,
@@ -910,7 +1046,7 @@ async def run_import(
                 result.revisions_skipped += 1
                 continue
             revision_index.register(rkey)
-        title = r_data.get("title")
+        title = clamp_str(r_data.get("title"), il.JOURNAL_TITLE, report=report)
         revision = ContentRevision(
             id=uuid.uuid4(),
             target_type=target_type,
@@ -985,7 +1121,12 @@ async def run_import(
                 board_member_id=board_member.id if board_member else None,
                 author_member_id=author.id if author else None,
                 body=encrypt(
-                    _resolve_md(msg_data.get("body")) or ""
+                    clamp_str(
+                        _resolve_md(msg_data.get("body")),
+                        il.MESSAGE_BODY,
+                        report=report,
+                    )
+                    or ""
                 ),
             )
             if created:
@@ -1038,11 +1179,18 @@ async def run_import(
                     result.polls_skipped += 1
                     continue
                 poll_index.register(pcreated)
-            description = p_data.get("description")
+            description = clamp_str(
+                p_data.get("description"), il.POLL_DESCRIPTION, report=report
+            )
             poll = Poll(
                 id=uuid.uuid4(),
                 system_id=system.id,
-                question=encrypt(p_data.get("question") or ""),
+                question=encrypt(
+                    clamp_str(
+                        p_data.get("question"), il.POLL_QUESTION, report=report
+                    )
+                    or ""
+                ),
                 description=encrypt(description) if description else None,
                 kind=p_data.get("kind") or PollKind.SINGLE_CHOICE.value,
                 results_visibility=(
@@ -1066,11 +1214,16 @@ async def run_import(
 
             # Options first; vote/event option references resolve through this.
             old_option_to_new: dict[str, PollOption] = {}
-            for o_data in p_data.get("options", []):
+            for o_data in clamp_list(
+                p_data.get("options", []), il.POLL_OPTIONS_COUNT, report=report
+            ):
                 option = PollOption(
                     id=uuid.uuid4(),
                     poll_id=poll.id,
-                    text=encrypt(o_data.get("text") or ""),
+                    text=encrypt(
+                        clamp_str(o_data.get("text"), il.POLL_OPTION, report=report)
+                        or ""
+                    ),
                     position=_coerce_int(
                         o_data.get("position"), default=0, minimum=0
                     ),
@@ -1317,13 +1470,26 @@ async def run_import(
                     f"Reminder '{rm_data.get('name', '?')}' trigger member "
                     "was not imported; kept without a member trigger"
                 )
-            body = _resolve_md_to_none(rm_data.get("body"))
+            body = clamp_str(
+                _resolve_md_to_none(rm_data.get("body")),
+                il.REMINDER_BODY,
+                report=report,
+            )
             reminder = Reminder(
                 id=uuid.uuid4(),
                 system_id=system.id,
                 channel_id=channel.id,
-                name=(rm_data.get("name") or "reminder")[:120],
-                title=encrypt(rm_data.get("title") or ""),
+                name=clamp_str(
+                    rm_data.get("name") or "reminder",
+                    il.REMINDER_NAME,
+                    report=report,
+                ),
+                title=encrypt(
+                    clamp_str(
+                        rm_data.get("title"), il.REMINDER_TITLE, report=report
+                    )
+                    or ""
+                ),
                 body=encrypt(body) if body else None,
                 enabled=bool(rm_data.get("enabled", True)),
                 trigger_type=rm_data.get("trigger_type") or "repeated",
@@ -1368,7 +1534,9 @@ async def run_import(
                     )
             result.reminders_imported += 1
 
-    result.warnings = warnings
+    # Clamp tally goes last so a "3 member names were shortened" note follows
+    # the per-record warnings in the job log.
+    result.warnings = warnings + report.to_warnings()
     return result
 
 
@@ -1376,6 +1544,25 @@ def _trunc(val: str | None, max_len: int) -> str | None:
     if not val:
         return None
     return val[:max_len]
+
+
+def _clamp_field_options(options: object, report: ClampReport) -> object:
+    """Cap a custom field's choice list to the schema limits (count +
+    per-choice length), mirroring sheaf/schemas/custom_field.py. Non-dict /
+    non-list shapes pass through untouched - the field-type validator owns
+    those - so this only ever trims an oversized SELECT/MULTISELECT choice set.
+    """
+    if not isinstance(options, dict):
+        return options
+    choices = options.get("choices")
+    if not isinstance(choices, list):
+        return options
+    capped = clamp_list(choices, il.CF_CHOICES_COUNT, report=report)
+    capped = [
+        clamp_str(c, il.CF_CHOICE, report=report) if isinstance(c, str) else c
+        for c in capped
+    ]
+    return {**options, "choices": capped}
 
 
 def _coerce_pin(val: object) -> int | None:

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -35,6 +35,7 @@ from sheaf.schemas.sp_import import (
     SPPreviewMember,
     SPPreviewSummary,
 )
+from sheaf.services import import_limits as il
 from sheaf.services.custom_fields import encrypt_field_value
 from sheaf.services.import_content_dedup import (
     ContentMatchIndex,
@@ -56,6 +57,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_parsing import sanitize_external_avatar_url
 from sheaf.services.member_limits import enforce_import_member_cap
 
@@ -269,6 +271,49 @@ def _sp_chat_rows(data: dict) -> list[tuple[str, dict]]:
     return rows
 
 
+def measure_sp_payload(data: dict, report: ClampReport) -> None:
+    """Tally which SP fields exceed the schema caps, into ``report`` - the
+    warn-before-import prediction.
+
+    Walks the same SP keys ``run_import`` clamps, with the same caps, so the
+    preview's warnings match what the import would shorten. Only string values
+    are measured (guarded by ``_coerce_str``) so a malformed upload can't raise.
+    SP custom fields only ever map to TEXT/DATE types, never a SELECT with a
+    choice list, so there is no choice-count cap to measure here (unlike the
+    native importer's ``custom_fields[].options.choices``)."""
+
+    def s(value: object, cap: il.Cap) -> None:
+        text = _coerce_str(value)
+        if text is not None:
+            clamp_str(text, cap, report=report)
+
+    # System name: settings.systemName (newer) or users[0].username/name (older).
+    sp_settings = data.get("settings")
+    sp_settings = sp_settings if isinstance(sp_settings, dict) else {}
+    sp_users = _get_collection(data, "users")
+    sp_user = sp_users[0] if sp_users else {}
+    s(
+        sp_settings.get("systemName")
+        or sp_user.get("username")
+        or sp_user.get("name"),
+        il.SYS_NAME,
+    )
+
+    for m in _get_collection(data, "members"):
+        s(m.get("name"), il.M_NAME)
+        s(m.get("displayName"), il.M_DISPLAY_NAME)
+        s(m.get("pronouns"), il.M_PRONOUNS)
+
+    for cf in _get_collection_alt(data, "frontStatuses", "customFronts"):
+        s(cf.get("name"), il.M_NAME)
+
+    for f in _get_collection(data, "customFields"):
+        s(f.get("name"), il.CF_NAME)
+
+    for g in _get_collection(data, "groups"):
+        s(g.get("name"), il.GROUP_NAME)
+
+
 def preview(data: dict) -> SPPreviewSummary:
     """Parse SP export JSON and return a summary for the user to review."""
     members = _get_collection(data, "members")
@@ -282,7 +327,7 @@ def preview(data: dict) -> SPPreviewSummary:
     users = _get_collection(data, "users")
     system_name = _coerce_str(users[0].get("username")) if users else None
 
-    return SPPreviewSummary(
+    summary = SPPreviewSummary(
         system_name=system_name,
         member_count=len(members),
         members=[
@@ -305,6 +350,13 @@ def preview(data: dict) -> SPPreviewSummary:
         message_count=len(_sp_chat_rows(data)),
     )
 
+    # Predict which over-cap fields the real import would shorten, so the user
+    # sees the warning before committing. Same caps as run_import.
+    report = ClampReport()
+    measure_sp_payload(data, report)
+    summary.limit_warnings = report.to_warnings()
+    return summary
+
 
 async def run_import(
     data: dict,
@@ -315,6 +367,11 @@ async def run_import(
     """Import SP export data into the user's system."""
     result = SPImportResult()
     warnings: list[str] = []
+    # Tally every cap a user-content write actually hit so the same numbers the
+    # preview predicted land in the job's warning log. SP's String(N) columns
+    # (display_name, pronouns, names) reject overflow at the DB, so these clamps
+    # are a correctness backstop as well as a courtesy.
+    report = ClampReport()
 
     # SP system-owner id, used to construct member / custom-front avatar URLs
     # from an avatarUuid (their avatars are served from the owner's namespace).
@@ -340,7 +397,7 @@ async def run_import(
             or _coerce_str(sp_user.get("name"))
         )
         if sp_name and not system.name:
-            system.name = sp_name[:100]
+            system.name = clamp_str(sp_name, il.SYS_NAME, report=report)
         sp_desc = _coerce_str(sp_user.get("desc")) or _coerce_str(
             sp_settings.get("desc")
         )
@@ -367,7 +424,9 @@ async def run_import(
     sp_id_to_name: dict[str, str] = {}
     for sp_m in sp_members:
         sp_id = sp_m.get("_id", "")
-        plaintext_name = (_coerce_str(sp_m.get("name")) or "unnamed")[:100]
+        plaintext_name = clamp_str(
+            _coerce_str(sp_m.get("name")) or "unnamed", il.M_NAME, report=report
+        )
         if sp_id:
             sp_id_to_name[sp_id] = plaintext_name
         plaintext_description = _coerce_str(sp_m.get("desc"))
@@ -376,13 +435,21 @@ async def run_import(
             system_id=system.id,
             name=encrypt(plaintext_name),
             name_hash=blind_index(plaintext_name),
-            display_name=_truncate(sp_m.get("displayName"), 100),
+            display_name=clamp_str(
+                _coerce_str(sp_m.get("displayName")) or None,
+                il.M_DISPLAY_NAME,
+                report=report,
+            ),
             description=(
                 encrypt(plaintext_description)
                 if plaintext_description is not None
                 else None
             ),
-            pronouns=_truncate(sp_m.get("pronouns"), 100),
+            pronouns=clamp_str(
+                _coerce_str(sp_m.get("pronouns")) or None,
+                il.M_PRONOUNS,
+                report=report,
+            ),
             avatar_url=_sp_avatar_url(sp_m, sp_owner_id),
             color=_normalize_color(sp_m.get("color")),
             privacy=_map_privacy(sp_m.get("private", True)),
@@ -398,7 +465,9 @@ async def run_import(
     if options.custom_fronts:
         for sp_cf in _get_collection_alt(data, "frontStatuses", "customFronts"):
             sp_id = sp_cf.get("_id", "")
-            plaintext_cf_name = (_coerce_str(sp_cf.get("name")) or "unnamed")[:100]
+            plaintext_cf_name = clamp_str(
+                _coerce_str(sp_cf.get("name")) or "unnamed", il.M_NAME, report=report
+            )
             if sp_id:
                 sp_id_to_name[sp_id] = plaintext_cf_name
             plaintext_cf_description = _coerce_str(sp_cf.get("desc"))
@@ -482,7 +551,11 @@ async def run_import(
             sp_fid = sp_f.get("_id", "")
             sp_type = sp_f.get("type", 0)
             sheaf_type = _SP_FIELD_TYPE_MAP.get(sp_type, FieldType.TEXT)
-            name = (sp_f.get("name") or f"field_{idx}")[:100]
+            name = clamp_str(
+                _coerce_str(sp_f.get("name")) or f"field_{idx}",
+                il.CF_NAME,
+                report=report,
+            )
             key = (name, sheaf_type.value)
 
             field_def = field_index.get(key)
@@ -554,7 +627,9 @@ async def run_import(
         # First pass: create groups without parent links
         for sp_g in sp_groups:
             sp_gid = sp_g.get("_id", "")
-            name = (sp_g.get("name") or "unnamed")[:100]
+            name = clamp_str(
+                _coerce_str(sp_g.get("name")) or "unnamed", il.GROUP_NAME, report=report
+            )
             existing_group = group_index.get(name) if dedupe else None
             if existing_group is not None:
                 sp_gid_to_group[sp_gid] = existing_group
@@ -723,7 +798,7 @@ async def run_import(
         result.messages_skipped = m_skipped
         result.messages_encrypted_skipped = m_encrypted
 
-    result.warnings = warnings
+    result.warnings = warnings + report.to_warnings()
     return result
 
 
@@ -884,13 +959,3 @@ def _map_privacy(private: object) -> str:
     """Map SP's boolean privacy to our enum value. Non-bool / missing -> private."""
     from sheaf.models.system import PrivacyLevel
     return PrivacyLevel.PUBLIC if private is False else PrivacyLevel.PRIVATE
-
-
-def _truncate(value: object, max_len: int) -> str | None:
-    """Truncate a string, or return None for empty / non-string values.
-
-    Type-guarded like `_coerce_str` so a number or object where SP expected a
-    string can't crash slicing."""
-    if not isinstance(value, str) or not value:
-        return None
-    return value[:max_len]

--- a/sheaf/services/tb_import.py
+++ b/sheaf/services/tb_import.py
@@ -43,6 +43,7 @@ from sheaf.schemas.tb_import import (
     TBPreviewMember,
     TBPreviewSummary,
 )
+from sheaf.services import import_limits as il
 from sheaf.services.import_content_dedup import (
     ContentMatchIndex,
     PairGuard,
@@ -56,6 +57,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_parsing import sanitize_external_avatar_url
 from sheaf.services.member_limits import enforce_import_member_cap
 
@@ -76,10 +78,37 @@ def _tupper_id(tupper: dict) -> str | None:
     return str(tid)
 
 
+def _measure_payload(data: dict, report: ClampReport) -> None:
+    """Tally which Tupperbox fields exceed the schema caps, into ``report``.
+
+    Reads the same source keys ``run_import`` clamps (a tupper's name + nick,
+    a group's name), calling the same helper with the same caps, so the
+    preview's warnings match what the import would shorten. Defensive: only
+    string values are measured, so a malformed upload can't raise here.
+    """
+
+    def s(value: object, cap: il.Cap) -> None:
+        if isinstance(value, str):
+            clamp_str(value, cap, report=report)
+
+    for t in _list(data, "tuppers"):
+        if not isinstance(t, dict):
+            continue
+        s(t.get("name"), il.M_NAME)
+        s(t.get("nick"), il.M_DISPLAY_NAME)
+
+    for g in _list(data, "groups"):
+        if isinstance(g, dict):
+            s(g.get("name"), il.GROUP_NAME)
+
+
 def preview(data: dict) -> TBPreviewSummary:
     """Summarise a Tupperbox export for the user before they confirm."""
     tuppers = _list(data, "tuppers")
     groups = _list(data, "groups")
+
+    report = ClampReport()
+    _measure_payload(data, report)
 
     return TBPreviewSummary(
         member_count=len(tuppers),
@@ -92,6 +121,7 @@ def preview(data: dict) -> TBPreviewSummary:
             if _tupper_id(t) is not None
         ],
         group_count=len(groups),
+        limit_warnings=report.to_warnings(),
     )
 
 
@@ -104,6 +134,9 @@ async def run_import(
     """Import a parsed Tupperbox export into the user's system."""
     result = TBImportResult()
     warnings: list[str] = []
+    # Tally over-cap fields clamped during this run; surfaced as warnings at
+    # the end (the preview shows the same prediction up front).
+    report = ClampReport()
 
     tuppers = _list(data, "tuppers")
     if options.member_ids is not None:
@@ -115,7 +148,7 @@ async def run_import(
     candidates: list[tuple[Member, str | None]] = []
     tuppers_no_name = 0
     for tupper in tuppers:
-        member = _build_member(tupper, system.id)
+        member = _build_member(tupper, system.id, report)
         if member is None:
             tuppers_no_name += 1
             continue
@@ -159,6 +192,7 @@ async def run_import(
                 system.id,
                 id_to_member,
                 db,
+                report,
                 conflict_strategy=options.conflict_strategy,
             )
         )
@@ -174,7 +208,9 @@ async def run_import(
             f"Imported {tuppers_no_id} tuppers with no id; they came across "
             "as members but couldn't be wired into any group."
         )
-    result.warnings = warnings
+    # Clamp tally goes last so a "3 member names were shortened" note follows
+    # the per-record warnings in the job log.
+    result.warnings = warnings + report.to_warnings()
     # See pk_import.run_import for the full rationale: `get_db`'s
     # auto-commit runs after the response is sent, which races a
     # follow-up request on slow CI. Commit explicitly here so writes
@@ -186,7 +222,9 @@ async def run_import(
 # --- Members -----------------------------------------------------------------
 
 
-def _build_member(tupper: dict, system_id: uuid.UUID) -> Member | None:
+def _build_member(
+    tupper: dict, system_id: uuid.UUID, report: ClampReport
+) -> Member | None:
     """Construct a Sheaf Member from a Tupperbox tupper object.
 
     Returns None if the row lacks a usable name. Tupperbox has no privacy
@@ -196,7 +234,7 @@ def _build_member(tupper: dict, system_id: uuid.UUID) -> Member | None:
     plaintext_name = _clean_str(tupper.get("name"))
     if not plaintext_name:
         return None
-    plaintext_name = plaintext_name[:100]
+    plaintext_name = clamp_str(plaintext_name, il.M_NAME, report=report)
     plaintext_description = _clean_str(tupper.get("description"))
 
     return Member(
@@ -204,7 +242,9 @@ def _build_member(tupper: dict, system_id: uuid.UUID) -> Member | None:
         system_id=system_id,
         name=encrypt(plaintext_name),
         name_hash=blind_index(plaintext_name),
-        display_name=_truncate(_clean_str(tupper.get("nick")), 100),
+        display_name=clamp_str(
+            _clean_str(tupper.get("nick")), il.M_DISPLAY_NAME, report=report
+        ),
         description=encrypt(plaintext_description) if plaintext_description else None,
         pronouns=None,  # Tupperbox doesn't model pronouns.
         avatar_url=sanitize_external_avatar_url(_clean_str(tupper.get("avatar_url"))),
@@ -223,6 +263,7 @@ async def _import_groups(
     system_id: uuid.UUID,
     id_to_member: dict[str, Member],
     db: AsyncSession,
+    report: ClampReport,
     *,
     conflict_strategy: ImportConflictStrategy = ImportConflictStrategy.CREATE,
 ) -> tuple[int, int, list[str]]:
@@ -256,7 +297,7 @@ async def _import_groups(
         if gid is None:
             groups_no_id += 1
             continue
-        name = name[:100]
+        name = clamp_str(name, il.GROUP_NAME, report=report)
         existing = group_index.get(name) if dedupe else None
         if existing is not None:
             sheaf_group_by_tbid[str(gid)] = existing
@@ -331,12 +372,6 @@ def _clean_str(value: Any) -> str | None:
         value = str(value)
     value = value.strip()
     return value or None
-
-
-def _truncate(value: str | None, max_len: int) -> str | None:
-    if value is None:
-        return None
-    return value[:max_len]
 
 
 def _normalize_birthday(value: Any) -> str | None:

--- a/tests/test_import_limits.py
+++ b/tests/test_import_limits.py
@@ -1,0 +1,104 @@
+"""Unit tests for the importer business-cap helpers.
+
+Pure - no DB / stack. Exercises the clamp primitives and the warning
+rendering that the preview surfaces.
+"""
+
+from __future__ import annotations
+
+from sheaf.services import import_limits as il
+
+
+def test_clamp_str_under_cap_is_untouched():
+    report = il.ClampReport()
+    assert il.clamp_str("short", il.M_NAME, report=report) == "short"
+    assert report.empty
+
+
+def test_clamp_str_none_passes_through():
+    report = il.ClampReport()
+    assert il.clamp_str(None, il.M_NAME, report=report) is None
+    assert report.empty
+
+
+def test_clamp_str_truncates_and_records():
+    report = il.ClampReport()
+    out = il.clamp_str("x" * 250, il.M_NAME, report=report)
+    assert out == "x" * 100
+    assert not report.empty
+    assert report.to_warnings() == [
+        "1 member name will be shortened to 100 characters"
+    ]
+
+
+def test_clamp_str_silent_without_report():
+    out = il.clamp_str("x" * 250, il.M_NAME)
+    assert out == "x" * 100  # still clamps - the backstop is unconditional
+
+
+def test_clamp_list_caps_count_and_records():
+    report = il.ClampReport()
+    out = il.clamp_list(list(range(50)), il.POLL_OPTIONS_COUNT, report=report)
+    assert out == list(range(20))
+    assert report.to_warnings() == [
+        "1 poll's option list will be trimmed to 20 entries"
+    ]
+
+
+def test_clamp_list_under_cap_untouched():
+    report = il.ClampReport()
+    out = il.clamp_list([1, 2, 3], il.POLL_OPTIONS_COUNT, report=report)
+    assert out == [1, 2, 3]
+    assert report.empty
+
+
+def test_clamp_list_none_passes_through():
+    assert il.clamp_list(None, il.POLL_OPTIONS_COUNT) is None
+
+
+def test_warnings_pluralise_on_count():
+    report = il.ClampReport()
+    for _ in range(3):
+        il.clamp_str("x" * 250, il.M_NAME, report=report)
+    assert report.to_warnings() == [
+        "3 member names will be shortened to 100 characters"
+    ]
+
+
+def test_warnings_are_deterministically_ordered():
+    report = il.ClampReport()
+    # Record in a deliberately non-alphabetical order.
+    il.clamp_str("x" * 200, il.SYS_NAME, report=report)
+    il.clamp_str("x" * 200, il.M_NAME, report=report)
+    il.clamp_list(list(range(150)), il.CF_CHOICES_COUNT, report=report)
+    warnings = report.to_warnings()
+    # str hits sorted by label, then list hits sorted by label.
+    assert warnings == [
+        "1 member name will be shortened to 100 characters",
+        "1 system name will be shortened to 100 characters",
+        "1 custom field's choice list will be trimmed to 100 entries",
+    ]
+
+
+def test_distinct_fields_each_get_a_line():
+    report = il.ClampReport()
+    il.clamp_str("x" * 200, il.M_NAME, report=report)
+    il.clamp_str("x" * 200, il.M_DISPLAY_NAME, report=report)
+    assert len(report.to_warnings()) == 2
+
+
+def test_caps_match_schema_limits():
+    # Guard against drift from the schema constants these mirror.
+    assert il.M_NAME.limit == 100
+    assert il.M_NOTE.limit == 5000
+    assert il.M_BIRTHDAY.limit == 10
+    assert il.M_PLURALKIT_ID.limit == 8
+    assert il.M_EMOJI.limit == 8
+    assert il.TAG_NAME.limit == 50
+    assert il.CF_CHOICES_COUNT.limit == 100
+    assert il.CF_CHOICE.limit == 100
+    assert il.POLL_OPTIONS_COUNT.limit == 20
+    assert il.POLL_OPTION.limit == 200
+    assert il.MESSAGE_BODY.limit == 5000
+    assert il.JOURNAL_TITLE.limit == 200
+    assert il.REMINDER_BODY.limit == 2000

--- a/tests/test_pk_import_unit.py
+++ b/tests/test_pk_import_unit.py
@@ -8,6 +8,7 @@ tests in test_pk_import.py cover the full end-to-end path.
 from datetime import UTC, datetime
 
 from sheaf.models.system import PrivacyLevel
+from sheaf.services.import_limits import ClampReport
 from sheaf.services.pk_import import (
     _map_privacy,
     _normalize_birthday,
@@ -134,11 +135,54 @@ def test_build_member_drops_non_http_avatar_scheme():
     import uuid as _uuid
 
     sys_id = _uuid.uuid4()
-    bad = build_member({"name": "X", "avatar_url": "javascript:alert(1)"}, sys_id)
+    report = ClampReport()
+    bad = build_member(
+        {"name": "X", "avatar_url": "javascript:alert(1)"}, sys_id, report=report
+    )
     assert bad is not None and bad.avatar_url is None
 
     good = build_member(
-        {"name": "Y", "avatar_url": "https://cdn.example.com/a.png"}, sys_id
+        {"name": "Y", "avatar_url": "https://cdn.example.com/a.png"},
+        sys_id,
+        report=report,
     )
     assert good is not None
     assert good.avatar_url == "https://cdn.example.com/a.png"
+
+
+def test_preview_flags_over_cap_member_name():
+    """A member name past the 100-char cap shows up in limit_warnings so the
+    user is warned it will be shortened before they confirm the import."""
+    data = {
+        "name": "Sys",
+        "members": [
+            {"id": "alpha", "name": "A" * 200},
+            {"id": "beta", "name": "Fine"},
+        ],
+    }
+    summary = preview(data)
+    assert summary.limit_warnings
+    assert any("member name" in w for w in summary.limit_warnings)
+
+
+def test_preview_flags_over_cap_group_name_and_pk_id():
+    """Group name and PK HID over their caps both surface as warnings."""
+    data = {
+        "members": [{"id": "x" * 30, "name": "ok", "display_name": "d" * 150}],
+        "groups": [{"name": "g" * 150}],
+    }
+    summary = preview(data)
+    joined = " ".join(summary.limit_warnings)
+    assert "group name" in joined
+    assert "member PluralKit ID" in joined
+    assert "member display name" in joined
+
+
+def test_preview_clean_export_has_no_limit_warnings():
+    data = {
+        "name": "Sys",
+        "members": [{"id": "alpha", "name": "Alpha", "pronouns": "they/them"}],
+        "groups": [{"name": "Group"}],
+    }
+    summary = preview(data)
+    assert summary.limit_warnings == []

--- a/tests/test_pluralspace_caps.py
+++ b/tests/test_pluralspace_caps.py
@@ -1,0 +1,80 @@
+"""Pure (no DB / no stack) test for the PluralSpace preview's business-cap
+prediction.
+
+Builds a tiny export zip whose data.json carries a few over-cap fields, runs
+the synchronous `preview`, and asserts `limit_warnings` is populated and names
+the right fields. This is the warn-before-import surface: the same caps the
+real import clamps, measured over PluralSpace's own key names.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+from sheaf.services.pluralspace_import import parse_export, preview
+
+
+def _build_zip(data: dict) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps({"format_version": "1.1"}))
+        zf.writestr("data.json", json.dumps(data))
+    return buf.getvalue()
+
+
+def test_preview_flags_over_cap_fields() -> None:
+    data = {
+        "system": {"name": "S" * 250},  # SYS_NAME cap 100
+        "members": [
+            {
+                "id": "m1",
+                "name": "N" * 250,  # M_NAME cap 100
+                "display_name": "D" * 250,  # M_DISPLAY_NAME cap 100
+                "pronouns": "P" * 250,  # M_PRONOUNS cap 100
+                "role": ["R" * 80],  # TAG_NAME cap 50
+            }
+        ],
+        "member_groups": [{"name": "G" * 250}],  # GROUP_NAME cap 100
+        "custom_fields": [{"name": "F" * 250, "field_type": "text"}],  # CF_NAME 100
+        "polls": [
+            {
+                "title": "Q" * 800,  # POLL_QUESTION cap 500
+                "description": "X" * 3000,  # POLL_DESCRIPTION cap 2000
+                "options": [{"id": "o1", "text": "O" * 400}],  # POLL_OPTION cap 200
+            }
+        ],
+        "chat_channels": [
+            {"name": "c1", "messages": [{"content": "B" * 6000}]}  # MESSAGE_BODY 5000
+        ],
+    }
+    parsed = parse_export(_build_zip(data))
+    summary = preview(parsed)
+
+    assert summary.limit_warnings, "expected at least one cap warning"
+    joined = " ".join(summary.limit_warnings).lower()
+    for needle in (
+        "system name",
+        "member name",
+        "member display name",
+        "member pronouns",
+        "tag name",
+        "group name",
+        "custom field name",
+        "poll question",
+        "poll description",
+        "poll option",
+        "message",
+    ):
+        assert needle in joined, f"missing cap warning for {needle!r}: {joined}"
+
+
+def test_preview_no_warnings_when_within_caps() -> None:
+    data = {
+        "system": {"name": "Small System"},
+        "members": [{"id": "m1", "name": "Alex", "pronouns": "they/them"}],
+    }
+    parsed = parse_export(_build_zip(data))
+    summary = preview(parsed)
+    assert summary.limit_warnings == []

--- a/tests/test_prism_import_caps.py
+++ b/tests/test_prism_import_caps.py
@@ -1,0 +1,62 @@
+"""Pure unit tests for the Prism importer's business-cap preview pass.
+
+These build a `ParsedPrism` directly from a decrypted-envelope dict, so
+they exercise the `preview` measurement (`limit_warnings`) without any
+crypto, database, or running server. The full encrypted-envelope path is
+covered by test_imports_prism_runner.py.
+"""
+
+from __future__ import annotations
+
+from sheaf.services.prism_crypto import DecryptedEnvelope
+from sheaf.services.prism_import import ParsedPrism, preview
+
+
+def _parsed(data: dict) -> ParsedPrism:
+    # `header` is unused by the preview path (ParsedPrism only reads .json
+    # and .media_blobs), so a None placeholder is fine for these pure tests.
+    return ParsedPrism(
+        envelope=DecryptedEnvelope(header=None, json=data, media_blobs={})
+    )
+
+
+def test_preview_flags_over_cap_member_name():
+    """A member name past the 100-char cap shows up in limit_warnings so the
+    user is warned before the import shortens it."""
+    parsed = _parsed(
+        {"headmates": [{"id": "m1", "name": "n" * 250}]}
+    )
+    summary = preview(parsed)
+    assert summary.limit_warnings
+    assert any("member name" in w for w in summary.limit_warnings)
+
+
+def test_preview_flags_over_cap_birthday_and_group_name():
+    """Birthday (the String(10) raw-write bug) and group name are both
+    measured against their caps."""
+    parsed = _parsed(
+        {
+            "headmates": [
+                {"id": "m1", "name": "ok", "birthday": "1990-04-15T00:00:00Z"}
+            ],
+            "memberGroups": [{"id": "g1", "name": "g" * 200}],
+        }
+    )
+    summary = preview(parsed)
+    joined = " ".join(summary.limit_warnings)
+    assert "member birthday" in joined
+    assert "group name" in joined
+
+
+def test_preview_clean_export_has_no_limit_warnings():
+    parsed = _parsed(
+        {
+            "headmates": [
+                {"id": "m1", "name": "Alex", "birthday": "04-15", "pronouns": "they"}
+            ],
+            "memberGroups": [{"id": "g1", "name": "Inner"}],
+            "customFields": [{"id": "f1", "name": "Likes"}],
+        }
+    )
+    summary = preview(parsed)
+    assert summary.limit_warnings == []

--- a/tests/test_sp_caps.py
+++ b/tests/test_sp_caps.py
@@ -1,0 +1,59 @@
+"""Pure unit tests for SimplyPlural import business-cap warnings.
+
+These exercise the preview measure pass only (no DB / job runner), confirming
+that over-cap SP fields surface in `limit_warnings` so the user is warned the
+import will shorten them before they confirm. The clamp the import actually
+applies uses the same caps, so these doubling as a regression guard on both.
+"""
+
+from sheaf.services.sp_import import preview
+
+
+def test_preview_flags_over_cap_member_name_and_display_name():
+    """A member name and displayName past the 100-char cap both surface."""
+    data = {
+        "members": [
+            {"_id": "alpha", "name": "A" * 200, "displayName": "d" * 150},
+            {"_id": "beta", "name": "Fine"},
+        ],
+    }
+    summary = preview(data)
+    joined = " ".join(summary.limit_warnings)
+    assert "member name" in joined
+    assert "member display name" in joined
+
+
+def test_preview_flags_over_cap_group_field_and_custom_front_names():
+    """Group name, custom-field name, and custom-front name over their caps
+    each surface. Custom fronts share the member-name cap (they are Member
+    rows), so an over-cap front name reads as a 'member name' warning."""
+    data = {
+        "groups": [{"_id": "g1", "name": "g" * 150}],
+        "customFields": [{"_id": "f1", "name": "f" * 150}],
+        "frontStatuses": [{"_id": "cf1", "name": "c" * 200}],
+    }
+    summary = preview(data)
+    joined = " ".join(summary.limit_warnings)
+    assert "group name" in joined
+    assert "custom field name" in joined
+    assert "member name" in joined  # custom front, capped as a member
+
+
+def test_preview_flags_over_cap_system_name():
+    """System name from settings.systemName over the 100-char cap surfaces."""
+    data = {"settings": {"systemName": "S" * 200}, "members": []}
+    summary = preview(data)
+    assert any("system name" in w for w in summary.limit_warnings)
+
+
+def test_preview_clean_export_has_no_limit_warnings():
+    data = {
+        "settings": {"systemName": "Sys"},
+        "members": [
+            {"_id": "alpha", "name": "Alpha", "displayName": "Al", "pronouns": "they"}
+        ],
+        "groups": [{"_id": "g1", "name": "Group"}],
+        "customFields": [{"_id": "f1", "name": "Pronoun set"}],
+    }
+    summary = preview(data)
+    assert summary.limit_warnings == []

--- a/tests/test_tb_import_unit.py
+++ b/tests/test_tb_import_unit.py
@@ -78,3 +78,38 @@ def test_preview_skips_tuppers_without_id():
     # But the surfaced members list only contains rows with usable IDs.
     assert len(summary.members) == 1
     assert summary.members[0].id == "1"
+
+
+def test_preview_warns_when_member_name_over_cap():
+    """An over-cap tupper name surfaces a limit warning the user sees up front."""
+    data = {
+        "tuppers": [
+            {"id": 1, "name": "x" * 200},  # M_NAME cap is 100
+        ],
+    }
+    summary = preview(data)
+    assert summary.limit_warnings
+    assert any("member name" in w for w in summary.limit_warnings)
+
+
+def test_preview_warns_for_nick_and_group_name_over_cap():
+    """nick maps to display_name and group name each have their own cap."""
+    data = {
+        "tuppers": [
+            {"id": 1, "name": "Alpha", "nick": "n" * 150},  # M_DISPLAY_NAME 100
+        ],
+        "groups": [{"id": 10, "name": "g" * 150}],  # GROUP_NAME 100
+    }
+    summary = preview(data)
+    joined = " ".join(summary.limit_warnings)
+    assert "member display name" in joined
+    assert "group name" in joined
+
+
+def test_preview_no_warnings_when_all_within_caps():
+    data = {
+        "tuppers": [{"id": 1, "name": "Alpha", "nick": "Al"}],
+        "groups": [{"id": 10, "name": "Core"}],
+    }
+    summary = preview(data)
+    assert summary.limit_warnings == []

--- a/web/src/lib/pk-import.ts
+++ b/web/src/lib/pk-import.ts
@@ -20,6 +20,7 @@ export interface PKPreviewSummary {
   switch_count: number;
   earliest_switch: string | null;
   latest_switch: string | null;
+  limit_warnings: string[];
 }
 
 export async function previewImportFromFile(file: File): Promise<PKPreviewSummary> {

--- a/web/src/lib/pluralspace-import.ts
+++ b/web/src/lib/pluralspace-import.ts
@@ -33,6 +33,7 @@ export interface PluralspacePreviewSummary {
   poll_count: number;
   thought_count: number;
   media_file_count: number;
+  limit_warnings: string[];
 }
 
 export async function previewImport(file: File): Promise<PluralspacePreviewSummary> {

--- a/web/src/lib/prism-import.ts
+++ b/web/src/lib/prism-import.ts
@@ -38,6 +38,7 @@ export interface PrismPreviewSummary {
   member_board_post_count: number;
   media_attachment_count: number;
   media_blob_count: number;
+  limit_warnings: string[];
 }
 
 export async function previewImport(

--- a/web/src/lib/sheaf-import.ts
+++ b/web/src/lib/sheaf-import.ts
@@ -29,6 +29,7 @@ export interface SheafPreviewSummary {
   // bundled images.
   archive: boolean;
   image_count: number;
+  limit_warnings: string[];
 }
 
 export async function previewSheafImport(file: File): Promise<SheafPreviewSummary> {

--- a/web/src/lib/sp-import.ts
+++ b/web/src/lib/sp-import.ts
@@ -21,6 +21,7 @@ export interface SPPreviewSummary {
   group_count: number;
   custom_field_count: number;
   note_count: number;
+  limit_warnings: string[];
 }
 
 export async function previewImport(file: File): Promise<SPPreviewSummary> {

--- a/web/src/lib/tb-import.ts
+++ b/web/src/lib/tb-import.ts
@@ -15,6 +15,7 @@ export interface TBPreviewSummary {
   member_count: number;
   members: TBPreviewMember[];
   group_count: number;
+  limit_warnings: string[];
 }
 
 export async function previewImport(file: File): Promise<TBPreviewSummary> {

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -444,6 +444,8 @@ function SheafImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
+
               <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
@@ -624,6 +626,8 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
                 selectedMembers={selectedMembers}
                 toggleMember={toggleMember}
               />
+
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
 
               <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
@@ -941,6 +945,8 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
+
               <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
@@ -1087,6 +1093,8 @@ function TBImportFlow({ onBack }: { onBack: () => void }) {
                 selectedMembers={selectedMembers}
                 toggleMember={toggleMember}
               />
+
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
 
               <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
@@ -1321,6 +1329,8 @@ function PSImportFlow({ onBack }: { onBack: () => void }) {
                 selectedMembers={selectedMembers}
                 toggleMember={toggleMember}
               />
+
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
 
               <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
@@ -1606,6 +1616,8 @@ function PrismImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
+
               <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
@@ -1870,6 +1882,8 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
                 toggleMember={toggleMember}
               />
 
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
+
               <ImportSubmit incoming={importIncoming} onImport={handleImport} />
             </CardContent>
           </Card>
@@ -1884,6 +1898,28 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
 // ---------------------------------------------------------------------------
 // Shared components
 // ---------------------------------------------------------------------------
+
+// Caution callout shown on a preview when the backend flags fields that
+// exceed Sheaf's business caps and would be shortened on import. Amber
+// (not destructive) tone: the import still succeeds, data is just
+// clamped. Renders nothing when there's nothing to warn about.
+function ImportLimitWarnings({ warnings }: { warnings: string[] }) {
+  if (warnings.length === 0) return null;
+  return (
+    <div className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400">
+      <p className="font-medium">Some data will be shortened</p>
+      <p className="mt-1">
+        These exceed Sheaf&apos;s limits and will be shortened when imported.
+        You can continue, or cancel and adjust the source.
+      </p>
+      <ul className="mt-2 list-disc space-y-0.5 pl-5">
+        {warnings.map((w, i) => (
+          <li key={i}>{w}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 function ErrorBanner({ message }: { message: string }) {
   return (


### PR DESCRIPTION
## What

Importers build database rows directly, so they bypassed the length and count limits the normal create/update API enforces. A crafted (or just messy) export could land an over-length member name, a 50k-character note, or a custom field with thousands of choices straight in the database. This adds a single shared clamp that every importer routes user-content through, and surfaces the clamping in the preview so nothing is silently shortened.

## How

A new `sheaf/services/import_limits.py` holds the canonical caps (mirroring `sheaf/schemas/*.py`) plus `clamp_str` / `clamp_list`, which truncate unconditionally and tally what they touched into a `ClampReport`. Clamping is the security backstop: even if a warning is missed, over-cap data can never be stored. Every importer (Sheaf native and the export-with-images archive, OpenPlural, PluralKit/Octocon, Tupperbox, SimplyPlural, PluralSpace, Prism) now routes its user-content scalar writes and its list builds (poll options, custom-field choices) through these helpers.

For warn-before-import, each preview runs the same helpers over the parsed file (string values only, so a malformed upload cannot raise) and returns `limit_warnings`, for example "3 member names will be shortened to 100 characters" or "1 poll's option list will be trimmed to 20 entries". The frontend renders these as an amber "Some data will be shortened, continue or cancel" callout above the Import button in all seven import flows; the same tally also lands in the import job event log. Because preview and the real import call the identical helper with the identical cap, the warning matches the clamp.

## Bugs fixed along the way

- Prism wrote a member `birthday` raw into a `String(10)` column; a birthday longer than 10 characters (e.g. a full ISO timestamp) would error the whole import on the database write.
- PluralSpace built poll options from an uncapped list.

## Notes

- Several "missing clamp" fields flagged in the initial audit were already bounded by existing normalisers (`_normalize_color`, `_normalize_birthday`, `sanitize_external_avatar_url`); those were left alone rather than double-clamped. Encrypted free-text bodies (member/system/journal descriptions) stay uncapped by design, matching the create API.
- The Ampersand importer lives on a separate, unmerged branch and is not covered here. It needs the same treatment when it lands; worth noting `import_limits` as the canonical clamp in the add-importer guidance so the next importer starts compliant.

## Test

- New pure unit tests for the clamp module and a preview-measurement test per importer (49 passing, no stack needed).
- `ruff check sheaf/ tests/` clean; frontend typecheck, lint, and build clean.
- Manually exercised on localdev with a 1000-member PluralKit export carrying deliberately over-cap fields: preview surfaces the shortening warnings and the member-cap path behaves as expected.
