### PR TITLE
Post-launch hardening: read/write bounds, retention correctness, at-rest encryption

### DIFF
--- a/alembic/versions/s0t1u2v3w4x5_add_fronts_system_ended_created_index.py
+++ b/alembic/versions/s0t1u2v3w4x5_add_fronts_system_ended_created_index.py
@@ -1,0 +1,52 @@
+"""Add ix_fronts_system_ended_created for the free-tier retention sweep
+
+Revision ID: s0t1u2v3w4x5
+Revises: r9s0t1u2v3w4
+Create Date: 2026-07-01
+
+The free-tier retention sweep filters:
+
+    system_id IN (...) AND created_at < cutoff
+      AND ended_at IS NOT NULL AND ended_at < cutoff
+
+(see sheaf/services/front_retention.py). Neither existing index covers
+`created_at` - ix_fronts_system_current is (system_id, ended_at) and
+ix_fronts_system_started is (system_id, started_at) - so the predicate
+seq-scanned the fronts table. This composite (system_id, ended_at,
+created_at) lets the sweep index-scan the closed, long-dormant rows.
+
+Built CONCURRENTLY: the prod fronts table may be large and a plain
+CREATE INDEX takes a SHARE lock that blocks writes for the whole build.
+CONCURRENTLY cannot run inside a transaction, so the create is wrapped in
+an autocommit block.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "s0t1u2v3w4x5"
+down_revision: Union[str, None] = "r9s0t1u2v3w4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_fronts_system_ended_created",
+            "fronts",
+            ["system_id", "ended_at", "created_at"],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_fronts_system_ended_created",
+            table_name="fronts",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/alembic/versions/t1u2v3w4x5y6_add_retention_pruned_activity_action.py
+++ b/alembic/versions/t1u2v3w4x5y6_add_retention_pruned_activity_action.py
@@ -1,0 +1,39 @@
+"""Add retention_pruned to the activity_action enum
+
+Revision ID: t1u2v3w4x5y6
+Revises: s0t1u2v3w4x5
+Create Date: 2026-07-01
+
+The free-tier front-retention and revision-retention sweeps already emit a
+content-free per-user account-activity trace when they remove rows, guarded
+by `getattr(ActivityAction, "RETENTION_PRUNED", None)` (see
+sheaf/services/front_retention.py and sheaf/services/retention.py). Those
+call sites are dormant until this enum value exists; this migration lights
+them up. `activity_action` is a native Postgres enum, so the value is added
+with ALTER TYPE ... ADD VALUE, which cannot run inside a transaction block -
+hence the autocommit block.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "t1u2v3w4x5y6"
+down_revision: Union[str, None] = "s0t1u2v3w4x5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE activity_action ADD VALUE IF NOT EXISTS 'retention_pruned'"
+        )
+
+
+def downgrade() -> None:
+    # Postgres has no DROP VALUE for an enum; removing a value means recreating
+    # the type and rewriting every dependent column, which is not worth it for
+    # an additive value. Downgrade is a no-op (matches the repo convention for
+    # enum-value adds, e.g. h7e8a9b0c1d2_add_admin_audit_ban_unban).
+    pass

--- a/alembic/versions/u2v3w4x5y6z7_encrypt_pending_action_content.py
+++ b/alembic/versions/u2v3w4x5y6z7_encrypt_pending_action_content.py
@@ -1,0 +1,167 @@
+"""Encrypt pending_actions.target_label and fronting_member_names at rest
+
+Revision ID: u2v3w4x5y6z7
+Revises: t1u2v3w4x5y6
+Create Date: 2026-07-01
+
+PendingAction is a transient row created for System Safety destructive-action
+grace windows. It stored DECRYPTED user content in two unencrypted columns
+that would land in any DB dump taken during the grace window:
+
+  - target_label (member names, journal titles, poll questions, message
+    previews)
+  - fronting_member_names (a list of decrypted member names)
+
+Everything else in Sheaf is encrypted at rest; these were the gap. This
+migration relaxes both columns to Text and encrypts the existing values in
+place, so they match the field-encryption model used by bios / journals /
+fronts. The app now writes ciphertext on every insert (see
+queue_pending_action) and decrypts defensively on read.
+
+Runs in the app container where SHEAF_ENCRYPTION_KEY is loaded, so it can
+call sheaf.crypto directly (same precedent as
+o5p6q7r8s9t0_encrypt_member_and_journal_content). The table is small and
+transient, so a row-by-row backfill is cheap.
+
+- target_label: String(200) -> Text (ciphertext is longer than 200 chars).
+- fronting_member_names: JSONB -> Text, holding encrypt(json.dumps(list)).
+  Its server_default '[]' no longer makes sense for encrypted text and is
+  dropped; the app supplies the value on every write.
+- fronting_member_ids stays JSONB - opaque UUIDs are not sensitive content.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "u2v3w4x5y6z7"
+down_revision: Union[str, None] = "t1u2v3w4x5y6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    import json
+
+    from sheaf.crypto import encrypt
+
+    bind = op.get_bind()
+
+    # Relax the column types BEFORE writing ciphertext into them. target_label
+    # widens to Text; fronting_member_names flips JSONB -> Text via a cast that
+    # renders each stored list as its JSON text form (e.g. '["Alice", "Bob"]').
+    # The server_default is dropped - the app sets the value on every write.
+    op.alter_column(
+        "pending_actions",
+        "target_label",
+        type_=sa.Text(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "pending_actions",
+        "fronting_member_names",
+        type_=sa.Text(),
+        postgresql_using="fronting_member_names::text",
+        server_default=None,
+        existing_nullable=False,
+    )
+
+    # Encrypt existing rows. Idempotent: a row that already decrypts is skipped
+    # so a re-run doesn't double-encrypt.
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, target_label, fronting_member_names FROM pending_actions"
+        )
+    ).fetchall()
+    for row in rows:
+        if _looks_like_ciphertext(row.target_label):
+            continue
+        try:
+            names_list = json.loads(row.fronting_member_names)
+        except Exception:
+            names_list = []
+        bind.execute(
+            sa.text(
+                "UPDATE pending_actions SET target_label = :t, "
+                "fronting_member_names = :n WHERE id = :id"
+            ),
+            {
+                "t": encrypt(row.target_label),
+                "n": encrypt(json.dumps(names_list)),
+                "id": row.id,
+            },
+        )
+
+
+def downgrade() -> None:
+    """Reverse the type changes, best-effort decrypting back to plaintext.
+
+    Same caveat as upgrade - must run in the app container with the same key
+    that wrote the ciphertexts. Where a value cannot be decrypted (a legacy
+    plaintext row) the stored value is kept as-is. This is inherently lossy in
+    the general case; it is only meaningful for a same-key round trip.
+    """
+    import json
+
+    from sheaf.crypto import decrypt
+
+    bind = op.get_bind()
+
+    # Decrypt while the columns are still Text, so the values are valid for the
+    # subsequent narrowing / JSONB cast.
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, target_label, fronting_member_names FROM pending_actions"
+        )
+    ).fetchall()
+    for row in rows:
+        try:
+            plain_label = decrypt(row.target_label)[:200]
+        except Exception:
+            plain_label = row.target_label[:200]
+        try:
+            names_list = json.loads(decrypt(row.fronting_member_names))
+        except Exception:
+            try:
+                names_list = json.loads(row.fronting_member_names)
+            except Exception:
+                names_list = []
+        bind.execute(
+            sa.text(
+                "UPDATE pending_actions SET target_label = :t, "
+                "fronting_member_names = :n WHERE id = :id"
+            ),
+            {"t": plain_label, "n": json.dumps(names_list), "id": row.id},
+        )
+
+    op.alter_column(
+        "pending_actions",
+        "target_label",
+        type_=sa.String(length=200),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "pending_actions",
+        "fronting_member_names",
+        type_=postgresql.JSONB(),
+        postgresql_using="fronting_member_names::jsonb",
+        server_default="[]",
+        existing_nullable=False,
+    )
+
+
+def _looks_like_ciphertext(value: str | None) -> bool:
+    """Heuristic: try to decrypt. A successful decrypt means the row is already
+    migrated (libsodium AEAD verification fails on plaintext that merely looks
+    like base64)."""
+    if not value or not isinstance(value, str):
+        return False
+    from sheaf.crypto import decrypt
+
+    try:
+        decrypt(value)
+        return True
+    except Exception:
+        return False

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -370,7 +370,7 @@ async def get_account_data(
                 "id": str(a.id),
                 "action_type": a.action_type,
                 "target_id": str(a.target_id),
-                "target_label": a.target_label,
+                "target_label": _decrypt_pending_label(a.target_label),
                 "requested_at": _iso(a.requested_at),
                 "finalize_after": _iso(a.finalize_after),
                 "status": a.status,
@@ -419,3 +419,17 @@ async def get_account_data(
 
 def _iso(value: datetime | None) -> str | None:
     return value.isoformat() if value else None
+
+
+def _decrypt_pending_label(value: str) -> str:
+    """Defensively decrypt a PendingAction.target_label for the data export.
+
+    The column is encrypted at rest (see queue_pending_action). A row written
+    by the old code during the deploy transition is still plaintext, so fall
+    back to the stored value on any decrypt failure rather than exporting
+    ciphertext or 500ing. Mirrors decrypt_text in sheaf/services/polls.py.
+    """
+    try:
+        return decrypt(value)
+    except Exception:
+        return value

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -46,6 +46,7 @@ router = APIRouter(prefix="/account", tags=["account"])
 
 @router.get("/activity", response_model=list[ActivityEventRead])
 async def list_account_activity(
+    request: Request,
     page: int = Query(default=1, ge=1),
     limit: int = Query(default=50, ge=1, le=200),
     user: User = Depends(get_current_user),
@@ -58,6 +59,21 @@ async def list_account_activity(
     account, distinct from the admin-activity view (admin actions) and the
     operator-facing security-event log.
     """
+    # This account router is deliberately left outside the scope-gating
+    # middleware on the assumption that every endpoint refuses API keys
+    # inline (see get_account_data below). A leaked key of any scope must
+    # not be able to read the account's security / 2FA / session timeline,
+    # so refuse it here too. Any new endpoint added to this router MUST
+    # repeat this guard.
+    if getattr(request.state, "auth_method", None) == "api_key":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "API keys cannot access account activity. Sign in with a "
+                "session or JWT to view your account activity."
+            ),
+        )
+
     stmt = (
         select(ActivityEvent)
         .where(ActivityEvent.user_id == user.id)

--- a/sheaf/api/v1/analytics.py
+++ b/sheaf/api/v1/analytics.py
@@ -1,9 +1,18 @@
 """Fronting analytics endpoint.
 
 Returns per-member time-on-front summaries over a configurable window.
-See sheaf.services.analytics for the aggregation semantics (co-fronting
-double-counts, ongoing fronts close at `until`, hour-of-day bucketing
-happens in the supplied timezone).
+The aggregation runs in Postgres: per-member totals are a SUM of clipped
+front durations, and the hour-of-day distribution is bucketed with a
+generate_series walk over local-hour boundaries. Keeping the work in SQL
+bounds both memory and event-loop time regardless of how many front rows
+the window spans - the response is per-member, not per-front, so only a
+handful of rows come back no matter how large the history is.
+
+The pure-Python reference implementation (clip_intervals / aggregate /
+_bucket_into_hours) still lives in sheaf.services.analytics; it backs the
+quick-switch scorer and the unit tests, and documents the exact semantics
+this SQL reproduces (co-fronting double-counts, ongoing fronts close at
+`until`, hour-of-day bucketing happens in the supplied timezone).
 """
 
 from __future__ import annotations
@@ -13,21 +22,16 @@ from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user
 from sheaf.database import get_db
-from sheaf.models.front import Front
+from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.member import Member
 from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.analytics import FrontingAnalytics, MemberFrontingStats
-from sheaf.services.analytics import (
-    aggregate,
-    clip_intervals,
-)
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
@@ -36,6 +40,78 @@ router = APIRouter(prefix="/analytics", tags=["analytics"])
 # walking an unbounded history. Anyone wanting decade-scale stats can
 # paginate by year and combine client-side.
 _MAX_WINDOW = timedelta(days=365 * 5)
+
+
+# Per-member totals: SUM/COUNT/MAX of clipped front durations. Ongoing
+# fronts (ended_at IS NULL) close at :until, matching the window's upper
+# edge (which defaults to now()). Each front's [started_at, ended_at] is
+# clipped to [:since, :until] server-side; durations are whole seconds
+# (floor), matching the per-front int() the reference aggregator applies.
+# Co-fronting double-counts because the front_members join fans a co-front
+# out to one row per member. Zero-length clips are dropped by the final
+# predicate, matching the reference's `duration <= 0` skip.
+_FRONTING_TOTALS_SQL = text(
+    """
+    SELECT fm.member_id AS member_id,
+           SUM(floor(extract(epoch FROM (
+               LEAST(COALESCE(f.ended_at, :until), :until)
+               - GREATEST(f.started_at, :since)
+           ))))::bigint AS total_seconds,
+           COUNT(*) AS session_count,
+           MAX(floor(extract(epoch FROM (
+               LEAST(COALESCE(f.ended_at, :until), :until)
+               - GREATEST(f.started_at, :since)
+           ))))::bigint AS longest_session_seconds
+    FROM fronts f
+    JOIN front_members fm ON fm.front_id = f.id
+    WHERE f.system_id = :system_id
+      AND f.started_at < :until
+      AND (f.ended_at IS NULL OR f.ended_at > :since)
+      AND LEAST(COALESCE(f.ended_at, :until), :until)
+          > GREATEST(f.started_at, :since)
+    GROUP BY fm.member_id
+    """
+)
+
+
+# Hour-of-day distribution in the requested timezone. Each clipped front is
+# split at local-hour boundaries and a slice's seconds are credited to the
+# local hour at its start. The generate_series walk is anchored at the UTC
+# instant of the front's local-hour floor and steps one UTC hour, so DST
+# transitions fall out on their own: a spring-forward hour maps to no UTC
+# instant and is skipped, a fall-back hour maps to two and is counted twice.
+# This mirrors _bucket_into_hours in sheaf.services.analytics. Per-slice
+# floor(...) matches the reference's per-slice int().
+_FRONTING_HOURS_SQL = text(
+    """
+    WITH clipped AS (
+        SELECT fm.member_id AS member_id,
+               GREATEST(f.started_at, :since) AS cs,
+               LEAST(COALESCE(f.ended_at, :until), :until) AS ce
+        FROM fronts f
+        JOIN front_members fm ON fm.front_id = f.id
+        WHERE f.system_id = :system_id
+          AND f.started_at < :until
+          AND (f.ended_at IS NULL OR f.ended_at > :since)
+          AND LEAST(COALESCE(f.ended_at, :until), :until)
+              > GREATEST(f.started_at, :since)
+    )
+    SELECT c.member_id AS member_id,
+           extract(hour FROM (gs AT TIME ZONE :tz))::int AS hod,
+           SUM(floor(extract(epoch FROM (
+               LEAST(gs + interval '1 hour', c.ce)
+               - GREATEST(gs, c.cs)
+           ))))::bigint AS secs
+    FROM clipped c
+    CROSS JOIN LATERAL generate_series(
+        date_trunc('hour', c.cs AT TIME ZONE :tz) AT TIME ZONE :tz,
+        c.ce,
+        interval '1 hour'
+    ) AS gs
+    WHERE LEAST(gs + interval '1 hour', c.ce) > GREATEST(gs, c.cs)
+    GROUP BY c.member_id, hod
+    """
+)
 
 
 def _parse_tz(tz_name: str) -> ZoneInfo:
@@ -48,7 +124,11 @@ def _parse_tz(tz_name: str) -> ZoneInfo:
         ) from exc
 
 
