### PR TITLE
Operator kill switch for data-deleting jobs, and a poll-purge activity trace

### DIFF
--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -85,6 +85,25 @@ class Settings(BaseSettings):
     orphan_cleanup_interval_hours: int = 24  # how often orphan file cleanup runs
     job_log_retention_days: int = 30  # how long to keep job run logs
 
+    # Incident-response master kill switch for data-deleting background jobs.
+    # Flip to False to halt EVERY job marked `destructive=True` in one move -
+    # the "stop all data deletion" lever an operator can reach for while
+    # investigating a suspected retention bug, instead of editing each job's
+    # interval to 0 one at a time.
+    # Non-deleting jobs and operational cleanups are unaffected. The one
+    # deliberate exception is the security-event (IP) cleanup below, which is a
+    # privacy obligation kept on its own switch so a blanket pause can't silence
+    # it.
+    destructive_jobs_enabled: bool = True
+
+    # Separate switch for the security-event (IP) cleanup only. That sweep
+    # enforces the 30-day IP retention promise (see security_event_retention_days)
+    # and is a privacy-policy obligation, so it is deliberately NOT gated by the
+    # destructive_jobs_enabled master switch - an incident pause must not leave
+    # IPs sitting past their retention window. Set False only if you must stop
+    # IP minimisation for a specific, considered reason.
+    security_event_cleanup_enabled: bool = True
+
     # File storage
     storage_backend: str = "filesystem"  # "filesystem" or "s3"
     storage_path: Path = Path("data/files")

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -40,6 +40,9 @@ class JobDefinition:
     func: JobFunc
     interval_seconds: Callable[[], int]
     enabled: Callable[[], bool]
+    # True for jobs that delete or hard-mutate user data. These are the jobs
+    # the destructive_jobs_enabled master switch pauses in one move.
+    destructive: bool = False
 
 
 _REGISTRY: dict[str, JobDefinition] = {}
@@ -51,6 +54,7 @@ def register_job(
     func: JobFunc,
     interval_seconds: Callable[[], int],
     enabled: Callable[[], bool] | None = None,
+    destructive: bool = False,
 ) -> None:
     """Register a job for periodic execution."""
     _REGISTRY[name] = JobDefinition(
@@ -59,11 +63,19 @@ def register_job(
         func=func,
         interval_seconds=interval_seconds,
         enabled=enabled or (lambda: True),
+        destructive=destructive,
     )
 
 
 def get_registry() -> dict[str, JobDefinition]:
     return _REGISTRY
+
+
+def _destructive_paused(job: JobDefinition) -> bool:
+    """True when a destructive job must be skipped because the master kill
+    switch is off. Split out so the runner loop and its tests share one
+    definition of the freeze."""
+    return job.destructive and not settings.destructive_jobs_enabled
 
 
 async def run_job(job_name: str, db: AsyncSession) -> JobRun:
@@ -189,7 +201,17 @@ async def job_runner_loop() -> None:
             if not job.enabled():
                 continue
 
-            # Use a job-scoped name — assigning to the outer `interval`
+            # Incident-response freeze: a destructive job is skipped while the
+            # master kill switch is off, exactly like a disabled one. One INFO
+            # line per skip so an operator can see the freeze is in effect.
+            if _destructive_paused(job):
+                logger.info(
+                    "skipping destructive job %s: destructive_jobs_enabled is off",
+                    name,
+                )
+                continue
+
+            # Use a job-scoped name - assigning to the outer `interval`
             # here would corrupt the loop's own wake cadence on the next
             # `asyncio.sleep(interval)`, drifting it to whatever the
             # last-registered job's interval happens to be.
@@ -1013,11 +1035,19 @@ def _register_all_jobs() -> None:
         return
     _registered = True
 
+    # process_account_deletions and finalize_pending_actions execute
+    # USER-REQUESTED deletions (a scheduled account deletion past its grace;
+    # System Safety destructive actions past their grace). They are included in
+    # the freeze so an incident pause stops ALL data deletion, in-flight user
+    # requests included. If an operator instead wants user-requested deletions
+    # to keep flowing while destructive_jobs_enabled is off, flip these two to
+    # destructive=False - that is the one deliberate change to make here.
     register_job(
         name="process_account_deletions",
         description="Permanently delete accounts past their grace period",
         func=_process_account_deletions,
         interval_seconds=lambda: settings.job_check_interval_minutes * 60,
+        destructive=True,
     )
 
     register_job(
@@ -1037,6 +1067,7 @@ def _register_all_jobs() -> None:
             settings.sheaf_mode == SheafMode.SAAS
             and settings.email_verification == "required"
         ),
+        destructive=True,
     )
 
     register_job(
@@ -1044,6 +1075,7 @@ def _register_all_jobs() -> None:
         description="Delete uploaded files no longer referenced by any member or system",
         func=_cleanup_orphaned_files,
         interval_seconds=lambda: settings.orphan_cleanup_interval_hours * 3600,
+        destructive=True,
     )
 
     register_job(
@@ -1052,6 +1084,7 @@ def _register_all_jobs() -> None:
         func=_prune_free_tier_fronts,
         interval_seconds=lambda: settings.retention_check_interval_hours * 3600,
         enabled=lambda: settings.sheaf_mode == SheafMode.SAAS,
+        destructive=True,
     )
 
     register_job(
@@ -1059,6 +1092,7 @@ def _register_all_jobs() -> None:
         description="Trim journal/bio revision history to per-user effective caps",
         func=_gc_revisions,
         interval_seconds=lambda: settings.journal_gc_interval_hours * 3600,
+        destructive=True,
     )
 
     register_job(
@@ -1075,11 +1109,17 @@ def _register_all_jobs() -> None:
         interval_seconds=lambda: 86400,  # daily
     )
 
