### PR TITLE
User-opt-in front-history privacy retention (setting, sweep, UI), plus export robustness and kill-switch guard

### DIFF
--- a/alembic/versions/x5y6z7a8b9c0_add_systems_front_retention_days.py
+++ b/alembic/versions/x5y6z7a8b9c0_add_systems_front_retention_days.py
@@ -1,0 +1,45 @@
+"""Add front_retention_days to systems
+
+Revision ID: x5y6z7a8b9c0
+Revises: w4x5y6z7a8b9
+Create Date: 2026-07-05
+
+User-opt-in front-history privacy retention window, in days. 0 = off = keep
+fronting history forever (the default); a positive value is the age-out window,
+keyed off each front's real-world end time (ended_at) by the sweep, which lands
+in a later change. This migration only adds the setting column - nothing deletes
+yet.
+
+ADD COLUMN with a constant non-null server_default ('0') is metadata-only on
+modern Postgres: existing rows adopt the default without a table rewrite. It
+still briefly takes ACCESS EXCLUSIVE, so fail fast rather than queue behind a
+long-running session.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "x5y6z7a8b9c0"
+down_revision: Union[str, None] = "w4x5y6z7a8b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.add_column(
+        "systems",
+        sa.Column(
+            "front_retention_days",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.drop_column("systems", "front_retention_days")

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -23,7 +23,7 @@ from sheaf.models.uploaded_file import UploadedFile
 from sheaf.models.user import AccountStatus, User, UserTier
 from sheaf.services.admin_audit import log_admin_action
 from sheaf.services.file_cleanup import cleanup_orphaned_files
-from sheaf.services.front_retention import prune_free_tier_fronts
+from sheaf.services.front_retention import sweep_front_retention
 
 logger = logging.getLogger("sheaf.admin")
 
@@ -568,8 +568,9 @@ async def run_retention(
     admin: User = Depends(get_admin_write_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Manually trigger front history retention pruning. Admin only."""
