### PR TITLE
Import volume caps: per-import row caps, bypass clamps, and entity volume metrics

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -320,6 +320,33 @@ detect non-zero from the first scrape.
 | `sheaf_targets_by_revision_count` | gauge | `le` (revisions-per-target threshold; `+Inf` = all targets) |
 | `sheaf_target_revision_count_max` | gauge | - |
 | `sheaf_content_revisions_created_total` | counter | - |
+| `sheaf_messages_total` | gauge | - |
+| `sheaf_systems_by_message_count` | gauge | `le` (live-message-count threshold; `+Inf` = all systems) |
+| `sheaf_system_message_count_max` | gauge | - |
+| `sheaf_messages_created_total` | counter | - |
+| `sheaf_polls_total` | gauge | - |
+| `sheaf_systems_by_poll_count` | gauge | `le` (poll-count threshold; `+Inf` = all systems) |
+| `sheaf_system_poll_count_max` | gauge | - |
+| `sheaf_polls_created_total` | counter | - |
+| `sheaf_open_polls_total` | gauge | - |
+| `sheaf_systems_by_open_poll_count` | gauge | `le` (open-poll-count threshold; `+Inf` = all systems) |
+| `sheaf_system_open_poll_count_max` | gauge | - |
+| `sheaf_groups_total` | gauge | - |
+| `sheaf_systems_by_group_count` | gauge | `le` (group-count threshold; `+Inf` = all systems) |
+| `sheaf_system_group_count_max` | gauge | - |
+| `sheaf_groups_created_total` | counter | - |
+| `sheaf_tags_total` | gauge | - |
+| `sheaf_systems_by_tag_count` | gauge | `le` (tag-count threshold; `+Inf` = all systems) |
+| `sheaf_system_tag_count_max` | gauge | - |
+| `sheaf_tags_created_total` | counter | - |
+| `sheaf_custom_fields_total` | gauge | - |
+| `sheaf_systems_by_custom_field_count` | gauge | `le` (field-count threshold; `+Inf` = all systems) |
+| `sheaf_system_custom_field_count_max` | gauge | - |
+| `sheaf_custom_fields_created_total` | counter | - |
+| `sheaf_reminders_total` | gauge | - |
+| `sheaf_systems_by_reminder_count` | gauge | `le` (reminder-count threshold; `+Inf` = all systems) |
+| `sheaf_system_reminder_count_max` | gauge | - |
+| `sheaf_reminders_created_total` | counter | - |
 
 `sheaf_systems_by_front_count` is a point-in-time cumulative distribution of
 per-system front-history size, re-set each gauge refresh: each `le` series is
@@ -344,6 +371,24 @@ message, and `sheaf_target_revision_count_max` is the most-revised single
 target (the save-spam outlier signal). `sheaf_content_revisions_created_total`
 is edit velocity on the live edit path (imports excluded). See
 `../sheaf-design-docs/usage-limits-and-tiers.md`.
+
+The board-message / poll / group / tag / custom-field / reminder sets apply
+the same lens to the remaining bulk-creatable user-content entities that
+gained per-import row caps, so the caps can be tuned from real per-system
+usage. Each set is a global `*_total`, an id-free per-system CDF snapshot
+(`sheaf_systems_by_<entity>_count`, re-set each distribution refresh, `+Inf`
+= all systems), the single-largest system (`sheaf_system_<entity>_count_max`),
+and a live-create `*_created_total` counter (imports excluded - imports have
+their own counters). `sheaf_messages_total` and `sheaf_systems_by_message_count`
+count live messages only (`deleted_at IS NULL`), matching the board summary.
+Polls carry two lenses: all polls, and OPEN polls
+(`sheaf_open_polls_total` / `sheaf_systems_by_open_poll_count` /
+`sheaf_system_open_poll_count_max`, where open = `closes_at` in the future).
+The open-poll set is the operationally useful one: it is what the tier
+concurrent-open-poll cap and the import clamp bound, so
+`sheaf_system_open_poll_count_max` read against the cap is the direct outlier
+signal. The `*_total` gauges refresh on the 60s gauge pass; the per-system
+distributions ride the hourly distribution job.
 
 ### Infra
 