+    # NOT marked destructive on purpose. This deletes IP-bearing security
+    # events to honour the retention promise: it removes no user content, it
+    # enforces a privacy obligation. It carries its own switch
+    # (security_event_cleanup_enabled) so the destructive_jobs_enabled master
+    # pause cannot silently stop IP minimisation while it is engaged.
     register_job(
         name="cleanup_security_events",
         description="Delete security-event rows past the retention window",
         func=_cleanup_security_events,
         interval_seconds=lambda: 86400,  # daily
+        enabled=lambda: settings.security_event_cleanup_enabled,
     )
 
     register_job(
@@ -1087,13 +1127,19 @@ def _register_all_jobs() -> None:
         description="Delete account-activity rows past the retention window",
         func=_cleanup_activity_events,
         interval_seconds=lambda: 86400,  # daily
+        destructive=True,
     )
 
+    # See the note on process_account_deletions above: this finalizes
+    # user-requested System Safety deletions and is frozen with them. Flip to
+    # destructive=False if user-requested deletions should keep running during
+    # an incident pause.
     register_job(
         name="finalize_pending_actions",
         description="Execute System Safety pending destructive actions past their grace period",
         func=_finalize_pending_actions,
         interval_seconds=lambda: settings.job_check_interval_minutes * 60,
+        destructive=True,
     )
 
     register_job(
@@ -1137,6 +1183,7 @@ def _register_all_jobs() -> None:
         description="Delete polls past their retention window post-close",
         func=_purge_expired_polls,
         interval_seconds=lambda: settings.poll_cleanup_interval_hours * 3600,
+        destructive=True,
     )
 
     # NOTE: the import *runner* is NOT registered here. It needs a

--- a/sheaf/services/polls.py
+++ b/sheaf/services/polls.py
@@ -16,12 +16,13 @@ import uuid
 from collections import Counter
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from sheaf.config import settings
 from sheaf.crypto import decrypt, encrypt
