### PR TITLE
Write-side bounds: write-time revision cap, debounce, and write rate limits

### DIFF
--- a/alembic/versions/v3w4x5y6z7a8_add_content_revision_inserted_at.py
+++ b/alembic/versions/v3w4x5y6z7a8_add_content_revision_inserted_at.py
@@ -1,0 +1,62 @@
+"""Add content_revisions.inserted_at
+
+Revision ID: v3w4x5y6z7a8
+Revises: u2v3w4x5y6z7
+Create Date: 2026-07-02
+
+content_revisions.created_at is overwritten on import from the *source* edit
+timestamp, so an imported-old edit history sorts as the "oldest" revisions and
+gets trimmed first even though it only just landed. This adds inserted_at as
+the true "when did this row arrive here" timestamp, which the retention trim
+now orders by. Same class of fix as fronts.created_at (see
+q8r9s0t1u2v3_add_front_created_at).
+
+ADD COLUMN with a non-volatile server_default (now() is stable within the
+statement) is metadata-only on modern Postgres: existing rows get the
+migration-time value without a table rewrite, which is exactly the safe
+backfill we want (imported/old history is treated as inserted now, never
+retroactively counted as old). It still briefly takes ACCESS EXCLUSIVE, so
+fail fast rather than queue behind a long-running session.
+
+The parallel index (retention orders by inserted_at) is created plainly inside
+the same migration. content_revisions is far less hot than fronts, so a plain
+CREATE INDEX is acceptable here rather than the CONCURRENTLY / autocommit_block
+dance.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "v3w4x5y6z7a8"
+down_revision: Union[str, None] = "u2v3w4x5y6z7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.add_column(
+        "content_revisions",
+        sa.Column(
+            "inserted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_content_revisions_inserted",
+        "content_revisions",
+        ["inserted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.drop_index(
+        "ix_content_revisions_inserted",
+        table_name="content_revisions",
+    )
+    op.drop_column("content_revisions", "inserted_at")

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -49,6 +49,12 @@ services:
       # stubbed PK API). A live loop would race them and process a job
       # with the real handler before the stubbed drive gets to it.
       IMPORT_RUNNER_ENABLED: "false"
+      # Revision debounce off in tests: many endpoint tests make several rapid
+      # edits and assert one revision per edit. The write-time debounce
+      # (default 5 min in prod) would fold those into one checkpoint. The
+      # write-time debounce behaviour has its own tests that set the window
+      # explicitly, so it stays covered.
+      REVISION_DEBOUNCE_MINUTES: "0"
       # Metrics endpoint. Default off so most configs do not have to
       # think about it; the dedicated metrics config row in run_tests.sh
       # flips ENABLED=true + BIND=main + TOKEN to exercise the endpoint.

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.crypto import decrypt, encrypt
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import check_front_switch_rate, write_rate_limit
 from sheaf.models.front import Front
 from sheaf.models.front_audit_event import FrontAuditEvent
 from sheaf.models.member import Member
@@ -381,7 +382,9 @@ async def get_current_fronts(
     "",
     response_model=FrontRead,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_scope("fronts:write"))],
+    # write_rate_limit(): counts against the combined per-account write
+    # budget shared with journals/messages/members/reminders.
+    dependencies=[Depends(require_scope("fronts:write")), write_rate_limit()],
 )
 async def create_front(
     body: FrontCreate,
@@ -389,6 +392,20 @@ async def create_front(
     db: AsyncSession = Depends(get_db),
 ):
     system = await _get_user_system(user, db)
+
+    # Per-system front-switch guard, in addition to the per-account write
+    # limit above. Keyed on the system rather than the caller, it catches a
+    # stuck switch-client / looping integration on a system that may have
+    # several legitimate writers. Checked before any front DB work so a
+    # runaway loop is cut off early.
+    if not await check_front_switch_rate(system.id):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                "Fronts are being created faster than we accept them for "
+                "your system; check for a looping client or integration."
+            ),
+        )
 
     # Validate member IDs belong to this system
     result = await db.execute(

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.api.v1.members import _get_user_system
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import write_rate_limit
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
@@ -158,7 +159,8 @@ async def list_journals(
     "",
     response_model=JournalEntryRead,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_scope("journals:write"))],
+    # write_rate_limit(): shared per-account write budget (see fronts).
+    dependencies=[Depends(require_scope("journals:write")), write_rate_limit()],
 )
 async def create_entry(
     body: JournalEntryCreate,
@@ -212,7 +214,9 @@ async def get_entry(
 @router.patch(
     "/{entry_id}",
     response_model=JournalEntryRead,
-    dependencies=[Depends(require_scope("journals:write"))],
+    # PATCH can generate a content revision, so it counts against the
+    # shared per-account write budget too.
+    dependencies=[Depends(require_scope("journals:write")), write_rate_limit()],
 )
 async def patch_entry(
     entry_id: uuid.UUID,

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.crypto import blind_index, encrypt
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import write_rate_limit
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.front import Front
 from sheaf.models.member import Member
@@ -153,7 +154,8 @@ async def list_members(
     "",
     response_model=MemberRead,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_scope("members:write"))],
+    # write_rate_limit(): shared per-account write budget (see fronts).
+    dependencies=[Depends(require_scope("members:write")), write_rate_limit()],
 )
 async def create_member(
     body: MemberCreate,
@@ -317,7 +319,9 @@ async def get_member(
 @router.patch(
     "/{member_id}",
     response_model=MemberRead,
-    dependencies=[Depends(require_scope("members:write"))],
+    # A bio edit can capture a content revision, so it counts against the
+    # shared per-account write budget too.
+    dependencies=[Depends(require_scope("members:write")), write_rate_limit()],
 )
 async def update_member(
     member_id: uuid.UUID,

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import write_rate_limit
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.member import Member
 from sheaf.models.message import BoardKind, Message
@@ -432,7 +433,8 @@ async def mark_seen(
     "",
     response_model=MessageRead,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_scope("messages:write"))],
+    # write_rate_limit(): shared per-account write budget (see fronts).
+    dependencies=[Depends(require_scope("messages:write")), write_rate_limit()],
 )
 async def post_message(
     body: MessageCreate,
@@ -495,7 +497,9 @@ async def post_message(
 @router.patch(
     "/{message_id}",
     response_model=MessageRead,
-    dependencies=[Depends(require_scope("messages:write"))],
+    # An edit captures a content revision, so it counts against the shared
+    # per-account write budget too.
+    dependencies=[Depends(require_scope("messages:write")), write_rate_limit()],
 )
 async def edit_message(
     message_id: uuid.UUID,

--- a/sheaf/api/v1/reminders.py
+++ b/sheaf/api/v1/reminders.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
+from sheaf.middleware.rate_limit import write_rate_limit
 from sheaf.models.member import Member
 from sheaf.models.notification_channel import NotificationChannel
 from sheaf.models.pending_action import PendingActionType
@@ -275,7 +276,8 @@ async def list_reminders(
     "",
     response_model=ReminderRead,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_scope("notifications:write"))],
+    # write_rate_limit(): shared per-account write budget (see fronts).
+    dependencies=[Depends(require_scope("notifications:write")), write_rate_limit()],
 )
 async def create_reminder(
     body: ReminderCreate,

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -316,6 +316,29 @@ class Settings(BaseSettings):
     rate_limit_global_per_ip: int = 600  # requests per window (all endpoints combined)
     rate_limit_global_window: int = 60  # window in seconds
 
+    # Per-account combined write rate limit. A single shared bucket across
+    # the whole mutating surface (fronts, journals, messages, members,
+    # reminders): one account cannot exceed this many writes per minute in
+    # total, regardless of how the writes split across endpoints or whether
+    # they arrive over a session, a JWT, or an API key (all three draw down
+    # the same per-account budget). Under preserve-by-default this bounds a
+    # looping client from creating unbounded rows. This is DB-protection, not
+    # a product limit - self-hosters running a heavy integration can raise it
+    # or set 0 to disable, but it is on by default so a buggy client benefits
+    # from the bound too. 0 = disabled.
+    write_rate_per_user_per_min: int = 60
+
+    # Per-SYSTEM front-switch guard. Separate from the per-user write limit:
+    # keyed on the system (which may have several legitimate writers), it
+    # specifically catches a stuck switch-client or looping integration
+    # hammering POST /fronts. A token bucket allows a sustained rate of
+    # front_switch_rate_per_system_per_min with short bursts up to
+    # front_switch_rate_burst absorbed. Also DB-protection, not a product
+    # limit; on by default. Raise or disable for a system that genuinely
+    # switches very fast. 0 (rate) = disabled.
+    front_switch_rate_per_system_per_min: int = 20
+    front_switch_rate_burst: int = 10
+
     # Per-user rate-limit hit history (admin abuse triage). Blocked
     # checks attributable to an authenticated user are recorded to a
     # capped Redis list so an admin can see what an account has tripped

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -129,7 +129,7 @@ class Settings(BaseSettings):
 
     # Revision-history retention caps per tier. 0 = unlimited.
     # Covers both journal entries and member bios under a single cap.
-    journal_max_revisions_free: int = 10
+    journal_max_revisions_free: int = 50
     journal_max_revisions_plus: int = 100
     journal_max_revisions_selfhosted: int = 0
     journal_max_revision_days_free: int = 30
@@ -137,6 +137,15 @@ class Settings(BaseSettings):
     journal_max_revision_days_selfhosted: int = 0
     # How often the revision-retention GC sweep runs.
     journal_gc_interval_hours: int = 6
+    # Debounce/checkpoint window (minutes) for live revision capture. Within
+    # this window of the newest unpinned revision's inserted_at, a fresh save
+    # REPLACES that revision's captured content in place instead of appending
+    # a new row - so a burst of rapid saves collapses into a single checkpoint
+    # while a long editing session still accrues a new checkpoint roughly every
+    # revision_debounce_minutes. inserted_at is deliberately not refreshed on
+    # replace, anchoring the window to when each checkpoint was born. 0 =
+    # disabled (every content-changing save appends a row, the old behaviour).
+    revision_debounce_minutes: int = 5
     # Notice period before a tier downgrade trims revision history.
     tier_downgrade_grace_days: int = 14
 

--- a/sheaf/middleware/rate_limit.py
+++ b/sheaf/middleware/rate_limit.py
@@ -11,6 +11,17 @@ Redis key layout:
 
 Each key is an integer counter with a TTL equal to the window size.
 
+Two further, coarser write-side guards live here too (see the
+write_rate_limit / check_front_switch_rate helpers below):
+  - a single per-account bucket shared across the whole mutating surface
+    (sheaf:rl:user:{user_id}:write), so one account has a combined
+    writes-per-minute ceiling rather than a per-route one; and
+  - a per-system token bucket for front switches
+    (sheaf:rl:frontswitch:{system_id}), catching a stuck switch-client
+    on a system that may legitimately have several writers.
+Both are DB-protection under preserve-by-default, not product limits;
+self-hosted operators can raise or disable them via config.
+
 Blocked checks that can be attributed to an authenticated user are
 additionally recorded to a per-user history list for admin abuse
 triage (see record_user_hit / read_user_hit_history):
@@ -206,8 +217,112 @@ async def read_user_hit_history(user_id) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Dependency factory — per-endpoint limits
+# Dependency factory - per-endpoint limits
 # ---------------------------------------------------------------------------
+
+async def _enforce_limit(
+    request: Request,
+    *,
+    limit: Limit,
+    key: str,
+    bucket: str | None,
+    fail_closed: bool,
+    detail: str = "Rate limit exceeded. Try again later.",
+) -> None:
+    """Core counter check shared by the dependency factories.
+
+    When `bucket` is None the matched route path is used as the key suffix,
+    giving the per-endpoint limit rate_limit() has always provided. When
+    `bucket` is a string, that fixed name replaces the route segment so
+    several endpoints share ONE counter - the shared-bucket approach the
+    combined per-user write limit relies on.
+    """
+    if not settings.rate_limit_enabled:
+        return
+
+    try:
+        r = await _get_redis()
+    except Exception as exc:
+        if fail_closed:
+            logger.error(
+                "Redis unavailable on fail-closed endpoint: %s",
+                request.url.path,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Service temporarily unavailable",
+            ) from exc
+        logger.warning("Redis unavailable - skipping rate limit check")
+        return
+
+    # Build the identifier
+    if key == "user":
+        # request.state.user_id is set by get_current_user for every auth
+        # method (session, JWT, and API key all stamp the account id), so a
+        # per-user bucket is really per-account regardless of how the caller
+        # authenticated - an API key and a browser session on the same
+        # account draw down the same counter.
+        user_id = getattr(request.state, "user_id", None)
+        identifier = (
+            f"ip:{_client_ip(request)}" if user_id is None
+            else f"user:{user_id}"
+        )
+    else:
+        identifier = f"ip:{_client_ip(request)}"
+
+    # A fixed bucket collapses several endpoints into one shared counter;
+    # without it the route path keeps limits per-endpoint.
+    route = request.scope.get("path", request.url.path)
+    key_suffix = bucket if bucket is not None else route
+    redis_key = f"{identifier}:{key_suffix}"
+
+    allowed, remaining, reset = await _check_limit(r, redis_key, limit)
+
+    # Metric bucket: an explicit shared bucket names its own label so a
+    # combined limit stays legible on dashboards instead of collapsing into
+    # "other". Otherwise derive it from the matched route template (with path
+    # params left as placeholders) so per-instance path noise doesn't bloat
+    # label cardinality. route_template restores the "/v1" prefix Starlette
+    # 1.0 drops from route.path.
+    full_route = route_template(request)
+    metric_bucket = bucket if bucket is not None else _route_to_bucket(full_route)
+    scope_label = "per_user" if (key == "user" and identifier.startswith("user:")) else "per_ip"
+    rate_limit_checks_total.labels(
+        bucket=metric_bucket,
+        scope=scope_label,
+        outcome="allowed" if allowed else "blocked",
+    ).inc()
+
+    if not allowed:
+        # Attribute the hit to a user when we can. key="user" limits
+        # always have one; key="ip" limits only when another dep
+        # resolved auth first. Best-effort: never let the history
+        # write break the 429 itself.
+        hit_user_id = getattr(request.state, "user_id", None)
+        if hit_user_id is not None and settings.rate_limit_history_enabled:
+            try:
+                await record_user_hit(
+                    r,
+                    hit_user_id,
+                    bucket=metric_bucket,
+                    scope=scope_label,
+                    route=full_route,
+                    ip=_client_ip(request),
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to record rate-limit hit history",
+                    exc_info=True,
+                )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=detail,
+            headers={
+                **_rate_limit_headers(limit, remaining, reset),
+                "Retry-After": str(reset),
+            },
+        )
+
 
 def rate_limit(
     requests: int,
@@ -228,89 +343,15 @@ def rate_limit(
              "user" keys fall back to IP if auth hasn't resolved yet.
         fail_closed: When True, reject requests with 503 if Redis is
             unreachable. Use on auth endpoints so a Redis outage can't be
-            used to bypass brute-force protection. Default False — most
+            used to bypass brute-force protection. Default False - most
             endpoints are better off staying available on Redis blips.
     """
     limit = Limit(requests=requests, window=window)
 
     async def _check(request: Request):