--- a/sheaf/api/v1/custom_fields.py
+++ b/sheaf/api/v1/custom_fields.py
@@ -12,6 +12,7 @@ from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.observability.metrics import custom_fields_created_total
 from sheaf.schemas.custom_field import (
     CustomFieldCreate,
     CustomFieldRead,
@@ -93,6 +94,7 @@ async def create_field(
     field = CustomFieldDefinition(system_id=system.id, **body.model_dump())
     db.add(field)
     await db.commit()
+    custom_fields_created_total.inc()
     await db.refresh(field)
     return field
 

--- a/sheaf/api/v1/groups.py
+++ b/sheaf/api/v1/groups.py
@@ -13,6 +13,7 @@ from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.observability.metrics import groups_created_total
 from sheaf.schemas.group import GroupCreate, GroupMemberUpdate, GroupRead, GroupUpdate
 from sheaf.schemas.member import MemberDeleteConfirm, MemberRead
 from sheaf.services.members import decrypt_member_for_read
@@ -117,6 +118,7 @@ async def create_group(
     group = Group(system_id=system.id, **body.model_dump())
     db.add(group)
     await db.commit()
+    groups_created_total.inc()
     await db.refresh(group)
     return group
 

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -26,6 +26,7 @@ from sheaf.models.message import BoardKind, Message
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.observability.metrics import messages_created_total
 from sheaf.schemas.journal import (
     ContentRevisionRead,
     PinRevisionRequest,
@@ -490,6 +491,7 @@ async def post_message(
     )
     db.add(msg)
     await db.commit()
+    messages_created_total.inc()
     await db.refresh(msg)
     return await _to_read(msg, db)
 

--- a/sheaf/api/v1/openplural_import.py
+++ b/sheaf/api/v1/openplural_import.py
@@ -15,8 +15,12 @@ journey.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
+from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.openplural_import import (
@@ -25,7 +29,11 @@ from sheaf.services.openplural_import import (
     parse_bundle_async,
     parse_json_async,
 )
-from sheaf.services.sheaf_import import SheafPreviewSummary, preview
+from sheaf.services.sheaf_import import (
+    SheafPreviewSummary,
+    open_poll_preview_warning,
+    preview,
+)
 
 router = APIRouter(prefix="/import", tags=["import"])
 
@@ -44,16 +52,28 @@ def _summary_dict(p: SheafPreviewSummary) -> dict:
         "journal_count": p.journal_count,
         "message_count": p.message_count,
         "poll_count": p.poll_count,
+        "open_poll_count": p.open_poll_count,
         "reminder_count": p.reminder_count,
         "channel_count": p.channel_count,
         "limit_warnings": p.limit_warnings,
     }
 
 
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
+
+
 @router.post("/openplural/preview")
 async def preview_openplural_import(
     file: UploadFile,
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Parse an OpenPlural export (JSON or .openplural.zip) and summarise it."""
     data = await file.read()
@@ -68,10 +88,19 @@ async def preview_openplural_import(
             detail="Import file is empty.",
         )
 
+    system = await _get_user_system(user, db)
+
     try:
         if looks_like_zip(data):
             parsed, envelope = await parse_bundle_async(data)
             summary = preview(parsed.data)
+            # Estimate: the import re-clamps the concurrent-open cap
+            # authoritatively.
+            poll_warning = await open_poll_preview_warning(
+                db, system.id, user, summary.open_poll_count
+            )
+            if poll_warning:
+                summary.limit_warnings.append(poll_warning)
             return {
                 **_summary_dict(summary),
                 "archive": True,
@@ -80,6 +109,12 @@ async def preview_openplural_import(
             }
         native, envelope = await parse_json_async(data)
         summary = preview(native)
+        # Estimate: the import re-clamps the concurrent-open cap authoritatively.
+        poll_warning = await open_poll_preview_warning(
+            db, system.id, user, summary.open_poll_count
+        )
+        if poll_warning:
+            summary.limit_warnings.append(poll_warning)
         return {
             **_summary_dict(summary),
             "archive": False,

--- a/sheaf/api/v1/pluralspace_import.py
+++ b/sheaf/api/v1/pluralspace_import.py
@@ -11,16 +11,31 @@ from __future__ import annotations
 import zipfile
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
+from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.pluralspace_import import parse_export_async, preview
+from sheaf.services.sheaf_import import open_poll_preview_warning
 
 router = APIRouter(prefix="/import", tags=["import"])
 
 MAX_IMPORT_SIZE = 100 * 1024 * 1024
+
+
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
 
 
 # Per-user rate limit: a worst-case preview decompresses and parses
@@ -28,7 +43,8 @@ MAX_IMPORT_SIZE = 100 * 1024 * 1024
 @router.post("/pluralspace/preview", dependencies=[rate_limit(10, 60, "user")])
 async def preview_pluralspace_import(
     file: UploadFile,
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Open a PluralSpace export zip and return a counts summary."""
     data = await file.read()
@@ -42,6 +58,8 @@ async def preview_pluralspace_import(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Import file is empty.",
         )
+
+    system = await _get_user_system(user, db)
 
     try:
         parsed = await parse_export_async(data)
@@ -57,4 +75,10 @@ async def preview_pluralspace_import(
         ) from exc
 
     summary = preview(parsed)
+    # Estimate: the import re-clamps the concurrent-open cap authoritatively.
+    poll_warning = await open_poll_preview_warning(
+        db, system.id, user, summary.open_poll_count
+    )
+    if poll_warning:
+        summary.limit_warnings.append(poll_warning)
     return summary.model_dump(mode="json")

--- a/sheaf/api/v1/polls.py
+++ b/sheaf/api/v1/polls.py
@@ -23,7 +23,11 @@ from sheaf.models.pending_action import PendingActionType
 from sheaf.models.poll import Poll, PollOption, PollVote, PollVoteEvent
 from sheaf.models.system import System
 from sheaf.models.user import User
-from sheaf.observability.metrics import tier_label, tier_limit_hits_total
+from sheaf.observability.metrics import (
+    polls_created_total,
+    tier_label,
+    tier_limit_hits_total,
+)
 from sheaf.schemas.member import MemberDeleteConfirm
 from sheaf.schemas.poll import (
     PollAuditRead,
@@ -312,6 +316,7 @@ async def create_poll(
         )
     db.add(poll)
     await db.commit()
+    polls_created_total.inc()
     refreshed = await _get_owned_poll(poll.id, system, db)
     return _to_read(refreshed)
 

--- a/sheaf/api/v1/prism_import.py
+++ b/sheaf/api/v1/prism_import.py
@@ -12,16 +12,31 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
+from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.prism_import import parse_envelope_bytes_async, preview
+from sheaf.services.sheaf_import import open_poll_preview_warning
 
 router = APIRouter(prefix="/import", tags=["import"])
 
 MAX_IMPORT_SIZE = 100 * 1024 * 1024
+
+
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
 
 
 # Tight per-user rate limit: each preview runs a full scrypt KDF
@@ -30,7 +45,8 @@ MAX_IMPORT_SIZE = 100 * 1024 * 1024
 async def preview_prism_import(
     file: Annotated[UploadFile, File()],
     passphrase: Annotated[str, Form()],
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Decrypt a PRISM1 envelope and return a counts summary.
 
@@ -54,6 +70,8 @@ async def preview_prism_import(
             detail="Decryption passphrase is required.",
         )
 
+    system = await _get_user_system(user, db)
+
     try:
         parsed = await parse_envelope_bytes_async(data, passphrase)
     except ImportPayloadError as exc:
@@ -63,4 +81,10 @@ async def preview_prism_import(
         ) from exc
 
     summary = preview(parsed)
+    # Estimate: the import re-clamps the concurrent-open cap authoritatively.
+    poll_warning = await open_poll_preview_warning(
+        db, system.id, user, summary.open_poll_count
+    )
+    if poll_warning:
+        summary.limit_warnings.append(poll_warning)
     return summary.model_dump(mode="json")

--- a/sheaf/api/v1/reminders.py
+++ b/sheaf/api/v1/reminders.py
@@ -28,6 +28,7 @@ from sheaf.models.reminder import Reminder
 from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.models.watch_token import WatchToken
+from sheaf.observability.metrics import reminders_created_total
 from sheaf.schemas.member import MemberDeleteConfirm
 from sheaf.schemas.reminder import (
     ReminderCreate,
@@ -326,6 +327,7 @@ async def create_reminder(
     )
     db.add(reminder)
     await db.commit()
+    reminders_created_total.inc()
     # Re-fetch with relations for the response shape.
     refreshed = await _get_owned_reminder(reminder.id, system, db)
     return _to_read(refreshed)

--- a/sheaf/api/v1/sheaf_import.py
+++ b/sheaf/api/v1/sheaf_import.py
@@ -13,13 +13,21 @@ source value to submit the job under.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
+from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.services.import_parsing import ImportPayloadError, safe_json_loads_async
 from sheaf.services.sheaf_archive_import import parse_archive_async
 from sheaf.services.sheaf_archive_import import preview as archive_preview
-from sheaf.services.sheaf_import import SheafPreviewSummary, preview
+from sheaf.services.sheaf_import import (
+    SheafPreviewSummary,
+    open_poll_preview_warning,
+    preview,
+)
 
 router = APIRouter(prefix="/import", tags=["import"])
 
@@ -70,16 +78,28 @@ def _summary_dict(p: SheafPreviewSummary) -> dict:
         "journal_count": p.journal_count,
         "message_count": p.message_count,
         "poll_count": p.poll_count,
+        "open_poll_count": p.open_poll_count,
         "reminder_count": p.reminder_count,
         "channel_count": p.channel_count,
         "limit_warnings": p.limit_warnings,
     }
 
 
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
+
+
 @router.post("/sheaf/preview")
 async def preview_import(
     file: UploadFile,
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Parse a Sheaf export (JSON or with-images zip) and summarise it."""
     data = await file.read()
@@ -88,6 +108,8 @@ async def preview_import(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail="Import file too large. Max 100MB.",
         )
+
+    system = await _get_user_system(user, db)
 
     if data[:2] == _ZIP_MAGIC:
         try:
@@ -98,6 +120,12 @@ async def preview_import(
                 detail=str(exc),
             ) from exc
         summary, image_count = archive_preview(parsed)
+        # Estimate: the import re-clamps the concurrent-open cap authoritatively.
+        poll_warning = await open_poll_preview_warning(
+            db, system.id, user, summary.open_poll_count
+        )
+        if poll_warning:
+            summary.limit_warnings.append(poll_warning)
         return {
             **_summary_dict(summary),
             "archive": True,
@@ -105,8 +133,15 @@ async def preview_import(
         }
 
     parsed_json = await _parse_json_export(data)
+    summary = preview(parsed_json)
+    # Estimate: the import re-clamps the concurrent-open cap authoritatively.
+    poll_warning = await open_poll_preview_warning(
+        db, system.id, user, summary.open_poll_count
+    )
+    if poll_warning:
+        summary.limit_warnings.append(poll_warning)
     return {
-        **_summary_dict(preview(parsed_json)),
+        **_summary_dict(summary),
         "archive": False,
         "image_count": 0,
     }

--- a/sheaf/api/v1/tags.py
+++ b/sheaf/api/v1/tags.py
@@ -13,6 +13,7 @@ from sheaf.models.pending_action import PendingActionType
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
 from sheaf.models.user import User
+from sheaf.observability.metrics import tags_created_total
 from sheaf.schemas.member import MemberDeleteConfirm, MemberRead
 from sheaf.schemas.tag import TagCreate, TagMemberUpdate, TagRead, TagUpdate
 from sheaf.services.members import decrypt_member_for_read
@@ -70,6 +71,7 @@ async def create_tag(
     tag = Tag(system_id=system.id, **body.model_dump())
     db.add(tag)
     await db.commit()
+    tags_created_total.inc()
     await db.refresh(tag)
     return tag
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -127,6 +127,24 @@ class Settings(BaseSettings):
     member_limit_plus: int = 0  # unlimited
     member_limit_selfhosted: int = 0  # unlimited
 
+    # Per-IMPORT-JOB hard row caps. These bound how many rows of each entity a
+    # SINGLE import can create in one transaction - parse-bomb / resource
+    # protection (each front, for instance, does a per-row flush), NOT a
+    # per-tenant product limit like the member cap above. A crafted or simply
+    # huge export can otherwise force hundreds of thousands of inserts in one
+    # go; these caps fail the job cleanly first. 0 = unlimited/disabled for
+    # that entity. Enforced by every importer before its write loop and
+    # predicted at preview. Self-hosters with genuinely large systems can raise
+    # them.
+    import_max_fronts: int = 100000
+    import_max_journal_entries: int = 50000
+    import_max_messages: int = 100000
+    import_max_revisions: int = 100000
+    import_max_polls: int = 10000
+    import_max_groups: int = 10000
+    import_max_tags: int = 10000
+    import_max_custom_fields: int = 10000
+
     # Revision-history retention caps per tier. 0 = unlimited.
     # Covers both journal entries and member bios under a single cap.
     journal_max_revisions_free: int = 50

--- a/sheaf/observability/gauges.py
+++ b/sheaf/observability/gauges.py
@@ -17,7 +17,7 @@ import logging
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.observability.metrics import (
@@ -28,25 +28,46 @@ from sheaf.observability.metrics import (
     auth_trusted_devices_active,
     cf_shield_active,
     content_revisions_total,
+    custom_fields_total,
     db_pool_connections,
     fronts_total,
+    groups_total,
     imports_in_progress,
     imports_oldest_pending_seconds,
     journal_entries_total,
     members_custom_front,
     members_total,
+    messages_total,
     notifications_outbox_depth,
     notifications_outbox_oldest_pending_seconds,
     notifications_subscriptions_active,
+    open_polls_total,
     pending_actions_active,
+    polls_total,
     redis_up,
+    reminders_total,
     requests_per_account_per_minute,
     requests_per_ip_per_minute,
+    system_custom_field_count_max,
     system_front_count_max,
+    system_group_count_max,
     system_journal_entry_count_max,
+    system_message_count_max,
+    system_open_poll_count_max,
+    system_poll_count_max,
+    system_reminder_count_max,
+    system_tag_count_max,
+    systems_by_custom_field_count,
     systems_by_front_count,
+    systems_by_group_count,
     systems_by_journal_entry_count,
+    systems_by_message_count,
+    systems_by_open_poll_count,
+    systems_by_poll_count,
+    systems_by_reminder_count,
+    systems_by_tag_count,
     systems_total,
+    tags_total,
     target_revision_count_max,
     targets_by_revision_count,
     users_pending_delete,
@@ -161,6 +182,43 @@ async def _refresh_db_counts(db: AsyncSession) -> None:
     cr_total = await db.scalar(select(func.count(ContentRevision.id)))
     content_revisions_total.set(int(cr_total or 0))
 
+    # Remaining bulk-creatable capped entities: cheap global COUNT(*)
+    # baselines here; the per-system distributions ride the slow
+    # refresh_gauge_distributions() pass. Messages count live only
+    # (deleted_at IS NULL), matching how the board summary counts them;
+    # open polls count deadline-in-the-future rows, matching the cap.
+    from sheaf.models.custom_field import CustomFieldDefinition
+    from sheaf.models.group import Group
+    from sheaf.models.message import Message
+    from sheaf.models.poll import Poll
+    from sheaf.models.reminder import Reminder
+    from sheaf.models.tag import Tag
+
+    msg_total = await db.scalar(
+        select(func.count(Message.id)).where(Message.deleted_at.is_(None))
+    )
+    messages_total.set(int(msg_total or 0))
+
+    poll_total = await db.scalar(select(func.count(Poll.id)))
+    polls_total.set(int(poll_total or 0))
+
+    open_poll_total = await db.scalar(
+        select(func.count(Poll.id)).where(Poll.closes_at > now)
+    )
+    open_polls_total.set(int(open_poll_total or 0))
+
+    group_total = await db.scalar(select(func.count(Group.id)))
+    groups_total.set(int(group_total or 0))
+
+    tag_total = await db.scalar(select(func.count(Tag.id)))
+    tags_total.set(int(tag_total or 0))
+
+    cf_total = await db.scalar(select(func.count(CustomFieldDefinition.id)))
+    custom_fields_total.set(int(cf_total or 0))
+
+    reminder_total = await db.scalar(select(func.count(Reminder.id)))
+    reminders_total.set(int(reminder_total or 0))
+
 
 async def refresh_gauge_distributions(db: AsyncSession) -> dict:
     """Heavy per-system / per-target distribution gauges, on a slow cadence.
@@ -211,9 +269,17 @@ async def _set_count_distribution(
 
 async def _refresh_distributions(db: AsyncSession) -> None:
     from sheaf.models.content_revision import ContentRevision
+    from sheaf.models.custom_field import CustomFieldDefinition
     from sheaf.models.front import Front
+    from sheaf.models.group import Group
     from sheaf.models.journal_entry import JournalEntry
+    from sheaf.models.message import Message
+    from sheaf.models.poll import Poll
+    from sheaf.models.reminder import Reminder
     from sheaf.models.system import System
+    from sheaf.models.tag import Tag
+
+    now = datetime.now(UTC)
 
     # Per-system front-count distribution. The outer join keeps systems with
     # zero fronts in the picture (count 0) so the distribution covers every
@@ -257,6 +323,107 @@ async def _refresh_distributions(db: AsyncSession) -> None:
         rev_per_target,
         targets_by_revision_count,
         target_revision_count_max,
+    )
+
+    # Live board messages per system (deleted_at IS NULL). The soft-delete
+    # filter sits in the join condition, not a WHERE, so systems with zero
+    # live messages stay in the distribution (the +Inf bucket is all systems).
+    message_per_system = (
+        select(func.count(Message.id).label("c"))
+        .select_from(System)
+        .outerjoin(
+            Message,
+            and_(Message.system_id == System.id, Message.deleted_at.is_(None)),
+        )
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db, message_per_system, systems_by_message_count, system_message_count_max
+    )
+
+    # All polls per system.
+    poll_per_system = (
+        select(func.count(Poll.id).label("c"))
+        .select_from(System)
+        .outerjoin(Poll, Poll.system_id == System.id)
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db, poll_per_system, systems_by_poll_count, system_poll_count_max
+    )
+
+    # Open polls per system (closes_at > now), the per-system view against the
+    # concurrent-open-poll cap. Filter in the join so zero-open systems stay.
+    open_poll_per_system = (
+        select(func.count(Poll.id).label("c"))
+        .select_from(System)
+        .outerjoin(
+            Poll, and_(Poll.system_id == System.id, Poll.closes_at > now)
+        )
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db,
+        open_poll_per_system,
+        systems_by_open_poll_count,
+        system_open_poll_count_max,
+    )
+
+    # Groups, tags, custom-field definitions, reminders per system.
+    group_per_system = (
+        select(func.count(Group.id).label("c"))
+        .select_from(System)
+        .outerjoin(Group, Group.system_id == System.id)
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db, group_per_system, systems_by_group_count, system_group_count_max
+    )
+
+    tag_per_system = (
+        select(func.count(Tag.id).label("c"))
+        .select_from(System)
+        .outerjoin(Tag, Tag.system_id == System.id)
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db, tag_per_system, systems_by_tag_count, system_tag_count_max
+    )
+
+    cf_per_system = (
+        select(func.count(CustomFieldDefinition.id).label("c"))
+        .select_from(System)
+        .outerjoin(
+            CustomFieldDefinition,
+            CustomFieldDefinition.system_id == System.id,
+        )
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db,
+        cf_per_system,
+        systems_by_custom_field_count,
+        system_custom_field_count_max,
+    )
+
+    reminder_per_system = (
+        select(func.count(Reminder.id).label("c"))
+        .select_from(System)
+        .outerjoin(Reminder, Reminder.system_id == System.id)
+        .group_by(System.id)
+        .subquery()
+    )
+    await _set_count_distribution(
+        db,
+        reminder_per_system,
+        systems_by_reminder_count,
+        system_reminder_count_max,
     )
 
 

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -568,6 +568,157 @@ content_revisions_created_total = _C(
     "velocity; the save-spam signal.",
 )
 
+# Per-system volume for the remaining bulk-creatable user-content entities
+# that gained per-import row caps (board messages, polls, groups, tags,
+# custom-field definitions, reminders). Same preserve-by-count lens as front
+# history: a global COUNT(*) total, an id-free per-system CDF snapshot re-set
+# each refresh (systems whose count is <= each `le` bucket, `+Inf` = all
+# systems), the single-largest system, and - where there's one clean create
+# choke point - a live-create Counter. FRONT_COUNT_BUCKETS thresholds are
+# reused (plain counts). These ground the import row-cap tuning in real usage.
+
+# Board messages. Counted live (deleted_at IS NULL), matching how the board
+# summary counts them - soft-deleted rows don't count against a system.
+messages_total = _G(
+    "sheaf_messages_total",
+    "All live board messages (deleted_at IS NULL) across all systems.",
+)
+systems_by_message_count = _G(
+    "sheaf_systems_by_message_count",
+    "Number of systems whose live board-message count is <= the `le` bucket "
+    "(point-in-time cumulative distribution, re-set each refresh).",
+    ["le"],
+)
+system_message_count_max = _G(
+    "sheaf_system_message_count_max",
+    "Largest single system's live board-message count.",
+)
+messages_created_total = _C(
+    "sheaf_messages_created_total",
+    "Board messages created via the live post path (not imports). Post "
+    "velocity, distinct from the HTTP request counter on POST /v1/messages.",
+)
+
+# Polls. Two lenses: all polls per system, and OPEN polls per system - the
+# latter is what the tier concurrency cap and the import clamp bound. An open
+# poll is one whose deadline is still in the future (closes_at > now), the
+# same definition the create-path cap uses.
+polls_total = _G(
+    "sheaf_polls_total",
+    "All polls across all systems (global volume baseline).",
+)
+systems_by_poll_count = _G(
+    "sheaf_systems_by_poll_count",
+    "Number of systems whose poll count is <= the `le` bucket (point-in-time "
+    "cumulative distribution, re-set each refresh).",
+    ["le"],
+)
+system_poll_count_max = _G(
+    "sheaf_system_poll_count_max",
+    "Largest single system's poll count.",
+)
+polls_created_total = _C(
+    "sheaf_polls_created_total",
+    "Polls created via the live create path (not imports).",
+)
+open_polls_total = _G(
+    "sheaf_open_polls_total",
+    "Polls currently open (closes_at > now) across all systems. Open polls "
+    "are what the tier concurrency cap and the import clamp bound.",
+)
+systems_by_open_poll_count = _G(
+    "sheaf_systems_by_open_poll_count",
+    "Number of systems whose OPEN poll count (closes_at > now) is <= the `le` "
+    "bucket (point-in-time cumulative distribution, re-set each refresh). The "
+    "direct per-system view against the concurrent-open-poll cap.",
+    ["le"],
+)
+system_open_poll_count_max = _G(
+    "sheaf_system_open_poll_count_max",
+    "Largest single system's open-poll count - the outlier signal against "
+    "the concurrent-open-poll cap.",
+)
+
+# Groups, tags, custom-field definitions, reminders. Lower-volume per-system
+# config entities that gained import row caps. Each has a single clean create
+# choke point, so all carry a live-create counter too.
+groups_total = _G(
+    "sheaf_groups_total",
+    "All groups across all systems (global volume baseline).",
+)
+systems_by_group_count = _G(
+    "sheaf_systems_by_group_count",
+    "Number of systems whose group count is <= the `le` bucket (point-in-time "
+    "cumulative distribution, re-set each refresh).",
+    ["le"],
+)
+system_group_count_max = _G(
+    "sheaf_system_group_count_max",
+    "Largest single system's group count.",
+)
+groups_created_total = _C(
+    "sheaf_groups_created_total",
+    "Groups created via the live create path (not imports).",
+)
+
+tags_total = _G(
+    "sheaf_tags_total",
+    "All tags across all systems (global volume baseline).",
+)
+systems_by_tag_count = _G(
+    "sheaf_systems_by_tag_count",
+    "Number of systems whose tag count is <= the `le` bucket (point-in-time "
+    "cumulative distribution, re-set each refresh).",
+    ["le"],
+)
+system_tag_count_max = _G(
+    "sheaf_system_tag_count_max",
+    "Largest single system's tag count.",
+)
+tags_created_total = _C(
+    "sheaf_tags_created_total",
+    "Tags created via the live create path (not imports).",
+)
+
+custom_fields_total = _G(
+    "sheaf_custom_fields_total",
+    "All custom-field definitions across all systems (global volume "
+    "baseline).",
+)
+systems_by_custom_field_count = _G(
+    "sheaf_systems_by_custom_field_count",
+    "Number of systems whose custom-field-definition count is <= the `le` "
+    "bucket (point-in-time cumulative distribution, re-set each refresh).",
+    ["le"],
+)
+system_custom_field_count_max = _G(
+    "sheaf_system_custom_field_count_max",
+    "Largest single system's custom-field-definition count.",
+)
+custom_fields_created_total = _C(
+    "sheaf_custom_fields_created_total",
+    "Custom-field definitions created via the live create path (not imports).",
+)
+
+reminders_total = _G(
+    "sheaf_reminders_total",
+    "All reminders across all systems (global volume baseline).",
+)
+systems_by_reminder_count = _G(
+    "sheaf_systems_by_reminder_count",
+    "Number of systems whose reminder count is <= the `le` bucket "
+    "(point-in-time cumulative distribution, re-set each refresh).",
+    ["le"],
+)
+system_reminder_count_max = _G(
+    "sheaf_system_reminder_count_max",
+    "Largest single system's reminder count.",
+)
+reminders_created_total = _C(
+    "sheaf_reminders_created_total",
+    "Reminders created via the live create path (not imports).",
+)
+
 # ---------------------------------------------------------------------------
 # Infra
 # ---------------------------------------------------------------------------

--- a/sheaf/schemas/pluralspace_import.py
+++ b/sheaf/schemas/pluralspace_import.py
@@ -72,6 +72,9 @@ class PluralspacePreviewSummary(BaseModel):
     chat_channel_count: int = 0
     chat_message_count: int = 0
     poll_count: int = 0
+    # Incoming polls that would import OPEN (used with the tier cap + a DB
+    # count of already-open polls to warn when the concurrent-open clamp fires).
+    open_poll_count: int = 0
     thought_count: int = 0
     media_file_count: int = 0
 

--- a/sheaf/schemas/prism_import.py
+++ b/sheaf/schemas/prism_import.py
@@ -72,6 +72,9 @@ class PrismPreviewSummary(BaseModel):
     conversation_count: int = 0
     message_count: int = 0
     poll_count: int = 0
+    # Incoming polls that would import OPEN (used with the tier cap + a DB
+    # count of already-open polls to warn when the concurrent-open clamp fires).
+    open_poll_count: int = 0
     poll_option_count: int = 0
     note_count: int = 0
     reminder_count: int = 0

--- a/sheaf/services/import_limits.py
+++ b/sheaf/services/import_limits.py
@@ -23,8 +23,11 @@ planned as the mechanical backstop; until it lands, keep these in sync by hand.)
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import NamedTuple
+
+from sheaf.services.import_parsing import ImportPayloadError
 
 
 class Cap(NamedTuple):
@@ -162,3 +165,84 @@ def clamp_list[T](
             report.record_list(cap)
         return items[: cap.limit]
     return items
+
+
+# --- Per-import row caps ----------------------------------------------------
+# Hard ceilings on how many rows of each entity a SINGLE import job may create.
+# Unlike the length clamps above (which shorten a value and keep going) or the
+# member cap (a per-tenant product limit), these are pure resource / parse-bomb
+# guards: they bound the work one crafted or oversized export can force in a
+# single transaction, independent of tier or existing row counts. An over-cap
+# import fails cleanly via ImportPayloadError - the same classified job failure
+# as the member cap - rather than grinding through hundreds of thousands of
+# per-row flushes. The values live in sheaf/config.py (import_max_*); 0 there
+# disables the cap for that entity.
+#
+# Keys are the labels importers pass; each maps to the import_max_<key> setting
+# and a user-facing plural noun. Every importer computes the per-entity count
+# it would create (reusing its preview/member-cap counts where it already has
+# them) and calls enforce_import_row_caps before its write loop; the preview
+# surfaces the same over-cap condition up front via import_row_cap_warnings.
+_ROW_CAP_LABELS: dict[str, str] = {
+    "fronts": "fronts",
+    "journal_entries": "journal entries",
+    "messages": "messages",
+    "revisions": "revisions",
+    "polls": "polls",
+    "groups": "groups",
+    "tags": "tags",
+    "custom_fields": "custom fields",
+}
+
+
+def _row_cap_for(entity: str) -> int:
+    """Configured cap for an entity label (0 = unlimited/disabled)."""
+    # Imported lazily so this module stays import-cheap and free of a
+    # config dependency at load time.
+    from sheaf.config import settings
+
+    return getattr(settings, f"import_max_{entity}", 0)
+
+
+def _over_cap(counts: Mapping[str, int]) -> Iterator[tuple[str, int, int]]:
+    """Yield (label, count, cap) for each entity whose count exceeds its cap.
+
+    Skips entities with a cap of 0 (disabled), a count at/under the cap, or a
+    key with no configured cap, so callers only see genuine breaches.
+    """
+    for entity, count in counts.items():
+        cap = _row_cap_for(entity)
+        if cap > 0 and count > cap:
+            yield _ROW_CAP_LABELS.get(entity, entity), count, cap
+
+
+def _row_cap_message(label: str, count: int, cap: int) -> str:
+    return (
+        f"This export has {count} {label}, more than the {cap} Sheaf imports "
+        "in one job. Split the file into smaller pieces, or contact support "
+        "to raise the limit."
+    )
+
+
+def enforce_import_row_caps(counts: Mapping[str, int]) -> None:
+    """Raise ImportPayloadError if any per-entity count exceeds its import cap.
+
+    ``counts`` maps entity labels (see :data:`_ROW_CAP_LABELS`) to the number
+    of rows of that entity this import would create. No-op for a cap of 0 or a
+    count under cap. Raising ImportPayloadError makes an over-cap import a
+    clean, classified job failure, matching the member cap. Importers call this
+    once, before their write loop, with only the entities they produce.
+    """
+    for label, count, cap in _over_cap(counts):
+        raise ImportPayloadError(_row_cap_message(label, count, cap))
+
+
+def import_row_cap_warnings(counts: Mapping[str, int]) -> list[str]:
+    """Non-raising preview counterpart of :func:`enforce_import_row_caps`.
+
+    Returns one actionable warning line per over-cap entity so the preview can
+    show "this export has N fronts, more than the M we import per job; split
+    the file" before the user commits. The import run still enforces (raises)
+    as the authoritative guard.
+    """
+    return [_row_cap_message(label, count, cap) for label, count, cap in _over_cap(counts)]

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -130,6 +130,15 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
     report = ClampReport()
     measure_pk_payload(data, report)
 
+    switch_count = (
+        switch_count_override if switch_count_override is not None else len(switches)
+    )
+    # PK switches become front-history rows on import; surface the per-import
+    # front / group caps up front alongside the clamp warnings.
+    limit_warnings = report.to_warnings() + il.import_row_cap_warnings(
+        {"fronts": switch_count, "groups": len(groups)}
+    )
+
     return PKPreviewSummary(
         system_name=_clean_str(data.get("name")),
         member_count=len(members),
@@ -142,10 +151,10 @@ def preview(data: dict, *, switch_count_override: int | None = None) -> PKPrevie
             if m.get("id")
         ],
         group_count=len(groups),
-        switch_count=switch_count_override if switch_count_override is not None else len(switches),
+        switch_count=switch_count,
         earliest_switch=min(timestamps) if timestamps else None,
         latest_switch=max(timestamps) if timestamps else None,
-        limit_warnings=report.to_warnings(),
+        limit_warnings=limit_warnings,
     )
 
 

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -30,7 +30,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
-from sheaf.services.import_limits import ClampReport
+from sheaf.services.import_limits import ClampReport, enforce_import_row_caps
 from sheaf.services.import_parsing import (
     ImportPayloadError,
     expect_dict,
@@ -143,6 +143,19 @@ async def _process_pk_export(
         strategy=options.conflict_strategy,
     )
     await enforce_import_member_cap(db, system, new_count)
+
+    # Per-import row caps (bomb protection). PK builds only fronts (from switch
+    # history) and groups beyond members; count each enabled section's source
+    # rows and hard-fail before writing if either blows its cap. Gross counts:
+    # dedup/skip only reduces the real write count.
+    enforce_import_row_caps(
+        {
+            "fronts": (
+                len(get_list(parsed, "switches")) if options.front_history else 0
+            ),
+            "groups": len(get_list(parsed, "groups")) if options.groups else 0,
+        }
+    )
 
     hid_to_member: dict[str, Member] = {}
     for member, hid in candidates:

--- a/sheaf/services/pluralspace_import.py
+++ b/sheaf/services/pluralspace_import.py
@@ -62,7 +62,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
@@ -128,6 +128,8 @@ from sheaf.services.import_parsing import (
     sanitize_external_avatar_url,
 )
 from sheaf.services.member_limits import enforce_import_member_cap
+from sheaf.services.polls import max_concurrent_open_for_tier
+from sheaf.services.sheaf_import import excess_open_polls_to_close
 
 logger = logging.getLogger("sheaf.imports.pluralspace")
 
@@ -303,6 +305,50 @@ def measure_export(data: dict, report: ClampReport) -> None:
                 s(msg.get("content"), il.MESSAGE_BODY)
 
 
+def _distinct_role_count(members_in: list) -> int:
+    """Number of distinct (case-insensitive) PluralSpace role names across
+    members - i.e. how many Tag rows roles-as-tags would create at most.
+    Used by both the preview prediction and the import's row-cap enforcement so
+    the two agree.
+    """
+    roles: set[str] = set()
+    for m in members_in:
+        if not isinstance(m, dict):
+            continue
+        for role in _list(m.get("role")):
+            role_str = _clean_str(role)
+            if role_str:
+                roles.add(role_str.lower())
+    return len(roles)
+
+
+def _distinct_group_count(member_groups: list, members_in: list) -> int:
+    """Number of distinct (case-insensitive) group names PluralSpace would
+    create - across the ``member_groups[]`` definitions AND the inline
+    ``members[].groups[]`` names, which ``_import_groups`` also turns into Group
+    rows. Counting only member_groups (as a naive count would) under-counts and
+    lets the group cap be bypassed via inline names. Used by both the preview
+    prediction and the row-cap enforcement so the two agree and the cap
+    reflects what actually gets written. Dedup key is the lowercased name,
+    matching ``_import_groups``; existing-group dedup is ignored, so this is a
+    gross upper bound (the safe direction for a cap).
+    """
+    names: set[str] = set()
+    for g in member_groups:
+        if isinstance(g, dict):
+            name = _clean_str(g.get("name"))
+            if name:
+                names.add(name.lower())
+    for m in members_in:
+        if not isinstance(m, dict):
+            continue
+        for raw in _list(m.get("groups")):
+            name = _clean_str(raw)
+            if name:
+                names.add(name.lower())
+    return len(names)
+
+
 def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
     """Walk the parsed export and return a counts + member-list summary.
 
@@ -346,6 +392,19 @@ def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
 
     report = ClampReport()
     measure_export(data, report)
+    row_cap_warnings = il.import_row_cap_warnings(
+        {
+            "tags": _distinct_role_count(members_raw),
+            "groups": _distinct_group_count(
+                _list(data.get("member_groups")), members_raw
+            ),
+            "custom_fields": len(_list(data.get("custom_fields"))),
+            "fronts": len(_list(data.get("fronts"))),
+            "journal_entries": len(_list(data.get("journal_entries"))),
+            "messages": chat_msg_count,
+            "polls": len(_list(data.get("polls"))),
+        }
+    )
 
     return PluralspacePreviewSummary(
         system_name=sys_name,
@@ -354,7 +413,9 @@ def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
         member_count=len(member_summaries),
         custom_front_count=custom_front_count,
         members=member_summaries,
-        group_count=len(_list(data.get("member_groups"))),
+        group_count=_distinct_group_count(
+            _list(data.get("member_groups")), members_raw
+        ),
         custom_field_count=len(_list(data.get("custom_fields"))),
         front_count=len(_list(data.get("fronts"))),
         journal_entry_count=len(_list(data.get("journal_entries"))),
@@ -363,7 +424,7 @@ def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
         poll_count=len(_list(data.get("polls"))),
         thought_count=len(_list(data.get("thoughts"))),
         media_file_count=len(parsed.media_paths),
-        limit_warnings=report.to_warnings(),
+        limit_warnings=report.to_warnings() + row_cap_warnings,
     )
 
 
@@ -468,6 +529,43 @@ async def run_import(
         strategy=conflict_strategy,
     )
     await enforce_import_member_cap(db, system, new_count)
+
+    # Per-import row caps (bomb protection). Count the rows each enabled section
+    # would create and hard-fail before writing if any blows its cap. Tags come
+    # from distinct member roles; messages are the flattened chat rows across
+    # channels. Gross source counts: dedup/skip only reduces the real write
+    # count.
+    il.enforce_import_row_caps(
+        {
+            "tags": (
+                _distinct_role_count(members_in) if roles_as_tags else 0
+            ),
+            "groups": (
+                _distinct_group_count(_list(data.get("member_groups")), members_in)
+                if groups
+                else 0
+            ),
+            "custom_fields": (
+                len(_list(data.get("custom_fields"))) if custom_fields else 0
+            ),
+            "fronts": len(_list(data.get("fronts"))) if fronts else 0,
+            "journal_entries": (
+                len(_list(data.get("journal_entries")))
+                if journal_entries
+                else 0
+            ),
+            "messages": (
+                sum(
+                    len(_list(c.get("messages")))
+                    for c in _list(data.get("chat_channels"))
+                    if isinstance(c, dict)
+                )
+                if chat_messages
+                else 0
+            ),
+            "polls": len(_list(data.get("polls"))) if polls else 0,
+        }
+    )
 
     # Map PS id -> resolved row (created / skipped / updated) so later
     # sections (avatars, tags, groups, fronts) link correctly.
@@ -616,6 +714,7 @@ async def run_import(
             ps_id_to_member,
             member_name_to_member,
             system.id,
+            user,
             db,
             result.warnings,
             report,
@@ -1222,6 +1321,7 @@ async def _import_polls(
     ps_id_to_member: dict[str, Member],
     member_name_to_member: dict[str, Member],
     system_id: uuid.UUID,
+    user: User,
     db: AsyncSession,
     warnings: list[str],
     report: ClampReport,
@@ -1237,7 +1337,10 @@ async def _import_polls(
     Open-ended polls (`closes_at: null`) get a one-year-from-creation
     close time because Sheaf requires it. Under dedupe, a poll matching
     an existing created_at is skipped wholesale (options + votes belong
-    to the poll row). Returns (imported, skipped).
+    to the poll row). Open polls beyond the importing user's
+    concurrent-open-poll cap are imported already-closed (the API
+    enforces the cap on create; the importer must not bypass it).
+    Returns (imported, skipped).
     """
     imported = 0
     skipped = 0
@@ -1246,6 +1349,22 @@ async def _import_polls(
     )
     open_ended_count = 0
     missing_voter_count = 0
+
+    # Concurrent-open-poll cap. One `now` for the whole section so the
+    # open/closed decision and the close-time we write stay consistent.
+    now = datetime.now(UTC)
+    open_cap = max_concurrent_open_for_tier(user.tier)
+    existing_open = 0
+    if open_cap > 0:
+        existing_open = (
+            await db.execute(
+                select(func.count(Poll.id)).where(
+                    Poll.system_id == system_id,
+                    Poll.closes_at > now,
+                )
+            )
+        ).scalar_one()
+    created_open_polls: list[tuple[datetime | None, Poll]] = []
     for p_data in polls_in:
         if not isinstance(p_data, dict):
             continue
@@ -1264,7 +1383,7 @@ async def _import_polls(
             poll_index.register(created_at)
         closes_at = _parse_iso(p_data.get("closes_at"))
         if closes_at is None:
-            base = created_at or datetime.now(UTC)
+            base = created_at or now
             closes_at = base + timedelta(days=365)
             open_ended_count += 1
 
@@ -1285,6 +1404,8 @@ async def _import_polls(
         if created_at:
             poll.created_at = created_at
         db.add(poll)
+        if closes_at > now:
+            created_open_polls.append((created_at or closes_at, poll))
 
         # Build options + invert option-keyed votes into voter-keyed.
         option_rows: list[tuple[str, PollOption]] = []
@@ -1332,6 +1453,21 @@ async def _import_polls(
             db.add(vote_row)
 
         imported += 1
+
+    # Flip the excess open polls to closed so the import can't leave the system
+    # over the tier's concurrent-open-poll cap. Non-destructive: options + votes
+    # are preserved; the poll just lands closed.
+    if open_cap > 0:
+        to_close = excess_open_polls_to_close(
+            created_open_polls, cap=open_cap, existing_open=existing_open
+        )
+        for closed_poll in to_close:
+            closed_poll.closes_at = now
+        if to_close:
+            warnings.append(
+                f"{len(to_close)} poll(s) exceed your concurrent-open-poll "
+                "limit and will be imported as closed."
+            )
 
     if open_ended_count:
         warnings.append(

--- a/sheaf/services/pluralspace_import.py
+++ b/sheaf/services/pluralspace_import.py
@@ -129,7 +129,10 @@ from sheaf.services.import_parsing import (
 )
 from sheaf.services.member_limits import enforce_import_member_cap
 from sheaf.services.polls import max_concurrent_open_for_tier
-from sheaf.services.sheaf_import import excess_open_polls_to_close
+from sheaf.services.sheaf_import import (
+    excess_open_polls_to_close,
+    open_poll_close_warning,
+)
 
 logger = logging.getLogger("sheaf.imports.pluralspace")
 
@@ -349,6 +352,30 @@ def _distinct_group_count(member_groups: list, members_in: list) -> int:
     return len(names)
 
 
+def _count_incoming_open_polls(polls: object, *, now: datetime | None = None) -> int:
+    """Count PluralSpace polls that would import OPEN. Mirrors ``_import_polls``'
+    close-time rule: an open-ended poll (``closes_at: null``) gets a one-year
+    window (open), otherwise it is open only if its ``closes_at`` is in the
+    future. Feeds the preview's concurrent-open estimate; the import re-clamps
+    authoritatively. Defensive so a malformed payload can't raise here."""
+    now = now or datetime.now(UTC)
+    count = 0
+    for p in _list(polls):
+        if not isinstance(p, dict):
+            continue
+        closes_at = _parse_iso(p.get("closes_at"))
+        if closes_at is None:
+            # Open-ended -> one-year-from-creation window, always future.
+            count += 1
+            continue
+        try:
+            if closes_at > now:
+                count += 1
+        except TypeError:
+            continue
+    return count
+
+
 def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
     """Walk the parsed export and return a counts + member-list summary.
 
@@ -422,6 +449,7 @@ def preview(parsed: _ParsedExport) -> PluralspacePreviewSummary:
         chat_channel_count=len(chat_channels),
         chat_message_count=chat_msg_count,
         poll_count=len(_list(data.get("polls"))),
+        open_poll_count=_count_incoming_open_polls(data.get("polls")),
         thought_count=len(_list(data.get("thoughts"))),
         media_file_count=len(parsed.media_paths),
         limit_warnings=report.to_warnings() + row_cap_warnings,
@@ -1464,10 +1492,7 @@ async def _import_polls(
         for closed_poll in to_close:
             closed_poll.closes_at = now
         if to_close:
-            warnings.append(
-                f"{len(to_close)} poll(s) exceed your concurrent-open-poll "
-                "limit and will be imported as closed."
-            )
+            warnings.append(open_poll_close_warning(len(to_close)))
 
     if open_ended_count:
         warnings.append(

--- a/sheaf/services/prism_import.py
+++ b/sheaf/services/prism_import.py
@@ -68,9 +68,10 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sheaf.config import settings
 from sheaf.crypto import blind_index, encrypt
 from sheaf.models.custom_field import (
     CustomFieldDefinition,
@@ -132,11 +133,13 @@ from sheaf.services.import_parsing import (
     sanitize_external_avatar_url,
 )
 from sheaf.services.member_limits import enforce_import_member_cap
+from sheaf.services.polls import max_concurrent_open_for_tier
 from sheaf.services.prism_crypto import (
     DecryptedEnvelope,
     decrypt_envelope,
     decrypt_media_blob,
 )
+from sheaf.services.sheaf_import import excess_open_polls_to_close
 
 logger = logging.getLogger("sheaf.imports.prism")
 
@@ -263,6 +266,22 @@ def preview(parsed: ParsedPrism) -> PrismPreviewSummary:
     report = ClampReport()
     _measure_prism_payload(data, report)
 
+    # Predict the per-import row caps too. Conversations + member board posts
+    # both become Message rows, so they share the messages cap.
+    row_cap_warnings = il.import_row_cap_warnings(
+        {
+            "groups": len(_list(data.get("memberGroups"))),
+            "custom_fields": len(_list(data.get("customFields"))),
+            "fronts": len(_list(data.get("frontSessions"))),
+            "journal_entries": len(_list(data.get("notes"))),
+            "polls": len(_list(data.get("polls"))),
+            "messages": (
+                len(_list(data.get("messages")))
+                + len(_list(data.get("memberBoardPosts")))
+            ),
+        }
+    )
+
     return PrismPreviewSummary(
         system_name=sys_name,
         format_version=_clean_str(data.get("formatVersion")),
@@ -284,7 +303,7 @@ def preview(parsed: ParsedPrism) -> PrismPreviewSummary:
         member_board_post_count=len(_list(data.get("memberBoardPosts"))),
         media_attachment_count=len(_list(data.get("mediaAttachments"))),
         media_blob_count=len(parsed.media_blobs),
-        limit_warnings=report.to_warnings(),
+        limit_warnings=report.to_warnings() + row_cap_warnings,
     )
 
 
@@ -407,6 +426,36 @@ async def run_import(
     )
     await enforce_import_member_cap(db, system, new_count)
 
+    # Per-import row caps (bomb protection). Count the rows each enabled Prism
+    # section would create and hard-fail before writing if any blows its cap.
+    # Both conversations and member board posts land as Message rows, so they
+    # share the messages cap. Prism has no revisions and roles-as-tags is
+    # reserved (a no-op), so neither is counted. Gross source counts:
+    # dedup/skip only reduces the real write count.
+    il.enforce_import_row_caps(
+        {
+            "groups": (
+                len(_list(data.get("memberGroups"))) if member_groups else 0
+            ),
+            "custom_fields": (
+                len(_list(data.get("customFields"))) if custom_fields else 0
+            ),
+            "fronts": (
+                len(_list(data.get("frontSessions"))) if front_sessions else 0
+            ),
+            "journal_entries": len(_list(data.get("notes"))) if notes else 0,
+            "polls": len(_list(data.get("polls"))) if polls else 0,
+            "messages": (
+                (len(_list(data.get("messages"))) if conversations else 0)
+                + (
+                    len(_list(data.get("memberBoardPosts")))
+                    if member_board_posts
+                    else 0
+                )
+            ),
+        }
+    )
+
     # Map PS id -> handle wrapping the resolved row (created / skipped /
     # updated) so every later section attributes to the right member.
     ps_id_to_handle: dict[str, _MemberHandle] = {}
@@ -524,6 +573,7 @@ async def run_import(
             _list(data.get("pollOptions")),
             ps_id_to_handle,
             system.id,
+            user,
             db,
             result.warnings,
             dedupe=content_dedupe,
@@ -957,6 +1007,7 @@ async def _import_polls(
     options_in: list,
     ps_id_to_handle: dict[str, _MemberHandle],
     system_id: uuid.UUID,
+    user: User,
     db: AsyncSession,
     warnings: list[str],
     *,
@@ -971,7 +1022,10 @@ async def _import_polls(
     `responseText` on "other" option votes is appended to the option
     text (Sheaf has no per-vote freeform field). Under dedupe, a poll
     matching an existing created_at is skipped wholesale (options +
-    votes belong to the poll row). Returns (imported, skipped).
+    votes belong to the poll row). Open polls beyond the importing
+    user's concurrent-open-poll cap are imported already-closed (the
+    API enforces the cap on create; the importer must not bypass it).
+    Returns (imported, skipped).
     """
     imported = 0
     skipped = 0
@@ -982,6 +1036,22 @@ async def _import_polls(
     anonymous_count = 0
     response_text_dropped = 0
     missing_voter = 0
+
+    # Concurrent-open-poll cap. One `now` for the whole section so the
+    # open/closed decision and the close-time we write stay consistent.
+    now = datetime.now(UTC)
+    open_cap = max_concurrent_open_for_tier(user.tier)
+    existing_open = 0
+    if open_cap > 0:
+        existing_open = (
+            await db.execute(
+                select(func.count(Poll.id)).where(
+                    Poll.system_id == system_id,
+                    Poll.closes_at > now,
+                )
+            )
+        ).scalar_one()
+    created_open_polls: list[tuple[datetime | None, Poll]] = []
 
     options_by_poll: dict[str, list[dict]] = {}
     for o in options_in:
@@ -1008,9 +1078,9 @@ async def _import_polls(
                 continue
             poll_index.register(created_at)
         if is_closed:
-            closes_at = created_at or datetime.now(UTC)
+            closes_at = created_at or now
         else:
-            base = created_at or datetime.now(UTC)
+            base = created_at or now
             closes_at = base + timedelta(days=365)
             open_ended += 1
         poll = Poll(
@@ -1030,6 +1100,8 @@ async def _import_polls(
         if created_at:
             poll.created_at = created_at
         db.add(poll)
+        if closes_at > now:
+            created_open_polls.append((created_at or closes_at, poll))
 
         opts = options_by_poll.get(prism_id or "", [])
         opts.sort(key=lambda o: (o.get("sortOrder") or 0))
@@ -1053,7 +1125,7 @@ async def _import_polls(
                     response_text_dropped += 1
                 option_id = uuid.uuid4()
                 voter_to_options.setdefault(handle.member.id, []).append(option_id)
-                # Stash on the per-vote entry — we'll resolve below.
+                # Stash on the per-vote entry - we'll resolve below.
                 vote["_sheaf_option_id"] = option_id
             display_text = text
             if response_texts:
@@ -1092,6 +1164,21 @@ async def _import_polls(
                 )
             )
         imported += 1
+
+    # Flip the excess open polls to closed so the import can't leave the system
+    # over the tier's concurrent-open-poll cap. Non-destructive: options + votes
+    # are preserved; the poll just lands closed.
+    if open_cap > 0:
+        to_close = excess_open_polls_to_close(
+            created_open_polls, cap=open_cap, existing_open=existing_open
+        )
+        for closed_poll in to_close:
+            closed_poll.closes_at = now
+        if to_close:
+            warnings.append(
+                f"{len(to_close)} poll(s) exceed your concurrent-open-poll "
+                "limit and will be imported as closed."
+            )
 
     if open_ended:
         warnings.append(
@@ -1322,8 +1409,20 @@ async def _import_media_attachments(
         )
         return 0
     imported = 0
-    quota_warned = False
+    # Count cap: the storage quota bounds restored BYTES, this bounds
+    # normalize_image passes (see MAX_IMPORT_RESTORED_IMAGES in config.py). A
+    # crafted file could otherwise force unbounded Pillow decodes even on a
+    # full account, since store_imported_image normalises before checking
+    # quota. Matches the archive importer's restore loop.
+    restore_cap = settings.max_import_restored_images
     for att in atts_in:
+        if restore_cap and imported >= restore_cap:
+            warnings.append(
+                f"Media attachment imports stopped after {restore_cap} files "
+                "(per-import limit, MAX_IMPORT_RESTORED_IMAGES). Remaining "
+                "attachments were skipped."
+            )
+            break
         if not isinstance(att, dict):
             continue
         media_id = _clean_str(att.get("mediaId"))
@@ -1361,11 +1460,15 @@ async def _import_media_attachments(
                     f"Media attachment {media_id!r} was rejected by the image "
                     "normaliser."
                 )
-            elif not quota_warned:  # quota_full
+            else:  # quota_full
+                # Storage is full: stop importing images entirely rather than
+                # running a normalize pass per remaining attachment on a full
+                # account. Matches the archive importer's quota break.
                 warnings.append(
-                    "Media attachment imports stopped: storage quota reached."
+                    "Media attachment imports stopped: storage quota reached. "
+                    "Remaining attachments were skipped."
                 )
-                quota_warned = True
+                break
             continue
         imported += 1
     return imported
@@ -1455,7 +1558,7 @@ def _parse_iso(value: Any) -> datetime | None:
         return None
     s = value.replace("Z", "+00:00")
     # Prism timestamps sometimes carry microseconds with > 6 digits.
-    # fromisoformat tolerates 0/3/6 — split trailing junk if any.
+    # fromisoformat tolerates 0/3/6 - split trailing junk if any.
     try:
         return datetime.fromisoformat(s)
     except ValueError:

--- a/sheaf/services/prism_import.py
+++ b/sheaf/services/prism_import.py
@@ -139,7 +139,10 @@ from sheaf.services.prism_crypto import (
     decrypt_envelope,
     decrypt_media_blob,
 )
-from sheaf.services.sheaf_import import excess_open_polls_to_close
+from sheaf.services.sheaf_import import (
+    excess_open_polls_to_close,
+    open_poll_close_warning,
+)
 
 logger = logging.getLogger("sheaf.imports.prism")
 
@@ -234,6 +237,30 @@ def _measure_prism_payload(data: dict, report: ClampReport) -> None:
         s(f.get("name"), il.CF_NAME)
 
 
+def _count_incoming_open_polls(polls: object, *, now: datetime | None = None) -> int:
+    """Count Prism polls that would import OPEN. Mirrors ``_import_polls``'
+    close-time rule: a non-closed poll gets ``closes_at = created + 1yr`` (open);
+    a closed poll keeps its ``createdAt`` (open only if that is in the future).
+    Feeds the preview's concurrent-open estimate; the import re-clamps
+    authoritatively. Defensive so a malformed payload can't raise here."""
+    now = now or datetime.now(UTC)
+    count = 0
+    for p in _list(polls):
+        if not isinstance(p, dict):
+            continue
+        created_at = _parse_iso(p.get("createdAt"))
+        if bool(p.get("isClosed")):
+            closes_at = created_at or now
+        else:
+            closes_at = (created_at or now) + timedelta(days=365)
+        try:
+            if closes_at > now:
+                count += 1
+        except TypeError:
+            continue
+    return count
+
+
 def preview(parsed: ParsedPrism) -> PrismPreviewSummary:
     """Walk the decrypted JSON and return counts + member list summary.
 
@@ -296,6 +323,7 @@ def preview(parsed: ParsedPrism) -> PrismPreviewSummary:
         conversation_count=len(_list(data.get("conversations"))),
         message_count=len(_list(data.get("messages"))),
         poll_count=len(_list(data.get("polls"))),
+        open_poll_count=_count_incoming_open_polls(data.get("polls")),
         poll_option_count=len(_list(data.get("pollOptions"))),
         note_count=len(_list(data.get("notes"))),
         reminder_count=len(_list(data.get("reminders"))),
@@ -1175,10 +1203,7 @@ async def _import_polls(
         for closed_poll in to_close:
             closed_poll.closes_at = now
         if to_close:
-            warnings.append(
-                f"{len(to_close)} poll(s) exceed your concurrent-open-poll "
-                "limit and will be imported as closed."
-            )
+            warnings.append(open_poll_close_warning(len(to_close)))
 
     if open_ended:
         warnings.append(

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -29,8 +29,10 @@ append-everything behaviour.
 
 import logging
 import uuid
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime
 
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
@@ -106,7 +108,10 @@ from sheaf.services.import_image_strip import (
 )
 from sheaf.services.import_limits import ClampReport, clamp_list, clamp_str
 from sheaf.services.member_limits import enforce_import_member_cap
-from sheaf.services.polls import max_retention_days_for_tier
+from sheaf.services.polls import (
+    max_concurrent_open_for_tier,
+    max_retention_days_for_tier,
+)
 
 logger = logging.getLogger("sheaf.import.sheaf")
 
@@ -189,6 +194,154 @@ def _clamp_poll_retention_days(value: int, cap: int) -> int:
         # ceiling rather than letting 0 slip past the cap.
         return cap
     return min(value, cap)
+
+
+def _open_poll_sort_key(source_time: datetime | None) -> tuple[int, float]:
+    """Sort key for ranking imported open polls by source time.
+
+    A poll with no source time ranks oldest (closed first). timestamp() gives a
+    total order that never raises on an aware/naive mix (or a crafted extreme
+    date), unlike comparing datetimes directly.
+    """
+    if source_time is None:
+        return (0, 0.0)
+    try:
+        return (1, source_time.timestamp())
+    except (OverflowError, OSError, ValueError):
+        return (1, 0.0)
+
+
+def excess_open_polls_to_close(
+    created_open: list[tuple[datetime | None, Poll]],
+    *,
+    cap: int,
+    existing_open: int,
+) -> list[Poll]:
+    """Pick which freshly-imported OPEN polls to flip to CLOSED so the system
+    stays within its tier's concurrent-open-poll cap.
+
+    The poll-create API caps how many polls a system may have open at once
+    (``max_concurrent_open_for_tier``); importers wrote Poll rows straight past
+    it, so an import could leave a system with hundreds of open polls. Given the
+    open polls this run would add (``created_open`` = (source_time, poll) pairs)
+    and how many are already open (``existing_open``), keep at most
+    ``cap - existing_open`` of the incoming ones open and return the rest to be
+    closed. Nothing is dropped - closing preserves the poll, its options and
+    votes.
+
+    Keep-open rule: the newest-by-source-time polls keep the open slots; the
+    oldest excess are closed. ``cap <= 0`` means the tier has no concurrent-open
+    limit, so nothing is closed. Shared by the native, Prism and PluralSpace
+    importers so the rule is identical everywhere.
+    """
+    if cap <= 0:
+        return []
+    keep = max(cap - existing_open, 0)
+    if len(created_open) <= keep:
+        return []
+    order = sorted(
+        range(len(created_open)),
+        key=lambda i: (_open_poll_sort_key(created_open[i][0]), i),
+        reverse=True,
+    )
+    # Newest `keep` stay open; the remainder (oldest excess) are closed.
+    return [created_open[i][1] for i in order[keep:]]
+
+
+@dataclass
+class DepthCorrection:
+    """Result of ``correct_nesting_depth``: the corrected parent map plus the
+    nodes whose parent changed (``moved`` = reparented for depth,
+    ``cycle_broken`` = rooted to cut a parent cycle)."""
+
+    parent_of: dict
+    moved: set
+    cycle_broken: set
+
+
+def correct_nesting_depth(parent_of: dict, *, max_depth: int) -> DepthCorrection:
+    """Clamp a group parent map so no node ends deeper than ``max_depth``.
+
+    ``parent_of`` maps node -> parent node (None, or an id not present, means
+    root; root depth is 1). Importers set ``parent_group_id`` with no depth
+    check, so an import could build a group tree deeper than the API's
+    ``MAX_GROUP_DEPTH``. This resolves the tree and returns a ``DepthCorrection``
+    that GUARANTEES every node's corrected depth is <= ``max_depth``.
+
+    Correction is top-down: a too-deep node hops up to its nearest ancestor
+    still shallower than the cap, so it lands at exactly ``max_depth`` and its
+    subtree hangs off the deepest allowed level (descendants are clamped the
+    same way as the walk reaches them). Termination is guaranteed: a first pass
+    cuts any parent cycle in malformed input (bounded by the node count), so the
+    depth pass only ever walks a finite acyclic chain.
+    """
+    nodes = set(parent_of)
+    work = dict(parent_of)
+    cycle_broken: set = set()
+
+    # --- Pass 1: cut parent cycles (functional graph: one parent per node). ---
+    # color: 1 = fully resolved (acyclic above), on-stack tracked per walk.
+    color: dict = {}
+    for start in nodes:
+        stack: list = []
+        cur = start
+        while cur is not None and cur in nodes:
+            c = color.get(cur)
+            if c == 1:
+                break  # chain above `cur` already known acyclic
+            if c == 0:
+                # `cur` is on the current stack: a loop. Root it to break the
+                # cycle, then stop (the rest of the chain is now acyclic).
+                work[cur] = None
+                cycle_broken.add(cur)
+                break
+            color[cur] = 0
+            stack.append(cur)
+            cur = work.get(cur)
+        for node in stack:
+            color[node] = 1
+
+    # --- Pass 2: resolve depth top-down and clamp. ---
+    depth: dict = {}
+    corrected_parent: dict = {}
+    moved: set = set()
+
+    def _resolve(start: object) -> None:
+        chain: list = []
+        cur = start
+        # Acyclic now, so this climb terminates at a resolved node / root /
+        # external parent.
+        while cur is not None and cur in nodes and cur not in depth:
+            chain.append(cur)
+            cur = work.get(cur)
+        # Process root-ward first so each node's parent is already resolved.
+        for node in reversed(chain):
+            p = work.get(node)
+            if p is None or p not in nodes:
+                corrected_parent[node] = None
+                depth[node] = 1
+                continue
+            pd = depth[p]
+            if pd < max_depth:
+                corrected_parent[node] = p
+                depth[node] = pd + 1
+            else:
+                # Too deep: hop up to the nearest ancestor shallower than the
+                # cap so this node lands at <= max_depth.
+                anc = p
+                while anc is not None and depth[anc] >= max_depth:
+                    anc = corrected_parent[anc]
+                corrected_parent[node] = anc
+                depth[node] = depth[anc] + 1 if anc is not None else 1
+                moved.add(node)
+
+    for n in nodes:
+        if n not in depth:
+            _resolve(n)
+
+    return DepthCorrection(
+        parent_of=corrected_parent, moved=moved, cycle_broken=cycle_broken
+    )
 
 
 class SheafPreviewSummary:
@@ -361,9 +514,59 @@ def preview(data: dict) -> SheafPreviewSummary:
 
     report = ClampReport()
     measure_native_payload(data, report)
-    summary.limit_warnings = report.to_warnings()
+    summary.limit_warnings = report.to_warnings() + il.import_row_cap_warnings(
+        {
+            "fronts": summary.front_count,
+            "journal_entries": summary.journal_count,
+            "messages": summary.message_count,
+            "revisions": len(data.get("revisions", [])),
+            "polls": summary.poll_count,
+            "groups": summary.group_count,
+            "tags": summary.tag_count,
+            "custom_fields": summary.custom_field_count,
+        }
+    )
+    summary.limit_warnings += _group_depth_warnings(data.get("groups", []))
 
     return summary
+
+
+def _group_depth_warnings(groups: object) -> list[str]:
+    """Predict the group-nesting-depth clamp from a native-shaped payload.
+
+    Pure function of the declared ``parent_id`` links (no DB), matching the
+    fresh-import case the run performs. Importers set ``parent_id`` with no
+    depth check, so this warns when the payload nests groups deeper than the
+    API's ``MAX_GROUP_DEPTH`` (they get reparented up to fit) or contains a
+    looping parent chain (it gets cut). Defensive against malformed shapes.
+    """
+    from sheaf.api.v1.groups import MAX_GROUP_DEPTH
+
+    parent_of: dict[str, str | None] = {}
+    ids: set[str] = set()
+    for g in _as_list(groups):
+        if isinstance(g, dict) and g.get("id"):
+            ids.add(g["id"])
+    for g in _as_list(groups):
+        if not isinstance(g, dict) or not g.get("id"):
+            continue
+        parent = g.get("parent_id")
+        parent_of[g["id"]] = parent if parent in ids else None
+    if not parent_of:
+        return []
+    correction = correct_nesting_depth(parent_of, max_depth=MAX_GROUP_DEPTH)
+    out: list[str] = []
+    if correction.moved:
+        out.append(
+            f"{len(correction.moved)} group(s) exceed the maximum nesting "
+            f"depth ({MAX_GROUP_DEPTH}) and were moved up to fit."
+        )
+    if correction.cycle_broken:
+        out.append(
+            f"{len(correction.cycle_broken)} group(s) had a looping parent "
+            "reference and were moved to the top level."
+        )
+    return out
 
 
 async def count_new_members_for_import(
@@ -473,7 +676,7 @@ async def run_import(
             if sys_data.get("name"):
                 system.name = clamp_str(sys_data["name"], il.SYS_NAME, report=report)
             if sys_data.get("description") is not None:
-                # Strip any /v1/files/... image embeds — those keys belong
+                # Strip any /v1/files/... image embeds - those keys belong
                 # to the exporting account, not this one.
                 system.description = _resolve_md(
                     sys_data["description"]
@@ -678,6 +881,28 @@ async def run_import(
         strategy=conflict_strategy,
     )
     await enforce_import_member_cap(db, system, new_count)
+
+    # Per-import row caps (bomb protection). Count the rows each enabled
+    # section would create from the parsed payload - only sections the caller
+    # opted into contribute, since a disabled section writes nothing. Revisions
+    # are always attempted, so they're always counted. Gross source counts:
+    # dedup/skip only ever reduces the real write count, so this can't
+    # under-count the ceiling. Raises ImportPayloadError before any section
+    # loop runs, matching the member cap.
+    il.enforce_import_row_caps(
+        {
+            "fronts": len(data.get("fronts", [])) if fronts else 0,
+            "journal_entries": len(data.get("journals", [])) if journals else 0,
+            "messages": len(data.get("messages", [])) if messages else 0,
+            "revisions": len(data.get("revisions", [])),
+            "polls": len(data.get("polls", [])) if polls else 0,
+            "groups": len(data.get("groups", [])) if groups else 0,
+            "tags": len(data.get("tags", [])) if tags else 0,
+            "custom_fields": (
+                len(data.get("custom_fields", [])) if custom_fields else 0
+            ),
+        }
+    )
 
     # Map old export ID → resolved Member (created / skipped / updated).
     # `written_old_ids` tracks the rows this run actually wrote, so the
@@ -895,6 +1120,50 @@ async def run_import(
                             group_id=group.id, member_id=member.id
                         )
                     )
+
+        # Clamp nesting depth. Importers set parent_id with no depth check, so a
+        # crafted (or just deep) export could build a group tree past the API's
+        # MAX_GROUP_DEPTH. Load the whole system's parent map in one query (the
+        # new links are flushed first) and reparent any group we created that
+        # ended too deep - or whose parent chain loops - up to the deepest
+        # allowed level. Non-destructive: no group or membership is lost.
+        if created_group_ids:
+            from sheaf.api.v1.groups import MAX_GROUP_DEPTH
+
+            await db.flush()
+            depth_rows = await db.execute(
+                select(Group.id, Group.parent_id).where(
+                    Group.system_id == system.id
+                )
+            )
+            parent_of = {gid: pid for gid, pid in depth_rows.all()}
+            correction = correct_nesting_depth(
+                parent_of, max_depth=MAX_GROUP_DEPTH
+            )
+            created_by_id = {
+                g.id: g
+                for g in old_gid_to_group.values()
+                if g.id in created_group_ids
+            }
+            depth_moved = 0
+            cycle_moved = 0
+            for gid, grp in created_by_id.items():
+                if gid in correction.moved:
+                    grp.parent_id = correction.parent_of[gid]
+                    depth_moved += 1
+                elif gid in correction.cycle_broken:
+                    grp.parent_id = correction.parent_of[gid]
+                    cycle_moved += 1
+            if depth_moved:
+                warnings.append(
+                    f"{depth_moved} group(s) exceed the maximum nesting depth "
+                    f"({MAX_GROUP_DEPTH}) and were moved up to fit."
+                )
+            if cycle_moved:
+                warnings.append(
+                    f"{cycle_moved} group(s) had a looping parent reference and "
+                    "were moved to the top level."
+                )
 
     # --- Fronts ---
     if fronts:
@@ -1192,6 +1461,29 @@ async def run_import(
             if importing_user is not None
             else 0
         )
+        # Concurrent-open-poll cap. The API caps how many polls a system may
+        # have open (closes_at in the future) at once; the importer bypassed it.
+        # We import every poll but flip the excess OPEN ones to CLOSED. Resolve
+        # the ceiling and the count of already-open polls once, up front.
+        poll_now = datetime.now(UTC)
+        poll_open_cap = (
+            max_concurrent_open_for_tier(importing_user.tier)
+            if importing_user is not None
+            else 0
+        )
+        existing_open_polls = 0
+        if poll_open_cap > 0:
+            existing_open_polls = (
+                await db.execute(
+                    select(func.count(Poll.id)).where(
+                        Poll.system_id == system.id,
+                        Poll.closes_at > poll_now,
+                    )
+                )
+            ).scalar_one()
+        # (source_time, poll) for polls this run imports OPEN, ranked below so
+        # the newest keep the open slots and the oldest excess are closed.
+        created_open_polls: list[tuple[datetime | None, Poll]] = []
         poll_index = (
             await load_poll_index(db, system.id) if dedupe else ContentMatchIndex()
         )
@@ -1245,6 +1537,10 @@ async def run_import(
             if pcreated:
                 poll.created_at = pcreated
             db.add(poll)
+            # Track polls that land OPEN so the concurrency clamp below can flip
+            # the excess to closed. Source time orders the keep-open decision.
+            if closes_at > poll_now:
+                created_open_polls.append((pcreated or closes_at, poll))
 
             # Options first; vote/event option references resolve through this.
             old_option_to_new: dict[str, PollOption] = {}
@@ -1323,6 +1619,24 @@ async def run_import(
                 db.add(event)
 
             result.polls_imported += 1
+
+        # Flip the excess open polls to closed so the system stays within the
+        # tier's concurrent-open cap. Closing = closes_at at import time, so the
+        # poll lands closed and purges like any normally-closed poll; its
+        # options and votes are preserved.
+        if poll_open_cap > 0:
+            to_close = excess_open_polls_to_close(
+                created_open_polls,
+                cap=poll_open_cap,
+                existing_open=existing_open_polls,
+            )
+            for closed_poll in to_close:
+                closed_poll.closes_at = poll_now
+            if to_close:
+                warnings.append(
+                    f"{len(to_close)} poll(s) exceed your concurrent-open-poll "
+                    "limit and will be imported as closed."
+                )
 
         await db.flush()
 

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -248,6 +248,93 @@ def excess_open_polls_to_close(
     return [created_open[i][1] for i in order[keep:]]
 
 
+def open_poll_import_overage(
+    *, incoming_open: int, cap: int, existing_open: int
+) -> int:
+    """How many freshly-imported OPEN polls would be flipped to CLOSED to keep
+    the system within its tier's concurrent-open-poll cap.
+
+    Pure count mirror of ``excess_open_polls_to_close`` (same rule, no Poll
+    rows): ``cap <= 0`` means the tier has no concurrent-open limit so nothing
+    is closed; otherwise the newest ``cap - existing_open`` incoming open polls
+    keep their slots and the rest are closed. Used by the preview to warn up
+    front; the import path re-clamps authoritatively.
+    """
+    if cap <= 0:
+        return 0
+    return max(0, min(incoming_open, existing_open + incoming_open - cap))
+
+
+def open_poll_close_warning(count: int) -> str:
+    """User-facing heads-up when ``count`` imported open polls will be flipped
+    to closed to stay within the tier's concurrent-open-poll cap. Shared by the
+    import path (authoritative) and the preview (estimate) so the wording is
+    identical everywhere."""
+    return (
+        f"{count} poll(s) exceed your concurrent-open-poll limit and will be "
+        "imported as closed."
+    )
+
+
+def count_incoming_open_polls(polls: object, *, now: datetime | None = None) -> int:
+    """Count payload polls that would import OPEN (parsed ``closes_at`` in the
+    future). Mirrors the import's open/closed decision so the preview's
+    concurrent-open estimate lines up with what the run would clamp. Reuses the
+    importer's ``_parse_iso`` and is defensive against malformed shapes and
+    naive/extreme datetimes so a crafted upload can't raise here.
+    """
+    now = now or datetime.now(UTC)
+    count = 0
+    for p in _as_list(polls):
+        if not isinstance(p, dict):
+            continue
+        closes_at = _parse_iso(p.get("closes_at"))
+        if closes_at is None:
+            continue
+        try:
+            if closes_at > now:
+                count += 1
+        except TypeError:
+            # Naive vs aware mismatch (crafted/legacy value): a real export
+            # carries aware timestamps, so treat an un-comparable one as not
+            # open rather than raising in the preview path.
+            continue
+    return count
+
+
+async def open_poll_preview_warning(
+    db: AsyncSession, system_id: uuid.UUID, user: User, incoming_open: int
+) -> str | None:
+    """Preview heads-up: how many of ``incoming_open`` incoming open polls would
+    be imported closed to keep the system within its tier's concurrent-open-poll
+    cap.
+
+    Counts the system's currently-open polls (``closes_at`` in the future) and
+    compares against the same tier cap the import clamp uses, then returns the
+    same warning string the import path emits, or ``None`` when nothing would be
+    closed. This is an ESTIMATE: existing-open can change before the real
+    import, which re-clamps authoritatively.
+    """
+    cap = max_concurrent_open_for_tier(user.tier)
+    if cap <= 0 or incoming_open <= 0:
+        return None
+    now = datetime.now(UTC)
+    existing_open = (
+        await db.execute(
+            select(func.count(Poll.id)).where(
+                Poll.system_id == system_id,
+                Poll.closes_at > now,
+            )
+        )
+    ).scalar_one()
+    overage = open_poll_import_overage(
+        incoming_open=incoming_open, cap=cap, existing_open=existing_open
+    )
+    if overage <= 0:
+        return None
+    return open_poll_close_warning(overage)
+
+
 @dataclass
 class DepthCorrection:
     """Result of ``correct_nesting_depth``: the corrected parent map plus the
@@ -356,6 +443,10 @@ class SheafPreviewSummary:
         self.journal_count: int = 0
         self.message_count: int = 0
         self.poll_count: int = 0
+        # Incoming polls that would import OPEN (closes_at in the future). The
+        # preview endpoint uses this + the tier cap + a DB count of already-open
+        # polls to warn when the concurrent-open clamp would close some.
+        self.open_poll_count: int = 0
         self.reminder_count: int = 0
         self.channel_count: int = 0
         # Fields/lists that exceed the schema caps and would be shortened on
@@ -507,6 +598,7 @@ def preview(data: dict) -> SheafPreviewSummary:
     summary.journal_count = len(data.get("journals", []))
     summary.message_count = len(data.get("messages", []))
     summary.poll_count = len(data.get("polls", []))
+    summary.open_poll_count = count_incoming_open_polls(data.get("polls", []))
     summary.reminder_count = len(data.get("reminders", []))
     summary.channel_count = sum(
         len(t.get("channels", [])) for t in data.get("watch_tokens", [])
@@ -1633,10 +1725,7 @@ async def run_import(
             for closed_poll in to_close:
                 closed_poll.closes_at = poll_now
             if to_close:
-                warnings.append(
-                    f"{len(to_close)} poll(s) exceed your concurrent-open-poll "
-                    "limit and will be imported as closed."
-                )
+                warnings.append(open_poll_close_warning(len(to_close)))
 
         await db.flush()
 

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -19,6 +19,7 @@ import re
 import uuid
 from datetime import UTC, datetime
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
@@ -354,7 +355,16 @@ def preview(data: dict) -> SPPreviewSummary:
     # sees the warning before committing. Same caps as run_import.
     report = ClampReport()
     measure_sp_payload(data, report)
-    summary.limit_warnings = report.to_warnings()
+    # Predict the per-import row caps too. Notes are not yet imported as
+    # journals, so they don't count toward any cap here.
+    summary.limit_warnings = report.to_warnings() + il.import_row_cap_warnings(
+        {
+            "fronts": len(fronts),
+            "custom_fields": len(fields),
+            "groups": len(groups),
+            "messages": summary.message_count,
+        }
+    )
     return summary
 
 
@@ -500,6 +510,31 @@ async def run_import(
         strategy=options.conflict_strategy,
     )
     await enforce_import_member_cap(db, system, new_count)
+
+    # Per-import row caps (bomb protection). Beyond members / custom fronts, SP
+    # writes front-history rows, custom fields, groups and chat messages; count
+    # each enabled section's source rows and hard-fail before writing if any
+    # blows its cap. Notes are not yet imported (journal feature pending), so
+    # there are no journal rows to count. Gross counts: dedup/skip only reduces
+    # the real write count.
+    il.enforce_import_row_caps(
+        {
+            "fronts": (
+                len(_get_collection_alt(data, "frontHistory", "fronters"))
+                if options.front_history
+                else 0
+            ),
+            "custom_fields": (
+                len(_get_collection(data, "customFields"))
+                if options.custom_fields
+                else 0
+            ),
+            "groups": (
+                len(_get_collection(data, "groups")) if options.groups else 0
+            ),
+            "messages": len(_sp_chat_rows(data)) if options.messages else 0,
+        }
+    )
 
     # Map SP member _id → resolved Sheaf Member for cross-referencing.
     # The map points at the resolved row (created / skipped / updated) so
@@ -696,6 +731,45 @@ async def run_import(
                 f"Dropped {unresolvable_parents} group parent links that "
                 "pointed at a group not present in the export."
             )
+
+        # Clamp nesting depth. SP builds a nested group tree via `parent` with
+        # no depth check, so a deep (or looping) export could exceed the API's
+        # MAX_GROUP_DEPTH. Mirror the native importer: load the system's parent
+        # map and reparent any group we created that ended too deep, or whose
+        # parent chain loops, up to the deepest allowed level. Non-destructive.
+        if created_group_ids:
+            from sheaf.api.v1.groups import MAX_GROUP_DEPTH
+            from sheaf.services.sheaf_import import correct_nesting_depth
+
+            await db.flush()
+            depth_rows = await db.execute(
+                select(Group.id, Group.parent_id).where(
+                    Group.system_id == system.id
+                )
+            )
+            parent_of = {gid: pid for gid, pid in depth_rows.all()}
+            correction = correct_nesting_depth(parent_of, max_depth=MAX_GROUP_DEPTH)
+            depth_moved = 0
+            cycle_moved = 0
+            for grp in sp_gid_to_group.values():
+                if grp.id not in created_group_ids:
+                    continue
+                if grp.id in correction.moved:
+                    grp.parent_id = correction.parent_of[grp.id]
+                    depth_moved += 1
+                elif grp.id in correction.cycle_broken:
+                    grp.parent_id = correction.parent_of[grp.id]
+                    cycle_moved += 1
+            if depth_moved:
+                warnings.append(
+                    f"{depth_moved} group(s) exceed the maximum nesting depth "
+                    f"({MAX_GROUP_DEPTH}) and were moved up to fit."
+                )
+            if cycle_moved:
+                warnings.append(
+                    f"{cycle_moved} group(s) had a looping parent reference and "
+                    "were moved to the top level."
+                )
 
     # --- Front history ---
     if options.front_history:

--- a/sheaf/services/tb_import.py
+++ b/sheaf/services/tb_import.py
@@ -121,7 +121,8 @@ def preview(data: dict) -> TBPreviewSummary:
             if _tupper_id(t) is not None
         ],
         group_count=len(groups),
-        limit_warnings=report.to_warnings(),
+        limit_warnings=report.to_warnings()
+        + il.import_row_cap_warnings({"groups": len(groups)}),
     )
 
 
@@ -161,6 +162,13 @@ async def run_import(
         strategy=options.conflict_strategy,
     )
     await enforce_import_member_cap(db, system, new_count)
+
+    # Per-import row caps (bomb protection). Beyond members, Tupperbox only
+    # writes groups; hard-fail before writing if they blow the cap. Gross
+    # count: dedup/skip only reduces the real write count.
+    il.enforce_import_row_caps(
+        {"groups": len(_list(data, "groups")) if options.groups else 0}
+    )
 
     id_to_member: dict[str, Member] = {}
     tuppers_no_id = 0

--- a/tests/test_import_caps_unit.py
+++ b/tests/test_import_caps_unit.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime, timedelta
 from sheaf.services.sheaf_import import (
     correct_nesting_depth,
     excess_open_polls_to_close,
+    open_poll_import_overage,
     preview,
 )
 
@@ -80,6 +81,55 @@ def test_open_polls_missing_source_time_ranks_oldest():
     to_close = excess_open_polls_to_close(created, cap=1, existing_open=0)
     assert set(to_close) == {"pN", "p0"}
     assert "p1" not in to_close  # newest kept open
+
+
+# ---------------------------------------------------------------------------
+# open_poll_import_overage (pure count mirror used by the preview)
+# ---------------------------------------------------------------------------
+
+
+def test_overage_unlimited_cap_is_zero():
+    # cap <= 0 means the tier has no concurrent-open limit.
+    assert open_poll_import_overage(incoming_open=50, cap=0, existing_open=0) == 0
+    assert open_poll_import_overage(incoming_open=50, cap=-1, existing_open=999) == 0
+
+
+def test_overage_within_cap_is_zero():
+    assert open_poll_import_overage(incoming_open=3, cap=5, existing_open=0) == 0
+    # exactly at the cap is still fine.
+    assert open_poll_import_overage(incoming_open=5, cap=5, existing_open=0) == 0
+
+
+def test_overage_counts_existing_plus_incoming():
+    # cap 5, already 4 open -> 1 slot for 3 incoming, so 2 must close.
+    assert open_poll_import_overage(incoming_open=3, cap=5, existing_open=4) == 2
+    # cap already full -> all incoming close.
+    assert open_poll_import_overage(incoming_open=3, cap=5, existing_open=5) == 3
+    # over-full counts the same as full, never more than incoming.
+    assert open_poll_import_overage(incoming_open=3, cap=5, existing_open=9) == 3
+
+
+def test_overage_capped_at_incoming():
+    # Overage never exceeds the incoming count (existing already way over cap).
+    assert open_poll_import_overage(incoming_open=2, cap=1, existing_open=100) == 2
+
+
+def test_overage_matches_list_helper():
+    # The pure count must equal what the list decision helper would close.
+    for incoming, cap, existing in [
+        (5, 2, 0),
+        (3, 5, 4),
+        (3, 5, 5),
+        (3, 5, 9),
+        (0, 5, 2),
+        (4, 0, 0),
+    ]:
+        closed = excess_open_polls_to_close(
+            _open(incoming), cap=cap, existing_open=existing
+        )
+        assert open_poll_import_overage(
+            incoming_open=incoming, cap=cap, existing_open=existing
+        ) == len(closed)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_import_caps_unit.py
+++ b/tests/test_import_caps_unit.py
@@ -1,0 +1,215 @@
+"""Unit tests for the importer concurrency / nesting-depth clamps.
+
+Pure logic, no DB and no docker stack. Two importer bypasses are covered:
+
+* Open-poll concurrency: importers wrote Poll rows straight past the
+  poll-create API's ``max_concurrent_open_for_tier`` cap. The fix keeps the
+  newest incoming open polls open and flips the older excess to closed.
+  ``excess_open_polls_to_close`` is the shared decision helper.
+* Group nesting depth: importers set ``parent_id`` with no depth check, so an
+  import could build a group tree deeper than ``MAX_GROUP_DEPTH`` (or with a
+  looping parent chain). ``correct_nesting_depth`` reparents the offenders up
+  to fit and cuts cycles, guaranteeing termination and a bounded depth.
+
+The native ``preview`` group-depth prediction is exercised too, since the
+warning it surfaces has to match what the run performs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sheaf.services.sheaf_import import (
+    correct_nesting_depth,
+    excess_open_polls_to_close,
+    preview,
+)
+
+_NOW = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _open(n: int) -> list[tuple[datetime, str]]:
+    """`n` incoming open polls, oldest first (p0 oldest ... p{n-1} newest)."""
+    return [(_NOW + timedelta(minutes=i), f"p{i}") for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# excess_open_polls_to_close
+# ---------------------------------------------------------------------------
+
+
+def test_open_polls_unlimited_cap_closes_nothing():
+    # cap <= 0 means the tier has no concurrent-open limit.
+    assert excess_open_polls_to_close(_open(50), cap=0, existing_open=0) == []
+    assert excess_open_polls_to_close(_open(50), cap=-1, existing_open=999) == []
+
+
+def test_open_polls_within_cap_closes_nothing():
+    assert excess_open_polls_to_close(_open(3), cap=5, existing_open=0) == []
+    # exactly at the cap is still fine.
+    assert excess_open_polls_to_close(_open(5), cap=5, existing_open=0) == []
+
+
+def test_open_polls_excess_closes_oldest_keeps_newest():
+    # 5 incoming, cap 2, none already open -> keep the 2 newest, close 3 oldest.
+    to_close = excess_open_polls_to_close(_open(5), cap=2, existing_open=0)
+    assert set(to_close) == {"p0", "p1", "p2"}
+    assert "p3" not in to_close and "p4" not in to_close
+    # Count matches the "N poll(s) ... imported as closed" warning.
+    assert len(to_close) == 3
+
+
+def test_open_polls_existing_open_reduces_slots():
+    # cap 5, already 4 open -> only 1 slot left for 3 incoming, close 2 oldest.
+    to_close = excess_open_polls_to_close(_open(3), cap=5, existing_open=4)
+    assert set(to_close) == {"p0", "p1"}
+
+
+def test_open_polls_cap_already_full_closes_all_incoming():
+    to_close = excess_open_polls_to_close(_open(3), cap=5, existing_open=5)
+    assert set(to_close) == {"p0", "p1", "p2"}
+    # Over-full counts the same as full: no negative slots.
+    assert set(
+        excess_open_polls_to_close(_open(3), cap=5, existing_open=9)
+    ) == {"p0", "p1", "p2"}
+
+
+def test_open_polls_missing_source_time_ranks_oldest():
+    # A poll with no source time is closed before any timestamped poll.
+    created = [(None, "pN"), (_NOW, "p0"), (_NOW + timedelta(hours=1), "p1")]
+    to_close = excess_open_polls_to_close(created, cap=1, existing_open=0)
+    assert set(to_close) == {"pN", "p0"}
+    assert "p1" not in to_close  # newest kept open
+
+
+# ---------------------------------------------------------------------------
+# correct_nesting_depth
+# ---------------------------------------------------------------------------
+
+
+def _depths(parent_of: dict) -> dict:
+    """Depth of every node (root = 1) from a corrected, acyclic parent map."""
+    out: dict = {}
+
+    def depth(n):
+        if n in out:
+            return out[n]
+        p = parent_of.get(n)
+        out[n] = 1 if (p is None or p not in parent_of) else depth(p) + 1
+        return out[n]
+
+    return {n: depth(n) for n in parent_of}
+
+
+def test_depth_shallow_tree_untouched():
+    parent_of = {"a": None, "b": "a", "c": "b"}
+    result = correct_nesting_depth(parent_of, max_depth=8)
+    assert result.moved == set()
+    assert result.cycle_broken == set()
+    assert result.parent_of == parent_of
+
+
+def test_depth_too_deep_chain_reparented_within_cap():
+    # g1 (root) .. g10, each the child of the previous -> depths 1..10.
+    parent_of = {"g1": None}
+    for i in range(2, 11):
+        parent_of[f"g{i}"] = f"g{i - 1}"
+    result = correct_nesting_depth(parent_of, max_depth=8)
+
+    # Nothing exceeds the cap after correction.
+    assert max(_depths(result.parent_of).values()) <= 8
+    # The two nodes past depth 8 were the ones moved.
+    assert result.moved == {"g9", "g10"}
+    assert result.cycle_broken == set()
+    # ...and they land at exactly the deepest allowed level.
+    depths = _depths(result.parent_of)
+    assert depths["g9"] == 8 and depths["g10"] == 8
+
+
+def test_depth_subtree_moves_and_stays_bounded():
+    # A too-deep node with its own descendant: both must end <= max_depth.
+    parent_of = {"r": None}
+    chain = ["r"]
+    for i in range(1, 12):
+        node = f"n{i}"
+        parent_of[node] = chain[-1]
+        chain.append(node)
+    result = correct_nesting_depth(parent_of, max_depth=8)
+    assert max(_depths(result.parent_of).values()) <= 8
+
+
+def test_depth_cycle_is_broken_and_terminates():
+    # A 3-node parent cycle must not hang and must end within the cap.
+    parent_of = {"a": "b", "b": "c", "c": "a"}
+    result = correct_nesting_depth(parent_of, max_depth=8)
+    assert result.cycle_broken  # at least one node rooted to cut the loop
+    assert max(_depths(result.parent_of).values()) <= 8
+
+
+def test_depth_self_loop_is_broken():
+    parent_of = {"a": "a"}
+    result = correct_nesting_depth(parent_of, max_depth=8)
+    assert result.cycle_broken == {"a"}
+    assert result.parent_of["a"] is None
+
+
+def test_depth_cycle_with_deep_tail_bounded():
+    # Cycle a<->b, plus a long tail hanging off b: everything ends bounded,
+    # and the call returns (the guard against a crafted cyclic parent set).
+    parent_of = {"a": "b", "b": "a"}
+    prev = "b"
+    for i in range(1, 15):
+        parent_of[f"t{i}"] = prev
+        prev = f"t{i}"
+    result = correct_nesting_depth(parent_of, max_depth=8)
+    assert max(_depths(result.parent_of).values()) <= 8
+
+
+# ---------------------------------------------------------------------------
+# native preview group-depth prediction
+# ---------------------------------------------------------------------------
+
+
+def _deep_group_payload(n: int) -> dict:
+    groups = [
+        {
+            "id": f"g{i}",
+            "name": f"G{i}",
+            "parent_id": f"g{i - 1}" if i > 1 else None,
+        }
+        for i in range(1, n + 1)
+    ]
+    return {"version": "2", "system": {"name": "Deep"}, "groups": groups}
+
+
+def test_preview_flags_over_depth_groups():
+    summary = preview(_deep_group_payload(10))
+    assert any(
+        "maximum nesting depth (8)" in w for w in summary.limit_warnings
+    ), summary.limit_warnings
+    # Two groups (depths 9 and 10) get moved up to fit.
+    assert any(
+        w.startswith("2 group(s) exceed") for w in summary.limit_warnings
+    ), summary.limit_warnings
+
+
+def test_preview_shallow_groups_have_no_depth_warning():
+    summary = preview(_deep_group_payload(5))
+    assert not any(
+        "nesting depth" in w for w in summary.limit_warnings
+    ), summary.limit_warnings
+
+
+def test_preview_flags_cyclic_group_parents():
+    payload = {
+        "version": "2",
+        "system": {"name": "Loop"},
+        "groups": [
+            {"id": "a", "name": "A", "parent_id": "b"},
+            {"id": "b", "name": "B", "parent_id": "a"},
+        ],
+    }
+    summary = preview(payload)  # must not hang
+    assert any(
+        "looping parent reference" in w for w in summary.limit_warnings
+    ), summary.limit_warnings

--- a/tests/test_import_limits.py
+++ b/tests/test_import_limits.py
@@ -6,7 +6,11 @@ rendering that the preview surfaces.
 
 from __future__ import annotations
 
+import pytest
+
+from sheaf.config import settings
 from sheaf.services import import_limits as il
+from sheaf.services.import_parsing import ImportPayloadError
 
 
 def test_clamp_str_under_cap_is_untouched():
@@ -134,3 +138,80 @@ def test_clamp_poll_retention_unlimited_tier_keeps_value():
     # including an imported 0 (unlimited).
     assert _clamp_poll_retention_days(365, 0) == 365
     assert _clamp_poll_retention_days(0, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-import row caps (bomb protection)
+# ---------------------------------------------------------------------------
+
+
+def test_row_caps_no_op_under_cap(monkeypatch):
+    monkeypatch.setattr(settings, "import_max_fronts", 100)
+    # Under cap and exactly at cap must not raise (cap is an upper bound).
+    il.enforce_import_row_caps({"fronts": 99})
+    il.enforce_import_row_caps({"fronts": 100})
+
+
+def test_row_caps_disabled_when_zero(monkeypatch):
+    monkeypatch.setattr(settings, "import_max_fronts", 0)
+    # 0 disables the cap - no ceiling at all.
+    il.enforce_import_row_caps({"fronts": 10_000_000})
+
+
+def test_row_caps_over_cap_raises_actionable_message(monkeypatch):
+    monkeypatch.setattr(settings, "import_max_fronts", 5)
+    with pytest.raises(ImportPayloadError) as exc:
+        il.enforce_import_row_caps({"fronts": 6})
+    msg = str(exc.value)
+    assert "6 fronts" in msg
+    assert "5 Sheaf imports in one job" in msg
+    assert "Split the file" in msg
+
+
+def test_row_caps_uses_readable_entity_labels(monkeypatch):
+    monkeypatch.setattr(settings, "import_max_journal_entries", 2)
+    monkeypatch.setattr(settings, "import_max_custom_fields", 2)
+    with pytest.raises(ImportPayloadError) as exc:
+        il.enforce_import_row_caps({"journal_entries": 3})
+    assert "3 journal entries" in str(exc.value)
+    with pytest.raises(ImportPayloadError) as exc:
+        il.enforce_import_row_caps({"custom_fields": 3})
+    assert "3 custom fields" in str(exc.value)
+
+
+def test_row_caps_unknown_key_is_ignored(monkeypatch):
+    # A label with no matching setting has no cap and must not raise.
+    il.enforce_import_row_caps({"widgets": 10_000_000})
+
+
+def test_row_cap_warnings_mirror_enforcement(monkeypatch):
+    monkeypatch.setattr(settings, "import_max_messages", 5)
+    monkeypatch.setattr(settings, "import_max_polls", 5)
+    warnings = il.import_row_cap_warnings({"messages": 6, "polls": 2})
+    # Only the over-cap entity produces a line; the under-cap one is silent.
+    assert len(warnings) == 1
+    assert "6 messages" in warnings[0]
+    assert "5 Sheaf imports in one job" in warnings[0]
+
+
+def test_row_cap_warnings_empty_when_all_under_cap(monkeypatch):
+    monkeypatch.setattr(settings, "import_max_fronts", 100)
+    assert il.import_row_cap_warnings({"fronts": 1}) == []
+
+
+def test_native_preview_surfaces_over_cap(monkeypatch):
+    """The native preview folds the row-cap prediction into limit_warnings so
+    the user sees an over-cap export before committing, not only when the job
+    fails."""
+    from sheaf.services import sheaf_import
+
+    monkeypatch.setattr(settings, "import_max_fronts", 1)
+    data = {
+        "version": 2,
+        "members": [{"id": "m1", "name": "Solo"}],
+        "fronts": [{"id": "f1"}, {"id": "f2"}, {"id": "f3"}],
+    }
+    summary = sheaf_import.preview(data)
+    assert any(
+        "3 fronts" in w and "one job" in w for w in summary.limit_warnings
+    ), summary.limit_warnings

--- a/tests/test_imports_pluralspace_runner.py
+++ b/tests/test_imports_pluralspace_runner.py
@@ -292,6 +292,42 @@ def test_preview_returns_summary(auth_client: httpx.Client):
     assert names == {"Alpha", "Beta"}
 
 
+def test_preview_warns_when_open_polls_exceed_concurrent_cap(
+    auth_client: httpx.Client,
+):
+    """PluralSpace polls that would import OPEN (future or open-ended close
+    time) past the tier's concurrent-open cap surface the clamp warning in
+    the preview, matching what the import raises."""
+    cap = auth_client.get("/v1/polls/server-config").json()[
+        "max_concurrent_open_polls"
+    ]
+    if cap == 0:
+        # Unlimited tier (selfhosted-style deployment): the clamp never fires.
+        return
+    over = 2
+    data = _sample_data()
+    data["polls"] = [
+        {
+            "id": str(uuid.uuid4()),
+            "title": f"open question {i}",
+            "closes_at": "2027-01-01T00:00:00+00:00",
+            "options": [],
+        }
+        for i in range(cap + over)
+    ]
+    resp = auth_client.post(
+        "/v1/import/pluralspace/preview",
+        files={"file": ("export.zip", _build_zip(data), "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["open_poll_count"] == cap + over
+    hits = [w for w in body["limit_warnings"] if "concurrent-open-poll" in w]
+    assert hits, body["limit_warnings"]
+    # Fresh account -> 0 existing open polls, so the overage is exactly `over`.
+    assert hits[0].startswith(f"{over} poll(s)")
+
+
 def test_preview_rejects_non_zip(auth_client: httpx.Client):
     resp = auth_client.post(
         "/v1/import/pluralspace/preview",

--- a/tests/test_imports_prism_runner.py
+++ b/tests/test_imports_prism_runner.py
@@ -403,6 +403,44 @@ def test_preview_decrypts_and_returns_summary(auth_client: httpx.Client):
     assert names == {"Member-A", "Member-B"}
 
 
+def test_preview_warns_when_open_polls_exceed_concurrent_cap(
+    auth_client: httpx.Client,
+):
+    """Prism polls that would import OPEN (not closed -> one-year window)
+    past the tier's concurrent-open cap surface the clamp warning in the
+    preview, matching what the import raises."""
+    cap = auth_client.get("/v1/polls/server-config").json()[
+        "max_concurrent_open_polls"
+    ]
+    if cap == 0:
+        # Unlimited tier (selfhosted-style deployment): the clamp never fires.
+        return
+    over = 2
+    payload, _ = _make_export(with_polls=False)
+    payload["polls"] = [
+        {
+            "id": str(uuid.uuid4()),
+            "question": f"Q{i}?",
+            "isClosed": False,
+            "createdAt": "2026-06-01T10:00:00.000Z",
+        }
+        for i in range(cap + over)
+    ]
+    envelope = synthesize_envelope(payload, _PASSPHRASE)
+    resp = auth_client.post(
+        "/v1/import/prism/preview",
+        files={"file": ("e.prism", envelope, "application/octet-stream")},
+        data={"passphrase": _PASSPHRASE},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["open_poll_count"] == cap + over
+    hits = [w for w in body["limit_warnings"] if "concurrent-open-poll" in w]
+    assert hits, body["limit_warnings"]
+    # Fresh account -> 0 existing open polls, so the overage is exactly `over`.
+    assert hits[0].startswith(f"{over} poll(s)")
+
+
 def test_preview_wrong_passphrase_is_400(auth_client: httpx.Client):
     payload, _ = _make_export()
     envelope = synthesize_envelope(payload, _PASSPHRASE)

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -17,7 +17,7 @@ from tests._import_runner_helpers import (
     wait_for_terminal,
 )
 
-# Minimal valid Sheaf export — version + a couple of members. Other
+# Minimal valid Sheaf export - version + a couple of members. Other
 # sections empty; enough to prove the runner walks the canonical
 # export dict.
 _SHEAF_EXPORT = {
@@ -495,6 +495,41 @@ def test_sheaf_runner_hard_fails_over_member_cap(admin_client: httpx.Client):
     assert admin_client.get("/v1/members/limit").json()["current"] == 0
 
 
+def test_sheaf_runner_hard_fails_over_row_cap(auth_client: httpx.Client):
+    """An import whose per-entity row count exceeds a per-import row cap fails
+    cleanly up front (bomb protection), like the member cap. A low cap is
+    injected into the runner process so the test doesn't have to build a
+    hundred-thousand-row fixture. Tags need no member cross-references, so
+    three of them exceed a cap of 1 with a one-member payload."""
+    export = {
+        "version": 2,
+        "system": {"name": "Bomb"},
+        "members": [{"id": "m1", "name": "Solo"}],
+        "tags": [
+            {"id": "t1", "name": "one", "member_ids": []},
+            {"id": "t2", "name": "two", "member_ids": []},
+            {"id": "t3", "name": "three", "member_ids": []},
+        ],
+    }
+    job = _post_file(auth_client, payload=json.dumps(export).encode())
+    drive_import_runner(
+        setup="import sheaf.config; sheaf.config.settings.import_max_tags = 1"
+    )
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    blob = (
+        (final.get("last_error") or "")
+        + " "
+        + " ".join(e["message"] for e in final["events"])
+    ).lower()
+    assert "tags" in blob and "one job" in blob, final
+
+    # Nothing was written: none of the tags landed.
+    names = {t["name"] for t in auth_client.get("/v1/tags").json()}
+    assert not ({"one", "two", "three"} & names), names
+
+
 # A foreign-looking owner UUID. Doesn't have to exist as a real user; the
 # import only inspects the structural shape of the key path, not whether
 # the embedded user_id resolves to anything live.
@@ -590,7 +625,7 @@ def test_sheaf_runner_strips_cross_account_image_refs(auth_client: httpx.Client)
 
     # Journal entry body lost the internal embed. `image_keys` is an
     # internal column used by the orphan sweeper, not exposed on
-    # JournalEntryRead — the body assertion above is the user-visible
+    # JournalEntryRead - the body assertion above is the user-visible
     # proof that the strip ran; the corresponding image_keys clear is
     # verified by the strip-helper unit tests.
     journals = auth_client.get("/v1/journals").json()
@@ -758,3 +793,171 @@ def test_sheaf_reimport_is_idempotent_across_all_sections(
     assert len(auth_client.get("/v1/members").json()) == 2
     assert len(auth_client.get("/v1/groups").json()) == 1
     assert len(auth_client.get("/v1/fields").json()) == 1
+
+
+def _deep_group_export(depth: int) -> dict:
+    """A single member plus a `depth`-long parent chain of groups, the deepest
+    group carrying the member. Used to prove the importer clamps nesting depth
+    the way the create API does (MAX_GROUP_DEPTH = 8)."""
+    groups = [
+        {
+            "id": f"g{i}",
+            "name": f"Deep {i}",
+            "parent_id": f"g{i - 1}" if i > 1 else None,
+            "member_ids": ["m1"] if i == depth else [],
+        }
+        for i in range(1, depth + 1)
+    ]
+    return {
+        "version": "2",
+        "system": {"name": "Deep Groups"},
+        "members": [{"id": "m1", "name": "DeepAda"}],
+        "fronts": [],
+        "groups": groups,
+        "tags": [],
+        "custom_fields": [],
+    }
+
+
+def test_sheaf_runner_clamps_group_nesting_depth(auth_client: httpx.Client):
+    """A crafted export nesting groups 10 deep imports every group, but the
+    ones past MAX_GROUP_DEPTH (8) are reparented up so none exceed the cap.
+    Memberships ride along untouched and the job warns about the move."""
+    job = _post_file(auth_client, payload=json.dumps(_deep_group_export(10)).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+    # Every group came across (nothing dropped for being too deep).
+    assert final["counts"]["groups_imported"] == 10, final["counts"]
+    # The clamp warned the user.
+    assert any(
+        "maximum nesting depth (8)" in e["message"] for e in final["events"]
+    ), final["events"]
+
+    groups = auth_client.get("/v1/groups").json()
+    assert len(groups) == 10
+    parent_of = {g["id"]: g["parent_id"] for g in groups}
+
+    def depth(gid: str) -> int:
+        seen: set[str] = set()
+        d = 0
+        cur: str | None = gid
+        while cur is not None and cur not in seen:
+            seen.add(cur)
+            d += 1
+            cur = parent_of.get(cur)
+        return d
+
+    # No group ends deeper than the cap.
+    assert max(depth(g["id"]) for g in groups) <= 8, parent_of
+
+    # The membership on the deepest source group survived the reparent.
+    deepest = next(g for g in groups if g["name"] == "Deep 10")
+    members = auth_client.get(f"/v1/groups/{deepest['id']}/members").json()
+    assert any(m["name"] == "DeepAda" for m in members), members
+
+
+def test_sheaf_runner_survives_cyclic_group_parents(auth_client: httpx.Client):
+    """A malformed export whose group parents loop must not hang the importer;
+    the cycle is cut (a group is rooted) and the job completes."""
+    export = {
+        "version": "2",
+        "system": {"name": "Loopy Groups"},
+        "members": [],
+        "fronts": [],
+        "groups": [
+            {"id": "a", "name": "Loop A", "parent_id": "b"},
+            {"id": "b", "name": "Loop B", "parent_id": "a"},
+        ],
+        "tags": [],
+        "custom_fields": [],
+    }
+    job = _post_file(auth_client, payload=json.dumps(export).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+    assert final["counts"]["groups_imported"] == 2, final["counts"]
+
+    groups = auth_client.get("/v1/groups").json()
+    parent_of = {g["id"]: g["parent_id"] for g in groups}
+    # The loop was broken: at least one of the two is now a root.
+    assert any(p is None for p in parent_of.values()), parent_of
+
+
+def test_sheaf_runner_clamps_concurrent_open_polls(auth_client: httpx.Client):
+    """A crafted export with more OPEN polls than the tier's concurrent-open
+    cap imports every poll (votes included) but flips the oldest excess to
+    closed, so the system never lands over the cap the create API enforces.
+
+    Guarded like test_polls_api.test_concurrent_cap_enforced: a selfhosted
+    deployment has no cap (0) and nothing to clamp, so the test is a no-op
+    there and does its real work under a capped (saas) tier."""
+    from datetime import UTC, datetime, timedelta
+
+    cfg = auth_client.get("/v1/polls/server-config").json()
+    cap = cfg["max_concurrent_open_polls"]
+    if cap == 0:
+        return
+
+    # How many polls the system already has open, so the assertions hold even
+    # if a prior test left some behind.
+    open_before = sum(
+        1 for p in auth_client.get("/v1/polls").json() if not p["is_closed"]
+    )
+
+    now = datetime.now(UTC)
+    n = cap + 2
+    polls = [
+        {
+            "id": f"p{i}",
+            "question": f"Q{i}",
+            "kind": "single_choice",
+            "results_visibility": "live",
+            # All open (close well in the future); distinct created_at so the
+            # keep-newest ordering is deterministic.
+            "closes_at": (now + timedelta(days=7)).isoformat(),
+            "created_at": (now + timedelta(minutes=i)).isoformat(),
+            "retention_days": 30,
+            "options": [
+                {"id": f"o{i}a", "text": "a", "position": 0},
+                {"id": f"o{i}b", "text": "b", "position": 1},
+            ],
+            "votes": [{"voted_as_member_id": "m1", "option_ids": [f"o{i}a"]}],
+        }
+        for i in range(n)
+    ]
+    export = {
+        "version": "2",
+        "system": {"name": "Poll Cap"},
+        "members": [{"id": "m1", "name": "PollAda"}],
+        "fronts": [],
+        "groups": [],
+        "tags": [],
+        "custom_fields": [],
+        "polls": polls,
+    }
+    job = _post_file(auth_client, payload=json.dumps(export).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+    # Every poll imported (nothing dropped for being over the cap).
+    assert final["counts"]["polls_imported"] == n, final["counts"]
+    # The clamp warned about the excess.
+    assert any(
+        "concurrent-open-poll limit" in e["message"] for e in final["events"]
+    ), final["events"]
+
+    listed = auth_client.get("/v1/polls").json()
+    open_now = sum(1 for p in listed if not p["is_closed"])
+    # The system never ends over the cap the create API enforces (fresh system,
+    # so open_before is 0 and open_now settles at exactly the cap).
+    assert open_now <= max(cap, open_before), (open_now, cap, open_before)
+    # We imported cap+2 open polls, so the excess had to land closed: the number
+    # of imported polls left open can't exceed the free slots that existed.
+    imported = [p for p in listed if p["question"].startswith("Q")]
+    imported_open = sum(1 for p in imported if not p["is_closed"])
+    assert imported_open <= max(cap - open_before, 0), (imported_open, cap)
+
+    # Non-destructive: every imported poll kept its single vote, closed or not.
+    assert len(imported) == n
+    assert all(p["total_votes"] == 1 for p in imported), imported

--- a/tests/test_imports_tb_sp_runner.py
+++ b/tests/test_imports_tb_sp_runner.py
@@ -188,6 +188,25 @@ def test_sp_warns_when_field_value_references_unknown_field(
     ), final["events"]
 
 
+def test_sp_clamps_deep_group_nesting(auth_client: httpx.Client):
+    """SP builds a nested group tree via `parent`; a chain deeper than the API's
+    MAX_GROUP_DEPTH is reparented up to fit, so the import completes (rather than
+    creating an over-deep tree) and warns. The reparent is only applied when a
+    group was too deep, so the depth warning firing means the clamp ran."""
+    groups = [{"_id": "g0", "name": "g0", "parent": "root"}]
+    for i in range(1, 12):  # 12-deep chain, well past the depth-8 cap
+        groups.append({"_id": f"g{i}", "name": f"g{i}", "parent": f"g{i - 1}"})
+    payload = _sp_payload(groups=groups)
+    job = _post_file(auth_client, source="simplyplural_file", payload=payload)
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert any(
+        "nesting depth" in w for w in _warnings(final["events"])
+    ), final["events"]
+
+
 def test_sp_warns_when_front_history_member_missing(auth_client: httpx.Client):
     payload = _sp_payload(
         frontHistory=[

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -243,6 +243,65 @@ def test_journal_revision_volume_metrics_present():
         assert _series_value(body, name) is not None, f"missing series: {name}"
 
 
+def test_capped_entity_volume_metrics_present():
+    """The remaining bulk-creatable capped entities (board messages, polls,
+    groups, tags, custom fields, reminders) each expose a label-less global
+    total, a label-less per-system max, and a live-create counter, all present
+    from the first scrape. The `le`-labelled per-system distribution gauges
+    only appear once the distribution refresher has run, so not asserted
+    here (see test_capped_entity_distributions_populate)."""
+    body = _scrape()
+    for name in (
+        "sheaf_messages_total",
+        "sheaf_system_message_count_max",
+        "sheaf_messages_created_total",
+        "sheaf_polls_total",
+        "sheaf_system_poll_count_max",
+        "sheaf_polls_created_total",
+        "sheaf_open_polls_total",
+        "sheaf_system_open_poll_count_max",
+        "sheaf_groups_total",
+        "sheaf_system_group_count_max",
+        "sheaf_groups_created_total",
+        "sheaf_tags_total",
+        "sheaf_system_tag_count_max",
+        "sheaf_tags_created_total",
+        "sheaf_custom_fields_total",
+        "sheaf_system_custom_field_count_max",
+        "sheaf_custom_fields_created_total",
+        "sheaf_reminders_total",
+        "sheaf_system_reminder_count_max",
+        "sheaf_reminders_created_total",
+    ):
+        assert _series_value(body, name) is not None, f"missing series: {name}"
+
+
+def test_capped_entity_distributions_populate(admin_client: httpx.Client):
+    """Triggering the hourly distribution job exercises the SQL-side
+    MAX + count(*) FILTER aggregation for every capped-entity distribution
+    and sets the `le`-labelled snapshot gauges. After a run each distribution
+    exposes its `+Inf` bucket (total groups counted). Mirrors the front /
+    journal distribution wiring, just asserted end-to-end."""
+    resp = admin_client.post(
+        "/v1/admin/jobs/refresh_metrics_gauge_distributions/run"
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "success"
+
+    body = _scrape()
+    for name in (
+        "sheaf_systems_by_message_count",
+        "sheaf_systems_by_poll_count",
+        "sheaf_systems_by_open_poll_count",
+        "sheaf_systems_by_group_count",
+        "sheaf_systems_by_tag_count",
+        "sheaf_systems_by_custom_field_count",
+        "sheaf_systems_by_reminder_count",
+    ):
+        val = _series_value(body, name, {"le": "+Inf"})
+        assert val is not None, f"missing +Inf bucket for {name}"
+
+
 # ---------------------------------------------------------------------------
 # Leader election
 # ---------------------------------------------------------------------------

--- a/tests/test_pluralspace_caps.py
+++ b/tests/test_pluralspace_caps.py
@@ -78,3 +78,25 @@ def test_preview_no_warnings_when_within_caps() -> None:
     parsed = parse_export(_build_zip(data))
     summary = preview(parsed)
     assert summary.limit_warnings == []
+
+
+def test_preview_surfaces_over_cap_messages(monkeypatch) -> None:
+    """Chat rows (flattened across channels) over the per-import messages cap
+    are predicted in the preview, ahead of the job's authoritative enforcement.
+    """
+    from sheaf.config import settings
+
+    monkeypatch.setattr(settings, "import_max_messages", 2)
+    data = {
+        "system": {"name": "Sys"},
+        "members": [{"id": "m1", "name": "Alex"}],
+        "chat_channels": [
+            {"name": "c1", "messages": [{"content": "a"}, {"content": "b"}]},
+            {"name": "c2", "messages": [{"content": "c"}]},
+        ],
+    }
+    parsed = parse_export(_build_zip(data))
+    summary = preview(parsed)
+    assert any(
+        "3 messages" in w and "one job" in w for w in summary.limit_warnings
+    ), summary.limit_warnings

--- a/tests/test_prism_import_caps.py
+++ b/tests/test_prism_import_caps.py
@@ -1,13 +1,21 @@
-"""Pure unit tests for the Prism importer's business-cap preview pass.
+"""Pure unit tests for the Prism importer's business-cap preview pass and
+its media parse-bomb caps.
 
 These build a `ParsedPrism` directly from a decrypted-envelope dict, so
 they exercise the `preview` measurement (`limit_warnings`) without any
-crypto, database, or running server. The full encrypted-envelope path is
-covered by test_imports_prism_runner.py.
+crypto, database, or running server. The media-cap tests call
+`_import_media_attachments` directly with `store_imported_image` stubbed,
+so no image decode or storage actually happens. The full encrypted-envelope
+path is covered by test_imports_prism_runner.py.
 """
 
 from __future__ import annotations
 
+import asyncio
+
+from sheaf.config import settings
+from sheaf.services import prism_import
+from sheaf.services.import_media import ImportImageError
 from sheaf.services.prism_crypto import DecryptedEnvelope
 from sheaf.services.prism_import import ParsedPrism, preview
 
@@ -60,3 +68,104 @@ def test_preview_clean_export_has_no_limit_warnings():
     )
     summary = preview(parsed)
     assert summary.limit_warnings == []
+
+
+def test_preview_surfaces_over_cap_fronts(monkeypatch):
+    """A frontSessions count over the per-import cap is predicted in the
+    preview so the user is warned before the job fails."""
+    monkeypatch.setattr(settings, "import_max_fronts", 1)
+    parsed = _parsed(
+        {
+            "headmates": [{"id": "m1", "name": "ok"}],
+            "frontSessions": [{"id": "s1"}, {"id": "s2"}],
+        }
+    )
+    summary = preview(parsed)
+    assert any(
+        "2 fronts" in w and "one job" in w for w in summary.limit_warnings
+    ), summary.limit_warnings
+
+
+def test_preview_over_cap_messages_counts_board_posts(monkeypatch):
+    """Conversations and member board posts both become Message rows, so the
+    messages cap prediction sums the two."""
+    monkeypatch.setattr(settings, "import_max_messages", 2)
+    parsed = _parsed(
+        {
+            "headmates": [{"id": "m1", "name": "ok"}],
+            "messages": [{"id": "c1"}, {"id": "c2"}],
+            "memberBoardPosts": [{"id": "b1"}],
+        }
+    )
+    summary = preview(parsed)
+    assert any(
+        "3 messages" in w for w in summary.limit_warnings
+    ), summary.limit_warnings
+
+
+# ---------------------------------------------------------------------------
+# Media parse-bomb caps (_import_media_attachments)
+# ---------------------------------------------------------------------------
+
+
+def _media_atts(n: int) -> tuple[list[dict], dict[str, bytes]]:
+    atts = [{"mediaId": f"m{i}", "encryptionKeyB64": "key"} for i in range(n)]
+    blobs = {f"m{i}": b"blob" for i in range(n)}
+    return atts, blobs
+
+
+def test_media_import_stops_at_image_cap(monkeypatch):
+    """Once max_import_restored_images images have been stored, the loop stops
+    rather than decoding every remaining attachment (each store runs a Pillow
+    normalisation pass, so an unbounded loop is the parse bomb)."""
+    monkeypatch.setattr(settings, "max_import_restored_images", 3)
+    monkeypatch.setattr(prism_import, "user_can_upload_images", lambda user: True)
+    monkeypatch.setattr(
+        prism_import, "decrypt_media_blob", lambda blob, key: b"decoded"
+    )
+    calls = {"n": 0}
+
+    async def fake_store(plaintext, *, db, user, purpose):
+        calls["n"] += 1
+        return object()
+
+    monkeypatch.setattr(prism_import, "store_imported_image", fake_store)
+
+    atts, blobs = _media_atts(10)
+    warnings: list[str] = []
+    imported = asyncio.run(
+        prism_import._import_media_attachments(
+            atts, blobs, None, object(), warnings
+        )
+    )
+    assert imported == 3
+    assert calls["n"] == 3  # stopped decoding once the cap was reached
+    assert any("MAX_IMPORT_RESTORED_IMAGES" in w for w in warnings), warnings
+
+
+def test_media_import_breaks_on_quota_full(monkeypatch):
+    """On the first quota_full, image import stops entirely rather than running
+    a normalise pass per remaining attachment on an already-full account."""
+    monkeypatch.setattr(settings, "max_import_restored_images", 1000)
+    monkeypatch.setattr(prism_import, "user_can_upload_images", lambda user: True)
+    monkeypatch.setattr(
+        prism_import, "decrypt_media_blob", lambda blob, key: b"decoded"
+    )
+    calls = {"n": 0}
+
+    async def fake_store(plaintext, *, db, user, purpose):
+        calls["n"] += 1
+        raise ImportImageError("quota_full")
+
+    monkeypatch.setattr(prism_import, "store_imported_image", fake_store)
+
+    atts, blobs = _media_atts(10)
+    warnings: list[str] = []
+    imported = asyncio.run(
+        prism_import._import_media_attachments(
+            atts, blobs, None, object(), warnings
+        )
+    )
+    assert imported == 0
+    assert calls["n"] == 1  # broke on the first quota_full, didn't decode 10
+    assert any("quota" in w.lower() for w in warnings), warnings

--- a/tests/test_sheaf_import.py
+++ b/tests/test_sheaf_import.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import json
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
@@ -22,6 +23,15 @@ def _upload(client: httpx.Client, path: str, payload: dict) -> httpx.Response:
         path,
         files={"file": ("export.json", io.BytesIO(body), "application/json")},
     )
+
+
+def _future_iso(days: int = 30) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def _open_poll(pid: str) -> dict:
+    """A native-shape poll that would import OPEN (closes_at in the future)."""
+    return {"id": pid, "question": "q?", "closes_at": _future_iso(), "options": []}
 
 
 def test_preview_rejects_missing_version(auth_client: httpx.Client):
@@ -92,3 +102,49 @@ def test_preview_accepts_v2_with_extra_keys(auth_client: httpx.Client):
     assert body["reminder_count"] == 1
     # channel_count sums channels across all watch tokens.
     assert body["channel_count"] == 2
+
+
+def test_preview_warns_when_open_polls_exceed_concurrent_cap(
+    auth_client: httpx.Client,
+):
+    """More incoming OPEN polls than the tier's concurrent-open cap allows
+    surfaces the same clamp warning the import would raise, so the user can
+    cancel/adjust before enqueueing."""
+    cap = auth_client.get("/v1/polls/server-config").json()[
+        "max_concurrent_open_polls"
+    ]
+    if cap == 0:
+        # Unlimited tier (selfhosted-style deployment): the clamp never fires.
+        return
+    over = 2
+    polls = [_open_poll(f"p{i}") for i in range(cap + over)]
+    resp = _upload(
+        auth_client,
+        "/v1/import/sheaf/preview",
+        {"version": "2", "system": {"name": "S"}, "members": [], "polls": polls},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["open_poll_count"] == cap + over
+    hits = [w for w in body["limit_warnings"] if "concurrent-open-poll" in w]
+    assert hits, body["limit_warnings"]
+    # A fresh account starts with 0 open polls, so the overage is exactly `over`.
+    assert hits[0].startswith(f"{over} poll(s)")
+
+
+def test_preview_no_warning_when_open_polls_within_cap(auth_client: httpx.Client):
+    cap = auth_client.get("/v1/polls/server-config").json()[
+        "max_concurrent_open_polls"
+    ]
+    # Unlimited tier: any count is within cap. Otherwise stay one under.
+    n = 3 if cap == 0 else max(cap - 1, 0)
+    polls = [_open_poll(f"p{i}") for i in range(n)]
+    resp = _upload(
+        auth_client,
+        "/v1/import/sheaf/preview",
+        {"version": "2", "system": {"name": "S"}, "members": [], "polls": polls},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["open_poll_count"] == n
+    assert not [w for w in body["limit_warnings"] if "concurrent-open-poll" in w]

--- a/tests/test_sp_caps.py
+++ b/tests/test_sp_caps.py
@@ -57,3 +57,19 @@ def test_preview_clean_export_has_no_limit_warnings():
     }
     summary = preview(data)
     assert summary.limit_warnings == []
+
+
+def test_preview_surfaces_over_cap_front_history(monkeypatch):
+    """Front-history rows over the per-import cap are predicted in the preview,
+    so the user is warned before the job fails (bomb protection)."""
+    from sheaf.config import settings
+
+    monkeypatch.setattr(settings, "import_max_fronts", 1)
+    data = {
+        "members": [{"_id": "a", "name": "A"}],
+        "frontHistory": [{"member": "a"}, {"member": "a"}],
+    }
+    summary = preview(data)
+    assert any(
+        "2 fronts" in w and "one job" in w for w in summary.limit_warnings
+    ), summary.limit_warnings


### PR DESCRIPTION
Third batch of the preserve-by-default resilience work. The last two PRs
bounded reads and per-account write rates; this bounds what a single IMPORT
can create, closes two importer bypasses of API invariants, and instruments
the entities involved so the caps can be tuned from real usage. Green across
all server configurations.

## Per-import row caps
Importers build database rows directly from an uploaded export, so a crafted
or just very large file could create hundreds of thousands of rows in one
transaction. Only the member cap and per-field clamps guarded this before.

- Per-import row caps for fronts, journal entries, board messages, revisions,
  polls, groups, tags, and custom fields, enforced before the write loop
  across every importer and surfaced at preview with a "split the file or
  contact support" message. Defaults are set generously above observed
  real-world usage (grounded in the volume metrics) and are config-overridable.
  The native importer's caps cover the OpenPlural and with-images-archive
  paths, which route through it.
- The Prism media importer no longer decodes every attachment on a full
  account: it honours the per-import image cap and stops once storage is full,
  matching the archive importer.

## Importer bypass clamps (non-destructive)
- Imported open polls beyond the tier's concurrent-open limit are imported
  already-closed (newest kept open); polls, options, and votes are preserved.
  The clamp is surfaced at preview (DB-accurate) as well as at import.
- Groups nested deeper than the API's limit are reparented up to fit, via a
  cycle-safe, provably-terminating depth pass; no groups or memberships lost.

## Volume metrics
Board messages, polls (plus an open-poll gauge), groups, tags, custom fields,
and reminders each get a global total, a label-less per-system distribution
and max, and a create counter, following the existing front/journal/revision
pattern (id-free snapshots; distributions computed in SQL on the hourly pass).
This closes the instrument-first gap so every new cap can be tuned from data.
Documented in docs/METRICS.md.

## Testing
Full suite green across all nine configurations. New tests cover the row-cap
enforcement and preview surfacing per importer, the Prism media cap, the
open-poll clamp (unit + preview + import), the group-depth clamp (including
cyclic-parent termination), the PluralSpace union group count, and the new
gauges.

## Follow-up
The new gauges need Grafana dashboard panels (operator side).