+from sheaf.models.activity_event import ActivityAction, ActivityActorType
 from sheaf.models.front import Front
 from sheaf.models.member import Member
 from sheaf.models.poll import (
@@ -30,7 +31,9 @@ from sheaf.models.poll import (
     PollVoteAction,
     PollVoteEvent,
 )
+from sheaf.models.system import System
 from sheaf.models.user import User, UserTier
+from sheaf.services.activity_log import log_activity
 
 logger = logging.getLogger("sheaf.polls")
 
@@ -392,12 +395,47 @@ def purges_at(poll: Poll) -> datetime:
 async def purge_expired_polls(db: AsyncSession) -> int:
     """Delete polls whose closes_at + retention_days has elapsed.
 
-    Cascades remove options, votes, and audit events.
+    Cascades remove options, votes, and audit events (DB-level ON DELETE
+    CASCADE on poll_options / poll_votes / poll_vote_events).
+
+    Nothing-silent: before deleting, group the expiring polls by owning user
+    and leave one content-free RETENTION_PRUNED account-activity trace per
+    affected user (detail {"polls_purged": n}), mirroring the front-retention
+    and revision-GC sweeps. A sweep that deletes with no trail is invisible
+    until someone reads the job internals, so every automated deletion leaves
+    one.
     """
     now = datetime.now(UTC)
-    result = await db.execute(select(Poll))
-    polls = list(result.scalars().all())
-    expired = [p for p in polls if purges_at(p) <= now]
-    for poll in expired:
-        await db.delete(poll)
-    return len(expired)
+
+    # Expiry is expressed entirely in Poll columns, so filter in SQL instead of
+    # scanning the whole table into Python: closes_at + retention_days days
+    # <= now. make_interval(days => retention_days) keeps the per-poll integer
+    # as an interval without hardcoding a day count.
+    expired_predicate = (
+        Poll.closes_at + func.make_interval(0, 0, 0, Poll.retention_days) <= now
+    )
+
+    # Per-user counts, taken before the delete so the trace matches what was
+    # actually removed.
+    per_user = await db.execute(
+        select(System.user_id, func.count(Poll.id))
+        .join(System, Poll.system_id == System.id)
+        .where(expired_predicate)
+        .group_by(System.user_id)
+    )
+    user_counts = {uid: cnt for uid, cnt in per_user.all()}
+
+    result = await db.execute(delete(Poll).where(expired_predicate))
+    purged = result.rowcount or 0
+
+    for uid, cnt in user_counts.items():
+        if cnt:
+            await log_activity(
+                db,
+                user_id=uid,
+                action=ActivityAction.RETENTION_PRUNED,
+                actor_type=ActivityActorType.SYSTEM,
+                detail={"polls_purged": cnt},
+            )
+
+    return purged

--- a/tests/test_job_runner_rework.py
+++ b/tests/test_job_runner_rework.py
@@ -521,3 +521,106 @@ def test_enqueue_notify_wakes_the_listener():
             await engine.dispose()
 
     asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Operator kill switch for data-deleting jobs
+
+
+def test_master_switch_pauses_only_destructive_jobs():
+    """With destructive_jobs_enabled off, a job marked destructive is frozen
+    (the runner's skip predicate returns True); a non-destructive job is not."""
+    from sheaf.config import settings
+    from sheaf.services import jobs as jobs_module
+
+    saved = dict(jobs_module._REGISTRY)
+    saved_flag = settings.destructive_jobs_enabled
+    try:
+        jobs_module._REGISTRY.clear()
+        jobs_module.register_job(
+            name="wipes-data", description="", func=None,
+            interval_seconds=lambda: 60, destructive=True,
+        )
+        jobs_module.register_job(
+            name="reads-only", description="", func=None,
+            interval_seconds=lambda: 60,
+        )
+        destructive = jobs_module._REGISTRY["wipes-data"]
+        safe = jobs_module._REGISTRY["reads-only"]
+
+        # Master on: nothing is paused.
+        settings.destructive_jobs_enabled = True
+        assert jobs_module._destructive_paused(destructive) is False
+        assert jobs_module._destructive_paused(safe) is False
+
+        # Master off: only the destructive job is frozen.
+        settings.destructive_jobs_enabled = False
+        assert jobs_module._destructive_paused(destructive) is True
+        assert jobs_module._destructive_paused(safe) is False
+    finally:
+        settings.destructive_jobs_enabled = saved_flag
+        jobs_module._REGISTRY.clear()
+        jobs_module._REGISTRY.update(saved)
+
+
+def test_expected_jobs_are_marked_destructive():
+    """The data-deleting jobs carry destructive=True; operational cleanups and
+    non-deleting jobs do not. Guards against a new deleting job being added
+    without wiring it into the freeze."""
+    from sheaf.services import jobs as jobs_module
+
+    jobs_module._register_all_jobs()
+    reg = jobs_module.get_registry()
+
+    destructive = {
+        "prune_free_tier_fronts",
+        "gc_revisions",
+        "purge_expired_polls",
+        "cleanup_orphaned_files",
+        "cleanup_unverified_accounts",
+        "cleanup_activity_events",
+        "process_account_deletions",
+        "finalize_pending_actions",
+    }
+    for name in destructive:
+        assert reg[name].destructive is True, name
+
+    not_destructive = {
+        "cleanup_security_events",
+        "cleanup_job_logs",
+        "cleanup_import_jobs",
+        "cleanup_notification_outbox",
+        "cleanup_export_jobs",
+        "tick_repeated_reminders",
+        "build_export_jobs",
+    }
+    for name in not_destructive:
+        assert reg[name].destructive is False, name
+
+
+def test_security_event_cleanup_kept_on_its_own_switch():
+    """cleanup_security_events is a privacy obligation: it is NOT destructive
+    (so the master pause never touches it) and follows its own
+    security_event_cleanup_enabled switch instead."""
+    from sheaf.config import settings
+    from sheaf.services import jobs as jobs_module
+
+    jobs_module._register_all_jobs()
+    job = jobs_module.get_registry()["cleanup_security_events"]
+
+    saved_master = settings.destructive_jobs_enabled
+    saved_own = settings.security_event_cleanup_enabled
+    try:
+        # Master pause on, own switch on: still runs (not destructive, enabled).
+        settings.destructive_jobs_enabled = False
+        settings.security_event_cleanup_enabled = True
+        assert jobs_module._destructive_paused(job) is False
+        assert job.enabled() is True
+
+        # Own switch off: skipped even with the master switch on.
+        settings.destructive_jobs_enabled = True
+        settings.security_event_cleanup_enabled = False
+        assert job.enabled() is False
+    finally:
+        settings.destructive_jobs_enabled = saved_master
+        settings.security_event_cleanup_enabled = saved_own

--- a/tests/test_polls_api.py
+++ b/tests/test_polls_api.py
@@ -514,3 +514,96 @@ def test_concurrent_cap_enforced(auth_client: httpx.Client):
         },
     )
     assert resp.status_code == 403