-        if not settings.rate_limit_enabled:
-            return
-
-        try:
-            r = await _get_redis()
-        except Exception as exc:
-            if fail_closed:
-                logger.error(
-                    "Redis unavailable on fail-closed endpoint: %s",
-                    request.url.path,
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="Service temporarily unavailable",
-                ) from exc
-            logger.warning("Redis unavailable — skipping rate limit check")
-            return
-
-        # Build the identifier
-        if key == "user":
-            # request.state.user_id is set by get_current_user
-            user_id = getattr(request.state, "user_id", None)
-            identifier = (
-                f"ip:{_client_ip(request)}" if user_id is None
-                else f"user:{user_id}"
-            )
-        else:
-            identifier = f"ip:{_client_ip(request)}"
-
-        # Include the route path so limits are per-endpoint
-        route = request.scope.get("path", request.url.path)
-        redis_key = f"{identifier}:{route}"
-
-        allowed, remaining, reset = await _check_limit(r, redis_key, limit)
-
-        # Bucket is derived from the matched route template (with path params
-        # left as placeholders) so per-instance path noise doesn't bloat label
-        # cardinality. route_template restores the "/v1" prefix Starlette 1.0
-        # drops from route.path.
-        full_route = route_template(request)
-        bucket = _route_to_bucket(full_route)
-        scope_label = "per_user" if (key == "user" and identifier.startswith("user:")) else "per_ip"
-        rate_limit_checks_total.labels(
-            bucket=bucket,
-            scope=scope_label,
-            outcome="allowed" if allowed else "blocked",
-        ).inc()
-
-        if not allowed:
-            # Attribute the hit to a user when we can. key="user" limits
-            # always have one; key="ip" limits only when another dep
-            # resolved auth first. Best-effort: never let the history
-            # write break the 429 itself.
-            hit_user_id = getattr(request.state, "user_id", None)
-            if hit_user_id is not None and settings.rate_limit_history_enabled:
-                try:
-                    await record_user_hit(
-                        r,
-                        hit_user_id,
-                        bucket=bucket,
-                        scope=scope_label,
-                        route=full_route,
-                        ip=_client_ip(request),
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to record rate-limit hit history",
-                        exc_info=True,
-                    )
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="Rate limit exceeded. Try again later.",
-                headers={
-                    **_rate_limit_headers(limit, remaining, reset),
-                    "Retry-After": str(reset),
-                },
-            )
+        await _enforce_limit(
+            request, limit=limit, key=key, bucket=None, fail_closed=fail_closed,
+        )
 
     if key == "user":
         # For per-user limits, we need auth to resolve first.
