### PR TITLE
Fix first-run toast, login device-name parity, and stale import copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **No more spurious "Not found." toast on a brand-new account.** The web app reads your saved client settings (theme, onboarding state, dismissed announcements, saved front-view defaults) on load, and a fresh account has no settings stored yet, so the backend returns the expected 404. Several of those reads defaulted to empty correctly but still surfaced the generic error toast, so every first load flashed "Not found." until onboarding wrote the first settings blob. Those reads now suppress the toast for their own expected-empty case.
+- **The trusted-device name field now appears on the standard login form too.** When 2FA is required and you tick "trust this device", the optional device-name field was only rendered on the registration-closed login variant, not the normal tabbed login, so most users could name a trusted device from one form but not the other. Both forms now offer it.
+- **The import history empty-state and the settings import card list every supported source.** The "no imports yet" copy named only four of the supported sources and the settings card omitted OpenPlural; both now reflect the full set (PluralKit, SimplyPlural, Tupperbox, PluralSpace, Prism, OpenPlural, and Sheaf exports).
+- **The notification-channel "Resolved members" preview no longer runs off the card.** On a large system the "Will receive" / "Will not receive" rosters rendered as one unbounded list; each column now scrolls internally past a bound instead of stretching the page.
+
 ## [1.2.0] - 2026-07-07
 
 ### Added