+
+
+# --- Retention purge nothing-silent trace ---------------------------------
+
+
+def test_purge_expired_polls_writes_activity_trace(auth_client: httpx.Client):
+    """Purging an expired poll leaves a content-free RETENTION_PRUNED activity
+    event for the owning user with the purged count, and the cascade removes
+    the poll's options."""
+    import asyncio
+    import os
+    import uuid
+
+    me = auth_client.get("/v1/auth/me").json()
+    system = auth_client.get("/v1/systems/me").json()
+    user_id = uuid.UUID(me["id"])
+    system_id = uuid.UUID(system["id"])
+
+    async def run() -> tuple[int, bool, bool, int]:
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.models.activity_event import ActivityAction, ActivityEvent
+        from sheaf.models.poll import Poll, PollOption
+        from sheaf.services.polls import purge_expired_polls
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        session_factory = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        now = datetime.now(UTC)
+        try:
+            # Insert an already-expired poll (closed 10 days ago, 1-day
+            # retention) directly, so it is eligible for the sweep.
+            async with session_factory() as db:
+                poll = Poll(
+                    id=uuid.uuid4(),
+                    system_id=system_id,
+                    question="expired-poll",
+                    description=None,
+                    kind="single_choice",
+                    results_visibility="live",
+                    closes_at=now - timedelta(days=10),
+                    retention_days=1,
+                )
+                db.add(poll)
+                await db.flush()
+                db.add(
+                    PollOption(
+                        id=uuid.uuid4(),
+                        poll_id=poll.id,
+                        text="opt",
+                        position=0,
+                    )
+                )
+                await db.commit()
+                poll_id = poll.id
+
+            async with session_factory() as db:
+                purged = await purge_expired_polls(db)
+                await db.commit()
+
+            async with session_factory() as db:
+                poll_gone = (await db.get(Poll, poll_id)) is None
+                opt_result = await db.execute(
+                    select(PollOption).where(PollOption.poll_id == poll_id)
+                )
+                options_gone = not opt_result.scalars().all()
+
+                ev_result = await db.execute(
+                    select(ActivityEvent).where(
+                        ActivityEvent.user_id == user_id,
+                        ActivityEvent.action == ActivityAction.RETENTION_PRUNED,
+                    )
+                )
+                traces = [
+                    e.detail["polls_purged"]
+                    for e in ev_result.scalars().all()
+                    if e.detail and "polls_purged" in e.detail
+                ]
+            traced = traces[0] if traces else 0
+            return purged, poll_gone, options_gone, traced
+        finally:
+            await engine.dispose()
+
+    purged, poll_gone, options_gone, traced = asyncio.run(run())
+    assert purged >= 1
+    assert poll_gone, "expired poll survived the purge"
+    assert options_gone, "cascade did not remove the poll's options"
+    assert traced >= 1, "no RETENTION_PRUNED trace with polls_purged for the user"