@@ -326,6 +367,156 @@ def rate_limit(
         return Depends(_check_after_auth)
 
     return Depends(_check)
+
+
+# ---------------------------------------------------------------------------
+# Combined per-account write limit
+# ---------------------------------------------------------------------------
+#
+# One shared bucket across the whole mutating surface (fronts, journals,
+# messages, members, reminders). Under preserve-by-default a single looping
+# client would otherwise create unbounded rows, so every write draws down one
+# combined per-account budget rather than a per-endpoint one. Unlike
+# rate_limit(), the ceiling is read from settings at request time so it can be
+# tuned or switched off without a code change, and 0 disables it outright.
+
+# Fixed key suffix + metric label for the shared write counter. All the write
+# endpoints must pass the same value or the combined limit fragments.
+_WRITE_BUCKET = "write"
+_WRITE_LIMIT_DETAIL = (
+    "Write rate limit exceeded: too many changes in a short time. "
+    "Slow down and try again shortly."
+)
+
+
+def write_rate_limit():
+    """FastAPI dependency: the combined per-account write rate limit.
+
+    Apply to every mutating endpoint that should count against the shared
+    budget. All applications share ONE Redis counter per account
+    (sheaf:rl:user:{user_id}:write), so the limit is a single combined
+    writes-per-minute ceiling, not 60/min per route.
+
+    Keyed on the authenticated account, which resolves identically for
+    session, JWT, and API-key auth (see _enforce_limit) - the scope is the
+    account, not the auth method.
+
+    Fail-open on Redis errors: this is DB-protection, not a security control
+    (the fail-closed limits on the auth endpoints cover brute force), so a
+    Redis blip should not block every write on the instance.
+    """
+    from sheaf.auth.dependencies import get_current_user
+
+    async def _check_write(
+        request: Request,
+        _user=Depends(get_current_user),
+    ):
+        per_min = settings.write_rate_per_user_per_min
+        if per_min <= 0:
+            return  # 0 (or negative) disables the combined write limit
+        await _enforce_limit(
+            request,
+            limit=Limit(requests=per_min, window=60),
+            key="user",
+            bucket=_WRITE_BUCKET,
+            fail_closed=False,
+            detail=_WRITE_LIMIT_DETAIL,
+        )
+
+    return Depends(_check_write)
+
+
+# ---------------------------------------------------------------------------
+# Per-system front-switch token bucket
+# ---------------------------------------------------------------------------
+#
+# Separate from the combined write limit: keyed on the system (which may have
+# several legitimate writers), this specifically catches a stuck switch-client
+# or looping integration hammering POST /fronts. A classic token bucket -
+# sustained refill at N/min with a small burst capacity - fits the shape
+# better than a fixed window: a normal cadence of switches never trips it, but
+# a runaway loop drains the bucket and is throttled.
+#
+# The refill-and-take is done in one Lua script so the read-modify-write is
+# atomic under concurrent switches on the same system (a plain GET/SET would
+# race). Returns 1 when a token was taken (allowed), 0 when the bucket was
+# empty (over the limit).
+_FRONT_SWITCH_BUCKET_LUA = """
+local rate = tonumber(ARGV[1])
+local capacity = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local state = redis.call('HMGET', KEYS[1], 'tokens', 'ts')
+local tokens = tonumber(state[1])
+local ts = tonumber(state[2])
+if tokens == nil then
+  tokens = capacity
+  ts = now
+end
+local elapsed = now - ts
+if elapsed < 0 then elapsed = 0 end
+tokens = math.min(capacity, tokens + elapsed * rate)
+local allowed = 0
+if tokens >= 1 then
+  tokens = tokens - 1
+  allowed = 1
+end
+redis.call('HMSET', KEYS[1], 'tokens', tokens, 'ts', now)
+redis.call('EXPIRE', KEYS[1], ttl)
+return allowed
+"""
+
+
+def _front_switch_key(system_id) -> str:
+    return f"sheaf:rl:frontswitch:{system_id}"
+
+
+async def check_front_switch_rate(system_id) -> bool:
+    """Per-system front-switch guard. Returns True if a switch may proceed,
+    False if the system is over its switch rate and the caller should 429.
+
+    Sustained rate is front_switch_rate_per_system_per_min; short bursts up
+    to front_switch_rate_burst are absorbed. Setting the per-minute rate to 0
+    disables the guard.
+
+    Fail-open on any Redis error: the combined per-user write limit and the
+    global per-IP backstop remain as coarser nets, and a Redis outage must
+    not wedge fronting for every system on the instance.
+    """
+    if not settings.rate_limit_enabled:
+        return True
+    per_min = settings.front_switch_rate_per_system_per_min
+    if per_min <= 0:
+        return True  # 0 (or negative) disables the per-system switch guard
+
+    capacity = max(1, settings.front_switch_rate_burst)
+    rate = per_min / 60.0  # tokens per second
+    # Long enough for an empty bucket to refill fully, plus a margin, so an
+    # active system keeps its refill state while an idle one ages out.
+    ttl = int(capacity / rate) + 60
+
+    try:
+        r = await _get_redis()
+        allowed = await r.eval(
+            _FRONT_SWITCH_BUCKET_LUA,
+            1,
+            _front_switch_key(system_id),
+            rate,
+            capacity,
+            time.time(),
+            ttl,
+        )
+    except Exception:
+        logger.warning("Redis unavailable - allowing front switch")
+        return True
+
+    ok = bool(allowed)
+    rate_limit_checks_total.labels(
+        bucket="front_switch",
+        scope="per_system",
+        outcome="allowed" if ok else "blocked",
+    ).inc()
+    return ok
 
 
 # ---------------------------------------------------------------------------

--- a/sheaf/models/content_revision.py
+++ b/sheaf/models/content_revision.py
@@ -64,6 +64,16 @@ class ContentRevision(UUIDMixin, Base):
         nullable=False,
     )
 
+    # True row-insertion time. Unlike created_at (which importers overwrite
+    # with the source edit timestamp), this is always when the row actually
+    # landed here. Retention trimming orders by this so imported history is
+    # counted from when it arrived, not when it was originally authored.
+    inserted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
     # NULL = not pinned. NOT NULL timestamp doubles as flag + UI sort.
     # Pinned revisions are exempt from the rolling retention sweep.
     pinned_at: Mapped[datetime | None] = mapped_column(
@@ -78,6 +88,7 @@ class ContentRevision(UUIDMixin, Base):
             "created_at",
         ),
         Index("ix_content_revisions_created", "created_at"),