--- a/web/src/components/announcement-banners.tsx
+++ b/web/src/components/announcement-banners.tsx
@@ -21,6 +21,9 @@ function useClientSettings(clientId: string) {
       try {
         const res = await apiFetch<{ settings: Record<string, unknown> }>(
           `/v1/settings/client/${encodeURIComponent(clientId)}`,
+          // No stored blob for this client 404s by design (e.g. a fresh
+          // account with nothing dismissed yet); expected, so don't toast.
+          { skipErrorToast: true },
         );
         return res.settings;
       } catch {

--- a/web/src/components/notifications/live-preview-card.tsx
+++ b/web/src/components/notifications/live-preview-card.tsx
@@ -75,7 +75,7 @@ function Column({
       {rows.length === 0 ? (
         <p className="text-xs text-muted-foreground">None.</p>
       ) : (
-        <ul className="space-y-1">
+        <ul className="max-h-72 space-y-1 overflow-y-auto pr-1">
           {rows.map((r) => (
             <li
               key={r.member_id}

--- a/web/src/components/onboarding-prompt.tsx
+++ b/web/src/components/onboarding-prompt.tsx
@@ -22,6 +22,9 @@ function useWebSettings() {
       try {
         const res = await apiFetch<{ settings: Record<string, unknown> }>(
           "/v1/settings/client/web",
+          // Fresh accounts have no blob yet, so the backend 404s by design;
+          // that is the normal pre-onboarding state, not a toastable error.
+          { skipErrorToast: true },
         );
         return res.settings;
       } catch {

--- a/web/src/components/settings/data-import-card.tsx
+++ b/web/src/components/settings/data-import-card.tsx
@@ -13,7 +13,7 @@ export function DataImportCard() {
           Supported sources: SimplyPlural (export file), PluralKit (export file
           or live API via your <code>pk;token</code>), Tupperbox (export file),
           Sheaf (export file), Octocon and compatible forks (via PK export), Prism
-          (export file), PluralSpace (export file).
+          (export file), PluralSpace (export file), OpenPlural (export file).
         </p>
         <Link to="/import">
           <Button variant="outline">Import data</Button>

--- a/web/src/hooks/use-developer-prefs.ts
+++ b/web/src/hooks/use-developer-prefs.ts
@@ -34,6 +34,9 @@ async function fetchWebSettings(): Promise<WebSettingsShape> {
   try {
     const res = await apiFetch<{ settings: WebSettingsShape }>(
       "/v1/settings/client/web",
+      // No settings blob on a fresh account is the expected 404 here, not an
+      // error the user should see toasted; we default to {} below.
+      { skipErrorToast: true },
     );
     return res.settings ?? {};
   } catch {

--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -161,6 +161,10 @@ async function fetchWebSettings(): Promise<WebClientSettings> {
   try {
     const res = await apiFetch<{ settings: WebClientSettings }>(
       "/v1/settings/client/web",
+      // A fresh account has no settings blob yet, so the backend 404s by
+      // design. That's the normal first-run state here, not an error worth
+      // a toast; we fall back to {} below.
+      { skipErrorToast: true },
     );
     return res.settings ?? {};
   } catch {

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -69,6 +69,9 @@ export function FrontsPage() {
       try {
         const res = await apiFetch<{ settings: Record<string, unknown> }>(
           "/v1/settings/client/web",
+          // A fresh account 404s here (no saved defaults yet); expected, so
+          // don't toast. We fall back to {} below.
+          { skipErrorToast: true },
         );
         return res.settings;
       } catch {

--- a/web/src/routes/imports.tsx
+++ b/web/src/routes/imports.tsx
@@ -108,7 +108,7 @@ export function ImportsPage() {
         <Card className="max-w-lg">
           <CardContent className="py-6 text-sm text-muted-foreground">
             No imports yet. Bring in data from PluralKit, SimplyPlural,
-            Tupperbox, or a Sheaf export.
+            Tupperbox, PluralSpace, Prism, OpenPlural, or a Sheaf export.
             <div className="mt-4">
               <Button size="sm" asChild>
                 <Link to="/import">Start an import</Link>

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -235,19 +235,32 @@ export function LoginPage() {
                           autoFocus
                         />
                       </div>
-                      <div className="flex items-start gap-3">
-                        <Checkbox
-                          id="login-remember"
-                          checked={rememberDevice}
-                          onCheckedChange={(v) => setRememberDevice(v === true)}
-                        />
-                        <Label
-                          htmlFor="login-remember"
-                          className="text-sm font-normal leading-snug cursor-pointer"
-                        >
-                          Trust this device for 30 days. Skip the 2FA prompt on
-                          this browser until then.
-                        </Label>
+                      <div className="space-y-2">
+                        <div className="flex items-start gap-3">
+                          <Checkbox
+                            id="login-remember"
+                            checked={rememberDevice}
+                            onCheckedChange={(v) =>
+                              setRememberDevice(v === true)
+                            }
+                          />
+                          <Label
+                            htmlFor="login-remember"
+                            className="text-sm font-normal leading-snug cursor-pointer"
+                          >
+                            Trust this device for 30 days. Skip the 2FA prompt
+                            on this browser until then.
+                          </Label>
+                        </div>
+                        {rememberDevice && (
+                          <Input
+                            id="login-device-nickname"
+                            value={deviceNickname}
+                            onChange={(e) => setDeviceNickname(e.target.value)}
+                            placeholder="Device name (optional)"
+                            maxLength={128}
+                          />
+                        )}
                       </div>
                     </>
                   )}


### PR DESCRIPTION
Four small UI fixes found while going over the first-run and import screens.

**Spurious "Not found." toast on brand-new accounts.** The web app reads your saved client settings (theme, developer prefs, onboarding state, saved front-view defaults, dismissed announcements) on load. A fresh account has no settings blob stored yet, so the backend returns the expected 404 (an intentional contract, not an error). Five of those reads defaulted to empty correctly but still surfaced the generic error toast, so every first load flashed "Not found." until onboarding wrote the first blob. Those reads now pass `skipErrorToast` for their own expected-empty case, matching the existing house pattern. Swept the rest of the tree for the same catch-and-default shape; the only other candidates were a localStorage read and the internal token-refresh, neither of which toasts.

**Trusted-device name field missing on the standard login.** When 2FA is required and you tick "trust this device", the optional device-name input was only rendered on the registration-closed login variant, not the normal tabbed login, so most users could name a trusted device from one form but not the other. Both forms now offer it. The submit handler already read the shared state, so this is purely the missing input.

**Stale supported-source copy.** The import-history empty-state named only four of the seven supported sources, and the settings import card omitted OpenPlural. Both now reflect the full set (PluralKit, SimplyPlural, Tupperbox, PluralSpace, Prism, OpenPlural, and Sheaf exports). Note the source list is now hardcoded in three places that had drifted apart; a shared constant to kill that drift class is worth a follow-up.

**Resolved-members preview overflow.** On the notification-channel detail page, the "Will receive" / "Will not receive" rosters rendered as one unbounded list, so a large system ran the columns off the card. Each column now scrolls internally past a bound instead of stretching the page.

Type-check and lint clean. No backend or schema changes.