### PR TITLE
Fix inverted re-auth direction in the revision-retention card

### DIFF
--- a/web/src/components/revision-retention-card.tsx
+++ b/web/src/components/revision-retention-card.tsx
@@ -228,8 +228,10 @@ function RetentionForm({ settings }: { settings: RetentionSettings }) {
   );
 }
 
-// Mirror of split_safety_changes' retention-field rule: None = +inf for
-// comparison so going from a concrete cap to None is a loosening.
+// Mirror of split_safety_changes' retention-field rule: None/0 = +inf, and a
+// SMALLER effective cap (fewer revisions kept, so more history deleted) is the
+// loosening direction that defers behind re-auth + the grace period. Raising a
+// cap, or going to unlimited, is a tightening and applies immediately.
 function isLoosening(
   settings: RetentionSettings,
   newRev: number | null,
@@ -244,5 +246,5 @@ function isLoosening(
 function isCapLoosening(current: number | null, next: number | null): boolean {
   const cur = current === null ? Infinity : current === 0 ? Infinity : current;
   const nxt = next === null ? Infinity : next === 0 ? Infinity : next;
-  return nxt > cur;
+  return nxt < cur;
 }


### PR DESCRIPTION
The revision-retention settings card gated re-auth on the wrong direction. It
asked for re-auth when a revision cap was RAISED, but the backend
(split_safety_changes) defers and requires re-auth when a cap is LOWERED - a
reduced cap deletes more history, so it is the loosening/destructive direction.
The card's own body text ("Lowering caps ... requires re-auth") already
described the correct behaviour; only the comparison was inverted.

Effect: harmless when the account's delete-confirmation tier is "none" (re-auth
is not enforced either way, and the only visible symptom was the re-auth fields
showing on the wrong direction). But on an account with a password or TOTP
delete-confirmation set, LOWERING a revision cap failed - the card never
rendered the credential fields, so it never collected the re-auth the backend
requires for that (deferred) change.

One-line fix (plus the comment): the loosening test now returns true for a
reduced effective cap, matching the backend and the front-history retention
card's direction logic. Type-checks and lints clean.

Found while building the front-history retention UI (PR #187), whose card was
written with the correct direction from the start.