+        Index("ix_content_revisions_inserted", "inserted_at"),
         Index("ix_content_revisions_user", "user_id"),
         Index(
             "ix_content_revisions_pinned",

--- a/sheaf/services/journals.py
+++ b/sheaf/services/journals.py
@@ -8,7 +8,7 @@ in `sheaf/api/v1/journals.py` and `sheaf/services/system_safety.py`.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -82,6 +82,69 @@ def effective_revision_caps(user: User, system: System) -> tuple[int, int]:
 # ---------------------------------------------------------------------------
 
 
+async def _latest_revision(
+    target_type_str: str,
+    target_id: uuid.UUID,
+    db: AsyncSession,
+) -> ContentRevision | None:
+    """Return the newest revision for a target by inserted_at, or None.
+
+    "Newest" is by ``inserted_at`` (true row-landing time), matching the
+    ordering the retention sweep and the write-time count cap use, so the
+    debounce window is measured against the same clock the trim honors.
+    """
+    result = await db.execute(
+        select(ContentRevision)
+        .where(
+            ContentRevision.target_type == target_type_str,
+            ContentRevision.target_id == target_id,
+        )
+        .order_by(ContentRevision.inserted_at.desc())
+        .limit(1)
+    )
+    return result.scalars().first()
+
+
+async def _enforce_write_time_count_cap(
+    *,
+    db: AsyncSession,
+    target_type_str: str,
+    target_id: uuid.UUID,
+    max_revisions: int,
+) -> None:
+    """Trim UNPINNED revisions past the count cap for a single target.
+
+    Runs at write time so the periodic GC sweep is a backstop rather than the
+    primary enforcement. Keeps the newest ``max_revisions`` unpinned rows by
+    ``inserted_at`` (matching the sweep's ordering) and deletes the older
+    overflow in one bounded DELETE. Pinned revisions (pinned_at IS NOT NULL)
+    are never counted or deleted. ``max_revisions == 0`` means unlimited.
+
+    The keep-set subquery is bounded to ``max_revisions`` rows, so this stays
+    O(cap)-ish rather than loading the whole history into Python.
+    """
+    if max_revisions <= 0:
+        return
+    keep_ids = (
+        select(ContentRevision.id)
+        .where(
+            ContentRevision.target_type == target_type_str,
+            ContentRevision.target_id == target_id,
+            ContentRevision.pinned_at.is_(None),
+        )
+        .order_by(ContentRevision.inserted_at.desc())
+        .limit(max_revisions)
+    )
+    await db.execute(
+        delete(ContentRevision).where(
+            ContentRevision.target_type == target_type_str,
+            ContentRevision.target_id == target_id,
+            ContentRevision.pinned_at.is_(None),
+            ContentRevision.id.not_in(keep_ids),
+        )
+    )
+
+
 async def capture_revision(
     *,
     db: AsyncSession,
@@ -94,13 +157,29 @@ async def capture_revision(
 ) -> ContentRevision:
     """Insert a content_revisions row capturing the *outgoing* content.
 
-    `title` and `body` are *plaintext* — encrypted at write time.
+    `title` and `body` are *plaintext* - encrypted at write time.
     image_keys is extracted from the plaintext body, then stored unencrypted
     so orphan cleanup can read it without key access.
+
+    Debounce (checkpoint semantics): when `revision_debounce_minutes` is
+    enabled and the target's newest revision is UNPINNED and landed within
+    that window, we REPLACE that revision's captured content in place (title,
+    body, image_keys, and the editor snapshot) instead of appending a new row.
+    `inserted_at` is deliberately NOT refreshed on replace: the window stays
+    anchored to when each checkpoint was born, so a burst of rapid saves
+    collapses into one revision while a long editing session still accrues a
+    fresh checkpoint roughly every `revision_debounce_minutes` (the first save
+    after the window elapses appends again). If the newest revision is pinned,
+    older than the window, missing (first-ever edit), or debounce is disabled,
+    we append a new row as before.
 
     If this is the first revision captured for the target AND the system has
     `auto_pin_first_revision=True`, the new row is pinned. Defends against
     spam-eviction even when the destructive-action grace flow is off.
+
+    After the write, the effective per-target count cap is enforced (oldest
+    unpinned overflow trimmed); this makes the GC sweep a backstop. Pinned
+    revisions are exempt.
 
     Caller is responsible for then overwriting the target row with the new
     content and committing.
@@ -110,12 +189,46 @@ async def capture_revision(
     )
     editor_ids, editor_names = await snapshot_current_fronts(system_id, db)
 
+    system = await db.get(System, system_id)
+    max_revisions = (
+        effective_revision_caps(user, system)[0] if system is not None else 0
+    )
+
+    enc_title = encrypt(title) if title is not None else None
+    enc_body = encrypt(body)
+    image_keys = extract_image_keys(body)
+
+    debounce_minutes = settings.revision_debounce_minutes
+    if debounce_minutes > 0:
+        latest = await _latest_revision(target_type_str, target_id, db)
+        if (
+            latest is not None
+            and latest.pinned_at is None
+            and _within_debounce_window(latest.inserted_at, debounce_minutes)
+        ):
+            # Replace the newest checkpoint in place. Reuse the same encrypt()
+            # calls as the append path so nothing plaintext is ever stored;
+            # image_keys stays the plaintext-extracted list, as today. Leave
+            # inserted_at untouched on purpose (see docstring).
+            latest.title = enc_title
+            latest.body = enc_body
+            latest.image_keys = image_keys
+            latest.editor_member_ids = editor_ids
+            latest.editor_member_names = editor_names
+            # No new row, so the cap usually has nothing to trim, but run it
+            # anyway - it is cheap and mops up any pre-existing overflow.
+            await _enforce_write_time_count_cap(
+                db=db,
+                target_type_str=target_type_str,
+                target_id=target_id,
+                max_revisions=max_revisions,
+            )
+            return latest
+
     existing_count = await revision_count_for(target_type_str, target_id, db)
     pinned_at: datetime | None = None
-    if existing_count == 0:
-        system = await db.get(System, system_id)
-        if system is not None and system.auto_pin_first_revision:
-            pinned_at = datetime.now(UTC)
+    if existing_count == 0 and system is not None and system.auto_pin_first_revision:
+        pinned_at = datetime.now(UTC)
 
     revision = ContentRevision(
         target_type=target_type_str,
@@ -123,14 +236,35 @@ async def capture_revision(
         user_id=user.id,
         editor_member_ids=editor_ids,
         editor_member_names=editor_names,
-        title=encrypt(title) if title is not None else None,
-        body=encrypt(body),
-        image_keys=extract_image_keys(body),
+        title=enc_title,
+        body=enc_body,
+        image_keys=image_keys,
         pinned_at=pinned_at,
     )
     db.add(revision)
     content_revisions_created_total.inc()
+    # Flush so the new row participates in the count-cap query below (and gets
+    # its server-default inserted_at), then trim the oldest unpinned overflow.
+    await db.flush()
+    await _enforce_write_time_count_cap(
+        db=db,
+        target_type_str=target_type_str,
+        target_id=target_id,
+        max_revisions=max_revisions,
+    )
     return revision
+
+
+def _within_debounce_window(inserted_at: datetime | None, minutes: int) -> bool:
+    """True if `inserted_at` is within `minutes` of now (UTC).
+
+    Guards against a naive datetime (older rows / test fixtures) by assuming
+    UTC when tzinfo is absent, so the comparison never raises.
+    """
+    if inserted_at is None:
+        return False
+    ref = inserted_at if inserted_at.tzinfo is not None else inserted_at.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - ref) <= timedelta(minutes=minutes)
 
 
 # ---------------------------------------------------------------------------

--- a/sheaf/services/retention.py
+++ b/sheaf/services/retention.py
@@ -182,9 +182,10 @@ async def _trim_target_group(
     imported history. Importers set ``created_at`` from the *source*
     timestamp, so an old-but-just-imported edit-history looked expired and was
     silently deleted by an age cutoff - the same class of bug as the front
-    retention incident. content_revisions has no separate row-insert column to
-    key a safe age window off, so we cap by NEWEST-N count only and never by
-    age.
+    retention incident. We cap by NEWEST-N count only and never by age. The
+    newest-N is ordered by ``inserted_at`` (the true row-landing time), so a
+    just-imported old-authored revision counts as recent instead of being
+    trimmed first.
 
     `max_revisions=0` means unlimited (no count cap). `max_days` is still
     accepted (it is plumbed through for display/caps reporting) but MUST NOT
@@ -206,13 +207,16 @@ async def _trim_target_group(
             ContentRevision.target_id == target_id,
             ContentRevision.pinned_at.is_(None),
         )
-        .order_by(ContentRevision.created_at.desc())
+        .order_by(ContentRevision.inserted_at.desc())
     )
     rows = list(result.scalars().all())
     if not rows:
         return 0
 
     # Keep the newest max_revisions; delete the rest. No age cutoff.
+    # "Newest" is by inserted_at (when the row landed), not created_at (the
+    # source edit time importers set): a just-imported old-authored revision
+    # must count as recent, not be trimmed first.
     keep: set[uuid.UUID] = {r.id for r in rows[:max_revisions]}
     to_delete = [r.id for r in rows if r.id not in keep]
     if not to_delete:

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -174,6 +174,13 @@ CLASSIFICATION: dict[type, dict] = {
         },
         "excluded": {
             "id": _SURROGATE_PK,
+            # inserted_at is local row-provenance: a re-imported revision is a
+            # new row and gets a fresh inserted_at (the server default), so it
+            # is deliberately not carried in the export. created_at still
+            # round-trips the source edit time; inserted_at tracks when the row
+            # landed here (what the retention sweep counts from). Same rationale
+            # as a fronts row created_at.
+            "inserted_at": _ROW_CREATED,
         },
     },
     WatchToken: {

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -269,17 +269,25 @@ def test_revision_history_lists_and_restores(auth_client: httpx.Client):
 
 def test_gc_revisions_trims_message_revisions(client: httpx.Client):
     """gc_revisions must include 'message' targets in its sweep, otherwise
-    edit history grows unbounded. Mirrors the journal/bio coverage."""
+    edit history grows unbounded. Mirrors the journal/bio coverage.
+
+    Backstop reframing: capture_revision now caps message-revision history at
+    write time, so an over-cap state can only arise from rows that bypassed it
+    (imports, legacy). We seed those directly and give the user an explicit low
+    override so the cap is independent of the free-tier default (now 50).
+    """
     import asyncio
     import os
     import uuid as _uuid
+    from datetime import UTC, datetime, timedelta
 
     from sqlalchemy import select
     from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
     from sqlalchemy.orm import sessionmaker
 
     from sheaf.config import settings
-    from sheaf.crypto import blind_index
+    from sheaf.crypto import blind_index, encrypt
+    from sheaf.models.content_revision import ContentRevision
     from sheaf.models.system import System
     from sheaf.models.user import User
     from sheaf.services.retention import gc_revisions
@@ -292,8 +300,9 @@ def test_gc_revisions_trims_message_revisions(client: httpx.Client):
     assert resp.status_code == 201, resp.text
     client.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
 
-    # Drop to free tier (count cap = 10) and disable auto-pin so the cap
-    # alone drives the trim.
+    # Free tier with an explicit count override of 5 (set directly, bypassing
+    # PATCH validation) so the cap under test is independent of the tier
+    # default. Auto-pin off is incidental here since we seed rows directly.
     async def _prep() -> None:
         db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
         engine = create_async_engine(db_url)
@@ -309,18 +318,63 @@ def test_gc_revisions_trims_message_revisions(client: httpx.Client):
                 await db.execute(select(System).where(System.user_id == user.id))
             ).scalar_one()
             system.auto_pin_first_revision = False
+            system.journal_max_revisions = 5
             await db.commit()
         await engine.dispose()
 
     asyncio.run(_prep())
 
+    # A real message so gc_revisions discovers the target; posting does not
+    # capture a revision, so the target starts empty.
     alice = _create_member(client, "Alice")
     msg = _post(client, author_member_id=alice, body="v0")
-    for i in range(1, 16):
-        client.patch(f"/v1/messages/{msg['id']}", json={"body": f"v{i}"})
+    target_id = _uuid.UUID(msg["id"])
 
-    revs_before = client.get(f"/v1/messages/{msg['id']}/revisions").json()
-    assert len(revs_before) == 15
+    # Seed 15 message revisions DIRECTLY (bypassing capture_revision) with
+    # distinct inserted_at, oldest first.
+    async def _seed() -> list[_uuid.UUID]:
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        anchor = datetime.now(UTC) - timedelta(hours=15)
+        try:
+            async with async_session() as db:
+                rows: list[ContentRevision] = []
+                for i in range(15):
+                    rev = ContentRevision(
+                        target_type="message",
+                        target_id=target_id,
+                        body=encrypt(f"seed-{i}"),
+                        inserted_at=anchor + timedelta(minutes=i),
+                    )
+                    db.add(rev)
+                    rows.append(rev)
+                await db.commit()
+                return [r.id for r in rows]
+        finally:
+            await engine.dispose()
+
+    seeded = asyncio.run(_seed())
+
+    async def _remaining_ids() -> set[_uuid.UUID]:
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                rows = (
+                    await db.execute(
+                        select(ContentRevision.id).where(
+                            ContentRevision.target_type == "message",
+                            ContentRevision.target_id == target_id,
+                        )
+                    )
+                ).scalars().all()
+                return set(rows)
+        finally:
+            await engine.dispose()
+
+    assert asyncio.run(_remaining_ids()) == set(seeded)
 
     async def _run_gc() -> int:
         db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
@@ -335,10 +389,12 @@ def test_gc_revisions_trims_message_revisions(client: httpx.Client):
             await engine.dispose()
 
     deleted = asyncio.run(_run_gc())
-    assert deleted >= 5
+    # 15 unpinned rows, cap 5 -> 10 deleted. (>= because the sweep runs over
+    # every user in the shared DB.)
+    assert deleted >= 10
 
-    revs_after = client.get(f"/v1/messages/{msg['id']}/revisions").json()
-    assert len(revs_after) == 10
+    # Newest 5 by inserted_at survive.
+    assert asyncio.run(_remaining_ids()) == set(seeded[10:15])
 
 
 def test_gc_revisions_sweeps_orphaned_message_revisions(client: httpx.Client):

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -172,6 +172,91 @@ def test_sync_export_per_user_rate_limit():
     assert 429 in statuses, statuses
 
 
+def test_per_user_write_rate_limit_combined():
+    """The combined per-account write limit (write_rate_per_user_per_min,
+    default 60/min) is one shared bucket across the whole mutating surface:
+    a burst of writes split across different endpoints trips a single 429,
+    not a separate per-route counter."""
+    email = f"rl-write-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=BASE_URL) as c:
+        resp = c.post(
+            "/v1/auth/register",
+            json={"email": email, "password": "testpassword123"},
+        )
+        assert resp.status_code == 201
+        c.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+
+        first_429 = None
+        allowed = 0
+        # Interleave two different write endpoints. Both draw down the same
+        # per-account bucket, so ~60 combined writes are absorbed and the
+        # burst past that returns 429 regardless of which endpoint it lands
+        # on. The bodyless journal POSTs 4xx on validation but still consume
+        # the budget (the rate-limit dependency runs before body parsing).
+        for i in range(90):
+            if i % 2 == 0:
+                r = c.post(
+                    "/v1/members",
+                    json={"name": f"rl-{uuid.uuid4().hex[:8]}"},
+                )
+            else:
+                r = c.post("/v1/journals")
+            if r.status_code == 429:
+                first_429 = r
+                break
+            allowed += 1
+
+    assert first_429 is not None, "combined write limit never tripped"
+    # Confirm it is the write limit, not some other 429 (member cap, etc.).
+    assert "write rate limit" in first_429.json()["detail"].lower()
+    # Roughly 60 combined writes pass before the shared bucket blocks; allow
+    # slack for counter granularity and the window boundary.
+    assert allowed >= 50, allowed
+
+
+def test_front_switch_guard_per_system():
+    """Rapid front creates past the per-system switch guard return 429,
+    while a normal small burst does not. This guard is keyed on the system
+    and is separate from the per-account write limit that also covers
+    POST /fronts."""
+    email = f"rl-switch-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    with httpx.Client(base_url=BASE_URL) as c:
+        resp = c.post(
+            "/v1/auth/register",
+            json={"email": email, "password": "testpassword123"},
+        )
+        assert resp.status_code == 201
+        c.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+
+        member = c.post(
+            "/v1/members", json={"name": f"rl-switch-{uuid.uuid4().hex[:8]}"}
+        )
+        assert member.status_code == 201
+        member_id = member.json()["id"]
+
+        statuses = []
+        first_429 = None
+        # Hammer front creates far past the burst capacity (default 10).
+        # The switch guard is checked before any front DB work, so a request
+        # that would otherwise 201/409 is cut off with 429 once the bucket
+        # drains.
+        for _ in range(40):
+            r = c.post("/v1/fronts", json={"member_ids": [member_id]})
+            statuses.append(r.status_code)
+            if r.status_code == 429 and first_429 is None:
+                first_429 = r
+
+    # A full bucket lets a normal small burst through: the first request is
+    # never blocked by the switch guard.
+    assert statuses[0] != 429, statuses
+    idx = statuses.index(429) if 429 in statuses else None
+    assert idx is not None, statuses
+    # Burst capacity absorbs the first several rapid creates before the guard
+    # trips, so the first 429 lands after a handful of accepted requests.
+    assert idx >= 5, statuses
+    assert "faster than we accept" in first_429.json()["detail"].lower()
+
+
 def test_per_user_block_records_admin_history(admin_client):
     """End-to-end: a blocked per-user check leaves a triage trail
     readable via GET /admin/users/{id}/rate-limit-history."""

--- a/tests/test_revision_retention.py
+++ b/tests/test_revision_retention.py
@@ -79,6 +79,119 @@ def _set_system_safety_via_db(user_email: str, **fields) -> None:
     asyncio.run(_run())
 
 
+def _seed_revisions_via_db(
+    *,
+    target_type: str,
+    target_id: uuid.UUID,
+    count: int,
+    pinned_indices: set[int] | None = None,
+) -> list[uuid.UUID]:
+    """Insert `count` ContentRevision rows for one target DIRECTLY.
+
+    Bypasses capture_revision on purpose - the same shape an importer produces
+    (rows built straight into the table), which is the only way to reach an
+    over-cap state now that capture_revision trims at write time. Each row gets
+    a distinct inserted_at (oldest first) so the newest-N sweep is
+    deterministic; indices in `pinned_indices` are pinned (exempt from the
+    count sweep). Returns the row ids oldest-first.
+    """
+    from sheaf.crypto import encrypt
+
+    pins = pinned_indices or set()
+
+    async def _run() -> list[uuid.UUID]:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.content_revision import ContentRevision
+
+        anchor = datetime.now(UTC) - timedelta(hours=count)
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        try:
+            async with async_session() as db:
+                rows: list[ContentRevision] = []
+                for i in range(count):
+                    rev = ContentRevision(
+                        target_type=target_type,
+                        target_id=target_id,
+                        body=encrypt(f"seed-{i}"),
+                        inserted_at=anchor + timedelta(minutes=i),
+                        pinned_at=datetime.now(UTC) if i in pins else None,
+                    )
+                    db.add(rev)
+                    rows.append(rev)
+                await db.commit()
+                return [r.id for r in rows]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+def _revision_ids_for(target_type: str, target_id: uuid.UUID) -> set[uuid.UUID]:
+    """Current ContentRevision ids for a target, read straight from the DB."""
+
+    async def _run() -> set[uuid.UUID]:
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.content_revision import ContentRevision
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        try:
+            async with async_session() as db:
+                rows = (
+                    await db.execute(
+                        select(ContentRevision.id).where(
+                            ContentRevision.target_type == target_type,
+                            ContentRevision.target_id == target_id,
+                        )
+                    )
+                ).scalars().all()
+                return set(rows)
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+def _run_gc() -> int:
+    """Run the GC sweep once and return items_processed."""
+
+    async def _run() -> int:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.services.retention import gc_revisions
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        try:
+            async with async_session() as db:
+                result = await gc_revisions(db)
+                await db.commit()
+                return result["items_processed"]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
 # ---------------------------------------------------------------------------
 # Read endpoint: tier caps + override + effective
 # ---------------------------------------------------------------------------
@@ -103,9 +216,9 @@ def test_get_retention_free_tier_caps(client: httpx.Client):
     email = _register(client)
     _set_user_tier_via_db(email, "free")
     body = client.get("/v1/retention").json()
-    assert body["tier_max_revisions"] == 10  # journal_max_revisions_free
+    assert body["tier_max_revisions"] == 50  # journal_max_revisions_free
     assert body["tier_max_days"] == 30  # journal_max_revision_days_free
-    assert body["effective_max_revisions"] == 10
+    assert body["effective_max_revisions"] == 50
     assert body["effective_max_days"] == 30
 
 
@@ -120,7 +233,7 @@ def test_override_below_tier_max_applies_immediately_when_no_grace(
     """Reductions are loosening, but with grace=0 they apply immediately."""
     email = _register(client)
     _set_user_tier_via_db(email, "free")
-    # Tightening from None (= tier max 10) to 5 is a loosening; grace=0 means
+    # Tightening from None (= tier max 50) to 5 is a loosening; grace=0 means
     # it lands immediately anyway.
     resp = client.patch("/v1/retention", json={"max_revisions": 5})
     assert resp.status_code == 200, resp.text
@@ -138,9 +251,9 @@ def test_override_reduction_with_grace_is_deferred(client: httpx.Client):
     resp = client.patch("/v1/retention", json={"max_revisions": 5})
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    # Override hasn't applied yet — still showing tier max as effective.
+    # Override hasn't applied yet - still showing tier max as effective.
     assert body["override_revisions"] is None
-    assert body["effective_max_revisions"] == 10
+    assert body["effective_max_revisions"] == 50
 
     # Pending change should be visible in the system safety endpoint.
     pending = client.get("/v1/system/safety").json()["pending_changes"]
@@ -319,56 +432,60 @@ def test_on_tier_change_upgrade_cancels_existing_notice():
 
 
 def test_gc_revisions_trims_to_count_cap(client: httpx.Client):
+    """Backstop sweep: gc_revisions trims an over-cap target seeded directly.
+
+    Write-time capping in capture_revision now prevents ever reaching an
+    over-cap state through the edit API, so the sweep can only be exercised
+    against rows that bypassed it (imports, legacy rows). We seed those rows
+    directly and give the user an explicit low override so the cap under test
+    is independent of the free-tier default (now 50).
+    """
     email = _register(client)
-    _set_user_tier_via_db(email, "free")  # cap = 10
-    # This test is about the rolling count cap in isolation; opt out of
-    # auto-pin so the trim count matches what the cap would do alone.
-    _set_system_safety_via_db(email, auto_pin_first_revision=False)
+    _set_user_tier_via_db(email, "free")
+    # Explicit cap of 5 via the system override (bypasses PATCH validation),
+    # independent of the tier default. Auto-pin off so the pinned-exemption
+    # case is the one we seed explicitly, not an incidental first-revision pin.
+    _set_system_safety_via_db(
+        email, journal_max_revisions=5, auto_pin_first_revision=False
+    )
 
-    # Create one entry and edit it 15 times to generate 15 revisions.
+    # A real journal entry so gc_revisions discovers the target. Creation does
+    # not capture a revision, so the target starts empty.
     entry = client.post("/v1/journals", json={"body": "v0"}).json()
-    for i in range(1, 16):
-        client.patch(
-            f"/v1/journals/{entry['id']}", json={"body": f"v{i}"}
-        )
+    target_id = uuid.UUID(entry["id"])
 
-    revs_before = client.get(
-        f"/v1/journals/{entry['id']}/revisions"
-    ).json()
-    assert len(revs_before) == 15
+    # Seed 15 revisions DIRECTLY (bypassing capture_revision). Pin the oldest
+    # to prove pinned rows are exempt from the count sweep.
+    seeded = _seed_revisions_via_db(
+        target_type="journal_entry",
+        target_id=target_id,
+        count=15,
+        pinned_indices={0},
+    )
+    assert _revision_ids_for("journal_entry", target_id) == set(seeded)
 
-    # Run the GC job directly.
-    async def _run_gc() -> int:
-        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-        from sqlalchemy.orm import sessionmaker
+    deleted = _run_gc()
+    # 14 unpinned rows, cap 5 -> keep newest 5, delete 9. (>= because the sweep
+    # runs over every user in the shared DB.)
+    assert deleted >= 9
 
-        from sheaf.config import settings
-        from sheaf.services.retention import gc_revisions
-
-        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
-        engine = create_async_engine(db_url)
-        async_session = sessionmaker(
-            engine, class_=AsyncSession, expire_on_commit=False
-        )
-        try:
-            async with async_session() as db:
-                result = await gc_revisions(db)
-                await db.commit()
-                return result["items_processed"]
-        finally:
-            await engine.dispose()
-
-    deleted = asyncio.run(_run_gc())
-    assert deleted >= 5
-
-    revs_after = client.get(
-        f"/v1/journals/{entry['id']}/revisions"
-    ).json()
-    assert len(revs_after) == 10
+    remaining = _revision_ids_for("journal_entry", target_id)
+    # Survivors: the pinned oldest (exempt) + the newest 5 unpinned by
+    # inserted_at.
+    expected = {seeded[0]} | set(seeded[10:15])
+    assert remaining == expected
 
 
 def test_gc_revisions_grace_window_defers_trim():
-    """Active trim notice should keep pre-downgrade caps until effective_at."""
+    """Active trim notice keeps the pre-downgrade cap until effective_at.
+
+    The deferral difference has to come from the tier caps themselves: an
+    override applies equally to the pre- and post-downgrade computations, so it
+    can never make one higher than the other. We therefore drive it off the
+    real PLUS (100) vs FREE (50) tier caps and seed enough rows to sit between
+    them - 60. During grace the sweep honors the higher pre-downgrade cap (100)
+    and trims nothing; once the notice lapses it trims to the FREE cap (50).
+    """
     from sheaf.crypto import blind_index
 
     email = f"gcgrace-{uuid.uuid4().hex[:8]}@sheaf.dev"
@@ -380,16 +497,24 @@ def test_gc_revisions_grace_window_defers_trim():
         assert resp.status_code == 201
         c.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
 
-        # Create 15 revisions while on PLUS (cap 100, no trimming yet).
-        # Disable auto-pin so we exercise the rolling cap in isolation.
+        # Start on PLUS and create a real journal entry so gc_revisions finds
+        # the target. No override, so the caps under test are the tier caps.
         _set_user_tier_via_db(email, "plus")
-        _set_system_safety_via_db(email, auto_pin_first_revision=False)
         entry = c.post("/v1/journals", json={"body": "v0"}).json()
-        for i in range(1, 16):
-            c.patch(f"/v1/journals/{entry['id']}", json={"body": f"v{i}"})
+        target_id = uuid.UUID(entry["id"])
 
-        # Downgrade through on_tier_change to create a notice
-        async def _downgrade() -> None:
+    # Seed 60 revisions DIRECTLY - above the FREE cap (50), below PLUS (100).
+    seeded = _seed_revisions_via_db(
+        target_type="journal_entry",
+        target_id=target_id,
+        count=60,
+    )
+    assert _revision_ids_for("journal_entry", target_id) == set(seeded)
+
+    # Downgrade PLUS -> FREE via on_tier_change to create the pending notice,
+    # then land the user on FREE.
+    def _downgrade() -> None:
+        async def _run() -> None:
             from sqlalchemy import select
             from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
             from sqlalchemy.orm import sessionmaker
@@ -398,61 +523,41 @@ def test_gc_revisions_grace_window_defers_trim():
             from sheaf.models.user import User, UserTier
             from sheaf.services.retention import on_tier_change
 
-            db_url = (
-                os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
-            )
+            db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
             engine = create_async_engine(db_url)
             async_session = sessionmaker(
                 engine, class_=AsyncSession, expire_on_commit=False
             )
             try:
                 async with async_session() as db:
-                    email_hash = blind_index(email)
                     user = (
                         await db.execute(
-                            select(User).where(User.email_hash == email_hash)
+                            select(User).where(
+                                User.email_hash == blind_index(email)
+                            )
                         )
                     ).scalar_one()
-                    await on_tier_change(
+                    notice = await on_tier_change(
                         user, UserTier.PLUS, UserTier.FREE, db
                     )
+                    assert notice is not None  # PLUS(100) -> FREE(50) reduces
                     user.tier = UserTier.FREE
                     await db.commit()
             finally:
                 await engine.dispose()
 
-        asyncio.run(_downgrade())
+        asyncio.run(_run())
 
-        # Run GC — should NOT trim because notice's effective_at is future.
-        async def _run_gc() -> None:
-            from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-            from sqlalchemy.orm import sessionmaker
+    _downgrade()
 
-            from sheaf.config import settings
-            from sheaf.services.retention import gc_revisions
+    # Sweep during grace: effective_at is in the future, so the pre-downgrade
+    # cap (100) is honored and nothing is trimmed.
+    _run_gc()
+    assert _revision_ids_for("journal_entry", target_id) == set(seeded)
 
-            db_url = (
-                os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
-            )
-            engine = create_async_engine(db_url)
-            async_session = sessionmaker(
-                engine, class_=AsyncSession, expire_on_commit=False
-            )
-            try:
-                async with async_session() as db:
-                    await gc_revisions(db)
-                    await db.commit()
-            finally:
-                await engine.dispose()
-
-        asyncio.run(_run_gc())
-
-        revs = c.get(f"/v1/journals/{entry['id']}/revisions").json()
-        # All 15 should still be present during grace.
-        assert len(revs) == 15
-
-        # Backdate the notice and re-run GC — now it trims.
-        async def _backdate() -> None:
+    # Backdate the notice so its window has passed, then sweep again.
+    def _backdate() -> None:
+        async def _run() -> None:
             from sqlalchemy import select
             from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
             from sqlalchemy.orm import sessionmaker
@@ -461,19 +566,18 @@ def test_gc_revisions_grace_window_defers_trim():
             from sheaf.models.retention_trim_notice import RetentionTrimNotice
             from sheaf.models.user import User
 
-            db_url = (
-                os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
-            )
+            db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
             engine = create_async_engine(db_url)
             async_session = sessionmaker(
                 engine, class_=AsyncSession, expire_on_commit=False
             )
             try:
                 async with async_session() as db:
-                    email_hash = blind_index(email)
                     user = (
                         await db.execute(
-                            select(User).where(User.email_hash == email_hash)
+                            select(User).where(
+                                User.email_hash == blind_index(email)
+                            )
                         )
                     ).scalar_one()
                     notice = (
@@ -488,9 +592,165 @@ def test_gc_revisions_grace_window_defers_trim():
             finally:
                 await engine.dispose()
 
-        asyncio.run(_backdate())
-        asyncio.run(_run_gc())
+        asyncio.run(_run())
 
-        revs_after = c.get(f"/v1/journals/{entry['id']}/revisions").json()
-        # Now trimmed to FREE cap (10).
-        assert len(revs_after) == 10
+    _backdate()
+    _run_gc()
+
+    # Now trimmed to the FREE cap (50): the oldest 10 by inserted_at are gone,
+    # the newest 50 survive.
+    remaining = _revision_ids_for("journal_entry", target_id)
+    assert remaining == set(seeded[10:60])
+
+
+# ---------------------------------------------------------------------------
+# inserted_at: true row-landing time drives the trim, not source created_at
+# ---------------------------------------------------------------------------
+
+
+def test_new_revision_has_inserted_at(client: httpx.Client):
+    """A revision created through the normal edit path gets inserted_at set."""
+    _register(client)
+    entry = client.post("/v1/journals", json={"body": "v0"}).json()
+    client.patch(f"/v1/journals/{entry['id']}", json={"body": "v1"})
+
+    async def _run() -> list:
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.content_revision import ContentRevision
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                rows = (
+                    await db.execute(
+                        select(ContentRevision).where(
+                            ContentRevision.target_id == uuid.UUID(entry["id"])
+                        )
+                    )
+                ).scalars().all()
+                return [r.inserted_at for r in rows]
+        finally:
+            await engine.dispose()
+
+    inserted = asyncio.run(_run())
+    assert len(inserted) >= 1
+    for ts in inserted:
+        assert ts is not None
+        assert (datetime.now(UTC) - ts) < timedelta(minutes=5)
+
+
+def test_imported_revision_inserted_at_is_now_not_source():
+    """Importers overwrite created_at with the source edit time but must NOT
+    touch inserted_at - it defaults to insert time, so imported history is
+    counted from when it landed here."""
+
+    async def _run() -> dict:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.content_revision import ContentRevision
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                source = datetime(2020, 1, 1, tzinfo=UTC)
+                rev = ContentRevision(
+                    target_type="journal_entry",
+                    target_id=uuid.uuid4(),
+                    body="imported body",
+                )
+                # Mirror the importer: created_at overwritten from source.
+                rev.created_at = source
+                db.add(rev)
+                await db.commit()
+                await db.refresh(rev)
+                return {"created": rev.created_at, "inserted": rev.inserted_at}
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(_run())
+    assert result["created"].year == 2020
+    assert result["inserted"].year != 2020
+    assert (datetime.now(UTC) - result["inserted"]) < timedelta(minutes=5)
+
+
+def test_trim_keeps_recently_inserted_over_old_source_time():
+    """The count trim keeps the most-recently-LANDED revisions. A just-imported
+    revision (old created_at, recent inserted_at) survives over one that was
+    inserted earlier but authored more recently."""
+
+    async def _run() -> dict:
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.content_revision import ContentRevision
+        from sheaf.services.retention import _trim_target_group
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                target_id = uuid.uuid4()
+                now = datetime.now(UTC)
+                # Imported: old source edit time, but only just landed.
+                landed_now = ContentRevision(
+                    target_type="journal_entry",
+                    target_id=target_id,
+                    body="imported-old",
+                    created_at=now - timedelta(days=100),
+                    inserted_at=now,
+                )
+                # Authored recently but inserted earlier than the import above.
+                landed_earlier = ContentRevision(
+                    target_type="journal_entry",
+                    target_id=target_id,
+                    body="landed-earlier",
+                    created_at=now - timedelta(days=1),
+                    inserted_at=now - timedelta(days=10),
+                )
+                db.add_all([landed_now, landed_earlier])
+                await db.commit()
+
+                deleted = await _trim_target_group(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=target_id,
+                    max_revisions=1,
+                    max_days=0,
+                )
+                await db.commit()
+
+                remaining = (
+                    await db.execute(
+                        select(ContentRevision.id).where(
+                            ContentRevision.target_type == "journal_entry",
+                            ContentRevision.target_id == target_id,
+                        )
+                    )
+                ).scalars().all()
+                return {
+                    "deleted": deleted,
+                    "kept": {str(i) for i in remaining},
+                    "landed_now": str(landed_now.id),
+                    "landed_earlier": str(landed_earlier.id),
+                }
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(_run())
+    assert result["deleted"] == 1
+    # The just-inserted (imported-old) revision survives; ordering by
+    # inserted_at, not created_at, is the whole point of the fix.
+    assert result["kept"] == {result["landed_now"]}

--- a/tests/test_revision_write_time.py
+++ b/tests/test_revision_write_time.py
@@ -1,0 +1,493 @@
+"""Tests for write-time revision capping + debounce in capture_revision.
+
+These drive `capture_revision` directly against the test database rather than
+through the edit endpoints. The debounce window and the "landed N minutes ago"
+timing can't be controlled through the black-box server (its
+revision_debounce_minutes is fixed by the running config, and we can't wait out
+a real window), so we exercise the service function in-process where we can set
+settings.revision_debounce_minutes and backdate inserted_at deterministically.
+The real capture path (encryption via encrypt(), image-key extraction, the
+count-cap trim) is fully exercised. Entities are created through the API so the
+user/system/entry rows are real.
+"""
+
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import httpx
+
+from sheaf.config import settings
+
+
+def _engine():
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+    return create_async_engine(db_url)
+
+
+def _register(client: httpx.Client, prefix: str = "wt") -> str:
+    email = f"{prefix}-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "testpassword123"},
+    )
+    assert resp.status_code == 201
+    client.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+    return email
+
+
+def _set_user_tier(email: str, tier: str) -> None:
+    from sqlalchemy import select
+
+    from sheaf.crypto import blind_index
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.user import User
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            user = (
+                await db.execute(
+                    select(User).where(User.email_hash == blind_index(email))
+                )
+            ).scalar_one()
+            user.tier = tier
+            await db.commit()
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def _set_system_fields(email: str, **fields) -> None:
+    from sqlalchemy import select
+
+    from sheaf.crypto import blind_index
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.system import System
+        from sheaf.models.user import User
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as db:
+            user = (
+                await db.execute(
+                    select(User).where(User.email_hash == blind_index(email))
+                )
+            ).scalar_one()
+            system = (
+                await db.execute(select(System).where(System.user_id == user.id))
+            ).scalar_one()
+            for k, v in fields.items():
+                setattr(system, k, v)
+            await db.commit()
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+async def _load_user_system(db, email: str):
+    from sqlalchemy import select
+
+    from sheaf.crypto import blind_index
+    from sheaf.models.system import System
+    from sheaf.models.user import User
+
+    user = (
+        await db.execute(select(User).where(User.email_hash == blind_index(email)))
+    ).scalar_one()
+    system = (
+        await db.execute(select(System).where(System.user_id == user.id))
+    ).scalar_one()
+    return user, system
+
+
+def _make_entry(client: httpx.Client) -> str:
+    """Create a journal entry (no revisions yet) and return its id."""
+    return client.post("/v1/journals", json={"title": "T0", "body": "B0"}).json()["id"]
+
+
+def _revisions_for(entry_id: str) -> list:
+    """Load all revision rows for a journal entry, newest inserted_at first."""
+    from sqlalchemy import select
+
+    async def _run() -> list:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.content_revision import ContentRevision
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                rows = (
+                    await db.execute(
+                        select(ContentRevision)
+                        .where(
+                            ContentRevision.target_id == uuid.UUID(entry_id),
+                            ContentRevision.target_type == "journal_entry",
+                        )
+                        .order_by(ContentRevision.inserted_at.desc())
+                    )
+                ).scalars().all()
+                # Detach copies of the fields we assert on.
+                return [
+                    {
+                        "id": r.id,
+                        "body": r.body,
+                        "title": r.title,
+                        "pinned_at": r.pinned_at,
+                        "inserted_at": r.inserted_at,
+                    }
+                    for r in rows
+                ]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Task B: write-time count cap
+# ---------------------------------------------------------------------------
+
+
+def test_append_past_cap_trims_oldest_unpinned_keeps_pins(
+    client: httpx.Client, monkeypatch
+):
+    """Appending past the effective count cap trims the oldest UNPINNED
+    revision and never touches a pinned one."""
+    email = _register(client, "wtcap")
+    _set_user_tier(email, "free")
+    # Effective cap = min(override, tier free 50) = 3. Auto-pin off so the
+    # cap runs in isolation; we pin one row by hand below.
+    _set_system_fields(email, journal_max_revisions=3, auto_pin_first_revision=False)
+    entry_id = _make_entry(client)
+
+    # Disable debounce so every capture appends a distinct row.
+    monkeypatch.setattr(settings, "revision_debounce_minutes", 0)
+
+    async def _run() -> dict:
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.content_revision import ContentRevision
+        from sheaf.services.journals import capture_revision
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                user, system = await _load_user_system(db, email)
+                now = datetime.now(UTC)
+                # Seed history directly: one PINNED (oldest) + three unpinned,
+                # with deterministic, strictly-increasing inserted_at.
+                pinned = ContentRevision(
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    body="pinned-oldest",
+                    inserted_at=now - timedelta(minutes=50),
+                    pinned_at=now - timedelta(minutes=50),
+                )
+                old0 = ContentRevision(
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    body="unpinned-0",
+                    inserted_at=now - timedelta(minutes=40),
+                )
+                old1 = ContentRevision(
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    body="unpinned-1",
+                    inserted_at=now - timedelta(minutes=30),
+                )
+                old2 = ContentRevision(
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    body="unpinned-2",
+                    inserted_at=now - timedelta(minutes=20),
+                )
+                db.add_all([pinned, old0, old1, old2])
+                await db.commit()
+
+                # Unpinned count is now 3 (at cap). This append pushes to 4,
+                # so the oldest unpinned (old0) must be trimmed.
+                new_rev = await capture_revision(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    user=user,
+                    system_id=system.id,
+                    title=None,
+                    body="fresh-outgoing",
+                )
+                await db.commit()
+
+                rows = (
+                    await db.execute(
+                        select(ContentRevision).where(
+                            ContentRevision.target_id == uuid.UUID(entry_id)
+                        )
+                    )
+                ).scalars().all()
+                return {
+                    "ids": {str(r.id) for r in rows},
+                    "pinned_id": str(pinned.id),
+                    "old0_id": str(old0.id),
+                    "old1_id": str(old1.id),
+                    "old2_id": str(old2.id),
+                    "new_id": str(new_rev.id),
+                    "pinned_present": any(
+                        r.id == pinned.id for r in rows
+                    ),
+                }
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(_run())
+    # old0 (oldest unpinned) trimmed; pinned + old1 + old2 + new survive.
+    assert result["old0_id"] not in result["ids"]
+    assert result["pinned_id"] in result["ids"]
+    assert result["old1_id"] in result["ids"]
+    assert result["old2_id"] in result["ids"]
+    assert result["new_id"] in result["ids"]
+    # Total = 1 pinned + 3 unpinned (cap).
+    assert len(result["ids"]) == 4
+    assert result["pinned_present"]
+
+
+# ---------------------------------------------------------------------------
+# Task C: debounce / checkpoint semantics
+# ---------------------------------------------------------------------------
+
+
+def test_two_edits_within_window_collapse_to_one_revision(
+    client: httpx.Client, monkeypatch
+):
+    """Two edits inside the debounce window produce ONE revision holding the
+    later outgoing content, and its inserted_at does not move."""
+    email = _register(client, "wtdebounce")
+    # Auto-pin off so the first captured revision is unpinned (replaceable).
+    _set_system_fields(email, auto_pin_first_revision=False)
+    entry_id = _make_entry(client)
+
+    monkeypatch.setattr(settings, "revision_debounce_minutes", 5)
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.services.journals import capture_revision
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                user, system = await _load_user_system(db, email)
+                for body in ("outgoing-1", "outgoing-2"):
+                    await capture_revision(
+                        db=db,
+                        target_type="journal_entry",
+                        target_id=uuid.UUID(entry_id),
+                        user=user,
+                        system_id=system.id,
+                        title="edit-title",
+                        body=body,
+                    )
+                await db.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())
+
+    from sheaf.crypto import decrypt
+
+    rows = _revisions_for(entry_id)
+    assert len(rows) == 1
+    # The single revision holds the LATER outgoing content (encrypted at rest).
+    assert decrypt(rows[0]["body"]) == "outgoing-2"
+
+
+def test_replace_does_not_move_inserted_at(client: httpx.Client, monkeypatch):
+    """A debounce replace must leave inserted_at anchored to the first save."""
+    email = _register(client, "wtanchor")
+    _set_system_fields(email, auto_pin_first_revision=False)
+    entry_id = _make_entry(client)
+
+    monkeypatch.setattr(settings, "revision_debounce_minutes", 5)
+
+    async def _run() -> dict:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.services.journals import capture_revision
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                user, system = await _load_user_system(db, email)
+                first = await capture_revision(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    user=user,
+                    system_id=system.id,
+                    title=None,
+                    body="first",
+                )
+                await db.flush()
+                # Refresh so the server-default inserted_at is materialised on
+                # the ORM object (async sessions won't lazy-load it on access).
+                await db.refresh(first)
+                first_inserted = first.inserted_at
+                replaced = await capture_revision(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    user=user,
+                    system_id=system.id,
+                    title=None,
+                    body="second",
+                )
+                await db.commit()
+                return {
+                    "same_row": first.id == replaced.id,
+                    "inserted_unchanged": replaced.inserted_at == first_inserted,
+                }
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(_run())
+    assert result["same_row"]
+    assert result["inserted_unchanged"]
+
+
+def test_two_edits_past_window_produce_two_revisions(
+    client: httpx.Client, monkeypatch
+):
+    """Two edits more than the debounce window apart produce TWO revisions."""
+    email = _register(client, "wtwindow")
+    _set_system_fields(email, auto_pin_first_revision=False)
+    entry_id = _make_entry(client)
+
+    monkeypatch.setattr(settings, "revision_debounce_minutes", 5)
+
+    async def _run() -> None:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.services.journals import capture_revision
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                user, system = await _load_user_system(db, email)
+                first = await capture_revision(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    user=user,
+                    system_id=system.id,
+                    title=None,
+                    body="first",
+                )
+                await db.flush()
+                # Backdate the first checkpoint past the window so the next
+                # save can't fold into it.
+                first.inserted_at = datetime.now(UTC) - timedelta(minutes=10)
+                await db.flush()
+                await capture_revision(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    user=user,
+                    system_id=system.id,
+                    title=None,
+                    body="second",
+                )
+                await db.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())
+
+    rows = _revisions_for(entry_id)
+    assert len(rows) == 2
+
+
+def test_pinned_most_recent_is_never_replaced(client: httpx.Client, monkeypatch):
+    """When the newest revision is pinned, a save inside the window appends a
+    new row rather than mutating the pin."""
+    email = _register(client, "wtpinned")
+    _set_system_fields(email, auto_pin_first_revision=False)
+    entry_id = _make_entry(client)
+
+    monkeypatch.setattr(settings, "revision_debounce_minutes", 5)
+
+    async def _run() -> dict:
+        from sqlalchemy.ext.asyncio import AsyncSession
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.services.journals import capture_revision
+
+        engine = _engine()
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with async_session() as db:
+                user, system = await _load_user_system(db, email)
+                first = await capture_revision(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    user=user,
+                    system_id=system.id,
+                    title=None,
+                    body="pinned-body",
+                )
+                await db.flush()
+                # Pin the newest (and only) revision.
+                first.pinned_at = datetime.now(UTC)
+                await db.flush()
+                second = await capture_revision(
+                    db=db,
+                    target_type="journal_entry",
+                    target_id=uuid.UUID(entry_id),
+                    user=user,
+                    system_id=system.id,
+                    title=None,
+                    body="new-body",
+                )
+                await db.commit()
+                return {
+                    "appended_new_row": second.id != first.id,
+                    "pinned_id": str(first.id),
+                }
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(_run())
+    assert result["appended_new_row"]
+
+    from sheaf.crypto import decrypt
+
+    rows = _revisions_for(entry_id)
+    assert len(rows) == 2
+    # The pinned row is untouched (still holds its original body).
+    pinned_rows = [r for r in rows if r["pinned_at"] is not None]
+    assert len(pinned_rows) == 1
+    assert str(pinned_rows[0]["id"]) == result["pinned_id"]
+    assert decrypt(pinned_rows[0]["body"]) == "pinned-body"


### PR DESCRIPTION
Second batch of the preserve-by-default resilience work. Where the last PR
bounded the read side, this bounds the write side: nothing today stops a
looping client or a save-spam session from creating unbounded rows. Two
self-contained commits, green across all server configurations.

## Write-time revision capping + debounce
Revision count was enforced only by a periodic sweep, so rows could pile up
between runs, and the sweep ordered by the source edit time (so a
just-imported old revision looked oldest and was trimmed first).

- Add `content_revisions.inserted_at`, the true row-landing time. The count
  trim now orders by it, so imported history is counted from when it arrived,
  not when it was originally authored.
- Enforce the per-target count cap in `capture_revision` itself (a single
  bounded delete of the oldest unpinned overflow). The GC sweep stays as a
  backstop for rows that bypass this path (imports, legacy rows).
- Debounce rapid saves: if the newest unpinned revision landed within
  `revision_debounce_minutes` (default 5), replace it in place instead of
  adding a row, without moving its `inserted_at`. A burst collapses into one
  checkpoint while a long session still accrues a fresh one every few minutes.
  Pins are never replaced.
- Raise the free-tier revision cap from 10 to 50.

## Per-account write and per-system front-switch rate limits
The only rate backstop was a global per-IP limit, so one looping client on a
single account was unbounded.

- A single per-account bucket (default 60/min) shared across the whole
  mutating surface, so an account has a combined ceiling rather than a
  per-route one. The limiter is refactored to support a shared bucket;
  existing per-endpoint limits are byte-for-byte unchanged. Keyed on the
  account, so a session and an API key share the budget.
- A per-system token bucket on front creation (default 20/min, burst 10),
  catching a stuck switch-client on a system that may have several writers.

Both are DB-protection, not product limits: configurable, defaulting on for
everyone, and fail-open on a Redis blip so they can never wedge writes.

## Testing
Full suite green across all nine configurations. New tests cover the
write-time cap, the debounce (append vs replace, pin exemption, window
boundary), the combined per-account write limit, and the per-system switch
guard. The GC-sweep tests now seed over-cap rows directly (the shape an
import produces), since the sweep is now a backstop rather than the primary
enforcement. The test stack disables the debounce so per-edit-per-revision
assertions hold; the debounce has its own tests that set the window.

## Notes
- Write-time capping uses the plain effective cap, not the tier-downgrade
  grace-aware one (that feature has no caller yet, and it would add a query
  per edit). Reconciling them is a follow-up for when billing lands.
- Chosen defaults: revision cap 50, debounce 5 min, write 60/min, switch
  20/min. All config-overridable.