-    count = await prune_free_tier_fronts(db)
+    """Manually trigger the user-opt-in front-history retention sweep. Admin only."""
+    result = await sweep_front_retention(db)
+    count = result.get("items_processed", 0)
     await log_admin_action(
         db,
         admin=admin,

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -563,20 +563,55 @@ async def reject_user(
 # Maintenance operations (kept from before, now using get_admin_write_user)
 # ---------------------------------------------------------------------------
 
+def _check_destructive_freeze(*, is_destructive: bool, override_freeze: bool) -> bool:
+    """Guard a manual destructive-job trigger against the kill switch.
+
+    When ``destructive_jobs_enabled`` is off, deletion is frozen for the
+    scheduled runner; a manual admin trigger must not silently bypass that.
+    Refuse a destructive job unless the caller explicitly passes
+    ``override_freeze=true``, and return whether the freeze was overridden so
+    the caller can record it in the admin audit. Non-destructive jobs are never
+    affected. The freeze being about unattended automation, a deliberate,
+    acknowledged, audited override is allowed; a reflexive one is not.
+    """
+    if is_destructive and not settings.destructive_jobs_enabled:
+        if not override_freeze:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "Data deletion is frozen (destructive_jobs_enabled is off). "
+                    "Pass override_freeze=true to run this destructive job anyway."
+                ),
+            )
+        return True
+    return False
+
+
 @router.post("/retention/run")
 async def run_retention(
+    override_freeze: bool = False,
     admin: User = Depends(get_admin_write_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Manually trigger the user-opt-in front-history retention sweep. Admin only."""
+    """Manually trigger the user-opt-in front-history retention sweep. Admin only.
+
+    Destructive: refuses while the kill switch is off unless
+    override_freeze=true, and records the override in the admin audit.
+    """
+    freeze_overridden = _check_destructive_freeze(
+        is_destructive=True, override_freeze=override_freeze
+    )
     result = await sweep_front_retention(db)
     count = result.get("items_processed", 0)
+    after = {"job": "retention/run", "pruned": count}
+    if freeze_overridden:
+        after["freeze_overridden"] = True
     await log_admin_action(
         db,
         admin=admin,
         action=AdminAuditAction.JOB_TRIGGER,
         target_type=AdminAuditTargetType.JOB,
-        after={"job": "retention/run", "pruned": count},
+        after=after,
     )
     await db.commit()
     return {"pruned": count}
@@ -584,10 +619,18 @@ async def run_retention(
 
 @router.post("/cleanup/run")
 async def run_cleanup(
+    override_freeze: bool = False,
     admin: User = Depends(get_admin_write_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Clean up orphaned files for all users. Admin only."""
+    """Clean up orphaned files for all users. Admin only.
+
+    Destructive: refuses while the kill switch is off unless
+    override_freeze=true, and records the override in the admin audit.
+    """
+    freeze_overridden = _check_destructive_freeze(
+        is_destructive=True, override_freeze=override_freeze
+    )
     result = await db.execute(select(User.id))
     user_ids = [str(uid) for (uid,) in result]
 
@@ -598,16 +641,19 @@ async def run_cleanup(
         total_orphaned += stats["orphaned"]
         total_freed += stats["freed_bytes"]
 
+    after = {
+        "job": "cleanup/run",
+        "orphaned": total_orphaned,
+        "freed_bytes": total_freed,
+    }
+    if freeze_overridden:
+        after["freeze_overridden"] = True
     await log_admin_action(
         db,
         admin=admin,
         action=AdminAuditAction.JOB_TRIGGER,
         target_type=AdminAuditTargetType.JOB,
-        after={
-            "job": "cleanup/run",
-            "orphaned": total_orphaned,
-            "freed_bytes": total_freed,
-        },
+        after=after,
     )
     await db.commit()
 
@@ -882,10 +928,15 @@ async def list_jobs(
 @router.post("/jobs/{job_name}/run")
 async def trigger_job(
     job_name: str,
+    override_freeze: bool = False,
     admin: User = Depends(get_admin_write_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Manually trigger a scheduled job. Requires admin:write."""
+    """Manually trigger a scheduled job. Requires admin:write.
+
+    A job marked destructive refuses while the kill switch is off unless
+    override_freeze=true, and the override is recorded in the admin audit.
+    """
     from sheaf.services.jobs import get_registry, run_job
 
     registry = get_registry()
@@ -895,13 +946,20 @@ async def trigger_job(
             detail=f"Unknown job: {job_name}",
         )
 
+    freeze_overridden = _check_destructive_freeze(
+        is_destructive=registry[job_name].destructive,
+        override_freeze=override_freeze,
+    )
     run = await run_job(job_name, db)
+    after = {"job": job_name, "status": run.status}
+    if freeze_overridden:
+        after["freeze_overridden"] = True
     await log_admin_action(
         db,
         admin=admin,
         action=AdminAuditAction.JOB_TRIGGER,
         target_type=AdminAuditTargetType.JOB,
-        after={"job": job_name, "status": run.status},
+        after=after,
     )
     await db.commit()
 

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -11,8 +11,9 @@ Async `POST /export/jobs` enqueues a build that includes image bytes,
 delivered as a zip via S3-presigned download or filesystem stream.
 """
 
+import logging
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from typing import Literal
 
@@ -53,6 +54,60 @@ from sheaf.services.members import member_plaintext
 from sheaf.services.openplural_archive import unpack_residual
 
 router = APIRouter(prefix="/export", tags=["export"])
+
+logger = logging.getLogger("sheaf.export")
+
+
+def _safe_decrypt(value: str | None) -> str | None:
+    """Decrypt an encrypted field for the export, tolerating a single
+    unreadable value instead of sinking the whole dump.
+
+    A data export is best-effort: if one field holds ciphertext that can't
+    be decrypted (corruption, a key-rotation edge, or plain bad data), that
+    one field should come back null while every other field still exports -
+    far better than 500ing the entire account backup over a single row.
+    Returns None for a None input, or None when decryption fails. The
+    warning lets an operator see it happened without leaking the field's
+    plaintext or ciphertext into the logs.
+    """
+    if value is None:
+        return None
+    try:
+        return decrypt(value)
+    except Exception:
+        logger.warning(
+            "An encrypted field could not be decrypted during export; "
+            "exporting it as null"
+        )
+        return None
+
+
+# Stand-in written into the export when a required text field (e.g. a member
+# name) can't be decrypted. Null would risk a NOT NULL violation on re-import;
+# a placeholder re-imports cleanly and signals the field was unrecoverable.
+_UNREADABLE_PLACEHOLDER = "[unreadable]"
+
+
+def _safe_plaintext(fn: Callable, *, fallback):
+    """Run a shared decrypt-to-plaintext helper while assembling the export,
+    tolerating a single unreadable field.
+
+    The export leans on shared service helpers (member / journal / revision /
+    custom-field plaintext) that raise on unreadable ciphertext. Left bare
+    that would 500 the entire export over one bad row. We can't soften those
+    helpers - they back read endpoints too - so we catch here, at the export
+    call site only, log a content-free warning, and fall back: a placeholder
+    for required fields, null for optional ones. The fallback shape mirrors
+    the helper's own return (a tuple for the two-value helpers).
+    """
+    try:
+        return fn()
+    except Exception:
+        logger.warning(
+            "An encrypted field could not be decrypted during export; "
+            "substituting a fallback value"
+        )
+        return fallback
 
 
 # asyncpg caps a single statement at 32767 bind parameters. Any `.in_(ids)`
@@ -152,8 +207,21 @@ async def export_all(
     members_result = await db.execute(
         select(Member).where(Member.system_id == system.id)
     )
+    # member_plaintext returns (name, description). Name is required (a
+    # placeholder on failure so re-import doesn't hit the NOT NULL column);
+    # description is optional (null). A single unreadable member field can't
+    # be more granular here - the helper decrypts both together - so if
+    # either raises, name falls back to the placeholder and description to
+    # null, and the rest of the export is unaffected.
     members_with_plaintext = [
-        (m, *member_plaintext(m)) for m in members_result.scalars().all()
+        (
+            m,
+            *_safe_plaintext(
+                lambda m=m: member_plaintext(m),
+                fallback=(_UNREADABLE_PLACEHOLDER, None),
+            ),
+        )
+        for m in members_result.scalars().all()
     ]
     members_with_plaintext.sort(key=lambda t: t[1].casefold())
 
@@ -321,7 +389,7 @@ async def export_all(
                 "emoji": m.emoji,
                 "is_custom_front": m.is_custom_front,
                 "privacy": m.privacy.value,
-                "note": decrypt(m.note) if m.note else None,
+                "note": _safe_decrypt(m.note) if m.note else None,
                 "quick_switch_pin": m.quick_switch_pin,
                 "notify_on_front_global": m.notify_on_front_global,
                 "notify_on_front_self": m.notify_on_front_self,
@@ -340,7 +408,7 @@ async def export_all(
                 "ended_at": f.ended_at.isoformat() if f.ended_at else None,
                 "member_ids": [str(m.id) for m in f.members],
                 "custom_status": (
-                    decrypt(f.custom_status) if f.custom_status else None
+                    _safe_decrypt(f.custom_status) if f.custom_status else None
                 ),
             }
             for f in fronts
@@ -376,7 +444,11 @@ async def export_all(
                 "values": [
                     {
                         "member_id": str(v.member_id),
-                        "value": field_value_plaintext(v),
+                        # Custom-field value is optional user content: null on
+                        # an unreadable field rather than sinking the export.
+                        "value": _safe_plaintext(
+                            lambda v=v: field_value_plaintext(v), fallback=None
+                        ),
                     }
                     for v in fd.values
                 ],
@@ -433,7 +505,7 @@ def _system_dict(system: System) -> dict:
         "id": str(system.id),
         "name": system.name,
         "description": system.description,
-        "note": decrypt(system.note) if system.note else None,
+        "note": _safe_decrypt(system.note) if system.note else None,
         "tag": system.tag,
         "avatar_url": system.avatar_url,
         "color": system.color,
@@ -474,7 +546,11 @@ def _system_dict(system: System) -> dict:
 
 
 def _journal_dict(entry: JournalEntry) -> dict:
-    title, body = entry_plaintext(entry)
+    # Journal title and body are optional content: null on an unreadable
+    # field rather than 500ing the whole export.
+    title, body = _safe_plaintext(
+        lambda: entry_plaintext(entry), fallback=(None, None)
+    )
     return {
         "id": str(entry.id),
         "member_id": str(entry.member_id) if entry.member_id else None,
@@ -493,7 +569,11 @@ def _journal_dict(entry: JournalEntry) -> dict:
 
 
 def _revision_dict(revision: ContentRevision) -> dict:
-    title, body = revision_plaintext(revision)
+    # Revision title and body are optional content: null on an unreadable
+    # field rather than 500ing the whole export.
+    title, body = _safe_plaintext(
+        lambda: revision_plaintext(revision), fallback=(None, None)
+    )
     return {
         "id": str(revision.id),
         "target_type": revision.target_type,
@@ -593,8 +673,8 @@ def _reminder_dict(reminder) -> dict:
     pending queue) is omitted and the channel_id is just the original UUID
     so a re-import on a fresh instance won't resolve unless the channels
     were imported there too."""
-    title = decrypt(reminder.title) if reminder.title else ""
-    body = decrypt(reminder.body) if reminder.body else None
+    title = _safe_decrypt(reminder.title) if reminder.title else ""
+    body = _safe_decrypt(reminder.body) if reminder.body else None
     return {
         "id": str(reminder.id),
         "channel_id": str(reminder.channel_id),
@@ -636,7 +716,7 @@ def _message_dict(msg) -> dict:
         "parent_message_id": (
             str(msg.parent_message_id) if msg.parent_message_id else None
         ),
-        "body": decrypt(msg.body) if msg.body else "",
+        "body": _safe_decrypt(msg.body) if msg.body else "",
         "created_at": msg.created_at.isoformat(),
         "updated_at": msg.updated_at.isoformat(),
     }
@@ -649,8 +729,8 @@ def _poll_dict(poll) -> dict:
     they're meaningful again."""
     return {
         "id": str(poll.id),
-        "question": decrypt(poll.question) if poll.question else "",
-        "description": decrypt(poll.description) if poll.description else None,
+        "question": _safe_decrypt(poll.question) if poll.question else "",
+        "description": _safe_decrypt(poll.description) if poll.description else None,
         "kind": poll.kind,
         "results_visibility": poll.results_visibility,
         "closes_at": poll.closes_at.isoformat(),
@@ -661,7 +741,7 @@ def _poll_dict(poll) -> dict:
         "options": [
             {
                 "id": str(opt.id),
-                "text": decrypt(opt.text) if opt.text else "",
+                "text": _safe_decrypt(opt.text) if opt.text else "",
                 "position": opt.position,
             }
             for opt in sorted(poll.options, key=lambda o: o.position)

--- a/sheaf/api/v1/openplural_import.py
+++ b/sheaf/api/v1/openplural_import.py
@@ -22,6 +22,7 @@ from sheaf.auth.dependencies import get_current_user
 from sheaf.database import get_db
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.services.front_retention import front_retention_preview_warning
 from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.openplural_import import (
     inherited_lineage,
@@ -101,6 +102,11 @@ async def preview_openplural_import(
             )
             if poll_warning:
                 summary.limit_warnings.append(poll_warning)
+            retention_warning = front_retention_preview_warning(
+                system.front_retention_days, summary.front_count > 0
+            )
+            if retention_warning:
+                summary.limit_warnings.append(retention_warning)
             return {
                 **_summary_dict(summary),
                 "archive": True,
@@ -115,6 +121,11 @@ async def preview_openplural_import(
         )
         if poll_warning:
             summary.limit_warnings.append(poll_warning)
+        retention_warning = front_retention_preview_warning(
+            system.front_retention_days, summary.front_count > 0
+        )
+        if retention_warning:
+            summary.limit_warnings.append(retention_warning)
         return {
             **_summary_dict(summary),
             "archive": False,

--- a/sheaf/api/v1/pk_import.py
+++ b/sheaf/api/v1/pk_import.py
@@ -11,13 +11,18 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
+from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.pk_import import (
     PKApiPreviewRequest,
     PKPreviewSummary,
 )
+from sheaf.services.front_retention import front_retention_preview_warning
 from sheaf.services.import_parsing import ImportPayloadError, safe_json_loads_async
 from sheaf.services.pk_api import (
     PKApiError,
@@ -31,6 +36,16 @@ logger = logging.getLogger("sheaf.import.pk")
 router = APIRouter(prefix="/import", tags=["import"])
 
 MAX_IMPORT_SIZE = 100 * 1024 * 1024  # 100MB — PK exports are tiny but be safe
+
+
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
 
 
 async def _parse_upload(file: UploadFile) -> dict[str, Any]:
@@ -74,11 +89,19 @@ def _api_error_to_http(exc: PKApiError) -> HTTPException:
 @router.post("/pluralkit/preview", response_model=PKPreviewSummary)
 async def preview_file_import(
     file: UploadFile,
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Parse a PK export file and return a summary."""
     data = await _parse_upload(file)
-    return build_preview(data)
+    summary = build_preview(data)
+    system = await _get_user_system(user, db)
+    retention_warning = front_retention_preview_warning(
+        system.front_retention_days, summary.switch_count > 0
+    )
+    if retention_warning:
+        summary.limit_warnings.append(retention_warning)
+    return summary
 
 
 # --- API path ----------------------------------------------------------------
@@ -87,7 +110,8 @@ async def preview_file_import(
 @router.post("/pluralkit-api/preview", response_model=PKPreviewSummary)
 async def preview_api_import(
     body: PKApiPreviewRequest,
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Preview an import by reading from the PluralKit API directly.
 
@@ -120,4 +144,10 @@ async def preview_api_import(
     if has_more:
         # Set the count to the page size; UI will format "100+".
         summary.switch_count = len(switch_sample)
+    system = await _get_user_system(user, db)
+    retention_warning = front_retention_preview_warning(
+        system.front_retention_days, summary.switch_count > 0
+    )
+    if retention_warning:
+        summary.limit_warnings.append(retention_warning)
     return summary

--- a/sheaf/api/v1/pluralspace_import.py
+++ b/sheaf/api/v1/pluralspace_import.py
@@ -19,6 +19,7 @@ from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.services.front_retention import front_retention_preview_warning
 from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.pluralspace_import import parse_export_async, preview
 from sheaf.services.sheaf_import import open_poll_preview_warning
@@ -81,4 +82,9 @@ async def preview_pluralspace_import(
     )
     if poll_warning:
         summary.limit_warnings.append(poll_warning)
+    retention_warning = front_retention_preview_warning(
+        system.front_retention_days, summary.front_count > 0
+    )
+    if retention_warning:
+        summary.limit_warnings.append(retention_warning)
     return summary.model_dump(mode="json")

--- a/sheaf/api/v1/prism_import.py
+++ b/sheaf/api/v1/prism_import.py
@@ -20,6 +20,7 @@ from sheaf.database import get_db
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.services.front_retention import front_retention_preview_warning
 from sheaf.services.import_parsing import ImportPayloadError
 from sheaf.services.prism_import import parse_envelope_bytes_async, preview
 from sheaf.services.sheaf_import import open_poll_preview_warning
@@ -87,4 +88,9 @@ async def preview_prism_import(
     )
     if poll_warning:
         summary.limit_warnings.append(poll_warning)
+    retention_warning = front_retention_preview_warning(
+        system.front_retention_days, summary.front_session_count > 0
+    )
+    if retention_warning:
+        summary.limit_warnings.append(retention_warning)
     return summary.model_dump(mode="json")

--- a/sheaf/api/v1/retention.py
+++ b/sheaf/api/v1/retention.py
@@ -72,6 +72,7 @@ async def get_retention(
         tier_max_days=tier_days,
         override_revisions=system.journal_max_revisions,
         override_days=system.journal_max_revision_days,
+        front_retention_days=system.front_retention_days,
         trim_notice=(
             RetentionTrimNoticeRead.model_validate(notice) if notice else None
         ),
@@ -104,6 +105,19 @@ async def update_retention(
         proposed["journal_max_revision_days"] = _coerce_override(
             sent["max_revision_days"], tier_days
         )
+    if "front_retention_days" in sent:
+        # Uncapped per tier, so NO _coerce_override (there is no tier max to
+        # enforce). The column is non-null (0 = off), so unlike the revision
+        # overrides there is no "clear override" null semantic - reject an
+        # explicit null rather than let it hit the NOT NULL column. The ge=0
+        # bound is enforced by the schema; re-check for defence in depth.
+        value = sent["front_retention_days"]
+        if value is None or value < 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="front_retention_days must be an integer >= 0",
+            )
+        proposed["front_retention_days"] = value
 
     split = split_safety_changes(system, proposed)
 
@@ -145,6 +159,7 @@ async def update_retention(
         tier_max_days=tier_days,
         override_revisions=system.journal_max_revisions,
         override_days=system.journal_max_revision_days,
+        front_retention_days=system.front_retention_days,
         trim_notice=(
             RetentionTrimNoticeRead.model_validate(notice) if notice else None
         ),

--- a/sheaf/api/v1/sheaf_import.py
+++ b/sheaf/api/v1/sheaf_import.py
@@ -20,6 +20,7 @@ from sheaf.auth.dependencies import get_current_user
 from sheaf.database import get_db
 from sheaf.models.system import System
 from sheaf.models.user import User
+from sheaf.services.front_retention import front_retention_preview_warning
 from sheaf.services.import_parsing import ImportPayloadError, safe_json_loads_async
 from sheaf.services.sheaf_archive_import import parse_archive_async
 from sheaf.services.sheaf_archive_import import preview as archive_preview
@@ -126,6 +127,11 @@ async def preview_import(
         )
         if poll_warning:
             summary.limit_warnings.append(poll_warning)
+        retention_warning = front_retention_preview_warning(
+            system.front_retention_days, summary.front_count > 0
+        )
+        if retention_warning:
+            summary.limit_warnings.append(retention_warning)
         return {
             **_summary_dict(summary),
             "archive": True,
@@ -140,6 +146,11 @@ async def preview_import(
     )
     if poll_warning:
         summary.limit_warnings.append(poll_warning)
+    retention_warning = front_retention_preview_warning(
+        system.front_retention_days, summary.front_count > 0
+    )
+    if retention_warning:
+        summary.limit_warnings.append(retention_warning)
     return {
         **_summary_dict(summary),
         "archive": False,

--- a/sheaf/api/v1/sp_import.py
+++ b/sheaf/api/v1/sp_import.py
@@ -7,16 +7,31 @@ writes nothing.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
+from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.schemas.sp_import import SPPreviewSummary
+from sheaf.services.front_retention import front_retention_preview_warning
 from sheaf.services.import_parsing import ImportPayloadError, safe_json_loads_async
 from sheaf.services.sp_import import preview
 
 router = APIRouter(prefix="/import", tags=["import"])
 
 MAX_IMPORT_SIZE = 100 * 1024 * 1024  # 100MB — SP exports can be large
+
+
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
 
 
 async def _parse_upload(file: UploadFile) -> dict:
@@ -39,8 +54,16 @@ async def _parse_upload(file: UploadFile) -> dict:
 @router.post("/simplyplural/preview", response_model=SPPreviewSummary)
 async def preview_import(
     file: UploadFile,
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
     """Parse an SP export file and return a summary of importable data."""
     data = await _parse_upload(file)
-    return preview(data)
+    summary = preview(data)
+    system = await _get_user_system(user, db)
+    retention_warning = front_retention_preview_warning(
+        system.front_retention_days, summary.front_history_count > 0
+    )
+    if retention_warning:
+        summary.limit_warnings.append(retention_warning)
+    return summary

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -69,9 +69,15 @@ class Settings(BaseSettings):
     sheaf_git_tag: str = ""
     sheaf_build_time: str = ""
 
-    # aaS settings
-    free_tier_front_retention_days: int = 30
-    retention_check_interval_hours: int = 6
+    # User-opt-in front-history retention sweep.
+    # Fixed import grace: a freshly-imported front is never aged out until it
+    # has actually lived in the database this many days, so importing old
+    # history with retention on doesn't abruptly delete it - the user gets a
+    # window to review it or raise the setting first. Not a per-system knob.
+    front_retention_import_grace_days: int = 14
+    # How often the front-retention sweep runs. Opt-in and idempotent, so a
+    # daily cadence is plenty; it is a no-op for systems with retention off.
+    front_retention_check_interval_hours: int = 24
 
     # Account deletion
     account_deletion_grace_days: int = 7

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -145,6 +145,15 @@ class System(UUIDMixin, TimestampMixin, Base):
         Integer, nullable=True
     )
 
+    # User-opt-in front-history privacy retention. 0 = off = keep fronting
+    # history forever (the default). A positive value is the age-out window in
+    # days, keyed off each front's real-world end time (ended_at) by the sweep,
+    # which lands in a later change. Enabling it or shortening the window routes
+    # through SafetyChangeRequest (asymmetric loosening) like the revision caps.
+    front_retention_days: Mapped[int] = mapped_column(
+        Integer, default=0, server_default="0", nullable=False
+    )
+
     # OpenPlural import residual: foreign data Sheaf does not model (other
     # apps' `extensions` namespaces, the chat/relationships modules,
     # front_events/front_comments, non-tag taxonomy) preserved verbatim on

--- a/sheaf/schemas/retention.py
+++ b/sheaf/schemas/retention.py
@@ -28,6 +28,10 @@ class RetentionResponse(BaseModel):
     tier_max_days: int
     override_revisions: int | None
     override_days: int | None
+    # User-opt-in front-history retention window in days. 0 = off = keep
+    # forever. Non-null on the model (unlike the revision overrides), so this
+    # is always a concrete int.
+    front_retention_days: int
     trim_notice: RetentionTrimNoticeRead | None = None
 
 
@@ -41,6 +45,13 @@ class RetentionUpdate(BaseModel):
 
     max_revisions: int | None = Field(default=None, ge=0, le=100000)
     max_revision_days: int | None = Field(default=None, ge=0, le=36500)
+
+    # Front-history retention window in days. 0 = off = keep forever. Uncapped
+    # per tier (no tier-max coercion), so only a sanity ceiling is applied.
+    # Enabling (0 -> N) or shortening (N -> smaller) is a tightening that
+    # defers behind the grace period with re-auth; turning it off or
+    # lengthening applies immediately.
+    front_retention_days: int | None = Field(default=None, ge=0, le=36500)
 
     # Re-auth needed for loosening (cap reductions).
     password: str | None = None

--- a/sheaf/services/front_retention.py
+++ b/sheaf/services/front_retention.py
@@ -1,8 +1,30 @@
-"""Front history retention / pruning for aaS free tier.
+"""User-opt-in front-history privacy retention sweep.
 
-In self-hosted mode this module is never invoked. In aaS mode it runs
-as a periodic task to prune front history older than the configured
-retention window for free-tier users.
+A person may not want a multi-year fronting record sitting around, so a
+per-system setting (``System.front_retention_days``, 0 = off) lets them age
+out their own closed fronting history. This is the only legitimate reason to
+delete someone's identity data, and it is theirs to choose - so unlike the
+operator cost-control pruner this replaces, it is NOT mode-gated: it applies in
+self-hosted deployments too.
+
+A front is pruned IFF ALL of these hold together (the design's "Option B"
+predicate):
+
+  - its owning system opted in (``front_retention_days`` > 0),
+  - it is closed (``ended_at`` IS NOT NULL) - open fronts are never pruned
+    while ongoing,
+  - it ended long ago in the real world (``ended_at`` < now minus the system's
+    own ``front_retention_days`` window), because the user's intent is "no
+    fronting record of me older than X exists", a statement about when the
+    fronting happened, and
+  - it has actually lived in this database past a fixed import grace
+    (``created_at`` < now minus ``front_retention_import_grace_days``). An
+    imported front carries its old real-world ``ended_at``, so a system that
+    turns retention on and imports two years of history has just landed a pile
+    of already-eligible rows; the grace means freshly-imported old history is
+    never abruptly deleted - the user has a couple of weeks to review it and
+    change their mind. This is the clause that fixed a retention bug (caught
+    and fixed the same day, no data lost).
 """
 
 import logging
@@ -11,122 +33,121 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from sheaf.config import SheafMode, settings
+from sheaf.config import settings
 from sheaf.models.activity_event import ActivityAction, ActivityActorType
 from sheaf.models.front import Front
 from sheaf.models.member import front_members
 from sheaf.models.system import System
-from sheaf.models.user import User, UserTier
 from sheaf.services.activity_log import log_activity
 
 logger = logging.getLogger("sheaf.retention")
 
+# Delete in bounded batches with a commit between each rather than one giant
+# DELETE, so a large opt-in system's backlog can't hold a single long
+# transaction / lock set. The loop re-runs the predicate until nothing is left.
+_SWEEP_BATCH_SIZE = 5000
 
-async def prune_free_tier_fronts(db: AsyncSession) -> dict:
-    """Delete closed, long-dormant front history for free-tier users.
 
-    A front is pruned IFF all three hold together:
+async def sweep_front_retention(db: AsyncSession) -> dict:
+    """Age out closed, long-ended fronting history for opted-in systems.
 
-      - ``created_at < cutoff`` - the row was *inserted* long ago. This is the
-        row-landing time (set to NOW on every insert), not the front's
-        real-world ``started_at``. It protects freshly-imported historical
-        fronts: an import carries old ``started_at`` / ``ended_at`` values but
-        lands with ``created_at`` = now, so it is never eligible until it has
-        actually lived in this database for the full window. Keying off
-        ``started_at`` (the original incident bug) deleted just-imported
-        history; keying off ``ended_at`` alone does not fix it, because
-        imported fronts also carry an old ``ended_at``.
-      - ``ended_at IS NOT NULL`` - the front is closed. Open fronts are never
-        pruned while ongoing.
-      - ``ended_at < cutoff`` - it also *ended* long ago. This protects a
-        genuinely long-running native front (months, years) that was created
-        long ago but only just closed: its most recent activity is recent, so
-        it is kept for the full window after it ends rather than vanishing the
-        instant it closes.
+    Deletes fronts (and their ``front_members`` junction rows) matching the
+    Option B predicate above, in batches with a per-batch commit. Not
+    mode-gated - this is a user privacy control, so it runs everywhere.
+
+    Nothing-silent: computes per-user counts before the delete loop and, after
+    deleting, leaves one content-free ``RETENTION_PRUNED`` account-activity
+    trace per affected user (detail ``{"fronts_pruned": n}``, actor SYSTEM),
+    mirroring the poll purge and revision GC. A sweep that deletes with no
+    trail is invisible until someone reads the job internals.
 
     Returns dict with items_processed count and per-user detail.
     """
-    if settings.sheaf_mode != SheafMode.SAAS:
-        logger.debug("Skipping pruning - not in aaS mode")
-        return {"items_processed": 0}
+    now = datetime.now(UTC)
+    # Fixed import grace: bound as a Python datetime cutoff (simpler than an SQL
+    # interval for a constant), unlike the per-system window below.
+    import_cutoff = now - timedelta(days=settings.front_retention_import_grace_days)
 
-    cutoff = datetime.now(UTC) - timedelta(days=settings.free_tier_front_retention_days)
-
-    # Find systems owned by free-tier users
-    free_system_ids = (
-        select(System.id)
-        .join(User, System.user_id == User.id)
-        .where(User.tier == UserTier.FREE)
-        .scalar_subquery()
+    # Shared eligibility predicate. The per-system window is expressed in SQL by
+    # joining fronts to systems and running make_interval on each system's own
+    # integer front_retention_days, exactly as purge_expired_polls does with the
+    # per-poll retention_days - so the window is per-system without hardcoding a
+    # day count.
+    eligible = (
+        System.front_retention_days > 0,  # opted in
+        Front.ended_at.is_not(None),  # closed; never prune open fronts
+        # Ended long ago in the real world, per that system's own window.
+        Front.ended_at < now - func.make_interval(0, 0, 0, System.front_retention_days),
+        Front.created_at < import_cutoff,  # not freshly imported
     )
 
-    # Count per-user before deleting (for detail log). Predicate mirrors the
-    # delete subquery below exactly - see the docstring for why all three
-    # clauses are required (created_at guards imported history, ended_at guards
-    # recently-active long fronts, IS NOT NULL never touches open fronts).
-    per_user_counts = await db.execute(
+    # Per-user counts, taken before the delete loop so the activity trace
+    # matches what was actually removed.
+    per_user = await db.execute(
         select(System.user_id, func.count(Front.id))
         .join(System, Front.system_id == System.id)
-        .where(
-            Front.system_id.in_(free_system_ids),
-            Front.created_at < cutoff,  # Inserted long ago (protects imports)
-            Front.ended_at.is_not(None),  # Never prune open fronts
-            Front.ended_at < cutoff,  # Ended long ago (protects recent activity)
-        )
+        .where(*eligible)
         .group_by(System.user_id)
     )
-    user_counts = {uid: cnt for uid, cnt in per_user_counts.all()}
+    user_counts = {uid: cnt for uid, cnt in per_user.all()}
 
-    # Find fronts to delete
-    old_fronts = (
-        select(Front.id)
-        .where(
-            Front.system_id.in_(free_system_ids),
-            Front.created_at < cutoff,  # Inserted long ago (protects imports)
-            Front.ended_at.is_not(None),  # Never prune open fronts
-            Front.ended_at < cutoff,  # Ended long ago (protects recent activity)
-        )
-        .scalar_subquery()
-    )
-
-    # Delete junction table rows first
-    await db.execute(
-        delete(front_members).where(front_members.c.front_id.in_(old_fronts))
-    )
-
-    # Delete fronts
-    result = await db.execute(
-        delete(Front).where(Front.id.in_(old_fronts))
-    )
-
-    count = result.rowcount
-    if count > 0:
-        logger.info("Pruned %d front records older than %s", count, cutoff.isoformat())
-
-    # Nothing-silent: leave a per-user account-activity trace whenever a prune
-    # actually removes rows for that user. The incident was hidden precisely
-    # because the sweep deleted with no trail. Content-free - counts only, no
-    # member content. This needs a new ActivityAction ("retention_pruned") plus
-    # its Postgres enum migration; until both land the lookup returns None and
-    # emission is a no-op (these jobs stay paused until re-enabled). See the
-    # follow-up flagged in the change report.
-    retention_action = getattr(ActivityAction, "RETENTION_PRUNED", None)
-    if retention_action is not None:
-        for uid, cnt in user_counts.items():
-            if cnt:
-                await log_activity(
-                    db,
-                    user_id=uid,
-                    action=retention_action,
-                    actor_type=ActivityActorType.SYSTEM,
-                    detail={"fronts_pruned": cnt},
+    # Batched delete loop. Each pass materialises up to _SWEEP_BATCH_SIZE
+    # eligible front ids into a Python list (so the junction delete and the
+    # front delete act on exactly the same rows - a LIMIT subquery re-evaluated
+    # per statement, with no ORDER BY, could otherwise pick different rows for
+    # each), deletes their junction rows first, then the fronts, and commits.
+    # Deleted rows drop out of the predicate, so the next pass picks up the
+    # following batch until none remain.
+    total = 0
+    while True:
+        batch = (
+            (
+                await db.execute(
+                    select(Front.id)
+                    .join(System, Front.system_id == System.id)
+                    .where(*eligible)
+                    .limit(_SWEEP_BATCH_SIZE)
                 )
+            )
+            .scalars()
+            .all()
+        )
+        if not batch:
+            break
+
+        # front_members has DB-level ON DELETE CASCADE on front_id, but delete
+        # the junction rows explicitly first to be safe (mirrors the retired
+        # pruner) rather than relying solely on the cascade.
+        await db.execute(
+            delete(front_members).where(front_members.c.front_id.in_(batch))
+        )
+        result = await db.execute(delete(Front).where(Front.id.in_(batch)))
+        await db.commit()
+
+        total += result.rowcount or 0
+        if len(batch) < _SWEEP_BATCH_SIZE:
+            break
+
+    if total > 0:
+        logger.info("Front-retention sweep pruned %d closed fronts", total)
+
+    # Nothing-silent: one per-user trace per user whose rows were removed.
+    # Content-free - counts only, no fronting content.
+    for uid, cnt in user_counts.items():
+        if cnt:
+            await log_activity(
+                db,
+                user_id=uid,
+                action=ActivityAction.RETENTION_PRUNED,
+                actor_type=ActivityActorType.SYSTEM,
+                detail={"fronts_pruned": cnt},
+            )
 
     detail_lines = [
-        f"User {uid}: pruned {cnt} fronts" for uid, cnt in user_counts.items()
+        f"User {uid}: pruned {cnt} fronts" for uid, cnt in user_counts.items() if cnt
     ]
 
     return {
-        "items_processed": count,
+        "items_processed": total,
         "details": "\n".join(detail_lines) if detail_lines else None,
     }

--- a/sheaf/services/front_retention.py
+++ b/sheaf/services/front_retention.py
@@ -42,6 +42,36 @@ from sheaf.services.activity_log import log_activity
 
 logger = logging.getLogger("sheaf.retention")
 
+
+def front_retention_preview_warning(
+    front_retention_days: int, has_front_history: bool
+) -> str | None:
+    """Preview heads-up for a system with front-history retention turned on that
+    is about to import fronting history.
+
+    An imported front carries its old real-world ``ended_at``, so a system with
+    retention on that imports old history has just landed rows the sweep will
+    age out once the fixed import grace elapses. The whole point of the grace is
+    that this is never a surprise, so the preview names the window and the grace
+    up front and tells the user how to keep older history.
+
+    Deliberately window-stated, not a per-front count: the exact number of
+    entries older than the window would mean threading the window into each
+    importer's front parse, which is a future refinement. Returns the warning
+    string when retention is on (> 0) AND the import contains any front history,
+    else ``None``.
+    """
+    if front_retention_days > 0 and has_front_history:
+        return (
+            f"You have front-history retention set to {front_retention_days} "
+            "days, so imported fronting history older than that will be aged "
+            f"out {settings.front_retention_import_grace_days} days after "
+            "import. To keep older history, raise or turn off your retention "
+            "window before importing."
+        )
+    return None
+
+
 # Delete in bounded batches with a commit between each rather than one giant
 # DELETE, so a large opt-in system's backlog can't hold a single long
 # transaction / lock set. The loop re-runs the predicate until nothing is left.

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -507,11 +507,13 @@ async def _cleanup_orphaned_files(db: AsyncSession) -> dict:
     }
 
 
-async def _prune_free_tier_fronts(db: AsyncSession) -> dict:
-    """Wrapper around existing front retention pruning."""
-    from sheaf.services.front_retention import prune_free_tier_fronts
+async def _sweep_front_retention(db: AsyncSession) -> dict:
+    """Wrapper around the user-opt-in front-history retention sweep."""
+    from sheaf.services.front_retention import sweep_front_retention
 
-    return await prune_free_tier_fronts(db)
+    result = await sweep_front_retention(db)
+    await db.commit()
+    return result
 
 
 async def _gc_revisions(db: AsyncSession) -> dict:
@@ -1078,12 +1080,15 @@ def _register_all_jobs() -> None:
         destructive=True,
     )
 
+    # User privacy control, not operator cost-control: unconditionally enabled
+    # (no mode gate) so it applies in self-hosted too, and inert for any system
+    # that has not opted in (front_retention_days = 0). destructive=True so the
+    # kill switch freezes it with the other data-deleting jobs.
     register_job(
-        name="prune_free_tier_fronts",
-        description="Prune front history older than retention window for free-tier users",
-        func=_prune_free_tier_fronts,
-        interval_seconds=lambda: settings.retention_check_interval_hours * 3600,
-        enabled=lambda: settings.sheaf_mode == SheafMode.SAAS,
+        name="front_retention_sweep",
+        description="Age out closed fronting history for systems that opted in to retention",
+        func=_sweep_front_retention,
+        interval_seconds=lambda: settings.front_retention_check_interval_hours * 3600,
         destructive=True,
     )
 

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -213,6 +213,12 @@ _RETENTION_FIELDS = (
     "journal_max_revisions",
     "journal_max_revision_days",
     "pinned_revision_max_per_target",
+    # front_retention_days is a WINDOW (days), same direction as the revision
+    # caps: smaller = more restrictive = more deletion = deferred. 0 = off =
+    # keep forever = loosest, which the branch below maps to +infinity (same as
+    # None), so 0 -> N and N -> M<N sort as tightening and defer, while N -> 0
+    # or lengthening the window loosens and applies immediately.
+    "front_retention_days",
 )
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -189,6 +189,39 @@ def test_cleanup_run(admin_client: httpx.Client):
     assert "total_freed_bytes" in data
 
 
+def test_manual_trigger_freeze_guard(monkeypatch):
+    """A manual destructive-job trigger refuses while the kill switch is off
+    unless explicitly overridden; non-destructive jobs are never affected."""
+    import pytest
+    from fastapi import HTTPException
+
+    from sheaf.api.v1 import admin
+    from sheaf.config import settings
+
+    # Non-destructive: never blocked, even while frozen.
+    monkeypatch.setattr(settings, "destructive_jobs_enabled", False)
+    assert (
+        admin._check_destructive_freeze(is_destructive=False, override_freeze=False)
+        is False
+    )
+    # Destructive + switch on: runs, and it is not an override.
+    monkeypatch.setattr(settings, "destructive_jobs_enabled", True)
+    assert (
+        admin._check_destructive_freeze(is_destructive=True, override_freeze=False)
+        is False
+    )
+    # Destructive + frozen + no override: refused with 409.
+    monkeypatch.setattr(settings, "destructive_jobs_enabled", False)
+    with pytest.raises(HTTPException) as exc_info:
+        admin._check_destructive_freeze(is_destructive=True, override_freeze=False)
+    assert exc_info.value.status_code == 409
+    # Destructive + frozen + explicit override: allowed, reported as overridden.
+    assert (
+        admin._check_destructive_freeze(is_destructive=True, override_freeze=True)
+        is True
+    )
+
+
 # ---------------------------------------------------------------------------
 # Admin API key scopes
 # ---------------------------------------------------------------------------

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -43,3 +43,123 @@ def test_export_with_data(auth_client: httpx.Client):
     assert len(data["groups"]) == 1
     assert member_id in data["groups"][0]["member_ids"]
     assert len(data["tags"]) == 1
+
+
+def test_export_survives_unreadable_encrypted_field(auth_client: httpx.Client):
+    """A single field of unreadable ciphertext must not sink the whole export.
+
+    Seed a front whose custom_status holds a non-ciphertext string (the exact
+    shape that crashed a live export with 'nacl ... nonce must be exactly 24
+    bytes long') and assert the export still returns 200 with that one field
+    null, while every other field exports normally.
+    """
+    import asyncio
+    import os
+    import uuid as _uuid
+
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from sheaf.config import settings
+    from sheaf.models.front import Front
+
+    member_resp = auth_client.post("/v1/members", json={"name": "SurvivorMember"})
+    assert member_resp.status_code == 201, member_resp.text
+    member_id = member_resp.json()["id"]
+
+    front_resp = auth_client.post("/v1/fronts", json={"member_ids": [member_id]})
+    assert front_resp.status_code in (200, 201), front_resp.text
+    front_id = _uuid.UUID(front_resp.json()["id"])
+
+    # Corrupt the front's custom_status directly: store a plain string that is
+    # not valid ciphertext, so decrypt() raises when the export reaches it.
+    async def _corrupt() -> None:
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        try:
+            async with async_session() as db:
+                front = (
+                    await db.execute(select(Front).where(Front.id == front_id))
+                ).scalar_one()
+                front.custom_status = "not-encrypted"
+                await db.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_corrupt())
+
+    resp = auth_client.get("/v1/export")
+    # The whole export must not 500 over the one bad field.
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    # The unreadable field exports as null...
+    assert len(data["fronts"]) == 1
+    assert data["fronts"][0]["custom_status"] is None
+    # ...and everything else still exports normally.
+    assert len(data["members"]) == 1
+    assert data["members"][0]["name"] == "SurvivorMember"
+    assert member_id in data["fronts"][0]["member_ids"]
+
+
+def test_export_placeholder_for_unreadable_required_field(auth_client: httpx.Client):
+    """An unreadable *required* field (a member name, routed through the
+    shared member_plaintext helper) must not 500 the export either. It exports
+    as the placeholder rather than null - a null would risk a NOT NULL
+    violation on re-import - while the rest of the export stays intact.
+    """
+    import asyncio
+    import os
+    import uuid as _uuid
+
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from sheaf.config import settings
+    from sheaf.models.member import Member
+
+    # A readable member so we can confirm the rest of the export survives.
+    good_resp = auth_client.post("/v1/members", json={"name": "ReadableMember"})
+    assert good_resp.status_code == 201, good_resp.text
+
+    bad_resp = auth_client.post("/v1/members", json={"name": "WillBeCorrupted"})
+    assert bad_resp.status_code == 201, bad_resp.text
+    bad_id = _uuid.UUID(bad_resp.json()["id"])
+
+    # Corrupt the member's encrypted name directly: a plain string that is not
+    # valid ciphertext, so member_plaintext -> decrypt raises during export.
+    async def _corrupt() -> None:
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        try:
+            async with async_session() as db:
+                member = (
+                    await db.execute(select(Member).where(Member.id == bad_id))
+                ).scalar_one()
+                member.name = "not-encrypted"
+                await db.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_corrupt())
+
+    resp = auth_client.get("/v1/export")
+    # The whole export must not 500 over the one unreadable required field.
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    names = {m["name"] for m in data["members"]}
+    # Corrupted required field falls back to the placeholder, not null...
+    assert "[unreadable]" in names
+    assert None not in names
+    # ...and the readable member still exports normally.
+    assert "ReadableMember" in names
+    assert len(data["members"]) == 2

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -91,6 +91,11 @@ CLASSIFICATION: dict[type, dict] = {
             "user_id": "owning account FK, re-pointed to the importing user",
             "created_at": _ROW_CREATED,
             "updated_at": _ROW_UPDATED,
+            "front_retention_days": (
+                "opt-in privacy setting that arms deletion; deliberately not "
+                "round-tripped so a restore never silently arms a deletion "
+                "policy - the user re-enables it through the guarded flow"
+            ),
         },
     },
     Member: {

--- a/tests/test_front_retention.py
+++ b/tests/test_front_retention.py
@@ -1,25 +1,26 @@
-"""Front-history retention pruning (aaS free tier).
+"""User-opt-in front-history retention sweep.
 
-A front is pruned only when ALL of these hold: it was *inserted* long ago
-(``created_at`` < cutoff), it is closed (``ended_at`` IS NOT NULL), and it
-also ended long ago (``ended_at`` < cutoff). These tests pin that rule:
+A front is aged out only when ALL of these hold together (the design's
+"Option B" predicate):
 
-  - ``created_at`` (row-insertion time) guards freshly-imported history. This
-    is the 2026-06-23 incident: an import carries an old real-world
-    ``started_at`` / ``ended_at`` but lands with ``created_at`` = now, so it
-    must never be pruned just for being historically old. Keying off
-    ``started_at`` (original bug) OR ``ended_at`` alone (the interim fix) both
-    delete just-imported history, because imports carry old values for both.
-  - ``ended_at`` < cutoff guards a genuinely long-running native front that
-    was created long ago but only just closed - its most recent activity is
-    recent, so it survives the window after ending.
-  - open fronts (``ended_at`` IS NULL) are never pruned while ongoing.
+  - its owning system opted in (``front_retention_days`` > 0),
+  - it is closed (``ended_at`` IS NOT NULL) - open fronts are never pruned,
+  - it ended long ago in the real world (``ended_at`` older than that system's
+    own ``front_retention_days`` window), and
+  - it has lived in this database past the fixed import grace
+    (``created_at`` older than ``front_retention_import_grace_days``).
 
-The prune is mode-gated (aaS only), so the service is driven in-process with
-sheaf_mode monkeypatched to SAAS and the user forced to the free tier in the
-DB. Fronts are seeded directly with explicit timestamps - including
-``created_at`` - because the API / import paths only ever stamp "now" for the
-insert time.
+The import-grace clause is the load-bearing one: an imported front carries an
+old real-world ``ended_at`` but lands with ``created_at`` = now, so it must not
+be aged out until it has actually lived here for the grace. Case (2) below is
+the regression guard for that - it is a retention bug that was caught and fixed
+the same day, no data lost.
+
+Unlike the retired operator pruner, this sweep is NOT mode-gated (it is a user
+privacy control, so it runs in self-hosted too) and is keyed off the
+per-system ``front_retention_days`` setting, not the user tier. Fronts are
+seeded directly with explicit timestamps - including ``created_at`` - because
+the API / import paths only ever stamp "now" for the insert time.
 """
 
 import asyncio
@@ -28,7 +29,6 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import httpx
-import pytest
 
 
 def _register(client: httpx.Client) -> str:
@@ -53,14 +53,14 @@ def _engine_session():
     return engine, sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
-def _set_tier_free_and_seed(email: str, specs: list[tuple]) -> list:
-    """Force the user to the free tier and insert one Front per spec.
+def _seed(email: str, retention_days: int, specs: list[tuple]) -> list:
+    """Set the user's system ``front_retention_days`` and insert one Front per
+    spec.
 
     specs is a list of (created_at, started_at, ended_at|None). ``created_at``
-    is set explicitly: it is the row-insertion time the retention rule keys
-    off, and the real API / import paths only ever stamp it "now", so a test
-    has to backdate it directly to exercise the rule. Returns the new front
-    ids in the same order.
+    is set explicitly: it is the row-insertion time the grace clause keys off,
+    and the real API / import paths only ever stamp it "now", so a test has to
+    backdate it directly. Returns the new front ids in the same order.
     """
 
     async def _run() -> list:
@@ -69,7 +69,7 @@ def _set_tier_free_and_seed(email: str, specs: list[tuple]) -> list:
         from sheaf.crypto import blind_index
         from sheaf.models.front import Front
         from sheaf.models.system import System
-        from sheaf.models.user import User, UserTier
+        from sheaf.models.user import User
 
         engine, async_session = _engine_session()
         ids = []
@@ -79,10 +79,10 @@ def _set_tier_free_and_seed(email: str, specs: list[tuple]) -> list:
                     select(User).where(User.email_hash == blind_index(email))
                 )
             ).scalar_one()
-            user.tier = UserTier.FREE
             system = (
                 await db.execute(select(System).where(System.user_id == user.id))
             ).scalar_one()
+            system.front_retention_days = retention_days
             for created, started, ended in specs:
                 front = Front(
                     system_id=system.id,
@@ -129,13 +129,45 @@ def _surviving_front_ids(email: str) -> set:
     return asyncio.run(_run())
 
 
-def _run_prune() -> dict:
-    async def _run() -> dict:
-        from sheaf.services.front_retention import prune_free_tier_fronts
+def _retention_traces(email: str) -> list:
+    """Return the detail dicts of every RETENTION_PRUNED activity row for the
+    user, so the nothing-silent trace can be asserted."""
+
+    async def _run() -> list:
+        from sqlalchemy import select
+
+        from sheaf.crypto import blind_index
+        from sheaf.models.activity_event import ActivityAction, ActivityEvent
+        from sheaf.models.user import User
 
         engine, async_session = _engine_session()
         async with async_session() as db:
-            result = await prune_free_tier_fronts(db)
+            user = (
+                await db.execute(
+                    select(User).where(User.email_hash == blind_index(email))
+                )
+            ).scalar_one()
+            rows = (
+                await db.execute(
+                    select(ActivityEvent).where(
+                        ActivityEvent.user_id == user.id,
+                        ActivityEvent.action == ActivityAction.RETENTION_PRUNED,
+                    )
+                )
+            ).scalars().all()
+        await engine.dispose()
+        return [r.detail for r in rows]
+
+    return asyncio.run(_run())
+
+
+def _run_sweep() -> dict:
+    async def _run() -> dict:
+        from sheaf.services.front_retention import sweep_front_retention
+
+        engine, async_session = _engine_session()
+        async with async_session() as db:
+            result = await sweep_front_retention(db)
             await db.commit()
         await engine.dispose()
         return result
@@ -143,77 +175,88 @@ def _run_prune() -> dict:
     return asyncio.run(_run())
 
 
-def test_prune_keys_off_insert_and_end_time(client: httpx.Client, monkeypatch):
-    """Prune only a front that was inserted long ago AND ended long ago AND is
-    closed. Five scenarios pin every arm of the rule; case (1) is the
-    regression guard for the 2026-06-23 imported-history incident."""
-    from sheaf.config import SheafMode, settings
+def test_sweep_ages_out_opted_in_old_history(client: httpx.Client, monkeypatch):
+    """Pin every arm of the Option B predicate for an opted-in system, plus the
+    opted-out escape and the nothing-silent activity trace."""
+    from sheaf.config import settings
 
-    monkeypatch.setattr(settings, "sheaf_mode", SheafMode.SAAS)
-    monkeypatch.setattr(settings, "free_tier_front_retention_days", 30)
+    # Pin the import grace so the test doesn't ride on the config default.
+    monkeypatch.setattr(settings, "front_retention_import_grace_days", 14)
 
-    email = _register(client)
     now = datetime.now(UTC)
 
-    imported, old_native, long_recent, still_open, recent = _set_tier_free_and_seed(
-        email,
+    # Opted-in system: 30-day window.
+    opted_in = _register(client)
+    pruned, imported, recent_end, still_open = _seed(
+        opted_in,
+        30,
         [
-            # (1) INCIDENT REGRESSION GUARD - imported historical front.
-            # Inserted now (created_at = now), but carries a ~2-year-old
-            # real-world start/end. It ended long ago yet was inserted just
-            # now, so it MUST SURVIVE. Keying off started_at or ended_at alone
-            # deletes this; the created_at clause is the whole point.
-            (now, now - timedelta(days=730), now - timedelta(days=700)),
-            # (2) Genuinely old native front: inserted ~200d ago, ended ~190d
-            # ago. Old on every axis -> pruned.
+            # (1) Genuinely old native front: inserted ~200d ago, ended ~190d
+            # ago. Old on every axis and past the import grace -> PRUNED.
             (
                 now - timedelta(days=200),
                 now - timedelta(days=200),
                 now - timedelta(days=190),
             ),
-            # (3) Long native front that only just ended: inserted ~200d ago
-            # but ended yesterday (inside the window). Recent activity -> MUST
-            # SURVIVE.
+            # (2) IMPORTED old history: carries a ~2-year-old real-world
+            # start/end but landed just now (created_at = now). Ended long ago
+            # yet inside the import grace -> MUST SURVIVE. This is the
+            # regression guard for the retention bug.
+            (now, now - timedelta(days=730), now - timedelta(days=700)),
+            # (3) Long native front that only just ended: inserted ~200d ago but
+            # ended 5d ago, inside the 30d window -> MUST SURVIVE.
             (
                 now - timedelta(days=200),
                 now - timedelta(days=200),
-                now - timedelta(days=1),
+                now - timedelta(days=5),
             ),
             # (4) Open front (ended_at NULL): never pruned while ongoing, even
-            # though it was inserted long ago.
+            # though inserted long ago.
             (now - timedelta(days=200), now - timedelta(days=200), None),
-            # (5) Recently created and recently ended: inside the window on
-            # every axis -> survives.
-            (now, now - timedelta(days=5), now - timedelta(days=3)),
         ],
     )
 
-    result = _run_prune()
-    # At least our one genuinely-old front (case 2) is removed. items_processed
-    # is a global count across all free-tier users, so only assert it ran;
-    # per-user survival is checked against this account's fronts below.
+    # Opted-out system (front_retention_days = 0): an equally-old front that
+    # WOULD be pruned if it were opted in. Retention off means never touched.
+    opted_out = _register(client)
+    (untouched,) = _seed(
+        opted_out,
+        0,
+        [
+            (
+                now - timedelta(days=200),
+                now - timedelta(days=200),
+                now - timedelta(days=190),
+            ),
+        ],
+    )
+
+    result = _run_sweep()
+    # items_processed is a global count across all opted-in systems, so only
+    # assert the sweep removed at least our one eligible front; per-user
+    # survival is checked against each account below.
     assert result["items_processed"] >= 1
 
-    surviving = _surviving_front_ids(email)
+    surviving = _surviving_front_ids(opted_in)
+    assert pruned not in surviving, (
+        "front ended and inserted long ago on an opted-in system should be aged out"
+    )
     assert imported in surviving, (
-        "REGRESSION: freshly-imported historical front was pruned - this is the "
-        "2026-06-23 incident. created_at (insert time) must protect it."
+        "REGRESSION: freshly-imported old history was aged out - the import "
+        "grace (created_at) must protect it."
     )
-    assert long_recent in surviving, "long front that ended yesterday was wrongly pruned"
+    assert recent_end in surviving, "front that ended inside the window was wrongly pruned"
     assert still_open in surviving, "open front must never be pruned"
-    assert recent in surviving, "recently created + ended front was wrongly pruned"
-    assert old_native not in surviving, (
-        "front inserted and ended long ago (all axes old) should be pruned"
+
+    # Opted-out system: nothing touched.
+    assert untouched in _surviving_front_ids(opted_out), (
+        "a system with front_retention_days = 0 must never have fronts pruned"
     )
 
-
-@pytest.mark.selfhosted
-def test_prune_noop_when_not_saas(client: httpx.Client):
-    """Self-hosted instances never prune: the mode gate short-circuits."""
-    from sheaf.config import SheafMode, settings
-
-    # Belt and braces: the default test stack is self-hosted, but assert the
-    # gate rather than the ambient config.
-    assert settings.sheaf_mode != SheafMode.SAAS
-    result = _run_prune()
-    assert result == {"items_processed": 0}
+    # Nothing-silent: exactly the opted-in user gets a RETENTION_PRUNED trace
+    # carrying the count actually removed for them (case 1 only).
+    traces = _retention_traces(opted_in)
+    assert traces == [{"fronts_pruned": 1}], traces
+    assert _retention_traces(opted_out) == [], (
+        "opted-out user must get no retention trace"
+    )

--- a/tests/test_job_runner_rework.py
+++ b/tests/test_job_runner_rework.py
@@ -573,7 +573,7 @@ def test_expected_jobs_are_marked_destructive():
     reg = jobs_module.get_registry()
 
     destructive = {
-        "prune_free_tier_fronts",
+        "front_retention_sweep",
         "gc_revisions",
         "purge_expired_polls",
         "cleanup_orphaned_files",

--- a/tests/test_revision_retention.py
+++ b/tests/test_revision_retention.py
@@ -268,6 +268,105 @@ def test_override_above_tier_max_is_rejected(client: httpx.Client):
 
 
 # ---------------------------------------------------------------------------
+# Front-history retention setting (inert - no sweep yet, settings surface only)
+# ---------------------------------------------------------------------------
+
+
+def test_get_retention_front_retention_default_off(client: httpx.Client):
+    """front_retention_days defaults to 0 (off = keep forever)."""
+    _register(client)
+    body = client.get("/v1/retention").json()
+    assert body["front_retention_days"] == 0
+
+
+def test_front_retention_enable_applies_immediately_when_no_grace(
+    client: httpx.Client,
+):
+    """Enabling (0 -> N) is a tightening, but with grace=0 it lands at once."""
+    _register(client)
+    resp = client.patch("/v1/retention", json={"front_retention_days": 30})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["front_retention_days"] == 30
+
+
+def test_front_retention_enable_with_grace_is_deferred(client: httpx.Client):
+    """Enabling (0 -> N) with a grace period defers behind SafetyChangeRequest.
+
+    The re-auth gate is satisfied trivially here: the default delete_confirmation
+    tier is NONE, so no password/TOTP is required to defer.
+    """
+    email = _register(client)
+    _set_system_safety_via_db(email, safety_grace_period_days=7)
+
+    resp = client.patch("/v1/retention", json={"front_retention_days": 30})
+    assert resp.status_code == 200, resp.text
+    # Not applied yet - still off while the change waits out the grace window.
+    assert resp.json()["front_retention_days"] == 0
+
+    # The pending change is visible on the system safety endpoint.
+    pending = client.get("/v1/system/safety").json()["pending_changes"]
+    assert any("front_retention_days" in p["changes"] for p in pending)
+
+
+def test_front_retention_shorten_with_grace_is_deferred(client: httpx.Client):
+    """Shortening the window (N -> smaller) is also a tightening and defers."""
+    email = _register(client)
+    _set_system_safety_via_db(
+        email, front_retention_days=90, safety_grace_period_days=7
+    )
+
+    resp = client.patch("/v1/retention", json={"front_retention_days": 30})
+    assert resp.status_code == 200, resp.text
+    # Still on the longer window until the deferred change finalizes.
+    assert resp.json()["front_retention_days"] == 90
+
+    pending = client.get("/v1/system/safety").json()["pending_changes"]
+    assert any(
+        p["changes"].get("front_retention_days") == 30 for p in pending
+    )
+
+
+def test_front_retention_turn_off_applies_immediately(client: httpx.Client):
+    """Turning it off (N -> 0) keeps more data, so it applies immediately even
+    with a grace period configured."""
+    email = _register(client)
+    _set_system_safety_via_db(
+        email, front_retention_days=30, safety_grace_period_days=7
+    )
+
+    resp = client.patch("/v1/retention", json={"front_retention_days": 0})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["front_retention_days"] == 0
+
+
+def test_front_retention_lengthen_applies_immediately(client: httpx.Client):
+    """Lengthening the window (N -> larger) keeps more data, applies at once."""
+    email = _register(client)
+    _set_system_safety_via_db(
+        email, front_retention_days=30, safety_grace_period_days=7
+    )
+
+    resp = client.patch("/v1/retention", json={"front_retention_days": 90})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["front_retention_days"] == 90
+
+
+def test_front_retention_rejects_null(client: httpx.Client):
+    """The column is non-null (0 = off), so there is no clear-override null
+    semantic - an explicit null is a client error."""
+    _register(client)
+    resp = client.patch("/v1/retention", json={"front_retention_days": None})
+    assert resp.status_code == 400
+
+
+def test_front_retention_rejects_negative(client: httpx.Client):
+    """ge=0 bound: a negative window is rejected by schema validation."""
+    _register(client)
+    resp = client.patch("/v1/retention", json={"front_retention_days": -5})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
 # tier_revision_caps + on_tier_change
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sheaf_import.py
+++ b/tests/test_sheaf_import.py
@@ -10,11 +10,16 @@ test_imports_sheaf_runner.py.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
+import os
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import httpx
+
+from tests.conftest import BASE_URL
 
 
 def _upload(client: httpx.Client, path: str, payload: dict) -> httpx.Response:
@@ -23,6 +28,57 @@ def _upload(client: httpx.Client, path: str, payload: dict) -> httpx.Response:
         path,
         files={"file": ("export.json", io.BytesIO(body), "application/json")},
     )
+
+
+def _register_client(c: httpx.Client) -> str:
+    """Register a fresh user on the given client and return the email, so a
+    test can reach into the DB to set that user's system settings."""
+    email = f"ret-preview-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = c.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "testpassword123"},
+    )
+    assert resp.status_code == 201, resp.text
+    c.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+    return email
+
+
+def _set_front_retention(email: str, days: int) -> None:
+    """Set the user's ``System.front_retention_days`` directly in the DB.
+
+    The real toggle routes through a SafetyChangeRequest (asymmetric
+    loosening), which is not what these preview tests exercise - they only
+    need the setting in place - so write it straight to the row."""
+
+    async def _run() -> None:
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.config import settings
+        from sheaf.crypto import blind_index
+        from sheaf.models.system import System
+        from sheaf.models.user import User
+
+        db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+        engine = create_async_engine(db_url)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        async with async_session() as db:
+            user = (
+                await db.execute(
+                    select(User).where(User.email_hash == blind_index(email))
+                )
+            ).scalar_one()
+            system = (
+                await db.execute(select(System).where(System.user_id == user.id))
+            ).scalar_one()
+            system.front_retention_days = days
+            await db.commit()
+        await engine.dispose()
+
+    asyncio.run(_run())
 
 
 def _future_iso(days: int = 30) -> str:
@@ -148,3 +204,59 @@ def test_preview_no_warning_when_open_polls_within_cap(auth_client: httpx.Client
     body = resp.json()
     assert body["open_poll_count"] == n
     assert not [w for w in body["limit_warnings"] if "concurrent-open-poll" in w]
+
+
+def _front_payload() -> dict:
+    """A minimal v2 export carrying one front, so front_count > 0."""
+    return {
+        "version": "2",
+        "system": {"name": "S"},
+        "members": [{"id": "m1", "name": "Alice"}],
+        "fronts": [{"id": "f1", "members": ["m1"]}],
+    }
+
+
+def test_preview_warns_when_retention_on_and_import_has_front_history():
+    """A system with front-history retention turned on that previews an import
+    containing fronting history is told, up front, that the imported history
+    older than its window will age out after the import grace - so there is no
+    surprise deletion later."""
+    with httpx.Client(base_url=BASE_URL) as c:
+        email = _register_client(c)
+        _set_front_retention(email, 30)
+        resp = _upload(c, "/v1/import/sheaf/preview", _front_payload())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["front_count"] == 1
+    hits = [w for w in body["limit_warnings"] if "front-history retention" in w]
+    assert hits, body["limit_warnings"]
+    # The window and the grace are both named, so the message is self-contained.
+    assert "30 days" in hits[0]
+    assert "14 days" in hits[0]
+
+
+def test_preview_no_retention_warning_when_retention_off():
+    """With retention off (the default, 0) the same front-carrying import
+    previews with no retention warning - nothing would age out."""
+    with httpx.Client(base_url=BASE_URL) as c:
+        _register_client(c)
+        resp = _upload(c, "/v1/import/sheaf/preview", _front_payload())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["front_count"] == 1
+    assert not [w for w in body["limit_warnings"] if "front-history retention" in w]
+
+
+def test_preview_no_retention_warning_when_import_has_no_fronts():
+    """Retention on but the import carries no fronting history: no warning,
+    because there is nothing that could age out."""
+    with httpx.Client(base_url=BASE_URL) as c:
+        email = _register_client(c)
+        _set_front_retention(email, 30)
+        payload = _front_payload()
+        payload["fronts"] = []
+        resp = _upload(c, "/v1/import/sheaf/preview", payload)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["front_count"] == 0
+    assert not [w for w in body["limit_warnings"] if "front-history retention" in w]

--- a/tests/test_sp_import_retention_preview.py
+++ b/tests/test_sp_import_retention_preview.py
@@ -1,0 +1,61 @@
+"""Integration tests for the front-history-retention warning on the
+SimplyPlural import *preview* endpoint.
+
+The SP preview endpoint gained a `db` dependency purely to read the previewing
+system's `front_retention_days`, so it can warn - before the user confirms -
+that imported fronting history older than their retention window will age out
+after the import grace. The over-cap SP warnings are covered as pure units in
+test_sp_caps.py; this exercises the endpoint-level retention warning, which
+needs the DB (and so cannot be a pure unit).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import httpx
+
+from tests.conftest import BASE_URL
+from tests.test_sheaf_import import _register_client, _set_front_retention
+
+
+def _upload_sp(client: httpx.Client, payload: dict) -> httpx.Response:
+    body = json.dumps(payload).encode("utf-8")
+    return client.post(
+        "/v1/import/simplyplural/preview",
+        files={"file": ("sp-export.json", io.BytesIO(body), "application/json")},
+    )
+
+
+def _sp_payload_with_front_history() -> dict:
+    """A minimal SP export whose `frontHistory` collection is non-empty, so
+    front_history_count > 0."""
+    return {
+        "members": [{"_id": "m1", "name": "Alice"}],
+        "frontHistory": [{"_id": "fh1", "member": "m1"}],
+    }
+
+
+def test_sp_preview_warns_when_retention_on_and_import_has_front_history():
+    with httpx.Client(base_url=BASE_URL) as c:
+        email = _register_client(c)
+        _set_front_retention(email, 30)
+        resp = _upload_sp(c, _sp_payload_with_front_history())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["front_history_count"] == 1
+    hits = [w for w in body["limit_warnings"] if "front-history retention" in w]
+    assert hits, body["limit_warnings"]
+    assert "30 days" in hits[0]
+    assert "14 days" in hits[0]
+
+
+def test_sp_preview_no_retention_warning_when_retention_off():
+    with httpx.Client(base_url=BASE_URL) as c:
+        _register_client(c)
+        resp = _upload_sp(c, _sp_payload_with_front_history())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["front_history_count"] == 1
+    assert not [w for w in body["limit_warnings"] if "front-history retention" in w]

--- a/web/src/components/front-retention-card.tsx
+++ b/web/src/components/front-retention-card.tsx
@@ -1,0 +1,323 @@
+import { type FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/use-auth";
+import { getRetention, updateRetention } from "@/lib/retention";
+import { getSystemSafety } from "@/lib/system-safety";
+import { apiErrorMessage } from "@/lib/api-errors";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type {
+  RetentionSettings,
+  RetentionUpdate,
+  SafetyChangeRequest,
+} from "@/types/api";
+
+// Fixed server-side grace before a freshly imported front can be aged out.
+// Mirrored here only for the explanatory copy; the sweep enforces it.
+const IMPORT_GRACE_DAYS = 14;
+
+function windowToString(days: number): string {
+  return days === 0 ? "" : String(days);
+}
+
+// "" (empty) or 0 both mean "off = keep forever".
+function parseWindow(input: string): number | "invalid" {
+  const trimmed = input.trim();
+  if (trimmed === "") return 0;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n < 0) return "invalid";
+  return n;
+}
+
+function windowDisplay(days: number): string {
+  return days === 0
+    ? "Off (fronting history kept forever)"
+    : `${days} day${days === 1 ? "" : "s"}`;
+}
+
+// 0 = off = the loosest possible window, so it compares as +infinity. A move
+// to a strictly smaller effective window (enabling from off, or shortening) is
+// the destructive direction. NOTE: this is the opposite keying to the revision
+// retention card's isLoosening, and is written from the front-retention rule
+// directly rather than reused.
+function toEffective(days: number): number {
+  return days === 0 ? Infinity : days;
+}
+
+function timeRemaining(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return "any moment now";
+  const hours = Math.ceil(ms / 3_600_000);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.ceil(ms / 86_400_000);
+  return `in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+export function FrontRetentionCard() {
+  const { data } = useQuery({
+    queryKey: ["retention"],
+    queryFn: getRetention,
+  });
+
+  if (!data) return null;
+  return <FrontRetentionForm settings={data} />;
+}
+
+function FrontRetentionForm({ settings }: { settings: RetentionSettings }) {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+  const safety = useQuery({
+    queryKey: ["system-safety"],
+    queryFn: getSystemSafety,
+  });
+  const gracePeriod = safety.data?.settings.grace_period_days ?? 0;
+  const authTier = safety.data?.settings.auth_tier ?? "none";
+  const pendingChange: SafetyChangeRequest | undefined =
+    safety.data?.pending_changes.find(
+      (c) => "front_retention_days" in c.changes,
+    );
+
+  const [draft, setDraft] = useState(
+    windowToString(settings.front_retention_days),
+  );
+  const [password, setPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
+  const [error, setError] = useState("");
+  const [exportPromptOpen, setExportPromptOpen] = useState(false);
+
+  const parsed = parseWindow(draft);
+  const invalid = parsed === "invalid";
+  const newDays = parsed === "invalid" ? settings.front_retention_days : parsed;
+  const dirty = newDays !== settings.front_retention_days;
+  // Destructive direction: enabling (off -> N) or shortening (N -> M, M < N).
+  const destructive =
+    toEffective(newDays) < toEffective(settings.front_retention_days);
+  const needsReauth = destructive && gracePeriod > 0;
+
+  const mutation = useMutation({
+    mutationFn: updateRetention,
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ["retention"] });
+      qc.invalidateQueries({ queryKey: ["system-safety"] });
+      setPassword("");
+      setTotpCode("");
+      setError("");
+      setExportPromptOpen(false);
+      setDraft(windowToString(res.front_retention_days));
+      if (res.front_retention_days === newDays) {
+        toast.success("Front retention settings saved");
+      } else {
+        // Deferred: the change lands as a pending SafetyChangeRequest and
+        // finalizes after the grace period.
+        toast.success(
+          `Change scheduled. It finalizes after the ${gracePeriod}-day grace period, and you can cancel until then.`,
+        );
+      }
+    },
+    onError: (err) => setError(apiErrorMessage(err, "Failed")),
+  });
+
+  function submit() {
+    const patch: RetentionUpdate = { front_retention_days: newDays };
+    if (needsReauth) {
+      patch.password = password || undefined;
+      patch.totp_code = totpCode || undefined;
+    }
+    mutation.mutate(patch);
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (invalid) {
+      setError("Window must be a non-negative whole number of days (0 or empty = off).");
+      return;
+    }
+    if (!dirty) return;
+    // The destructive direction gets the "export a copy first" prompt in the
+    // path before anything is scheduled for deletion.
+    if (destructive) {
+      setExportPromptOpen(true);
+      return;
+    }
+    submit();
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Fronting History Retention</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Optionally age out your own closed fronting history once it passes a
+          window you choose. Off by default: your history is kept forever unless
+          you turn this on. Freshly imported history gets a fixed{" "}
+          {IMPORT_GRACE_DAYS}-day grace before it can be aged out, so an import
+          you want to review does not vanish out from under you. Open fronts are
+          never aged out while they are ongoing.
+        </p>
+        {pendingChange && (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm">
+            <div className="font-medium">
+              Change to{" "}
+              {windowDisplay(
+                Number(pendingChange.changes.front_retention_days ?? 0),
+              )}{" "}
+              scheduled.
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Finalizes {timeRemaining(pendingChange.finalize_after)}. You can
+              cancel it from{" "}
+              <span className="font-medium">System Safety</span> above until
+              then.
+            </div>
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="front-retention-days" className="text-sm">
+              Retention window (days)
+            </Label>
+            <Input
+              id="front-retention-days"
+              type="number"
+              min={0}
+              value={draft}
+              placeholder="0 = off"
+              onChange={(e) => setDraft(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Currently: {windowDisplay(settings.front_retention_days)}. Set 0
+              (or leave empty) to turn it off.
+            </p>
+          </div>
+          {needsReauth && (
+            <div className="space-y-3 border-t pt-3">
+              <p className="text-sm text-muted-foreground">
+                Turning retention on or shortening the window schedules deletion
+                of history older than the window, so it requires re-auth and
+                takes effect after the {gracePeriod}-day grace period. You can
+                cancel during that window.
+              </p>
+              {(authTier === "password" || authTier === "both") && (
+                <div className="space-y-1">
+                  <Label htmlFor="front-retention-password" className="text-sm">Password</Label>
+                  <Input
+                    id="front-retention-password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                  />
+                </div>
+              )}
+              {(authTier === "totp" || authTier === "both") &&
+                user?.totp_enabled && (
+                  <div className="space-y-1">
+                    <Label htmlFor="front-retention-totp" className="text-sm">TOTP code</Label>
+                    <Input
+                      id="front-retention-totp"
+                      value={totpCode}
+                      onChange={(e) => setTotpCode(e.target.value)}
+                      placeholder="6-digit code"
+                      inputMode="numeric"
+                      maxLength={6}
+                      pattern="[0-9]{6}"
+                      autoComplete="off"
+                      required
+                    />
+                  </div>
+                )}
+            </div>
+          )}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex gap-2">
+            <Button
+              type="submit"
+              size="sm"
+              disabled={!dirty || invalid || mutation.isPending}
+            >
+              {mutation.isPending ? "Saving…" : "Save"}
+            </Button>
+            {dirty && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() =>
+                  setDraft(windowToString(settings.front_retention_days))
+                }
+                disabled={mutation.isPending}
+              >
+                Revert
+              </Button>
+            )}
+          </div>
+        </form>
+        <div className="space-y-2 border-t pt-3 text-xs text-muted-foreground">
+          <p>
+            Re-importing a backup restores fronting history you have aged out,
+            since import cannot tell it was deliberately removed. If you want it
+            gone for good, do not re-import an older export of it.
+          </p>
+          <p>
+            Aging out deletes from your live data, which is the privacy promise
+            here. Operational backups age out on their own schedule, as
+            described in the privacy policy.
+          </p>
+        </div>
+      </CardContent>
+
+      <Dialog open={exportPromptOpen} onOpenChange={setExportPromptOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Export a copy first?</DialogTitle>
+            <DialogDescription>
+              {newDays === 0
+                ? "This will start aging out fronting history."
+                : `This will start aging out fronting history older than ${newDays} day${
+                    newDays === 1 ? "" : "s"
+                  }.`}{" "}
+              Once it is aged out, re-importing a backup is the only way back,
+              and that defeats the point. Export a copy first if you might want
+              one.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setExportPromptOpen(false);
+                navigate("/settings/data");
+              }}
+            >
+              Export front history first
+            </Button>
+            <Button onClick={submit} disabled={mutation.isPending}>
+              {mutation.isPending ? "Saving…" : "Continue without exporting"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/web/src/components/system-safety-card.tsx
+++ b/web/src/components/system-safety-card.tsx
@@ -91,6 +91,10 @@ function changeSummary(changes: Record<string, unknown>): string {
       parts.push(
         v === null ? "revision age cap → tier default" : `revision age cap → ${v} days`,
       );
+    } else if (k === "front_retention_days") {
+      parts.push(
+        v === 0 ? "front retention → off" : `front retention → ${v} days`,
+      );
     } else {
       parts.push(`${k} → ${v}`);
     }

--- a/web/src/routes/settings/safety.tsx
+++ b/web/src/routes/settings/safety.tsx
@@ -1,11 +1,13 @@
 import { SystemSafetyCard } from "@/components/system-safety-card";
 import { RevisionRetentionCard } from "@/components/revision-retention-card";
+import { FrontRetentionCard } from "@/components/front-retention-card";
 
 export function SettingsSafetyPage() {
   return (
     <>
       <SystemSafetyCard />
       <RevisionRetentionCard />
+      <FrontRetentionCard />
     </>
   );
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -610,11 +610,19 @@ export interface RetentionSettings {
   override_revisions: number | null;
   override_days: number | null;
   trim_notice: RetentionTrimNotice | null;
+  // Age-out window for closed fronting history, in days. 0 = off = keep
+  // forever. Enabling or shortening this schedules deletion of history
+  // older than the window (after a fixed import grace), so those changes
+  // route through the System Safety grace + re-auth path; turning it off
+  // or lengthening applies immediately.
+  front_retention_days: number;
 }
 
 export interface RetentionUpdate {
   max_revisions?: number | null;
   max_revision_days?: number | null;
+  // 0 = off = keep fronting history forever.
+  front_retention_days?: number;
   password?: string;
   totp_code?: string;
 }


### PR DESCRIPTION
The final piece of the preserve-by-default plan: user-opt-in front-history
retention. Every other part of that work bounds reads and writes without
deleting identity data; this is the one deletion path that is legitimate,
because the user chooses it, and it retires the operator front-pruner that
started this whole line of work. Design: front-history-privacy-retention.md.

## The feature
- A per-system setting, front_retention_days (0 = off, the default). Off by
  default; a privacy control, not a paid lever, so it is uncapped per tier.
- Enabling or shortening the window schedules deletion, so it routes through
  the existing System Safety grace + re-auth path (a deferred change with a
  countdown you can cancel); turning it off or lengthening applies immediately.
- The sweep ages out a front only when its system opted in, it is closed, it
  ended longer ago than that system's window, AND it has lived in the database
  past a fixed 14-day import grace. That import grace is the key safety
  property: a freshly imported old history is never abruptly deleted, so a user
  who imports an archive to look at it has two weeks to review it or change the
  setting. The sweep is batched, marked destructive (so the kill switch freezes
  it), and leaves a per-user activity-log trace.
- The import preview warns, before you commit, that retention is on and old
  imported history will age out, and how to keep it.
- The old free-tier operator front-pruner is retired outright (it was cost
  control keyed off the wrong column), not kept dormant.
- front_retention_days is deliberately excluded from the data export, so a
  restore never silently re-arms a deletion policy from a file.

## UI
A settings card next to revision retention: set/clear the window, the re-auth +
grace flow, a pending-change countdown, a prompt to export a copy before
enabling, and plain copy about the re-import footgun and that deletion is from
live data.

## Also in here
- Manual admin job triggers (POST /retention/run, /cleanup/run, and the generic
  /jobs/{name}/run) now respect the deletion kill switch: a destructive job
  refuses with 409 while destructive_jobs_enabled is off unless the caller
  passes override_freeze=true, and the override is recorded in the admin audit.
  Previously they called the jobs directly, so a manual run bypassed a freeze.
- The account export is now best-effort against a single unreadable encrypted
  field: it null-fills an optional field (or uses an "[unreadable]" placeholder
  for a required one) and logs a warning, instead of a single bad field 500ing
  the whole backup.

## Testing
Backend suite green across all nine configurations; new tests cover the setting
and its safety-split direction, the sweep predicate (including the imported-old
survives the grace case), the import warning, the kill-switch guard on manual
triggers, and the export robustness. The backend was also driven end to end
against a live instance (enable-defers, sweep, activity trace, import warning,
export exclusion all confirmed). Frontend type-checks and lints clean.

## Noted for follow-up (not in this PR)
The revision-retention card's re-auth direction looks inverted relative to the
backend split (it gates re-auth on raising a cap, but the backend defers
lowering one); harmless when the delete-confirmation tier is "none", but it
would block lowering a revision cap on an account that has one set. The front
card here uses the correct direction; the revision card wants a small separate
fix.