-@router.get("/fronting", response_model=FrontingAnalytics)
+@router.get(
+    "/fronting",
+    response_model=FrontingAnalytics,
+    dependencies=[rate_limit(20, 60, "user")],
+)
 async def fronting_analytics(
     since: datetime | None = Query(default=None),
     until: datetime | None = Query(default=None),
@@ -62,9 +142,9 @@ async def fronting_analytics(
     The window is clamped to 5 years; past that, paginate by year and
     combine client-side.
 
-    Co-fronting double-counts: if Alice and Bob co-front for an hour,
-    both see +3600 seconds. This matches the reading users expect for
-    "how much did Alice front this month".
+    Co-fronting double-counts: if Alice and Bob co-front for an hour, both
+    see +3600 seconds. This matches the reading users expect for "how much
+    did Alice front this month".
     """
     now = datetime.now(UTC)
     until_ts = until or now
@@ -81,7 +161,11 @@ async def fronting_analytics(
             detail="Window too large; max 5 years.",
         )
 
-    zone = _parse_tz(tz)
+    # Validate the timezone up front so a bad tz is a 400, not a SQL error.
+    # Postgres does the actual local-hour conversion from the same name.
+    _parse_tz(tz)
+
+    window_seconds = int((until_ts - since_ts).total_seconds())
 
     system_result = await db.execute(
         select(System).where(System.user_id == user.id)
@@ -92,60 +176,69 @@ async def fronting_analytics(
             status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
         )
 
-    # Load fronts overlapping the window. We need ended_at IS NULL OR
-    # ended_at > since to keep ongoing fronts and recently-ended ones.
-    fronts_result = await db.execute(
-        select(Front)
-        .options(selectinload(Front.members))
-        .where(
-            Front.system_id == system.id,
-            Front.started_at < until_ts,
-            (Front.ended_at.is_(None)) | (Front.ended_at > since_ts),
-        )
-    )
-    fronts = list(fronts_result.scalars().all())
+    base_params = {
+        "system_id": system.id,
+        "since": since_ts,
+        "until": until_ts,
+    }
 
-    rows: list[tuple[datetime, datetime | None, list[uuid.UUID]]] = [
-        (f.started_at, f.ended_at, [m.id for m in f.members])
-        for f in fronts
-    ]
-    intervals = clip_intervals(rows, since=since_ts, until=until_ts)
+    # Per-member totals and hour-of-day distribution, both aggregated in
+    # Postgres. Each returns at most one row per member (24 per member for
+    # the hour buckets), so the payload back to Python is tiny regardless
+    # of how many fronts the window covers.
+    totals_result = await db.execute(_FRONTING_TOTALS_SQL, base_params)
+    totals = {row.member_id: row for row in totals_result}
+
+    hours_result = await db.execute(
+        _FRONTING_HOURS_SQL, {**base_params, "tz": tz}
+    )
+    hour_buckets: dict[uuid.UUID, list[int]] = {}
+    for row in hours_result:
+        buckets = hour_buckets.setdefault(row.member_id, [0] * 24)
+        buckets[row.hod] = int(row.secs or 0)
 
     # Member metadata for the response (is_custom_front flag) plus a
     # zero-stats entry for every member so the UI can list members who
-    # didn't front in the window without special-casing them.
+    # didn't front in the window without special-casing them. Members are
+    # per-system and bounded, so loading them is cheap - it's the fronts
+    # table that could be huge, and that never leaves Postgres now.
     members_result = await db.execute(
         select(Member).where(Member.system_id == system.id)
     )
     members = list(members_result.scalars().all())
-    member_is_custom = {m.id: m.is_custom_front for m in members}
 
-    aggregated = aggregate(
-        intervals,
-        since=since_ts,
-        until=until_ts,
-        tz=zone,
-        member_is_custom_front=member_is_custom,
-    )
-
-    # Backfill members with no fronting time so the response includes
-    # everyone — UI can sort by total_seconds desc and the no-front
-    # members fall to the bottom naturally.
     member_stats: list[MemberFrontingStats] = []
     for member in members:
-        if member.id in aggregated:
-            member_stats.append(MemberFrontingStats(**aggregated[member.id]))
-        else:
+        row = totals.get(member.id)
+        if row is None:
+            # No fronting time in the window; still list them so the UI
+            # can sort by total_seconds desc and they fall to the bottom.
             member_stats.append(
                 MemberFrontingStats(
                     member_id=member.id,
                     is_custom_front=member.is_custom_front,
                 )
             )
+            continue
+        total_seconds = int(row.total_seconds or 0)
+        member_stats.append(
+            MemberFrontingStats(
+                member_id=member.id,
+                is_custom_front=member.is_custom_front,
+                total_seconds=total_seconds,
+                percent_of_window=(
+                    round(100.0 * total_seconds / window_seconds, 2)
+                    if window_seconds > 0
+                    else 0.0
+                ),
+                session_count=int(row.session_count or 0),
+                longest_session_seconds=int(row.longest_session_seconds or 0),
+                hour_of_day_seconds=hour_buckets.get(member.id, [0] * 24),
+            )
+        )
 
     member_stats.sort(key=lambda s: s.total_seconds, reverse=True)
 
-    window_seconds = int((until_ts - since_ts).total_seconds())
     return FrontingAnalytics(
         since=since_ts,
         until=until_ts,

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -78,6 +78,7 @@ from sheaf.observability.metrics import (
     auth_password_reset_total,
     auth_recovery_codes_used_total,
 )
+from sheaf.redact import redact_email
 from sheaf.request import client_ip
 from sheaf.schemas.user import (
     SecondarySessionRequest,
@@ -944,11 +945,15 @@ async def change_email(
         await _send_verification_email(db, user, new_email)
         verification_sent = True
 
+    # target_label lands in the unencrypted activity-log column (retained
+    # ~a year); the address itself is encrypted at rest two lines up, so
+    # store only a redacted form here rather than reintroducing plaintext
+    # PII into DB dumps / backups / replicas.
     await log_activity(
         db,
         user_id=user.id,
         action=ActivityAction.EMAIL_CHANGED,
-        target_label=new_email,
+        target_label=redact_email(new_email),
     )
     await db.commit()
 

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -17,7 +17,7 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, EmailStr
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -384,9 +384,31 @@ async def register(
             status_code=status.HTTP_409_CONFLICT, detail="Email already registered"
         ) from exc
 
-    # Track invite code usage
+    # Track invite code usage. Claim the use atomically: a conditional UPDATE
+    # that only increments while the code is under its cap, guarded by
+    # rowcount. The earlier _validate_invite_code check is a fast pre-reject,
+    # but two concurrent registrations can both pass it on a stale read and a
+    # plain use_count += 1 would lose one of the increments, over-redeeming a
+    # single-use code. max_uses = 0 means unlimited.
     if invite is not None:
-        invite.use_count += 1
+        from sheaf.models.invite_code import InviteCode
+
+        claim = await db.execute(
+            update(InviteCode)
+            .where(
+                InviteCode.id == invite.id,
+                or_(
+                    InviteCode.max_uses == 0,
+                    InviteCode.use_count < InviteCode.max_uses,
+                ),
+            )
+            .values(use_count=InviteCode.use_count + 1)
+        )
+        if claim.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invite code has reached maximum uses",
+            )
         user.invite_code_id = invite.id
 
     # Auto-create a system for the user

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -12,13 +12,14 @@ delivered as a zip via S3-presigned download or filesystem stream.
 """
 
 import uuid
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -26,6 +27,7 @@ from sheaf.auth.dependencies import get_current_user
 from sheaf.auth.lockout import ensure_not_locked, record_login_failure
 from sheaf.auth.passwords import verify_password
 from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
+from sheaf.config import settings
 from sheaf.crypto import decrypt
 from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
@@ -53,7 +55,73 @@ from sheaf.services.openplural_archive import unpack_residual
 router = APIRouter(prefix="/export", tags=["export"])
 
 
-@router.get("")
+# asyncpg caps a single statement at 32767 bind parameters. Any `.in_(ids)`
+# over a user-scaled id list can blow past that on a large account (a hard
+# 500), so we batch such lists into chunks well under the limit and merge.
+_BIND_PARAM_CHUNK = 1000
+
+
+def _chunked(items: list, size: int = _BIND_PARAM_CHUNK) -> Iterator[list]:
+    """Yield `items` in slices of at most `size`. Empty input yields nothing."""
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+async def _count_where(db: AsyncSession, model, condition) -> int:
+    """Cheap COUNT(*) for `model` rows matching `condition`."""
+    return int(
+        (
+            await db.execute(select(func.count()).select_from(model).where(condition))
+        ).scalar_one()
+    )
+
+
+async def _enforce_sync_export_size(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Refuse the sync export path for accounts too large to assemble in
+    memory on the event loop, pointing the caller at the async job flow.
+
+    A FastAPI route dependency rather than an inline check: it must guard the
+    HTTP endpoint only. The async export builder calls export_all() directly
+    as a function (not over HTTP), so it deliberately bypasses this guard -
+    the whole point is that oversized accounts go through that streaming
+    path instead.
+
+    Cheap COUNTs first (do not load-then-check). Counts the system-scoped
+    tables that dominate the in-memory payload; revisions/files/etc. scale
+    with these, so bounding them bounds the whole dump. get_current_user /
+    get_db are cached within the request, so this shares the handler's
+    session and user - no duplicate auth or connection.
+    """
+    threshold = settings.export_sync_max_rows
+    if threshold <= 0:
+        return  # guard disabled
+
+    system_id = (
+        await db.execute(select(System.id).where(System.user_id == user.id))
+    ).scalar_one_or_none()
+    if system_id is None:
+        return  # nothing to export
+
+    from sheaf.models.message import Message
+
+    total = 0
+    for model in (Member, Front, JournalEntry, Message):
+        total += await _count_where(db, model, model.system_id == system_id)
+        if total > threshold:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=(
+                    "Your account is too large to export synchronously. Use "
+                    "the async export instead: POST /v1/export/jobs, which "
+                    "streams the result to a downloadable file."
+                ),
+            )
+
+
+@router.get("", dependencies=[rate_limit(6, 3600, "user"), Depends(_enforce_sync_export_size)])
 async def export_all(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -136,10 +204,15 @@ async def export_all(
     member_id_set = {m.id for m, *_ in members_with_plaintext}
     journal_id_set = {e.id for e in journal_entries}
     targets = list(member_id_set | journal_id_set)
-    if targets:
+    # Batch the target-id IN() over chunks so a large account can't exceed
+    # asyncpg's 32767 bind-param ceiling (which would 500 the whole export).
+    # Chunking loses the single query's global ORDER BY, so re-sort the
+    # merged batches by created_at to preserve the export's ordering.
+    revisions = []
+    for chunk in _chunked(targets):
         revisions_result = await db.execute(
             select(ContentRevision)
-            .where(ContentRevision.target_id.in_(targets))
+            .where(ContentRevision.target_id.in_(chunk))
             .where(
                 ContentRevision.target_type.in_(
                     [
@@ -150,9 +223,8 @@ async def export_all(
             )
             .order_by(ContentRevision.created_at.asc())
         )
-        revisions = list(revisions_result.scalars().all())
-    else:
-        revisions = []
+        revisions.extend(revisions_result.scalars().all())
+    revisions.sort(key=lambda r: r.created_at)
 
     # Watch tokens + their channels - owner-side notification config the
     # user explicitly built up. Re-importable in the sense that the

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -40,6 +40,26 @@ from sheaf.services.system_safety import (
 router = APIRouter(prefix="/fronts", tags=["fronts"])
 
 
+# Namespace for the per-system front-switch advisory lock. Postgres keeps
+# the two-int4 advisory-lock key space disjoint from the single-bigint
+# space the leader election uses (sheaf/services/leader.py), so this only
+# has to stay distinct from any *other* two-int4 advisory lock we might add
+# later. Arbitrary but must not change across deploys.
+_FRONT_SWITCH_LOCK_NS = 0x53480001  # "SH" + 0x0001: front-switch serialisation
+
+
+def _system_front_lock_key(system_id: uuid.UUID) -> int:
+    """Map a system id to a signed int4 for the front-switch advisory lock.
+
+    Deterministic across processes (unlike the built-in ``hash``). A given
+    system always maps to the same key, so its concurrent switches serialise
+    exactly; a collision between two *different* systems only ever adds a
+    little cross-system serialisation of the rare front-create path, never
+    wrong data. Low 31 bits keep the value in non-negative int4 range.
+    """
+    return system_id.int & 0x7FFFFFFF
+
+
 async def _get_user_system(user: User, db: AsyncSession) -> System:
     result = await db.execute(select(System).where(System.user_id == user.id))
     system = result.scalar_one_or_none()
@@ -212,7 +232,19 @@ async def _build_coalesced_member_since(
 async def list_fronts(
     response: Response,
     limit: int = Query(default=50, le=200),
-    offset: int = Query(default=0, ge=0),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        # Legacy offset paging walks and discards `offset` rows server-side,
+        # so an unbounded value is a cheap way to make the DB do arbitrary
+        # work. Cap it; anyone paging deeper should switch to `cursor`, which
+        # stays flat-cost at any depth.
+        le=10_000,
+        description=(
+            "Legacy offset paging, bounded at 10000. For deeper history use "
+            "the `cursor` param, which stays cheap at any depth."
+        ),
+    ),
     cursor: str | None = Query(
         default=None,
         description=(
@@ -371,6 +403,29 @@ async def create_front(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="One or more member IDs are invalid",
         )
+
+    # Serialise front switches for this system. create_front is check-then-
+    # act: it reads the open fronts to auto-end (replace) or to reject an
+    # exact-duplicate member set, then inserts a new open front. Under
+    # READ COMMITTED two concurrent switches each read the pre-insert state,
+    # both pass their checks, and both insert - leaving two overlapping or
+    # duplicate open fronts. A transaction-scoped advisory lock keyed on the
+    # system serialises the whole read-decide-insert section and releases
+    # automatically on commit or rollback, so a stuck request can't hold it.
+    # Explicit int4 casts pin the two-key pg_advisory_xact_lock(int, int)
+    # overload regardless of how the driver types the bound ints (a bare
+    # bigint would fail to resolve the two-key form). Both values are built
+    # to fit signed int4 above.
+    await db.execute(
+        text(
+            "SELECT pg_advisory_xact_lock("
+            "CAST(:ns AS integer), CAST(:key AS integer))"
+        ),
+        {
+            "ns": _FRONT_SWITCH_LOCK_NS,
+            "key": _system_front_lock_key(system.id),
+        },
+    )
 
     before_state = await snapshot_front_state(db, system.id)
 
@@ -581,6 +636,20 @@ async def update_front(
 )
 async def list_front_audit(
     front_id: uuid.UUID,
+    response: Response,
+    # A front has no cap on the number of edits, and every audit row
+    # carries two JSONB snapshots, so returning the whole log unbounded is
+    # an O(edits) read. Page it. Default is generous enough that no real
+    # UI hits the boundary; deeper callers follow the cursor. Constants are
+    # inline (no config knob) - bump here if audit histories grow.
+    limit: int = Query(default=200, ge=1, le=500),
+    cursor: str | None = Query(
+        default=None,
+        description=(
+            "Opaque pagination cursor. Pass the `X-Sheaf-Next-Cursor` value "
+            "from the previous response to fetch the next (older) page."
+        ),
+    ),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -589,9 +658,13 @@ async def list_front_audit(
     Gated by `fronts:read` (router-level dep). The audit log is
     system-internal; same caller can read the live entry, so the audit
     rows reveal nothing further. Hard-deleted with the entry via
-    ON DELETE CASCADE on front_id."""
+    ON DELETE CASCADE on front_id.
+
+    Keyset-paginated the same way `GET /v1/fronts` is: the body stays a
+    plain array, and `X-Sheaf-Has-More` / `X-Sheaf-Next-Cursor` headers
+    signal and drive the next page."""
     system = await _get_user_system(user, db)
-    # Ownership check via the live front row — if the entry doesn't
+    # Ownership check via the live front row - if the entry doesn't
     # belong to the caller's system, return 404 regardless of whether
     # audit rows happen to exist.
     front_result = await db.execute(
@@ -604,11 +677,40 @@ async def list_front_audit(
             status_code=status.HTTP_404_NOT_FOUND, detail="Front not found"
         )
 
-    audit_result = await db.execute(
+    query = (
         select(FrontAuditEvent)
         .where(FrontAuditEvent.front_id == front_id)
-        .order_by(FrontAuditEvent.created_at.desc())
+        # id is the deterministic tiebreaker for rows sharing a created_at,
+        # matching the cursor's row comparison so pages neither skip nor
+        # duplicate.
+        .order_by(FrontAuditEvent.created_at.desc(), FrontAuditEvent.id.desc())
     )
+    if cursor is not None:
+        try:
+            cursor_created, cursor_id = decode_cursor(cursor)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid cursor",
+            ) from exc
+        query = query.where(
+            tuple_(FrontAuditEvent.created_at, FrontAuditEvent.id)
+            < tuple_(cursor_created, cursor_id)
+        )
+
+    # limit + 1 probe answers "is there more?" without a COUNT.
+    result = await db.execute(query.limit(limit + 1))
+    rows = list(result.scalars().all())
+    has_more = len(rows) > limit
+    page = rows[:limit]
+
+    response.headers["X-Sheaf-Has-More"] = "true" if has_more else "false"
+    if has_more and page:
+        last = page[-1]
+        response.headers["X-Sheaf-Next-Cursor"] = encode_cursor(
+            last.created_at, last.id
+        )
+
     return [
         FrontAuditEventRead(
             id=row.id,
@@ -619,7 +721,7 @@ async def list_front_audit(
             after=_audit_snapshot_to_read(row.after_snapshot),
             created_at=row.created_at,
         )
-        for row in audit_result.scalars().all()
+        for row in page
     ]
 
 

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -296,25 +296,73 @@ async def delete_entry(
 )
 async def list_revisions(
     entry_id: uuid.UUID,
+    response: Response,
+    # "Bounded by retention" only holds on the hosted tiers; self-hosted
+    # defaults the revision cap to 0 (unlimited), and pinned revisions are
+    # exempt from the sweep, so the list can grow without limit. Page it.
+    # Default covers the hosted Plus rolling cap (100) with headroom so no
+    # hosted caller is truncated; self-hosted / pinned-heavy entries follow
+    # the cursor. Constants inline (no config knob).
+    limit: int = Query(default=200, ge=1, le=500),
+    cursor: str | None = Query(
+        default=None,
+        description=(
+            "Opaque pagination cursor. Pass the `X-Sheaf-Next-Cursor` value "
+            "from the previous response to fetch the next (older) page."
+        ),
+    ),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    """List an entry's revision history, newest first.
+
+    Keyset-paginated: the body stays a plain array, and `X-Sheaf-Has-More`
+    / `X-Sheaf-Next-Cursor` headers signal and drive the next page (same
+    shape as `GET /v1/fronts`)."""
     system = await _get_user_system(user, db)
-    # Verify ownership of the entry first; revisions are bounded by retention
-    # and don't need their own pagination in v1.
+    # Verify ownership of the entry first.
     await _get_own_entry(entry_id, system.id, db)
-    result = await db.execute(
+    query = (
         select(ContentRevision)
         .where(
             ContentRevision.target_type
             == ContentRevisionTarget.JOURNAL_ENTRY.value,
             ContentRevision.target_id == entry_id,
         )
-        .order_by(ContentRevision.created_at.desc())
+        # created_at is a per-transaction now(), so a burst of revisions can
+        # tie; id is the deterministic tiebreaker the cursor comparison uses
+        # too, keeping pages stable.
+        .order_by(ContentRevision.created_at.desc(), ContentRevision.id.desc())
     )
+    if cursor is not None:
+        try:
+            cursor_created, cursor_id = decode_cursor(cursor)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid cursor",
+            ) from exc
+        query = query.where(
+            tuple_(ContentRevision.created_at, ContentRevision.id)
+            < tuple_(cursor_created, cursor_id)
+        )
+
+    # limit + 1 probe answers "is there more?" without a COUNT.
+    result = await db.execute(query.limit(limit + 1))
+    rows = list(result.scalars().all())
+    has_more = len(rows) > limit
+    page = rows[:limit]
+
+    response.headers["X-Sheaf-Has-More"] = "true" if has_more else "false"
+    if has_more and page:
+        last = page[-1]
+        response.headers["X-Sheaf-Next-Cursor"] = encode_cursor(
+            last.created_at, last.id
+        )
+
     return [
         ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
-        for r in result.scalars().all()
+        for r in page
     ]
 
 

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -44,6 +44,7 @@ from sheaf.services.journals import (
 )
 from sheaf.services.member_limits import count_members, get_member_limit
 from sheaf.services.members import decrypt_member_for_read, member_plaintext
+from sheaf.services.pagination import decode_cursor, encode_cursor
 from sheaf.services.system_safety import (
     is_safeguarded,
     pending_finalize_after_by_target,
@@ -548,23 +549,72 @@ async def set_member_tags(
 )
 async def list_bio_revisions(
     member_id: uuid.UUID,
+    response: Response,
+    # "Bounded by retention" only holds on the hosted tiers; self-hosted
+    # defaults the revision cap to 0 (unlimited), and pinned revisions are
+    # exempt from the sweep, so a bio's history can grow without limit. Page
+    # it, matching the journal / message / front-audit revision lists. Default
+    # covers the hosted Plus rolling cap (100) with headroom; self-hosted /
+    # pinned-heavy bios follow the cursor. Constants inline (no config knob).
+    limit: int = Query(default=200, ge=1, le=500),
+    cursor: str | None = Query(
+        default=None,
+        description=(
+            "Opaque pagination cursor. Pass the `X-Sheaf-Next-Cursor` value "
+            "from the previous response to fetch the next (older) page."
+        ),
+    ),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    """List a member bio's revision history, newest first.
+
+    Keyset-paginated: the body stays a plain array, and `X-Sheaf-Has-More`
+    / `X-Sheaf-Next-Cursor` headers signal and drive the next (older) page
+    (same shape as `GET /v1/fronts` and the journal revision list)."""
     system = await _get_user_system(user, db)
     member = await _get_own_member(member_id, system, db)
-    result = await db.execute(
+    query = (
         select(ContentRevision)
         .where(
             ContentRevision.target_type
             == ContentRevisionTarget.MEMBER_BIO.value,
             ContentRevision.target_id == member.id,
         )
-        .order_by(ContentRevision.created_at.desc())
+        # created_at is a per-transaction now(), so a burst of revisions can
+        # tie; id is the deterministic tiebreaker the cursor comparison uses
+        # too, keeping pages stable.
+        .order_by(ContentRevision.created_at.desc(), ContentRevision.id.desc())
     )
+    if cursor is not None:
+        try:
+            cursor_created, cursor_id = decode_cursor(cursor)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid cursor",
+            ) from exc
+        query = query.where(
+            tuple_(ContentRevision.created_at, ContentRevision.id)
+            < tuple_(cursor_created, cursor_id)
+        )
+
+    # limit + 1 probe answers "is there more?" without a COUNT.
+    result = await db.execute(query.limit(limit + 1))
+    rows = list(result.scalars().all())
+    has_more = len(rows) > limit
+    page = rows[:limit]
+
+    response.headers["X-Sheaf-Has-More"] = "true" if has_more else "false"
+    if has_more and page:
+        last = page[-1]
+        response.headers["X-Sheaf-Next-Cursor"] = encode_cursor(
+            last.created_at, last.id
+        )
+
     return [
         ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
-        for r in result.scalars().all()
+        for r in page
     ]
 
 

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user, require_scope
@@ -66,6 +66,7 @@ from sheaf.services.messages import (
 from sheaf.services.messages import (
     mark_seen as svc_mark_seen,
 )
+from sheaf.services.pagination import decode_cursor, encode_cursor
 from sheaf.services.system_safety import (
     is_safeguarded,
     pending_finalize_after_by_target,
@@ -653,22 +654,70 @@ async def delete_thread(
 )
 async def list_revisions(
     message_id: uuid.UUID,
+    response: Response,
+    # Same rationale as the journals revision list: the revision cap is 0
+    # (unlimited) on self-hosted and pinned rows are exempt from the sweep,
+    # so the history can grow without limit. Page it; default covers the
+    # hosted Plus rolling cap (100) with headroom, cursor covers the rest.
+    # Constants inline (no config knob).
+    limit: int = Query(default=200, ge=1, le=500),
+    cursor: str | None = Query(
+        default=None,
+        description=(
+            "Opaque pagination cursor. Pass the `X-Sheaf-Next-Cursor` value "
+            "from the previous response to fetch the next (older) page."
+        ),
+    ),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    """List a message's revision history, newest first.
+
+    Keyset-paginated: the body stays a plain array, and `X-Sheaf-Has-More`
+    / `X-Sheaf-Next-Cursor` headers signal and drive the next page (same
+    shape as `GET /v1/fronts`)."""
     system = await _get_user_system(user, db)
     msg = await _get_owned_message(message_id, system, db)
-    result = await db.execute(
+    query = (
         select(ContentRevision)
         .where(
             ContentRevision.target_type == ContentRevisionTarget.MESSAGE.value,
             ContentRevision.target_id == msg.id,
         )
-        .order_by(ContentRevision.created_at.desc())
+        # created_at is a per-transaction now(), so a burst of revisions can
+        # tie; id is the deterministic tiebreaker the cursor comparison uses
+        # too, keeping pages stable.
+        .order_by(ContentRevision.created_at.desc(), ContentRevision.id.desc())
     )
+    if cursor is not None:
+        try:
+            cursor_created, cursor_id = decode_cursor(cursor)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid cursor",
+            ) from exc
+        query = query.where(
+            tuple_(ContentRevision.created_at, ContentRevision.id)
+            < tuple_(cursor_created, cursor_id)
+        )
+
+    # limit + 1 probe answers "is there more?" without a COUNT.
+    result = await db.execute(query.limit(limit + 1))
+    rows = list(result.scalars().all())
+    has_more = len(rows) > limit
+    page = rows[:limit]
+
+    response.headers["X-Sheaf-Has-More"] = "true" if has_more else "false"
+    if has_more and page:
+        last = page[-1]
+        response.headers["X-Sheaf-Next-Cursor"] = encode_cursor(
+            last.created_at, last.id
+        )
+
     return [
         ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
-        for r in result.scalars().all()
+        for r in page
     ]
 
 

--- a/sheaf/api/v1/system_safety.py
+++ b/sheaf/api/v1/system_safety.py
@@ -8,6 +8,7 @@ mapped to the internal column names (`safety_grace_period_days`,
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -17,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.api.v1.members import _get_user_system
 from sheaf.auth.dependencies import get_current_user, require_scope
+from sheaf.crypto import decrypt
 from sheaf.database import get_db
 from sheaf.models.pending_action import PendingAction, PendingActionStatus
 from sheaf.models.safety_change_request import (
@@ -86,6 +88,45 @@ def _settings_from_system(system: System) -> SystemSafetySettings:
     )
 
 
+def _pending_action_to_read(a: PendingAction) -> PendingActionRead:
+    """Build a PendingActionRead, decrypting the at-rest content columns.
+
+    `target_label` and `fronting_member_names` are encrypted at rest (see
+    queue_pending_action). Decrypt defensively: a row written by the old code
+    during the deploy transition (before the encrypting migration and new
+    write path both landed) is still plaintext, so fall back to treating the
+    stored value as plaintext rather than 500ing. Mirrors the tolerant
+    pattern of `decrypt_text` in sheaf/services/polls.py.
+    """
+    try:
+        target_label = decrypt(a.target_label)
+    except Exception:
+        target_label = a.target_label
+
+    try:
+        fronting_member_names = json.loads(decrypt(a.fronting_member_names))
+    except Exception:
+        # Legacy plaintext row: the pre-migration JSONB list, now stored as a
+        # JSON-array string in the Text column. Parse it if we can, else [].
+        try:
+            fronting_member_names = json.loads(a.fronting_member_names)
+        except Exception:
+            fronting_member_names = []
+
+    return PendingActionRead(
+        id=a.id,
+        action_type=a.action_type,
+        target_id=a.target_id,
+        target_label=target_label,
+        requested_at=a.requested_at,
+        requested_by_user_id=a.requested_by_user_id,
+        finalize_after=a.finalize_after,
+        fronting_member_ids=a.fronting_member_ids,
+        fronting_member_names=fronting_member_names,
+        status=a.status,
+    )
+
+
 async def _load_pending(
     system_id: uuid.UUID, db: AsyncSession
 ) -> tuple[list[PendingAction], list[SafetyChangeRequest]]:
@@ -117,7 +158,7 @@ async def get_system_safety(
     actions, changes = await _load_pending(system.id, db)
     return SystemSafetyResponse(
         settings=_settings_from_system(system),
-        pending_actions=[PendingActionRead.model_validate(a) for a in actions],
+        pending_actions=[_pending_action_to_read(a) for a in actions],
         pending_changes=[SafetyChangeRequestRead.model_validate(c) for c in changes],
     )
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -19,6 +19,33 @@ class Settings(BaseSettings):
     # Database
     database_url: str = "postgresql+asyncpg://sheaf:changeme@db:5432/sheaf"
 
+    # Connection pool. Single-process asyncio app: one pool is shared by the
+    # request path and every background loop (job runner, dispatcher, import
+    # runner, export builder). Defaults sized for one uvicorn process; raise
+    # pool_size/max_overflow together with Postgres max_connections if you
+    # run more processes, and mind that each process opens its own pool.
+    db_pool_size: int = 10
+    db_max_overflow: int = 20
+    db_pool_timeout: int = 30  # seconds to wait for a free connection
+
+    # Request-path Postgres statement_timeout (milliseconds), applied
+    # per-transaction inside get_db so a pathological O(history) query can't
+    # pin a pooled connection indefinitely. 0 = unlimited. Deliberately does
+    # NOT apply to background jobs - see db_job_statement_timeout_ms.
+    db_statement_timeout_ms: int = 30000
+
+    # Statement timeout (milliseconds) for background jobs that opt into
+    # database.job_session(). Background work (export builds, retention
+    # sweeps, analytics) legitimately runs far longer than a request, so this
+    # defaults to 0 = unlimited; set a large ceiling if you want a backstop
+    # against a runaway job query without capping normal long jobs.
+    db_job_statement_timeout_ms: int = 0
+
+    # Readiness probe (/health/ready) per-dependency timeout in seconds. Kept
+    # tight so a wedged DB or Redis surfaces to the load balancer fast rather
+    # than hanging the health check.
+    health_check_timeout_seconds: float = 2.0
+
     # Redis
     redis_url: str = "redis://redis:6379/0"
 
@@ -560,6 +587,13 @@ class Settings(BaseSettings):
     poll_cleanup_interval_hours: int = 6
 
     # Async data export jobs
+    # Sync GET /v1/export assembles the whole account in memory and
+    # JSON-serialises it on the event loop. Above this many rows (members +
+    # fronts + journal entries + messages) it refuses and points the user at
+    # the async POST /v1/export/jobs flow, which streams to a file on disk.
+    # Guards the event loop against a multi-hundred-MB in-process serialise.
+    # 0 = no limit (the async path is always available regardless).
+    export_sync_max_rows: int = 50000
     # Lifetime of a generated export file before it's auto-deleted from
     # storage and the job row marked EXPIRED. 72h gives the user three days
     # to grab it; long enough for "I'll do this from my desktop later",

--- a/sheaf/database.py
+++ b/sheaf/database.py
@@ -1,15 +1,31 @@
 import time
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
-from sqlalchemy import event
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from sheaf.config import settings
 
+# Single shared engine + pool. The request path and every background loop
+# (job runner, dispatcher, import runner, export builder) draw from this one
+# pool; gauges/leader/import_runner import `engine` directly for pool stats
+# and advisory-lock connections, so it stays the canonical handle.
+#
+# statement_timeout is deliberately NOT set on the engine/connection here.
+# A connection-level cap would apply to every session drawn from the pool,
+# including the long-running background jobs (export builds, retention
+# sweeps, analytics) that legitimately outlast any request. Instead the
+# SHORT request cap is applied per-transaction inside get_db, and jobs stay
+# uncapped by default (opting into db_job_statement_timeout_ms via
+# job_session()). See _set_local_statement_timeout below.
 engine = create_async_engine(
     settings.database_url,
     echo=False,
     pool_pre_ping=True,
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
+    pool_timeout=settings.db_pool_timeout,
 )
 
 async_session_factory = async_sessionmaker(
@@ -56,11 +72,57 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, executem
     )
 
 
+async def _set_local_statement_timeout(session: AsyncSession, timeout_ms: int) -> None:
+    """Apply a transaction-local Postgres statement_timeout to `session`.
+
+    A value <= 0 is a no-op (unlimited). SET LOCAL is scoped to the current
+    transaction, so the cap neither leaks to the next caller that checks out
+    this pooled connection nor bleeds past a commit. Postgres SET does not
+    accept bind parameters, so the value is formatted in directly - it comes
+    from a pydantic int setting, never user input, and is re-cast to int
+    here, so there is no injection surface.
+    """
+    if timeout_ms <= 0:
+        return
+    await session.execute(text(f"SET LOCAL statement_timeout = {int(timeout_ms)}"))
+
+
 async def get_db() -> AsyncGenerator[AsyncSession]:
     async with async_session_factory() as session:
+        # Bound the request path so a pathological O(history) query can't pin
+        # a pooled connection indefinitely. Applied per-transaction, so it
+        # never touches the background jobs, which use async_session_factory()
+        # / job_session() directly and legitimately run longer than a request.
+        await _set_local_statement_timeout(session, settings.db_statement_timeout_ms)
         try:
             yield session
             await session.commit()
         except Exception:
             await session.rollback()
             raise
+
+
+@asynccontextmanager
+async def job_session() -> AsyncGenerator[AsyncSession]:
+    """Session for background jobs that want an explicit statement_timeout
+    ceiling (db_job_statement_timeout_ms, default 0 = unlimited).
+
+    Same engine/pool as everything else; the only difference from
+    async_session_factory() is the optional per-transaction cap. Jobs today
+    use async_session_factory() directly and are therefore uncapped - adopt
+    this where a job issues unbounded-size queries and you want a safety
+    ceiling that is still far above the short request timeout. Unlike get_db
+    this does NOT auto-commit; the job manages its own transactions.
+
+    Note: SET LOCAL is per-transaction, so for a job that commits between
+    units of work the cap re-applies only to the first transaction after
+    entry. Jobs here follow an execute-then-commit pattern (not
+    `async with db.begin()`), so the pre-emptive SET joins the same
+    transaction as the job's first query. Left as an opt-in because the
+    default ceiling is unlimited.
+    """
+    async with async_session_factory() as session:
+        await _set_local_statement_timeout(
+            session, settings.db_job_statement_timeout_ms
+        )
+        yield session

--- a/sheaf/main.py
+++ b/sheaf/main.py
@@ -296,7 +296,53 @@ app.include_router(v1_router)
 
 @app.get("/health")
 async def health():
+    # Liveness: is the process up and serving? Deliberately checks nothing
+    # else and always returns 200 - existing infra treats this as the
+    # liveness probe. Use /health/ready for dependency (readiness) checks.
     return {"status": "ok"}
+
+
+@app.get("/health/ready")
+async def health_ready() -> JSONResponse:
+    """Readiness: can this replica actually serve traffic right now?
+
+    Fast SELECT 1 against Postgres and a Redis PING, each bounded by a tight
+    timeout so a wedged dependency surfaces to the load balancer instead of
+    hanging the probe. 200 when both pass, 503 otherwise with which one
+    failed. Infra must be pointed at this path for readiness; /health stays
+    the always-200 liveness probe.
+    """
+    from sqlalchemy import text
+
+    from sheaf.auth.sessions import get_redis
+    from sheaf.database import async_session_factory
+
+    timeout = settings.health_check_timeout_seconds
+    checks: dict[str, str] = {}
+    ok = True
+
+    try:
+        async with async_session_factory() as db:
+            await asyncio.wait_for(db.execute(text("SELECT 1")), timeout=timeout)
+        checks["database"] = "ok"
+    except Exception:
+        logger.warning("Readiness check: database unavailable", exc_info=True)
+        checks["database"] = "error"
+        ok = False
+
+    try:
+        redis = await get_redis()
+        await asyncio.wait_for(redis.ping(), timeout=timeout)
+        checks["redis"] = "ok"
+    except Exception:
+        logger.warning("Readiness check: redis unavailable", exc_info=True)
+        checks["redis"] = "error"
+        ok = False
+
+    return JSONResponse(
+        status_code=200 if ok else 503,
+        content={"status": "ok" if ok else "unavailable", "checks": checks},
+    )
 
 
 # RFC 9116 security.txt. The contact and policy point at the upstream project

--- a/sheaf/models/activity_event.py
+++ b/sheaf/models/activity_event.py
@@ -64,6 +64,7 @@ class ActivityAction(enum.StrEnum):
     # Automated / system (actor = system)
     IMPORT_COMPLETED = "import_completed"
     EXPORT_READY = "export_ready"
+    RETENTION_PRUNED = "retention_pruned"
 
 
 class ActivityEvent(UUIDMixin, Base):

--- a/sheaf/models/front.py
+++ b/sheaf/models/front.py
@@ -57,6 +57,13 @@ class Front(UUIDMixin, Base):
         Index("ix_fronts_system_started", "system_id", "started_at"),
         # Fast lookup for "who is currently fronting" (ended_at IS NULL)
         Index("ix_fronts_system_current", "system_id", "ended_at"),
+        # Free-tier retention sweep: system_id IN (...) AND created_at < cutoff
+        # AND ended_at IS NOT NULL AND ended_at < cutoff. Neither index above
+        # covers created_at, so the predicate seq-scanned; this composite lets
+        # it index-scan the closed-and-old rows.
+        Index(
+            "ix_fronts_system_ended_created", "system_id", "ended_at", "created_at"
+        ),
         # A closed front can't end before it starts. The edit endpoint already
         # checks this, but creation/import paths build Front rows directly and
         # bypassed it - this is the mechanical backstop so a mis-ordered front

--- a/sheaf/models/pending_action.py
+++ b/sheaf/models/pending_action.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from enum import StrEnum
 
-from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -44,7 +44,12 @@ class PendingAction(UUIDMixin, Base):
 
     action_type: Mapped[str] = mapped_column(String(32), nullable=False)
     target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    target_label: Mapped[str] = mapped_column(String(200), nullable=False)
+    # Encrypted at rest: this holds decrypted user content (member names,
+    # journal titles, poll questions, message previews) that would otherwise
+    # land in any DB dump taken during the grace window. Text because
+    # ciphertext is longer than the 200-char plaintext bound. Written via
+    # encrypt() in queue_pending_action; decrypted defensively on read.
+    target_label: Mapped[str] = mapped_column(Text, nullable=False)
 
     requested_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
@@ -59,13 +64,16 @@ class PendingAction(UUIDMixin, Base):
     )
 
     # Snapshot of who was fronting when the action was requested.
-    # Frozen — members may be deleted or front composition may change before finalization.
+    # Frozen - members may be deleted or front composition may change before finalization.
+    # ids are opaque UUIDs (not sensitive) and stay JSONB.
     fronting_member_ids: Mapped[list] = mapped_column(
         JSONB, nullable=False, default=list, server_default="[]"
     )
-    fronting_member_names: Mapped[list] = mapped_column(
-        JSONB, nullable=False, default=list, server_default="[]"
-    )
+    # Encrypted at rest for the same reason as target_label: these are
+    # decrypted member names. Stored as encrypt(json.dumps(list_of_names))
+    # in a Text column. No server_default - the app sets the value on every
+    # write and the encrypting migration backfills existing rows.
+    fronting_member_names: Mapped[str] = mapped_column(Text, nullable=False)
 
     status: Mapped[str] = mapped_column(
         String(16),

--- a/sheaf/observability/gauges.py
+++ b/sheaf/observability/gauges.py
@@ -147,83 +147,116 @@ async def _refresh_db_counts(db: AsyncSession) -> None:
     total_fronts = await db.scalar(select(func.count(Front.id)))
     fronts_total.set(int(total_fronts or 0))
 
-    # Per-system front-count distribution. One grouped query; the outer join
-    # keeps systems with zero fronts in the picture so the distribution
-    # covers every system. We never label by system_id - we set a snapshot
-    # cumulative gauge (count of systems at/under each threshold) plus the
-    # single max, which is enough to spot an outlier without naming it.
-    per_system = (
-        (
-            await db.execute(
-                select(func.count(Front.id))
-                .select_from(System)
-                .outerjoin(Front, Front.system_id == System.id)
-                .group_by(System.id)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    counts = [int(c or 0) for c in per_system]
-    system_front_count_max.set(max(counts) if counts else 0)
-    for threshold in FRONT_COUNT_BUCKETS:
-        systems_by_front_count.labels(le=str(threshold)).set(
-            sum(1 for c in counts if c <= threshold)
-        )
-    systems_by_front_count.labels(le="+Inf").set(len(counts))
-
-    # Journal entries + content-revision (edit-history) volume, same
-    # preserve-by-count lens. One grouped query each; the snapshot CDF +
-    # max are set the same way as the front distribution above.
+    # Journal entries + content-revision (edit-history) volume - the cheap
+    # global COUNT(*) baselines only. The per-system / per-target
+    # distributions that back these (and the front distribution above) are
+    # whole-table scans that change slowly, so they ride a slower cadence in
+    # refresh_gauge_distributions() rather than this 60s pass.
     from sheaf.models.content_revision import ContentRevision
     from sheaf.models.journal_entry import JournalEntry
 
-    def _set_distribution(cdf_gauge, max_gauge, values: list[int]) -> None:
-        max_gauge.set(max(values) if values else 0)
-        for threshold in FRONT_COUNT_BUCKETS:
-            cdf_gauge.labels(le=str(threshold)).set(
-                sum(1 for v in values if v <= threshold)
-            )
-        cdf_gauge.labels(le="+Inf").set(len(values))
-
     je_total = await db.scalar(select(func.count(JournalEntry.id)))
     journal_entries_total.set(int(je_total or 0))
-    je_per_system = [
-        int(c or 0)
-        for c in (
-            await db.execute(
-                select(func.count(JournalEntry.id))
-                .select_from(System)
-                .outerjoin(JournalEntry, JournalEntry.system_id == System.id)
-                .group_by(System.id)
-            )
-        )
-        .scalars()
-        .all()
-    ]
-    _set_distribution(
-        systems_by_journal_entry_count,
-        system_journal_entry_count_max,
-        je_per_system,
-    )
 
     cr_total = await db.scalar(select(func.count(ContentRevision.id)))
     content_revisions_total.set(int(cr_total or 0))
-    # Revisions per target (one journal entry / member bio / message).
-    rev_per_target = [
-        int(c or 0)
-        for c in (
-            await db.execute(
-                select(func.count(ContentRevision.id)).group_by(
-                    ContentRevision.target_type, ContentRevision.target_id
-                )
-            )
+
+
+async def refresh_gauge_distributions(db: AsyncSession) -> dict:
+    """Heavy per-system / per-target distribution gauges, on a slow cadence.
+
+    The per-system front and journal-entry distributions and the per-target
+    revision distribution each scan a whole table. They change slowly and
+    feed capacity / retention decisions rather than alerting, so they run on
+    their own hourly job (registered in sheaf/services/jobs.py) instead of
+    the 60s gauge refresh. Everything is aggregated in SQL: each query
+    returns a single row (max + one count per bucket + the total), so no
+    per-system or per-target rows are ever hydrated into Python.
+    """
+    await _refresh_distributions(db)
+    return {"items_processed": 1}
+
+
+async def _set_count_distribution(
+    db: AsyncSession, per_group, cdf_gauge, max_gauge
+) -> None:
+    """Set a snapshot CDF gauge + max gauge from a per-group count subquery.
+
+    `per_group` is a subquery exposing one integer column `c` per group
+    (per system, per target, ...). The distribution is computed entirely in
+    SQL via MAX(c) and COUNT(*) FILTER (WHERE c <= threshold), so only a
+    single aggregate row comes back - we never label by id and never
+    hydrate one row per group. Preserves the id-free snapshot semantics:
+    `cdf_gauge` is re-set per `le` bucket to the number of groups at/under
+    that threshold, plus a `+Inf` bucket = total groups, and `max_gauge` is
+    the single largest group.
+    """
+    cols = [func.max(per_group.c.c).label("max_c")]
+    for threshold in FRONT_COUNT_BUCKETS:
+        cols.append(
+            func.count()
+            .filter(per_group.c.c <= threshold)
+            .label(f"le_{threshold}")
         )
-        .scalars()
-        .all()
-    ]
-    _set_distribution(
-        targets_by_revision_count, target_revision_count_max, rev_per_target
+    cols.append(func.count().label("total"))
+    row = (await db.execute(select(*cols))).one()
+
+    max_gauge.set(int(row.max_c or 0))
+    for threshold in FRONT_COUNT_BUCKETS:
+        cdf_gauge.labels(le=str(threshold)).set(
+            int(getattr(row, f"le_{threshold}"))
+        )
+    cdf_gauge.labels(le="+Inf").set(int(row.total))
+
+
+async def _refresh_distributions(db: AsyncSession) -> None:
+    from sheaf.models.content_revision import ContentRevision
+    from sheaf.models.front import Front
+    from sheaf.models.journal_entry import JournalEntry
+    from sheaf.models.system import System
+
+    # Per-system front-count distribution. The outer join keeps systems with
+    # zero fronts in the picture (count 0) so the distribution covers every
+    # system - the +Inf bucket equals the system count.
+    front_per_system = (
+        select(func.count(Front.id).label("c"))
+        .select_from(System)
+        .outerjoin(Front, Front.system_id == System.id)
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db, front_per_system, systems_by_front_count, system_front_count_max
+    )
+
+    # Journal entries per system, same preserve-by-count lens.
+    je_per_system = (
+        select(func.count(JournalEntry.id).label("c"))
+        .select_from(System)
+        .outerjoin(JournalEntry, JournalEntry.system_id == System.id)
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db,
+        je_per_system,
+        systems_by_journal_entry_count,
+        system_journal_entry_count_max,
+    )
+
+    # Revisions per target (one journal entry / member bio / message). No
+    # outer join - a target only exists once it has a revision, so the +Inf
+    # bucket is the number of distinct edited targets.
+    rev_per_target = (
+        select(func.count(ContentRevision.id).label("c"))
+        .group_by(ContentRevision.target_type, ContentRevision.target_id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db,
+        rev_per_target,
+        targets_by_revision_count,
+        target_revision_count_max,
     )
 
 

--- a/sheaf/services/front_history_export.py
+++ b/sheaf/services/front_history_export.py
@@ -186,9 +186,19 @@ def _build_json(
 
 
 def _ics_escape(text: str) -> str:
-    """Escape a TEXT value per RFC 5545 (backslash, newline, comma, semicolon)."""
+    """Escape a TEXT value per RFC 5545 (backslash, newline, comma, semicolon).
+
+    Carriage returns are normalised to the escaped newline: a bare or CRLF
+    CR embedded in user content (a member name, custom_status, or the system
+    name) would otherwise terminate the content line and let the value
+    inject its own calendar properties or a whole VEVENT into anyone's
+    calendar that imports the feed. CRLF is collapsed first so it yields a
+    single escaped newline, matching how a lone newline is handled.
+    """
     return (
         text.replace("\\", "\\\\")
+        .replace("\r\n", "\\n")
+        .replace("\r", "\\n")
         .replace("\n", "\\n")
         .replace(",", "\\,")
         .replace(";", "\\;")

--- a/sheaf/services/front_retention.py
+++ b/sheaf/services/front_retention.py
@@ -12,23 +12,37 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import SheafMode, settings
+from sheaf.models.activity_event import ActivityAction, ActivityActorType
 from sheaf.models.front import Front
 from sheaf.models.member import front_members
 from sheaf.models.system import System
 from sheaf.models.user import User, UserTier
+from sheaf.services.activity_log import log_activity
 
 logger = logging.getLogger("sheaf.retention")
 
 
 async def prune_free_tier_fronts(db: AsyncSession) -> dict:
-    """Delete front history that ended outside the retention window for
-    free-tier users.
+    """Delete closed, long-dormant front history for free-tier users.
 
-    The cutoff is applied to ``ended_at``, not ``started_at``: the window is
-    "history active in the last N days", so a single long-running front
-    (months, years) is kept for the full window *after it ends* rather than
-    vanishing the instant it closes just because it started long ago. Open
-    fronts have no ``ended_at`` and so are never pruned while ongoing.
+    A front is pruned IFF all three hold together:
+
+      - ``created_at < cutoff`` - the row was *inserted* long ago. This is the
+        row-landing time (set to NOW on every insert), not the front's
+        real-world ``started_at``. It protects freshly-imported historical
+        fronts: an import carries old ``started_at`` / ``ended_at`` values but
+        lands with ``created_at`` = now, so it is never eligible until it has
+        actually lived in this database for the full window. Keying off
+        ``started_at`` (the original incident bug) deleted just-imported
+        history; keying off ``ended_at`` alone does not fix it, because
+        imported fronts also carry an old ``ended_at``.
+      - ``ended_at IS NOT NULL`` - the front is closed. Open fronts are never
+        pruned while ongoing.
+      - ``ended_at < cutoff`` - it also *ended* long ago. This protects a
+        genuinely long-running native front (months, years) that was created
+        long ago but only just closed: its most recent activity is recent, so
+        it is kept for the full window after it ends rather than vanishing the
+        instant it closes.
 
     Returns dict with items_processed count and per-user detail.
     """
@@ -46,14 +60,18 @@ async def prune_free_tier_fronts(db: AsyncSession) -> dict:
         .scalar_subquery()
     )
 
-    # Count per-user before deleting (for detail log)
+    # Count per-user before deleting (for detail log). Predicate mirrors the
+    # delete subquery below exactly - see the docstring for why all three
+    # clauses are required (created_at guards imported history, ended_at guards
+    # recently-active long fronts, IS NOT NULL never touches open fronts).
     per_user_counts = await db.execute(
         select(System.user_id, func.count(Front.id))
         .join(System, Front.system_id == System.id)
         .where(
             Front.system_id.in_(free_system_ids),
+            Front.created_at < cutoff,  # Inserted long ago (protects imports)
             Front.ended_at.is_not(None),  # Never prune open fronts
-            Front.ended_at < cutoff,
+            Front.ended_at < cutoff,  # Ended long ago (protects recent activity)
         )
         .group_by(System.user_id)
     )
@@ -64,8 +82,9 @@ async def prune_free_tier_fronts(db: AsyncSession) -> dict:
         select(Front.id)
         .where(
             Front.system_id.in_(free_system_ids),
+            Front.created_at < cutoff,  # Inserted long ago (protects imports)
             Front.ended_at.is_not(None),  # Never prune open fronts
-            Front.ended_at < cutoff,
+            Front.ended_at < cutoff,  # Ended long ago (protects recent activity)
         )
         .scalar_subquery()
     )
@@ -83,6 +102,25 @@ async def prune_free_tier_fronts(db: AsyncSession) -> dict:
     count = result.rowcount
     if count > 0:
         logger.info("Pruned %d front records older than %s", count, cutoff.isoformat())
+
+    # Nothing-silent: leave a per-user account-activity trace whenever a prune
+    # actually removes rows for that user. The incident was hidden precisely
+    # because the sweep deleted with no trail. Content-free - counts only, no
+    # member content. This needs a new ActivityAction ("retention_pruned") plus
+    # its Postgres enum migration; until both land the lookup returns None and
+    # emission is a no-op (these jobs stay paused until re-enabled). See the
+    # follow-up flagged in the change report.
+    retention_action = getattr(ActivityAction, "RETENTION_PRUNED", None)
+    if retention_action is not None:
+        for uid, cnt in user_counts.items():
+            if cnt:
+                await log_activity(
+                    db,
+                    user_id=uid,
+                    action=retention_action,
+                    actor_type=ActivityActorType.SYSTEM,
+                    detail={"fronts_pruned": cnt},
+                )
 
     detail_lines = [
         f"User {uid}: pruned {cnt} fronts" for uid, cnt in user_counts.items()

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -1173,6 +1173,9 @@ def _register_all_jobs() -> None:
     # Cheap; the queries are all COUNT(*) on indexed predicates plus
     # bounded Redis SCANs. Disabled when metrics are off so it doesn't
     # waste a tick on every deployment.
+    from sheaf.observability.gauges import (
+        refresh_gauge_distributions as _refresh_metrics_gauge_distributions,
+    )
     from sheaf.observability.gauges import refresh_gauges as _refresh_metrics_gauges
 
     register_job(
@@ -1180,6 +1183,19 @@ def _register_all_jobs() -> None:
         description="Refresh DB- and Redis-sourced Prometheus gauges",
         func=_refresh_metrics_gauges,
         interval_seconds=lambda: settings.metrics_gauge_refresh_seconds,
+        enabled=lambda: settings.metrics_enabled,
+    )
+
+    # Heavy per-system / per-target distribution gauges. Whole-table scans
+    # aggregated in SQL to a single row each; they change slowly and feed
+    # capacity/retention decisions, not alerting, so they run hourly rather
+    # than on the 60s gauge cadence. Runs once on startup (no prior run) so
+    # the distribution gauges populate promptly.
+    register_job(
+        name="refresh_metrics_gauge_distributions",
+        description="Refresh per-system / per-target distribution gauges",
+        func=_refresh_metrics_gauge_distributions,
+        interval_seconds=lambda: 3600,  # hourly
         enabled=lambda: settings.metrics_enabled,
     )
 

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -710,7 +710,11 @@ async def _finalize_pending_actions(db: AsyncSession) -> dict:
     for row in pending:
         try:
             await finalize_pending_action(row, db)
-            detail_lines.append(f"{row.action_type} {row.target_label}")
+            # Log the (non-sensitive) target id, not target_label: the label is
+            # encrypted at rest, and job_runs.details is itself a retained
+            # unencrypted column, so logging the decrypted label there would
+            # reopen the same content leak this change closes.
+            detail_lines.append(f"{row.action_type} {row.target_id}")
             pending_actions_finalized_total.labels(
                 category=row.action_type, outcome="completed",
             ).inc()

--- a/sheaf/services/messages.py
+++ b/sheaf/services/messages.py
@@ -175,25 +175,57 @@ async def mark_seen(
 # Replaces what was previously a full-table message scan into Python
 # dicts. Called 3x around front-start, so cutting it cold pays back
 # fast on systems with thousands of messages.
+#
+# The `agg` CTE never touches m.body: COUNT / MAX / the unread FILTER read
+# only indexed columns + created_at. The newest body is fetched separately
+# by `latest` via DISTINCT ON, which returns exactly one row (one body) per
+# board. The old form used (array_agg(m.body ORDER BY created_at DESC))[1],
+# which materialised every message body on the board just to keep the first
+# - ruinous on a busy wall, and this is a sidebar-frequency call. Both parts
+# ride ix_messages_board_created (system_id, board_kind, board_member_id,
+# created_at); DISTINCT ON on the same key/order is a plain index scan.
+# Tie on identical created_at is resolved arbitrarily, exactly as the
+# array_agg form was.
 _BOARD_AGG_SQL = text(
     """
-    SELECT m.board_kind,
-           m.board_member_id,
-           COUNT(*)::int AS total_count,
-           MAX(m.created_at) AS last_at,
-           (array_agg(m.body ORDER BY m.created_at DESC))[1] AS last_body,
-           COUNT(*) FILTER (
-             WHERE rs.last_seen_at IS NOT NULL
-               AND m.created_at > rs.last_seen_at
-           )::int AS unread_count,
-           rs.last_seen_at IS NOT NULL AS has_read_state
-    FROM messages m
-    LEFT JOIN message_read_state rs
-      ON rs.member_id = :caller_member_id
-      AND rs.board_kind = m.board_kind
-      AND rs.board_member_id IS NOT DISTINCT FROM m.board_member_id
-    WHERE m.system_id = :system_id AND m.deleted_at IS NULL
-    GROUP BY m.board_kind, m.board_member_id, rs.last_seen_at
+    WITH agg AS (
+        SELECT m.board_kind,
+               m.board_member_id,
+               COUNT(*)::int AS total_count,
+               MAX(m.created_at) AS last_at,
+               COUNT(*) FILTER (
+                 WHERE rs.last_seen_at IS NOT NULL
+                   AND m.created_at > rs.last_seen_at
+               )::int AS unread_count,
+               rs.last_seen_at IS NOT NULL AS has_read_state
+        FROM messages m
+        LEFT JOIN message_read_state rs
+          ON rs.member_id = :caller_member_id
+          AND rs.board_kind = m.board_kind
+          AND rs.board_member_id IS NOT DISTINCT FROM m.board_member_id
+        WHERE m.system_id = :system_id AND m.deleted_at IS NULL
+        GROUP BY m.board_kind, m.board_member_id, rs.last_seen_at
+    ),
+    latest AS (
+        SELECT DISTINCT ON (m.board_kind, m.board_member_id)
+               m.board_kind,
+               m.board_member_id,
+               m.body AS last_body
+        FROM messages m
+        WHERE m.system_id = :system_id AND m.deleted_at IS NULL
+        ORDER BY m.board_kind, m.board_member_id, m.created_at DESC
+    )
+    SELECT agg.board_kind,
+           agg.board_member_id,
+           agg.total_count,
+           agg.last_at,
+           latest.last_body,
+           agg.unread_count,
+           agg.has_read_state
+    FROM agg
+    JOIN latest
+      ON latest.board_kind = agg.board_kind
+      AND latest.board_member_id IS NOT DISTINCT FROM agg.board_member_id
     """
 )
 

--- a/sheaf/services/retention.py
+++ b/sheaf/services/retention.py
@@ -19,6 +19,7 @@ from sqlalchemy import and_, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import settings
+from sheaf.models.activity_event import ActivityAction, ActivityActorType
 from sheaf.models.content_revision import ContentRevision
 from sheaf.models.retention_trim_notice import (
     RetentionTrimNotice,
@@ -26,6 +27,7 @@ from sheaf.models.retention_trim_notice import (
 )
 from sheaf.models.system import System
 from sheaf.models.user import User, UserTier
+from sheaf.services.activity_log import log_activity
 from sheaf.services.journals import (
     _combine_cap,
     effective_revision_caps,
@@ -176,13 +178,25 @@ async def _trim_target_group(
 ) -> int:
     """Trim revisions for a single target. Returns the number deleted.
 
-    `max_revisions=0` means unlimited (no count cap).
-    `max_days=0` means unlimited (no age cap).
+    Count-only by design; the age window was removed because it destroys
+    imported history. Importers set ``created_at`` from the *source*
+    timestamp, so an old-but-just-imported edit-history looked expired and was
+    silently deleted by an age cutoff - the same class of bug as the front
+    retention incident. content_revisions has no separate row-insert column to
+    key a safe age window off, so we cap by NEWEST-N count only and never by
+    age.
 
-    Pinned revisions (pinned_at IS NOT NULL) are exempt from both caps. They
-    form a separate budget bounded by the per-target pin cap, not this sweep.
+    `max_revisions=0` means unlimited (no count cap). `max_days` is still
+    accepted (it is plumbed through for display/caps reporting) but MUST NOT
+    drive any DELETE here.
+
+    Pinned revisions (pinned_at IS NOT NULL) are exempt from the count cap.
+    They form a separate budget bounded by the per-target pin cap, not this
+    sweep.
     """
-    if max_revisions == 0 and max_days == 0:
+    # No count cap -> nothing to trim. The age window that used to run even
+    # when max_revisions == 0 is gone (see docstring).
+    if max_revisions == 0:
         return 0
 
     result = await db.execute(
@@ -198,16 +212,8 @@ async def _trim_target_group(
     if not rows:
         return 0
 
-    # Keep up to max_revisions newest if a count cap exists.
-    keep: set[uuid.UUID] = (
-        {r.id for r in rows[:max_revisions]} if max_revisions > 0 else {r.id for r in rows}
-    )
-
-    # Then drop any kept rows older than max_days.
-    if max_days > 0:
-        cutoff = datetime.now(UTC) - timedelta(days=max_days)
-        keep = {r.id for r in rows if r.id in keep and r.created_at >= cutoff}
-
+    # Keep the newest max_revisions; delete the rest. No age cutoff.
+    keep: set[uuid.UUID] = {r.id for r in rows[:max_revisions]}
     to_delete = [r.id for r in rows if r.id not in keep]
     if not to_delete:
         return 0
@@ -277,10 +283,27 @@ async def gc_revisions(db: AsyncSession) -> dict:
 
         if user_deleted:
             total_deleted += user_deleted
+            # Count-only trim: report the operative count cap. max_days is no
+            # longer a deletion driver (see _trim_target_group), so it is left
+            # out of the trace rather than implying an age cutoff ran.
             detail_lines.append(
                 f"User {user.id}: trimmed {user_deleted} revisions "
-                f"(caps: {max_rev} count, {max_days} days)"
+                f"(newest {max_rev} kept)"
             )
+            # Nothing-silent: per-user account-activity trace when a sweep
+            # actually removes revisions. Content-free (counts only). Dormant
+            # until the new ActivityAction ("retention_pruned") + its Postgres
+            # enum migration land; the lookup is None until then, so this is a
+            # no-op while the jobs stay paused. See the change report.
+            retention_action = getattr(ActivityAction, "RETENTION_PRUNED", None)
+            if retention_action is not None:
+                await log_activity(
+                    db,
+                    user_id=user.id,
+                    action=retention_action,
+                    actor_type=ActivityActorType.SYSTEM,
+                    detail={"revisions_trimmed": user_deleted},
+                )
 
         # Mark the notice completed if its window has passed.
         if notice is not None and notice.effective_at <= datetime.now(UTC):

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -65,6 +65,7 @@ from sheaf.models.poll import (
 from sheaf.models.reminder import Reminder, reminder_scope_members
 from sheaf.models.system import DateFormat, PrivacyLevel, System
 from sheaf.models.tag import Tag
+from sheaf.models.user import User
 from sheaf.models.watch_token import WatchToken
 from sheaf.services import import_limits as il
 from sheaf.services.custom_fields import encrypt_field_value
@@ -105,6 +106,7 @@ from sheaf.services.import_image_strip import (
 )
 from sheaf.services.import_limits import ClampReport, clamp_list, clamp_str
 from sheaf.services.member_limits import enforce_import_member_cap
+from sheaf.services.polls import max_retention_days_for_tier
 
 logger = logging.getLogger("sheaf.import.sheaf")
 
@@ -167,6 +169,26 @@ def _coerce_int(val: object, *, default: int, minimum: int | None = None) -> int
     if minimum is not None and val < minimum:
         return default
     return val
+
+
+def _clamp_poll_retention_days(value: int, cap: int) -> int:
+    """Clamp an imported poll retention to the importing user's tier ceiling.
+
+    `value` is the already-coerced retention_days from the file (>= 0, where
+    0 means unlimited). `cap` is ``max_retention_days_for_tier`` (0 = unlimited).
+    The native API enforces this ceiling via ``validate_retention_days``; the
+    importer read the value straight from the file and bypassed it, so an
+    import could set unlimited or over-cap retention. Clamp (never reject),
+    matching the importer's business-caps pattern.
+    """
+    if cap <= 0:
+        # Tier has no retention ceiling - keep the imported value as-is.
+        return value
+    if value == 0:
+        # Imported "unlimited", which a capped tier can't grant - pin to the
+        # ceiling rather than letting 0 slip past the cap.
+        return cap
+    return min(value, cap)
 
 
 class SheafPreviewSummary:
@@ -1161,6 +1183,15 @@ async def run_import(
 
     # --- Polls (config + current votes + audit log) ---
     if polls:
+        # Imported poll retention is clamped to the importing user's tier cap -
+        # the API enforces this via validate_retention_days, so the importer
+        # must not be a bypass. Resolve the ceiling once for the whole section.
+        importing_user = await db.get(User, system.user_id)
+        poll_retention_cap = (
+            max_retention_days_for_tier(importing_user.tier)
+            if importing_user is not None
+            else 0
+        )
         poll_index = (
             await load_poll_index(db, system.id) if dedupe else ContentMatchIndex()
         )
@@ -1198,8 +1229,11 @@ async def run_import(
                     or PollResultsVisibility.LIVE.value
                 ),
                 closes_at=closes_at,
-                retention_days=_coerce_int(
-                    p_data.get("retention_days"), default=30, minimum=0
+                retention_days=_clamp_poll_retention_days(
+                    _coerce_int(
+                        p_data.get("retention_days"), default=30, minimum=0
+                    ),
+                    poll_retention_cap,
                 ),
                 include_custom_fronts=bool(
                     p_data.get("include_custom_fronts", False)

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -9,6 +9,7 @@ Contains:
 
 from __future__ import annotations
 
+import json
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -21,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.auth.lockout import ensure_not_locked, record_login_failure
 from sheaf.auth.passwords import verify_password
 from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
-from sheaf.crypto import decrypt
+from sheaf.crypto import decrypt, encrypt
 from sheaf.models.content_revision import ContentRevision
 from sheaf.models.custom_field import CustomFieldDefinition
 from sheaf.models.front import Front
@@ -334,16 +335,19 @@ async def queue_pending_action(
     """Create a PendingAction row with a fronting snapshot. Caller commits."""
     fronting_ids, fronting_names = await snapshot_current_fronts(system.id, db)
     now = datetime.now(UTC)
+    # target_label and fronting_member_names hold decrypted user content, so
+    # they are encrypted at rest here (the row is transient but lands in any
+    # DB dump taken during the grace window). Read sites decrypt defensively.
     pending = PendingAction(
         system_id=system.id,
         action_type=action_type,
         target_id=target_id,
-        target_label=target_label,
+        target_label=encrypt(target_label),
         requested_at=now,
         requested_by_user_id=user.id,
         finalize_after=now + timedelta(days=system.safety_grace_period_days),
         fronting_member_ids=fronting_ids,
-        fronting_member_names=fronting_names,
+        fronting_member_names=encrypt(json.dumps(fronting_names)),
         status=PendingActionStatus.PENDING,
     )
     db.add(pending)

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -254,12 +254,22 @@ def split_safety_changes(system: System, updates: dict[str, Any]) -> SafetyChang
             else:
                 applied[field] = new_value
         elif field in _RETENTION_FIELDS:
-            # None = "use tier default" — treat as +infinity so going from a
-            # concrete cap to None is loosening; setting from None to a cap
-            # is tightening (unless tier max is lower, which is enforced
-            # separately at the router).
-            new_eff = float("inf") if new_value is None else new_value
-            cur_eff = float("inf") if current is None else current
+            # For a revision-retention cap, BOTH None ("use tier default") and
+            # 0 ("unlimited") mean the loosest possible cap - keep everything -
+            # so both map to +infinity. The deferred/guarded path is the
+            # data-destroying direction: the effective cap getting *smaller*
+            # (unlimited -> a finite N, or N -> M with M<N), because a smaller
+            # cap widens what the GC sweep deletes. Raising the cap, or moving
+            # to unlimited, keeps more and applies immediately.
+            #
+            # Treating a stored 0 as the literal integer zero (the prior bug)
+            # made 0 sort as the *smallest* cap, so a 0 -> 5 change - the most
+            # destructive transition, since it turns "keep everything" into
+            # "delete all but the newest 5" - passed `5 < 0` == False and was
+            # applied immediately with no grace and no re-auth. Mapping 0 to
+            # +infinity puts it back on the deferred path.
+            new_eff = float("inf") if new_value is None or new_value == 0 else new_value
+            cur_eff = float("inf") if current is None or current == 0 else current
             if new_eff < cur_eff:
                 deferred[field] = new_value
             else:

--- a/tests/test_account_activity.py
+++ b/tests/test_account_activity.py
@@ -2,11 +2,34 @@
 and a representative end-to-end record (creating an API key logs an
 `api_key_created` event)."""
 
+from types import SimpleNamespace
+
 import httpx
+import pytest
+from fastapi import HTTPException
+
+from sheaf.api.v1.account import list_account_activity
 
 
 def test_activity_requires_auth(client: httpx.Client):
     assert client.get("/v1/account/activity").status_code in (401, 403)
+
+
+async def test_activity_refuses_api_key_auth():
+    """A leaked API key of any scope must not read the account's security /
+    2FA / session timeline. This account router sits outside scope-gating on
+    the assumption each endpoint refuses keys inline, mirroring
+    get_account_data. Driven directly (no stack) so the inline guard is
+    covered without the full HTTP round-trip."""
+    request = SimpleNamespace(state=SimpleNamespace(auth_method="api_key"))
+    with pytest.raises(HTTPException) as exc:
+        await list_account_activity(
+            request=request,
+            user=SimpleNamespace(id="unused"),
+            db=None,
+        )
+    assert exc.value.status_code == 403
+    assert "API key" in exc.value.detail
 
 
 def test_activity_starts_empty_and_is_a_list(auth_client: httpx.Client):

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -168,6 +168,77 @@ def test_analytics_treats_ongoing_front_as_ending_at_until(
     assert diff <= 5, f"expected ~7200s, got {by_id[member['id']]['total_seconds']}"
 
 
+def test_analytics_longest_session_and_counts(auth_client: httpx.Client):
+    """total_seconds SUMs, session_count COUNTs and longest_session_seconds
+    MAXes across a member's fronts - the aggregation the SQL path computes."""
+    member = auth_client.post("/v1/members", json={"name": "Busy"}).json()
+    now = datetime.now(UTC)
+    sessions = [
+        (now - timedelta(hours=6), now - timedelta(hours=5)),  # 1h
+        (now - timedelta(hours=4), now - timedelta(hours=1)),  # 3h (longest)
+        (
+            now - timedelta(hours=12),
+            now - timedelta(hours=12) + timedelta(minutes=30),
+        ),  # 30m
+    ]
+    for start, end in sessions:
+        start = start.replace(microsecond=0)
+        end = end.replace(microsecond=0)
+        front = auth_client.post(
+            "/v1/fronts",
+            json={"member_ids": [member["id"]], "started_at": _iso(start)},
+        ).json()
+        auth_client.patch(
+            f"/v1/fronts/{front['id']}", json={"ended_at": _iso(end)}
+        )
+
+    data = auth_client.get("/v1/analytics/fronting").json()
+    stats = {m["member_id"]: m for m in data["members"]}[member["id"]]
+    assert stats["session_count"] == 3
+    assert stats["longest_session_seconds"] == 3 * 3600
+    assert stats["total_seconds"] == 3600 + 3 * 3600 + 1800
+
+
+def test_analytics_hour_of_day_respects_timezone(auth_client: httpx.Client):
+    """hour_of_day_seconds bucket the front in the requested timezone. Uses a
+    fixed-offset zone (Etc/GMT-5 = UTC+5, no DST) so the expected bucket is
+    deterministic and Python/Postgres agree on the offset."""
+    member = auth_client.post("/v1/members", json={"name": "Clocked"}).json()
+    # A clean one-hour front aligned to a UTC hour boundary, a few hours ago
+    # so it lands well inside the default 30-day window.
+    start = (datetime.now(UTC) - timedelta(hours=5)).replace(
+        minute=0, second=0, microsecond=0
+    )
+    end = start + timedelta(hours=1)
+    front = auth_client.post(
+        "/v1/fronts",
+        json={"member_ids": [member["id"]], "started_at": _iso(start)},
+    ).json()
+    auth_client.patch(
+        f"/v1/fronts/{front['id']}", json={"ended_at": _iso(end)}
+    )
+
+    utc_data = auth_client.get(
+        "/v1/analytics/fronting", params={"tz": "UTC"}
+    ).json()
+    utc_buckets = {m["member_id"]: m for m in utc_data["members"]}[
+        member["id"]
+    ]["hour_of_day_seconds"]
+    assert utc_buckets[start.hour] == 3600
+    assert sum(utc_buckets) == 3600
+
+    # Etc/GMT-5 is UTC+5 (the POSIX sign is inverted), so the same wall-clock
+    # hour shifts five buckets forward.
+    plus5_data = auth_client.get(
+        "/v1/analytics/fronting", params={"tz": "Etc/GMT-5"}
+    ).json()
+    plus5_buckets = {m["member_id"]: m for m in plus5_data["members"]}[
+        member["id"]
+    ]["hour_of_day_seconds"]
+    assert plus5_buckets[(start.hour + 5) % 24] == 3600
+    assert sum(plus5_buckets) == 3600
+
+
 def test_analytics_percent_of_window(auth_client: httpx.Client):
     """percent_of_window should match total_seconds / window_seconds * 100."""
     member = auth_client.post("/v1/members", json={"name": "Percent"}).json()

--- a/tests/test_front_history_export.py
+++ b/tests/test_front_history_export.py
@@ -113,6 +113,36 @@ def test_ics_structure_and_escaping():
     assert "X-WR-CALNAME:Test\\; System front history" in text
 
 
+def test_ics_neutralises_carriage_return_injection():
+    # A member name / custom_status / system name carrying a CR (bare or as
+    # CRLF) must not be able to terminate its content line and inject its own
+    # calendar properties or a sibling VEVENT into whoever imports the feed.
+    rows = [
+        {
+            "id": "44444444-4444-4444-4444-444444444444",
+            "started_at": datetime(2026, 6, 4, 8, 0, 0, tzinfo=UTC),
+            "ended_at": datetime(2026, 6, 4, 9, 0, 0, tzinfo=UTC),
+            "members": ["Mallory\r\nATTENDEE:mailto:evil@example.com"],
+            "custom_status": "line1\rline2",  # bare CR
+        },
+    ]
+    raw = serialize_front_history(
+        rows, "Sys\r\nX-WR-CALDESC:pwned", "fronts_ics", _EXPORTED_AT
+    )
+    text = raw.decode("utf-8")
+    # Still exactly one event: the CR did not open a second VEVENT.
+    assert text.count("BEGIN:VEVENT") == 1
+    # The injected ATTENDEE stays inside SUMMARY as an escaped newline, never
+    # a content line of its own.
+    assert "\r\nATTENDEE:" not in text
+    assert "SUMMARY:Mallory\\nATTENDEE:mailto:evil@example.com" in text
+    # A bare CR in the DESCRIPTION is escaped too, not a line break.
+    assert "DESCRIPTION:line1\\nline2" in text
+    # The calendar name likewise cannot inject a sibling property.
+    assert "\r\nX-WR-CALDESC:" not in text
+    assert "X-WR-CALNAME:Sys\\nX-WR-CALDESC:pwned front history" in text
+
+
 def test_unknown_format_raises():
     try:
         serialize_front_history([], None, "fronts_xml", _EXPORTED_AT)

--- a/tests/test_front_retention.py
+++ b/tests/test_front_retention.py
@@ -1,15 +1,25 @@
 """Front-history retention pruning (aaS free tier).
 
-Retention keys off a front's END time, not its start: a long-running front
-(months/years) is kept for the full window after it closes, and is never
-pruned while still open. These tests pin that, since keying off start time
-(the old behaviour) would silently delete a months-long front the instant
-it ended, even though it was the most recently active period.
+A front is pruned only when ALL of these hold: it was *inserted* long ago
+(``created_at`` < cutoff), it is closed (``ended_at`` IS NOT NULL), and it
+also ended long ago (``ended_at`` < cutoff). These tests pin that rule:
+
+  - ``created_at`` (row-insertion time) guards freshly-imported history. This
+    is the 2026-06-23 incident: an import carries an old real-world
+    ``started_at`` / ``ended_at`` but lands with ``created_at`` = now, so it
+    must never be pruned just for being historically old. Keying off
+    ``started_at`` (original bug) OR ``ended_at`` alone (the interim fix) both
+    delete just-imported history, because imports carry old values for both.
+  - ``ended_at`` < cutoff guards a genuinely long-running native front that
+    was created long ago but only just closed - its most recent activity is
+    recent, so it survives the window after ending.
+  - open fronts (``ended_at`` IS NULL) are never pruned while ongoing.
 
 The prune is mode-gated (aaS only), so the service is driven in-process with
 sheaf_mode monkeypatched to SAAS and the user forced to the free tier in the
-DB. Fronts are seeded directly with explicit timestamps because the API only
-ever stamps "now".
+DB. Fronts are seeded directly with explicit timestamps - including
+``created_at`` - because the API / import paths only ever stamp "now" for the
+insert time.
 """
 
 import asyncio
@@ -46,7 +56,10 @@ def _engine_session():
 def _set_tier_free_and_seed(email: str, specs: list[tuple]) -> list:
     """Force the user to the free tier and insert one Front per spec.
 
-    specs is a list of (started_at, ended_at|None); returns the new front
+    specs is a list of (created_at, started_at, ended_at|None). ``created_at``
+    is set explicitly: it is the row-insertion time the retention rule keys
+    off, and the real API / import paths only ever stamp it "now", so a test
+    has to backdate it directly to exercise the rule. Returns the new front
     ids in the same order.
     """
 
@@ -70,8 +83,13 @@ def _set_tier_free_and_seed(email: str, specs: list[tuple]) -> list:
             system = (
                 await db.execute(select(System).where(System.user_id == user.id))
             ).scalar_one()
-            for started, ended in specs:
-                front = Front(system_id=system.id, started_at=started, ended_at=ended)
+            for created, started, ended in specs:
+                front = Front(
+                    system_id=system.id,
+                    started_at=started,
+                    ended_at=ended,
+                    created_at=created,
+                )
                 db.add(front)
                 await db.flush()
                 ids.append(front.id)
@@ -125,9 +143,10 @@ def _run_prune() -> dict:
     return asyncio.run(_run())
 
 
-def test_prune_keys_off_end_time_not_start(client: httpx.Client, monkeypatch):
-    """A months-long front that only just ended survives the window; one
-    that ended outside it is pruned; an open one is never touched."""
+def test_prune_keys_off_insert_and_end_time(client: httpx.Client, monkeypatch):
+    """Prune only a front that was inserted long ago AND ended long ago AND is
+    closed. Five scenarios pin every arm of the rule; case (1) is the
+    regression guard for the 2026-06-23 imported-history incident."""
     from sheaf.config import SheafMode, settings
 
     monkeypatch.setattr(settings, "sheaf_mode", SheafMode.SAAS)
@@ -135,28 +154,57 @@ def test_prune_keys_off_end_time_not_start(client: httpx.Client, monkeypatch):
 
     email = _register(client)
     now = datetime.now(UTC)
-    six_months_ago = now - timedelta(days=180)
 
-    recent_long, stale_long, still_open = _set_tier_free_and_seed(
+    imported, old_native, long_recent, still_open, recent = _set_tier_free_and_seed(
         email,
         [
-            # Started 6 months ago, ended yesterday: active within the
-            # window, must survive (the old started_at logic deleted this).
-            (six_months_ago, now - timedelta(days=1)),
-            # Started 6 months ago, ended 60 days ago: outside the window.
-            (six_months_ago, now - timedelta(days=60)),
-            # Started 6 months ago, still open: never pruned while ongoing.
-            (six_months_ago, None),
+            # (1) INCIDENT REGRESSION GUARD - imported historical front.
+            # Inserted now (created_at = now), but carries a ~2-year-old
+            # real-world start/end. It ended long ago yet was inserted just
+            # now, so it MUST SURVIVE. Keying off started_at or ended_at alone
+            # deletes this; the created_at clause is the whole point.
+            (now, now - timedelta(days=730), now - timedelta(days=700)),
+            # (2) Genuinely old native front: inserted ~200d ago, ended ~190d
+            # ago. Old on every axis -> pruned.
+            (
+                now - timedelta(days=200),
+                now - timedelta(days=200),
+                now - timedelta(days=190),
+            ),
+            # (3) Long native front that only just ended: inserted ~200d ago
+            # but ended yesterday (inside the window). Recent activity -> MUST
+            # SURVIVE.
+            (
+                now - timedelta(days=200),
+                now - timedelta(days=200),
+                now - timedelta(days=1),
+            ),
+            # (4) Open front (ended_at NULL): never pruned while ongoing, even
+            # though it was inserted long ago.
+            (now - timedelta(days=200), now - timedelta(days=200), None),
+            # (5) Recently created and recently ended: inside the window on
+            # every axis -> survives.
+            (now, now - timedelta(days=5), now - timedelta(days=3)),
         ],
     )
 
     result = _run_prune()
+    # At least our one genuinely-old front (case 2) is removed. items_processed
+    # is a global count across all free-tier users, so only assert it ran;
+    # per-user survival is checked against this account's fronts below.
     assert result["items_processed"] >= 1
 
     surviving = _surviving_front_ids(email)
-    assert recent_long in surviving, "front that ended yesterday was wrongly pruned"
+    assert imported in surviving, (
+        "REGRESSION: freshly-imported historical front was pruned - this is the "
+        "2026-06-23 incident. created_at (insert time) must protect it."
+    )
+    assert long_recent in surviving, "long front that ended yesterday was wrongly pruned"
     assert still_open in surviving, "open front must never be pruned"
-    assert stale_long not in surviving, "front that ended 60 days ago should be pruned"
+    assert recent in surviving, "recently created + ended front was wrongly pruned"
+    assert old_native not in surviving, (
+        "front inserted and ended long ago (all axes old) should be pruned"
+    )
 
 
 @pytest.mark.selfhosted

--- a/tests/test_fronts.py
+++ b/tests/test_fronts.py
@@ -182,3 +182,72 @@ def test_history_cursor_takes_precedence_over_offset(auth_client: httpx.Client):
     assert resp.status_code == 200
     page2 = resp.json()
     assert {f["id"] for f in page2}.isdisjoint({f["id"] for f in first})
+
+
+# --- Offset upper bound (FIX 2) --------------------------------------------
+
+
+def test_list_offset_upper_bound_rejected(auth_client: httpx.Client):
+    """Legacy offset paging is capped so a giant offset can't make the DB
+    walk-and-discard an arbitrary number of rows. Over the cap is a 422;
+    the cap itself is still accepted."""
+    over = auth_client.get("/v1/fronts", params={"offset": 10_001})
+    assert over.status_code == 422, over.text
+
+    at_cap = auth_client.get("/v1/fronts", params={"offset": 10_000})
+    assert at_cap.status_code == 200, at_cap.text
+
+
+# --- Concurrent switch serialisation (FIX 1) -------------------------------
+
+
+def _concurrent_posts(token: str, payload: dict, n: int) -> list[int]:
+    """Fire `n` identical POST /v1/fronts concurrently, each on its own
+    client sharing `token`. Returns the list of status codes."""
+    import os
+    from concurrent.futures import ThreadPoolExecutor
+
+    base_url = os.environ["SHEAF_TEST_URL"]
+
+    def _one(_: int) -> int:
+        with httpx.Client(base_url=base_url) as c:
+            c.headers["Authorization"] = token
+            return c.post("/v1/fronts", json=payload).status_code
+
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        return list(pool.map(_one, range(n)))
+
+
+def test_concurrent_duplicate_switches_serialise(auth_client: httpx.Client):
+    """Two concurrent non-replace switches with the same member set must
+    not both land: the per-system advisory lock serialises the duplicate
+    check, so exactly one wins (201) and the rest get 409. Without the
+    lock both reads miss each other's uncommitted insert and both create
+    an open front with the same set."""
+    token = auth_client.headers["Authorization"]
+    member_id = _create_member(auth_client, "RaceDup")
+    payload = {"member_ids": [member_id], "replace_fronts": False}
+
+    codes = _concurrent_posts(token, payload, 5)
+    assert codes.count(201) == 1, codes
+    assert codes.count(409) == 4, codes
+
+    # Exactly one open front with that set exists.
+    current = auth_client.get("/v1/fronts/current").json()
+    matching = [f for f in current if f["member_ids"] == [member_id]]
+    assert len(matching) == 1, current
+
+
+def test_concurrent_replace_switches_leave_one_open(auth_client: httpx.Client):
+    """Concurrent replace switches serialise to a single open front: each
+    auto-ends the currently-open set before opening its own, so once they
+    run one-at-a-time only the last-committed front is left open."""
+    token = auth_client.headers["Authorization"]
+    member_id = _create_member(auth_client, "RaceReplace")
+    payload = {"member_ids": [member_id], "replace_fronts": True}
+
+    codes = _concurrent_posts(token, payload, 5)
+    assert all(c == 201 for c in codes), codes
+
+    current = auth_client.get("/v1/fronts/current").json()
+    assert len(current) == 1, current

--- a/tests/test_fronts_audit.py
+++ b/tests/test_fronts_audit.py
@@ -300,3 +300,48 @@ def test_audit_ownership_other_systems_get_404(auth_client: httpx.Client):
         other.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
         resp = other.get(f"/v1/fronts/{front['id']}/audit")
     assert resp.status_code == 404
+
+
+# --- Audit pagination ------------------------------------------------------
+
+
+def test_audit_pagination_walks_all_rows(auth_client: httpx.Client):
+    """The audit list is keyset-paginated like GET /v1/fronts: a small
+    `limit` truncates the page and signals more via the headers, and
+    following X-Sheaf-Next-Cursor walks every row exactly once."""
+    m = _create_member(auth_client, "AuditPaged")
+    front = _open_front(auth_client, [m])
+    # Five distinct edits -> five audit rows.
+    for i in range(5):
+        auth_client.patch(
+            f"/v1/fronts/{front['id']}",
+            json={"custom_status": f"status {i}"},
+        )
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(10):  # generous loop bound
+        params: dict[str, str] = {"limit": "2"}
+        if cursor:
+            params["cursor"] = cursor
+        resp = auth_client.get(f"/v1/fronts/{front['id']}/audit", params=params)
+        assert resp.status_code == 200, resp.text
+        page = resp.json()
+        assert len(page) <= 2
+        seen.extend(row["id"] for row in page)
+        if resp.headers["X-Sheaf-Has-More"] != "true":
+            assert "X-Sheaf-Next-Cursor" not in resp.headers
+            break
+        cursor = resp.headers["X-Sheaf-Next-Cursor"]
+
+    assert len(seen) == 5, seen
+    assert len(seen) == len(set(seen)), "page boundary produced a duplicate"
+
+
+def test_audit_pagination_rejects_bad_cursor(auth_client: httpx.Client):
+    m = _create_member(auth_client, "AuditBadCursor")
+    front = _open_front(auth_client, [m])
+    resp = auth_client.get(
+        f"/v1/fronts/{front['id']}/audit", params={"cursor": "not-a-cursor"}
+    )
+    assert resp.status_code == 400, resp.text

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,26 @@
+"""Liveness and readiness probe tests.
+
+/health is the always-200 liveness probe (existing infra depends on that
+semantics). /health/ready actively checks Postgres and Redis and returns
+503 if either is down - infra should point the readiness check at it.
+"""
+
+import httpx
+
+
+def test_health_liveness(client: httpx.Client):
+    """/health is unconditional 200 - it must not check dependencies."""
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_health_ready_ok(client: httpx.Client):
+    """In the test stack both Postgres and Redis are up, so readiness
+    reports 200 with each dependency marked ok."""
+    resp = client.get("/health/ready")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["database"] == "ok"
+    assert body["checks"]["redis"] == "ok"

--- a/tests/test_import_limits.py
+++ b/tests/test_import_limits.py
@@ -102,3 +102,35 @@ def test_caps_match_schema_limits():
     assert il.MESSAGE_BODY.limit == 5000
     assert il.JOURNAL_TITLE.limit == 200
     assert il.REMINDER_BODY.limit == 2000
+
+
+# ---------------------------------------------------------------------------
+# Poll retention import clamp (per-tier ceiling; importer must not bypass it)
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_poll_retention_over_cap_is_pinned():
+    from sheaf.services.sheaf_import import _clamp_poll_retention_days
+
+    # Value above the tier ceiling is pulled down to the ceiling.
+    assert _clamp_poll_retention_days(90, 30) == 30
+    # At or under the ceiling passes through untouched.
+    assert _clamp_poll_retention_days(30, 30) == 30
+    assert _clamp_poll_retention_days(7, 30) == 7
+
+
+def test_clamp_poll_retention_imported_zero_becomes_cap_on_capped_tier():
+    from sheaf.services.sheaf_import import _clamp_poll_retention_days
+
+    # 0 = "unlimited" in the file, which a capped tier can't grant - pin to
+    # the ceiling rather than let it bypass the cap.
+    assert _clamp_poll_retention_days(0, 30) == 30
+
+
+def test_clamp_poll_retention_unlimited_tier_keeps_value():
+    from sheaf.services.sheaf_import import _clamp_poll_retention_days
+
+    # cap == 0 means the tier has no ceiling: keep whatever was imported,
+    # including an imported 0 (unlimited).
+    assert _clamp_poll_retention_days(365, 0) == 365
+    assert _clamp_poll_retention_days(0, 0) == 0

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -117,6 +117,20 @@ def test_list_jobs_contains_known_jobs(admin_client: httpx.Client):
     assert expected.issubset(names)
 
 
+def test_trigger_refresh_metrics_gauge_distributions(admin_client: httpx.Client):
+    """The heavy distribution gauges run on their own hourly job. Triggering
+    it exercises the SQL-side MAX + count(*) FILTER aggregation (no per-row
+    hydration) and should report success with an items_processed count."""
+    resp = admin_client.post(
+        "/v1/admin/jobs/refresh_metrics_gauge_distributions/run"
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["job_name"] == "refresh_metrics_gauge_distributions"
+    assert data["status"] == "success"
+    assert "items_processed" in data
+
+
 def test_trigger_cleanup_notification_outbox(admin_client: httpx.Client):
     """The outbox sweep is wired and runnable; with no terminal rows it's a
     no-op that still reports success + an items_processed count."""

--- a/tests/test_journals.py
+++ b/tests/test_journals.py
@@ -499,3 +499,46 @@ def test_image_delete_queues_when_safeguarded(client: httpx.Client):
     # Still in /v1/files/list during grace
     listing2 = client.get("/v1/files/list").json()
     assert any(f["key"] == key for f in listing2)
+
+
+def test_revision_list_pagination_walks_all(auth_client: httpx.Client):
+    """The revision list is keyset-paginated: a small `limit` truncates
+    the page and signals more via X-Sheaf-Has-More / X-Sheaf-Next-Cursor,
+    and following the cursor walks every revision exactly once. Body stays
+    a plain array for backward compatibility."""
+    entry = auth_client.post("/v1/journals", json={"body": "v0"}).json()
+    # Five body edits -> five outgoing revisions.
+    for i in range(1, 6):
+        r = auth_client.patch(
+            f"/v1/journals/{entry['id']}", json={"body": f"v{i}"}
+        )
+        assert r.status_code == 200, r.text
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(10):  # generous loop bound
+        params: dict[str, str] = {"limit": "2"}
+        if cursor:
+            params["cursor"] = cursor
+        resp = auth_client.get(
+            f"/v1/journals/{entry['id']}/revisions", params=params
+        )
+        assert resp.status_code == 200, resp.text
+        page = resp.json()
+        assert isinstance(page, list) and len(page) <= 2
+        seen.extend(row["id"] for row in page)
+        if resp.headers["X-Sheaf-Has-More"] != "true":
+            break
+        cursor = resp.headers["X-Sheaf-Next-Cursor"]
+
+    assert len(seen) == 5, seen
+    assert len(seen) == len(set(seen)), "page boundary produced a duplicate"
+
+
+def test_revision_list_rejects_bad_cursor(auth_client: httpx.Client):
+    entry = auth_client.post("/v1/journals", json={"body": "x"}).json()
+    resp = auth_client.get(
+        f"/v1/journals/{entry['id']}/revisions",
+        params={"cursor": "not-a-cursor"},
+    )
+    assert resp.status_code == 400, resp.text

--- a/tests/test_members.py
+++ b/tests/test_members.py
@@ -88,3 +88,45 @@ def test_archive_member_idempotent(auth_client: httpx.Client):
     again = auth_client.post(f"/v1/members/{mid}/archive").json()
     # Re-archiving is a no-op; the timestamp does not move.
     assert first["archived_at"] == again["archived_at"]
+
+
+def test_bio_revision_list_pagination_walks_all(auth_client: httpx.Client):
+    """The member bio-revision list is keyset-paginated, matching the journal /
+    message / front-audit revision lists: a small `limit` truncates the page and
+    signals more via X-Sheaf-Has-More / X-Sheaf-Next-Cursor, following the cursor
+    walks every revision exactly once, and the body stays a plain array."""
+    mid = auth_client.post(
+        "/v1/members", json={"name": "Bio", "description": "v0"}
+    ).json()["id"]
+    # Five bio (description) edits -> five outgoing revisions captured.
+    for i in range(1, 6):
+        r = auth_client.patch(f"/v1/members/{mid}", json={"description": f"v{i}"})
+        assert r.status_code == 200, r.text
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(10):  # generous loop bound
+        params: dict[str, str] = {"limit": "2"}
+        if cursor:
+            params["cursor"] = cursor
+        resp = auth_client.get(f"/v1/members/{mid}/revisions", params=params)
+        assert resp.status_code == 200, resp.text
+        page = resp.json()
+        assert isinstance(page, list) and len(page) <= 2
+        seen.extend(row["id"] for row in page)
+        if resp.headers["X-Sheaf-Has-More"] != "true":
+            break
+        cursor = resp.headers["X-Sheaf-Next-Cursor"]
+
+    assert len(seen) == 5, seen
+    assert len(seen) == len(set(seen)), "page boundary produced a duplicate"
+
+
+def test_bio_revision_list_rejects_bad_cursor(auth_client: httpx.Client):
+    mid = auth_client.post(
+        "/v1/members", json={"name": "BadCursor", "description": "x"}
+    ).json()["id"]
+    resp = auth_client.get(
+        f"/v1/members/{mid}/revisions", params={"cursor": "not-a-cursor"}
+    )
+    assert resp.status_code == 400, resp.text

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -648,3 +648,64 @@ def test_safety_settings_exposes_messages_toggle(auth_client: httpx.Client):
     assert resp.status_code == 200
     settings = resp.json()["settings"]
     assert "applies_to_messages" in settings
+
+
+def test_message_revision_list_pagination_walks_all(auth_client: httpx.Client):
+    """Message revision history is keyset-paginated like the front history:
+    a small `limit` truncates the page, the X-Sheaf-* headers signal/drive
+    the next page, and the walk yields the same rows as one big page. Body
+    stays a plain array (backward compatible)."""
+    alice = _create_member(auth_client, "Alice")
+    msg = _post(auth_client, author_member_id=alice, body="v0")
+    for i in range(1, 6):
+        auth_client.patch(f"/v1/messages/{msg['id']}", json={"body": f"v{i}"})
+
+    full = auth_client.get(
+        f"/v1/messages/{msg['id']}/revisions", params={"limit": 500}
+    ).json()
+    full_ids = {r["id"] for r in full}
+    assert len(full_ids) > 2, full_ids
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(20):  # generous loop bound
+        params: dict[str, str] = {"limit": "2"}
+        if cursor:
+            params["cursor"] = cursor
+        resp = auth_client.get(
+            f"/v1/messages/{msg['id']}/revisions", params=params
+        )
+        assert resp.status_code == 200, resp.text
+        page = resp.json()
+        assert isinstance(page, list) and len(page) <= 2
+        seen.extend(row["id"] for row in page)
+        if resp.headers["X-Sheaf-Has-More"] != "true":
+            break
+        cursor = resp.headers["X-Sheaf-Next-Cursor"]
+
+    assert set(seen) == full_ids, seen
+    assert len(seen) == len(set(seen)), "page boundary produced a duplicate"
+
+
+def test_message_revision_list_rejects_bad_cursor(auth_client: httpx.Client):
+    alice = _create_member(auth_client, "Alice")
+    msg = _post(auth_client, author_member_id=alice, body="x")
+    resp = auth_client.get(
+        f"/v1/messages/{msg['id']}/revisions", params={"cursor": "not-a-cursor"}
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_board_summary_preview_is_newest_body(auth_client: httpx.Client):
+    """Board summary's last_message_preview must be the *newest* message
+    body and message_count the full total. Guards the DISTINCT-ON latest
+    body rewrite (which no longer array_aggs every body on the board)."""
+    alice = _create_member(auth_client, "Alice")
+    _post(auth_client, author_member_id=alice, body="oldest")
+    _post(auth_client, author_member_id=alice, body="middle")
+    _post(auth_client, author_member_id=alice, body="newest")
+
+    boards = auth_client.get("/v1/messages/boards").json()
+    system_board = next(b for b in boards if b["board_kind"] == "system")
+    assert system_board["last_message_preview"] == "newest"
+    assert system_board["message_count"] == 3

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -152,6 +152,26 @@ def test_different_endpoints_have_separate_limits(anon_client):
     assert resp.status_code == 200
 
 
+def test_sync_export_per_user_rate_limit():
+    """GET /v1/export is rate_limit(6, 3600, "user") - the sync full-account
+    dump is heavy (assembled in memory on the event loop), so it gets a
+    conservative per-user hourly cap on top of the global per-IP backstop."""
+    email = f"rl-export-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=BASE_URL) as c:
+        resp = c.post(
+            "/v1/auth/register",
+            json={"email": email, "password": "testpassword123"},
+        )
+        assert resp.status_code == 201
+        c.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+
+        # 6 allowed in the window; the 7th trips the per-user limit.
+        statuses = [c.get("/v1/export").status_code for _ in range(8)]
+
+    assert statuses[0] == 200, statuses
+    assert 429 in statuses, statuses
+
+
 def test_per_user_block_records_admin_history(admin_client):
     """End-to-end: a blocked per-user check leaves a triage trail
     readable via GET /admin/users/{id}/rate-limit-history."""

--- a/tests/test_revision_pinning.py
+++ b/tests/test_revision_pinning.py
@@ -260,13 +260,14 @@ def test_finalize_pending_unpin_clears_pin():
     """The PendingAction finalize for REVISION_UNPIN must clear pinned_at, not delete."""
 
     async def _run() -> None:
+        import json
         from datetime import UTC, datetime
 
         from sqlalchemy import select
         from sqlalchemy.ext.asyncio import AsyncSession
         from sqlalchemy.orm import sessionmaker
 
-        from sheaf.crypto import blind_index
+        from sheaf.crypto import blind_index, encrypt
         from sheaf.models.content_revision import ContentRevision
         from sheaf.models.pending_action import (
             PendingAction,
@@ -309,12 +310,13 @@ def test_finalize_pending_unpin_clears_pin():
                 system_id=system.id,
                 action_type=PendingActionType.REVISION_UNPIN,
                 target_id=revision.id,
-                target_label="test pin",
+                # target_label and fronting_member_names are encrypted at rest.
+                target_label=encrypt("test pin"),
                 requested_at=datetime.now(UTC),
                 requested_by_user_id=user.id,
                 finalize_after=datetime.now(UTC),
                 fronting_member_ids=[],
-                fronting_member_names=[],
+                fronting_member_names=encrypt(json.dumps([])),
                 status=PendingActionStatus.PENDING,
             )
             db.add(pending)

--- a/tests/test_system_safety.py
+++ b/tests/test_system_safety.py
@@ -539,3 +539,51 @@ def test_member_pending_delete_at_null_when_not_queued(client: httpx.Client):
     assert client.get(f"/v1/members/{member['id']}").json()["pending_delete_at"] is None
     listed = client.get("/v1/members").json()
     assert next(m for m in listed if m["id"] == member["id"])["pending_delete_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Retention-cap loosening: 0 = unlimited (pure unit test of split_safety_changes)
+# ---------------------------------------------------------------------------
+
+
+def test_split_safety_treats_zero_retention_cap_as_unlimited():
+    """0 = unlimited for a revision-retention cap, exactly like None.
+
+    Moving from unlimited (0 or None) to a finite cap is the data-destroying
+    direction - it turns "keep everything" into "delete all but the newest N" -
+    so it must take the deferred/guarded path (grace + re-auth), never apply
+    silently.
+
+    Regression guard: the prior code treated a stored 0 as the literal integer
+    zero (the smallest cap), so a 0 -> 5 change passed `5 < 0` == False and was
+    applied immediately with no grace and no re-auth.
+    """
+    from sheaf.models.system import System
+    from sheaf.services.system_safety import split_safety_changes
+
+    # current = 0 (unlimited) -> finite cap 5: destructive, must defer.
+    split = split_safety_changes(
+        System(journal_max_revisions=0), {"journal_max_revisions": 5}
+    )
+    assert split.deferred == {"journal_max_revisions": 5}
+    assert split.applied == {}
+
+    # current = None (use tier default) -> finite cap 5: same, must defer.
+    split_none = split_safety_changes(
+        System(journal_max_revisions=None), {"journal_max_revisions": 5}
+    )
+    assert split_none.deferred == {"journal_max_revisions": 5}
+
+    # Safe direction: finite cap 5 -> 0 (unlimited) keeps more, applies now.
+    split_loosen = split_safety_changes(
+        System(journal_max_revisions=5), {"journal_max_revisions": 0}
+    )
+    assert split_loosen.applied == {"journal_max_revisions": 0}
+    assert split_loosen.deferred == {}
+
+    # Tightening between two finite caps still defers (10 -> 5).
+    split_tighten = split_safety_changes(
+        System(journal_max_revisions=10), {"journal_max_revisions": 5}
+    )
+    assert split_tighten.deferred == {"journal_max_revisions": 5}
+    assert split_tighten.applied == {}

--- a/tests/test_system_safety.py
+++ b/tests/test_system_safety.py
@@ -138,6 +138,72 @@ def test_delete_queues_when_safety_on(client: httpx.Client):
     assert listing["pending_actions"][0]["target_label"] == "Beta"
 
 
+def _read_pending_row_raw(pending_id: str) -> tuple[str, str]:
+    """Return the raw at-rest (target_label, fronting_member_names) strings
+    straight from the DB, bypassing the API's decrypt-on-read."""
+    result: dict = {}
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.pending_action import PendingAction
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            pending = await db.get(PendingAction, uuid.UUID(pending_id))
+            assert pending is not None
+            result["target_label"] = pending.target_label
+            result["fronting_member_names"] = pending.fronting_member_names
+        await engine.dispose()
+
+    asyncio.run(_run())
+    return result["target_label"], result["fronting_member_names"]
+
+
+def test_pending_action_content_encrypted_at_rest(client: httpx.Client):
+    """target_label and fronting_member_names are ciphertext in the DB, but the
+    read endpoint returns the plaintext."""
+    import json
+
+    from sheaf.crypto import decrypt
+
+    email, _ = _register(client)
+    _set_system_safety_via_db(
+        email,
+        safety_grace_period_days=7,
+        safety_applies_to_members=True,
+        safety_applies_to_fronts=True,
+    )
+    alice = client.post("/v1/members", json={"name": "Alice"}).json()
+    victim = client.post("/v1/members", json={"name": "Victim Member"}).json()
+
+    # Alice is fronting when the destructive action is queued.
+    client.post("/v1/fronts", json={"member_ids": [alice["id"]]})
+
+    resp = client.delete(f"/v1/members/{victim['id']}")
+    assert resp.status_code == 202, resp.text
+    pending_id = resp.json()["pending_action_id"]
+
+    # At rest: neither column contains the plaintext, and both decrypt back.
+    raw_label, raw_names = _read_pending_row_raw(pending_id)
+    assert raw_label != "Victim Member"
+    assert "Victim Member" not in raw_label
+    assert decrypt(raw_label) == "Victim Member"
+
+    assert raw_names != "Alice"
+    assert "Alice" not in raw_names
+    assert json.loads(decrypt(raw_names)) == ["Alice"]
+
+    # Read endpoint returns the decrypted plaintext.
+    pending = client.get("/v1/system/safety").json()["pending_actions"][0]
+    assert pending["target_label"] == "Victim Member"
+    assert pending["fronting_member_names"] == ["Alice"]
+
+
 def test_delete_queues_captures_fronting_snapshot(client: httpx.Client):
     email, _ = _register(client)
     _set_system_safety_via_db(


### PR DESCRIPTION
Post-launch hardening across three areas: bounding read/write cost so a large
tenant cannot destabilise the database, closing the retention bug class behind
the front-history incident, and encrypting the last content fields that were
stored in the clear. Six self-contained commits, each reviewed and covered by
tests.

## Resilience and DB health
- Apply a per-transaction `statement_timeout` on the request path (via `SET
  LOCAL`), so a pathological query is cancelled instead of pinning a pooled
  connection. Background jobs opt out and stay uncapped.
- Make the connection pool size, overflow, and timeout configurable.
- Rate-limit the synchronous full-account export, refuse it above a row
  threshold (pointing at the async job flow), and batch the revision lookup so
  a large account no longer exceeds the driver bind-parameter limit.
- Add a `/health/ready` readiness probe (DB + Redis, tight timeout); `/health`
  stays the always-200 liveness probe.

## Bounded history reads
- Keyset-paginate the front list, the journal / message / member-bio revision
  lists, and the front audit log (all previously returned every row).
- Cap the front-list offset.
- Rewrite the board summaries so they no longer aggregate every message body to
  take the newest one.
- Compute the fronting analytics and the per-system / per-target metric
  distributions in SQL, and move the heavy distribution gauges onto an hourly
  job.
- Serialise concurrent front switches for a system with a per-system advisory
  lock, closing a check-then-act race.

## Retention correctness
- Prune a free-tier front only when it was both inserted long ago and ended
  long ago and is closed, so imported history and recently-closed long fronts
  both survive. Adds the matching composite index.
- Make the revision garbage collector count-only, dropping the age window that
  had the same imported-history bug.
- Treat a retention cap of 0 (unlimited) correctly in the safety-change
  classifier, so unlimited-to-finite takes the deferred, re-auth-gated path.
- Clamp an imported poll's retention to the tier maximum.
- Record a per-user activity entry whenever a sweep removes rows, so an
  automated deletion is never silent. Adds the `retention_pruned` action.

## At-rest encryption and endpoint hardening
- Encrypt `PendingAction.target_label` and `fronting_member_names`, which held
  decrypted user content in unencrypted columns that persisted for the whole
  grace window. Encrypt at the single write path, decrypt defensively on read,
  migrate existing rows, and stop the finalize job logging the label.
- Redact the address in the email-change activity entry (unencrypted, retained
  column).
- Refuse API keys on the account-activity read.
- Escape carriage returns in the ICS export to prevent calendar-property
  injection.
- Claim an invite code atomically so a capped code cannot be over-redeemed
  under concurrent registration.

## Migrations
Three, chained: the fronts retention index, the `retention_pruned` enum value,
and the pending-action content encryption.

## Testing
Full suite green across all nine server configurations. New tests cover the
readiness probe, the export rate limit, every new paginated list, the analytics
and gauge SQL, the retention rule (with the imported-history case as the
regression guard), the safety-classifier fix, the importer poll clamp, and the
pending-action at-rest encryption.

## Operational note
The free-tier retention and revision-GC jobs remain paused in production
(interval 0). This PR makes them safe to run, but they should stay paused until
a build containing it is deployed.

## Follow-ups (not in this PR)
- A row-insert timestamp on `content_revisions` so count-only trimming does not
  disfavour imported revisions.
- Invite-registration test scaffolding, so the redemption fix gets a regression
  test.
- The broader preserve-by-default retention design (user-opt-in age-out,
  write-time revision caps, read-time coalescing).
