### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-07
+
 ### Added
 
 - **User-opt-in front-history retention.** You can now set a per-system window that ages out closed fronting history older than a chosen age. It is off by default and is a privacy control rather than a paid feature, so it is not tiered per plan. Enabling it or shortening the window is a deferred, re-auth-gated System Safety change with a cancellable countdown (turning it off or lengthening the window applies immediately), and a front is only ever removed once it is closed, ended longer ago than the window, and has lived in the database past a fixed 14-day import grace - so a freshly imported archive is never abruptly deleted and you have two weeks to review it or change the setting. The settings card sits next to revision retention and prompts you to export a copy before enabling; the import preview warns, before you commit, when retention is on and old imported history will age out, and how to keep it. The setting is deliberately excluded from the data export, so restoring a backup never silently re-arms a deletion policy from a file. Deletions leave a per-user account-activity trace and honour the deletion kill switch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sheaf"
-version = "1.1.1"
+version = "1.2.0"
 description = "Open-source plural system tracking"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1673,7 +1673,7 @@ wheels = [
 
 [[package]]
 name = "sheaf"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
         "@tailwindcss/typography": "^0.5.19",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
### Added

- User-opt-in front-history retention.
- Operator kill switch for data-affecting jobs.
- Per-import row caps.
- Per-account write rate limit and per-system front-switch guard.
- Readiness probe. A new `/health/ready` endpoint checks the database and Redis under a tight timeout, for use as a readiness gate; `/health` stays the always-200 liveness probe.
- Volume metrics for bulk-creatable content.

### Changed

- Revision history is now capped at write time, with a short debounce.
- Importers now honour the API limits they previously bypassed.
- The free-tier operator front-pruner is retired.
- Performance hardening for large accounts.

### Fixed

- Fixed an edge case that caused orphaned-file cleanup to delete images that are still in use.