### PR DESCRIPTION
A retention bug (caught and fixed the same day, no data lost) showed there was
no single lever to halt the data-deleting background jobs while investigating -
the only option was to zero each job's interval one at a time, and several
cleanup jobs are hardcoded and cannot be disabled at all. This adds the lever
and closes the last silent-deletion gap.

## Master kill switch
- `destructive_jobs_enabled` (default on). Flip it off and the runner skips
  every job marked destructive in one move, logging that the freeze is in
  effect. Marked destructive: the front / revision / poll retention sweeps,
  orphaned-file and unverified-account cleanup, activity-log aging, and the two
  jobs that execute user-requested deletions (scheduled account deletion and
  System Safety finalizations). The last two are frozen with everything else so
  a pause stops all deletion; a comment marks them as the one place to exempt
  if user-requested deletions should keep flowing during a freeze.
- The default is on, so normal operation is unchanged; the switch only affects
  behaviour when an operator deliberately activates it.
- The security-event (IP) cleanup enforces the 30-day IP retention promise, so
  it is deliberately NOT under the master switch. It keeps its own
  `security_event_cleanup_enabled` flag, so a blanket pause cannot silently
  stop IP minimisation.
- Operational cleanups that only remove ephemeral rows (job logs, import-job
  rows, delivered notifications, expired export artefacts) are left ungated.

## Nothing-silent for poll purge
The front-retention and revision sweeps already leave a per-user activity trace
when they delete; the poll-retention purge did not. It now records one
content-free RETENTION_PRUNED entry per affected user, so an automated deletion
is always visible rather than only discoverable by reading the job internals.
While grouping the purge by owner, the expiry check also moved into SQL instead
of scanning the whole poll table into Python; the cascade still removes options,
votes, and audit events.

## Testing
Full suite green across all nine configurations. New tests cover the freeze
(destructive jobs skipped when off, non-destructive still run, security cleanup
kept on its own switch), a registry guard asserting the exact destructive
classification so a new deleting job cannot be added without wiring the freeze,
and the poll-purge activity trace with cascade removal.
