### PR TITLE
Add a global display-timezone preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Global display-timezone preference.** You can now set the timezone your timestamps are shown in, instead of always following the device's clock. It is a per-account preference that syncs across your devices (a sibling of the existing date-format setting) and can be overridden per device, so a machine in another zone can pin its own without changing the account default. The default is "automatic", which keeps today's behaviour (each device uses its own local time). Absolute times carry the zone they are shown in (for example `1:37pm EST`) so there is no ambiguity. The setting is included in your data export and restored on import.
+
 ## [1.2.1] - 2026-07-11
 
 ### Security

--- a/alembic/versions/y6z7a8b9c0d1_add_systems_timezone.py
+++ b/alembic/versions/y6z7a8b9c0d1_add_systems_timezone.py
@@ -1,0 +1,38 @@
+"""Add timezone to systems
+
+Revision ID: y6z7a8b9c0d1
+Revises: x5y6z7a8b9c0
+Create Date: 2026-07-12
+
+Global display-timezone preference. NULL = "auto" = each device renders in its
+own local clock (the default); a non-null value is an IANA zone name validated
+at the API/import boundary. This migration only adds the nullable column -
+rendering against it lands in the client changes.
+
+ADD COLUMN of a nullable column with no default is metadata-only on modern
+Postgres: no table rewrite, existing rows read as NULL. It still briefly takes
+ACCESS EXCLUSIVE, so fail fast rather than queue behind a long-running session.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "y6z7a8b9c0d1"
+down_revision: Union[str, None] = "x5y6z7a8b9c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.add_column(
+        "systems",
+        sa.Column("timezone", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    op.drop_column("systems", "timezone")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
     "prometheus-client>=0.20.0",
     "Pillow>=11.0.0",
     "nh3>=0.2.18",
+    # Bundled IANA tz database so zoneinfo works deterministically regardless of
+    # the container base image (python:3.12-slim does not reliably ship
+    # /usr/share/zoneinfo). Backs System.timezone validation + rendering.
+    "tzdata>=2024.1",
 ]
 
 [project.optional-dependencies]

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -514,6 +514,8 @@ def _system_dict(system: System) -> dict:
         "replace_fronts_default": system.replace_fronts_default,
         "coalesce_contiguous_fronts": system.coalesce_contiguous_fronts,
         "date_format": system.date_format.value,
+        # NULL (auto) round-trips as null; a set zone as its IANA name.
+        "timezone": system.timezone,
         "delete_confirmation": system.delete_confirmation.value,
         # System Safety: per-category toggles + grace period + auto-pin.
         "safety": {

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -64,6 +64,13 @@ class System(UUIDMixin, TimestampMixin, Base):
         default=DateFormat.YMD,
         nullable=False,
     )
+    # Global display timezone for rendered timestamps. NULL = "auto" = each
+    # device uses its own local clock (the default); a non-null value is an
+    # IANA zone name (e.g. "America/New_York") validated against the tz
+    # database at write time. This is the synced account default - clients may
+    # layer a per-device override on top locally. Twin of date_format: both are
+    # exported, round-tripped display preferences, not instance-local chrome.
+    timezone: Mapped[str | None] = mapped_column(String(64), nullable=True)
     # When True, creating a new front automatically ends all currently open fronts.
     replace_fronts_default: Mapped[bool] = mapped_column(
         Boolean, default=True, server_default="true", nullable=False

--- a/sheaf/schemas/system.py
+++ b/sheaf/schemas/system.py
@@ -10,6 +10,7 @@ from sheaf.files import (
     resolve_description_urls,
 )
 from sheaf.models.system import DateFormat, DeleteConfirmation, PrivacyLevel
+from sheaf.timezones import is_valid_timezone
 
 
 class SystemCreate(BaseModel):
@@ -41,6 +42,11 @@ class SystemUpdate(BaseModel):
     color: str | None = Field(default=None, max_length=7)
     privacy: PrivacyLevel | None = None
     date_format: DateFormat | None = None
+    # Unlike the NOT-NULL prefs above, `null` here is a *meaningful* value
+    # (auto = device-local), so timezone is deliberately kept out of the
+    # _reject_explicit_null validator. Omitted -> unchanged (PATCH semantics
+    # via model_fields_set); null -> auto; a string must be a real IANA zone.
+    timezone: str | None = Field(default=None, max_length=64)
     replace_fronts_default: bool | None = None
     coalesce_contiguous_fronts: bool | None = None
 
@@ -48,6 +54,16 @@ class SystemUpdate(BaseModel):
     @classmethod
     def _normalize_avatar(cls, v: str | None) -> str | None:
         return normalize_avatar_url(v)
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_timezone(cls, v: str | None) -> str | None:
+        # None (auto) is allowed and passes through. A non-null value must be
+        # a known IANA zone, else 422 rather than persisting junk that every
+        # client would then fail to format against.
+        if v is not None and not is_valid_timezone(v):
+            raise ValueError(f"unknown timezone {v!r}")
+        return v
 
     @field_validator("description", mode="before")
     @classmethod
@@ -86,6 +102,7 @@ class SystemRead(BaseModel):
     privacy: PrivacyLevel
     delete_confirmation: DeleteConfirmation
     date_format: DateFormat
+    timezone: str | None
     replace_fronts_default: bool
     coalesce_contiguous_fronts: bool
     created_at: datetime

--- a/sheaf/services/openplural_export.py
+++ b/sheaf/services/openplural_export.py
@@ -181,6 +181,7 @@ def build_envelope(
         sys_ext = {
             "note": sys_data.get("note"),
             "date_format": sys_data.get("date_format"),
+            "timezone": sys_data.get("timezone"),
             "replace_fronts_default": sys_data.get("replace_fronts_default"),
             "coalesce_contiguous_fronts": sys_data.get("coalesce_contiguous_fronts"),
             "delete_confirmation": sys_data.get("delete_confirmation"),

--- a/sheaf/services/openplural_import.py
+++ b/sheaf/services/openplural_import.py
@@ -155,6 +155,7 @@ def to_native(envelope: dict) -> dict:
             "color": sys_in.get("color"),
             "privacy": _op_privacy(sys_in.get("privacy")),
             "date_format": ext.get("date_format"),
+            "timezone": ext.get("timezone"),
             "replace_fronts_default": ext.get("replace_fronts_default"),
             "coalesce_contiguous_fronts": ext.get("coalesce_contiguous_fronts"),
             "delete_confirmation": ext.get("delete_confirmation"),

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -112,6 +112,7 @@ from sheaf.services.polls import (
     max_concurrent_open_for_tier,
     max_retention_days_for_tier,
 )
+from sheaf.timezones import is_valid_timezone
 
 logger = logging.getLogger("sheaf.import.sheaf")
 
@@ -164,6 +165,17 @@ _SAFETY_APPLIES_KEYS = (
 def _date_format(val: object) -> DateFormat | None:
     if isinstance(val, str) and val in _VALID_DATE_FORMAT:
         return DateFormat(val)
+    return None
+
+
+def _timezone(val: object) -> str | None:
+    """Coerce an imported timezone to a valid IANA zone, or None (auto).
+
+    Anything that is not a known zone - including null, the wrong type, or a
+    zone name this build's tz database doesn't recognise - falls back to auto
+    rather than persisting a value clients can't format against."""
+    if isinstance(val, str) and is_valid_timezone(val):
+        return val
     return None
 
 
@@ -817,6 +829,10 @@ async def run_import(
             df = _date_format(sys_data.get("date_format"))
             if df is not None:
                 system.date_format = df
+            # Present-and-null (auto), present-and-zone, or present-and-junk
+            # (-> auto) all round-trip; absent leaves the default (auto).
+            if "timezone" in sys_data:
+                system.timezone = _timezone(sys_data.get("timezone"))
 
             # System Safety toggles + grace period + auto-pin. delete_confirmation
             # is deliberately NOT restored: importing a TOTP-requiring tier onto

--- a/sheaf/timezones.py
+++ b/sheaf/timezones.py
@@ -1,0 +1,32 @@
+"""IANA timezone validation for the global display-timezone preference.
+
+`System.timezone` stores an IANA zone name (e.g. "America/New_York") or NULL,
+where NULL means "auto" - each device renders in its own local clock. Any
+non-null value written through the API or restored from an import must be a
+real zone, so both the schema validator and the importer route through
+`is_valid_timezone` here.
+
+We depend on the `tzdata` package rather than the system zone database so the
+valid-zone set is identical everywhere: the backend container base
+(python:3.12-slim) does not reliably ship /usr/share/zoneinfo, which would make
+`available_timezones()` return a near-empty set and reject every zone in prod
+while passing locally. The set includes the city zones plus the generic
+fixed-offset zones the picker offers ("EST", "EST5EDT", "Etc/GMT+5", ...).
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from zoneinfo import available_timezones
+
+
+@lru_cache(maxsize=1)
+def _valid_timezones() -> frozenset[str]:
+    # available_timezones() rebuilds its set on every call; cache it once.
+    return frozenset(available_timezones())
+
+
+def is_valid_timezone(value: str) -> bool:
+    """True if `value` is a known IANA zone name. Does not accept the "auto"
+    sentinel - callers represent auto as NULL/None, not a string."""
+    return value in _valid_timezones()

--- a/tests/test_account_export_completeness.py
+++ b/tests/test_account_export_completeness.py
@@ -63,6 +63,7 @@ def test_export_includes_system_preferences(auth_client: httpx.Client):
     sys = export["system"]
     assert "replace_fronts_default" in sys
     assert "date_format" in sys
+    assert "timezone" in sys
     assert "delete_confirmation" in sys
 
 

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -73,7 +73,7 @@ CLASSIFICATION: dict[type, dict] = {
     System: {
         "exported": {
             "name", "description", "note", "tag", "avatar_url", "color",
-            "privacy", "delete_confirmation", "date_format",
+            "privacy", "delete_confirmation", "date_format", "timezone",
             "replace_fronts_default", "coalesce_contiguous_fronts",
             "auto_pin_first_revision", "safety_grace_period_days",
             "safety_applies_to_members", "safety_applies_to_groups",

--- a/tests/test_openplural_export.py
+++ b/tests/test_openplural_export.py
@@ -29,6 +29,7 @@ def _native() -> dict:
             "id": "s1", "name": "Sys", "description": "d", "note": "sysnote",
             "tag": "|S|", "avatar_url": "/v1/files/avatars/u/a.png",
             "color": "#fff", "privacy": "public", "date_format": "ymd",
+            "timezone": "America/New_York",
             "replace_fronts_default": True, "coalesce_contiguous_fronts": False,
             "delete_confirmation": "password",
             "safety": {"grace_period_days": 7},
@@ -178,6 +179,7 @@ def test_round_trip_to_native_restores_fields():
     assert back["system"]["name"] == "Sys"
     assert back["system"]["note"] == "sysnote"
     assert back["system"]["date_format"] == "ymd"
+    assert back["system"]["timezone"] == "America/New_York"
     assert back["system"]["safety"] == {"grace_period_days": 7}
     m1 = next(m for m in back["members"] if m["id"] == "m1")
     assert m1["name"] == "Alex"

--- a/tests/test_openplural_parity.py
+++ b/tests/test_openplural_parity.py
@@ -40,7 +40,8 @@ DISPOSITION: dict[str, dict[str, object]] = {
         "name": CORE, "description": CORE, "tag": CORE, "color": CORE,
         "privacy": CORE, "avatar_url": CORE,
         # extensions.sheaf.* (note + prefs + the safety/retention blocks).
-        "note": EXT, "date_format": EXT, "replace_fronts_default": EXT,
+        "note": EXT, "date_format": EXT, "timezone": EXT,
+        "replace_fronts_default": EXT,
         "coalesce_contiguous_fronts": EXT, "delete_confirmation": EXT,
         "auto_pin_first_revision": EXT,
         "safety_grace_period_days": EXT, "safety_applies_to_members": EXT,

--- a/tests/test_system_timezone.py
+++ b/tests/test_system_timezone.py
@@ -1,0 +1,59 @@
+"""End-to-end coverage for the System.timezone display preference.
+
+Counterpart to test_patch_null_rejection.py: timezone is the one system pref
+where explicit `null` is *accepted* (null = auto = device-local), so it needs
+its own null-is-fine assertion plus the unknown-zone rejection and the export
+round-trip. Needs the docker stack (auth_client)."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def test_default_timezone_is_null(auth_client: httpx.Client):
+    sys = auth_client.get("/v1/systems/me").json()
+    assert sys["timezone"] is None
+
+
+def test_patch_sets_and_reads_timezone(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        "/v1/systems/me", json={"timezone": "America/New_York"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["timezone"] == "America/New_York"
+    # Persisted, not just echoed.
+    assert auth_client.get("/v1/systems/me").json()["timezone"] == "America/New_York"
+
+
+def test_patch_accepts_generic_zone(auth_client: httpx.Client):
+    resp = auth_client.patch("/v1/systems/me", json={"timezone": "EST"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["timezone"] == "EST"
+
+
+def test_patch_null_sets_auto(auth_client: httpx.Client):
+    # Pin a zone, then clear it back to auto with an explicit null.
+    auth_client.patch("/v1/systems/me", json={"timezone": "Europe/London"})
+    resp = auth_client.patch("/v1/systems/me", json={"timezone": None})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["timezone"] is None
+
+
+def test_patch_rejects_unknown_timezone(auth_client: httpx.Client):
+    resp = auth_client.patch(
+        "/v1/systems/me", json={"timezone": "Mars/Olympus_Mons"}
+    )
+    assert resp.status_code == 422
+
+
+def test_omitted_timezone_left_unchanged(auth_client: httpx.Client):
+    auth_client.patch("/v1/systems/me", json={"timezone": "Asia/Tokyo"})
+    # A PATCH that doesn't mention timezone must not reset it.
+    auth_client.patch("/v1/systems/me", json={"name": "Renamed"})
+    assert auth_client.get("/v1/systems/me").json()["timezone"] == "Asia/Tokyo"
+
+
+def test_export_includes_timezone(auth_client: httpx.Client):
+    auth_client.patch("/v1/systems/me", json={"timezone": "America/Chicago"})
+    export = auth_client.get("/v1/export").json()
+    assert export["system"]["timezone"] == "America/Chicago"

--- a/tests/test_timezone_validation.py
+++ b/tests/test_timezone_validation.py
@@ -1,0 +1,63 @@
+"""Pure-Python coverage for the display-timezone validation layer.
+
+Runs headless (no docker stack): exercises `is_valid_timezone` and the
+`SystemUpdate` schema validator directly. The end-to-end API + export/import
+behaviour lives in `test_system_timezone.py` (needs the stack)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from sheaf.schemas.system import SystemUpdate
+from sheaf.timezones import is_valid_timezone
+
+
+def test_known_city_zone_is_valid():
+    assert is_valid_timezone("America/New_York")
+
+
+def test_generic_fixed_offset_zones_are_valid():
+    # The picker offers these "generic" zones (no city), so validation must
+    # accept them too, not just Area/Location city zones.
+    assert is_valid_timezone("EST")
+    assert is_valid_timezone("EST5EDT")
+    assert is_valid_timezone("Etc/GMT+5")
+    assert is_valid_timezone("UTC")
+
+
+def test_unknown_and_junk_zones_are_invalid():
+    assert not is_valid_timezone("Mars/Olympus_Mons")
+    assert not is_valid_timezone("america/new_york")  # case-sensitive
+    assert not is_valid_timezone("")
+    assert not is_valid_timezone("auto")  # auto is NULL, not a zone string
+
+
+def test_schema_accepts_valid_zone():
+    body = SystemUpdate(timezone="America/New_York")
+    assert body.timezone == "America/New_York"
+    assert "timezone" in body.model_fields_set
+
+
+def test_schema_accepts_null_as_auto():
+    # null is a *meaningful* value here (auto), so it must pass validation -
+    # unlike the NOT-NULL prefs which reject explicit null.
+    body = SystemUpdate(timezone=None)
+    assert body.timezone is None
+    assert "timezone" in body.model_fields_set
+
+
+def test_schema_omitted_timezone_is_unset():
+    # Omitted -> not in fields_set, so the PATCH handler leaves it unchanged.
+    body = SystemUpdate(name="x")
+    assert "timezone" not in body.model_fields_set
+
+
+def test_schema_rejects_unknown_zone():
+    with pytest.raises(ValidationError):
+        SystemUpdate(timezone="Mars/Olympus_Mons")
+
+
+def test_schema_rejects_overlong_zone():
+    with pytest.raises(ValidationError):
+        SystemUpdate(timezone="A" * 65)

--- a/uv.lock
+++ b/uv.lock
@@ -1697,6 +1697,7 @@ dependencies = [
     { name = "pywebpush" },
     { name = "redis", extra = ["hiredis"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1751,6 +1752,7 @@ requires-dist = [
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
 provides-extras = ["s3", "ses", "sendgrid", "smtp", "dev"]
@@ -1847,6 +1849,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -19,6 +19,33 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Timezone guard: dates must render through the blessed formatters
+      // (useDateFormatters / formatDate / formatDateTime in @/lib/date-format)
+      // so they honour the user's timezone preference and carry a zone stamp.
+      // Raw toLocale* on a date silently renders in the browser's zone and
+      // dodges the preference - see lib/date-format.ts. Numeric
+      // `n.toLocaleString()` is unaffected (only the Date form is caught).
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.property.name='toLocaleDateString']",
+          message:
+            'Do not format dates with toLocaleDateString (ignores the timezone preference). Use formatDate from useDateFormatters()/@/lib/date-format.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='toLocaleTimeString']",
+          message:
+            'Do not format times with toLocaleTimeString (ignores the timezone preference). Use formatDateTime from useDateFormatters()/@/lib/date-format.',
+        },
+        {
+          selector:
+            "CallExpression[callee.property.name='toLocaleString'][callee.object.callee.name='Date']",
+          message:
+            'Do not format a Date with toLocaleString (ignores the timezone preference). Use formatDateTime from useDateFormatters()/@/lib/date-format. (Numeric toLocaleString is fine.)',
+        },
+      ],
+    },
   },
   // shadcn/ui components export variant helpers alongside components
   {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "diff": "^9.0.0",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.577.0",
@@ -3815,6 +3816,15 @@
       "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
       "license": "MIT"
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "diff": "^9.0.0",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.577.0",

--- a/web/src/components/content-revision-list.tsx
+++ b/web/src/components/content-revision-list.tsx
@@ -20,10 +20,9 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DestructiveConfirmDialog } from "@/components/destructive-confirm-dialog";
-import { formatDateTime } from "@/lib/date-format";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import type {
   ContentRevision,
-  DateFormat,
   DeleteConfirmation,
   DestructiveConfirm,
   UnpinRevisionResponse,
@@ -76,7 +75,6 @@ export function ContentRevisionList({
   authTier,
   invalidateOnRestore,
   emptyMessage = "No revisions yet. Edits will appear here.",
-  dateFormat = "ymd",
 }: {
   targetId: string;
   currentBody: string;
@@ -95,9 +93,9 @@ export function ContentRevisionList({
   authTier?: DeleteConfirmation;
   invalidateOnRestore: readonly (readonly unknown[])[];
   emptyMessage?: string;
-  dateFormat?: DateFormat;
 }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const { data, isLoading } = useQuery({
     queryKey,
     queryFn: () => list(targetId),
@@ -144,7 +142,7 @@ export function ContentRevisionList({
       invalidateAll();
       setUnpinConfirm(null);
       if (resp.pending_action_id && resp.finalize_after) {
-        const when = new Date(resp.finalize_after).toLocaleString();
+        const when = formatDateTime(resp.finalize_after);
         toast.success(`Unpin queued — finalizes ${when}. Cancel from Safety settings.`);
       } else {
         toast.success("Revision unpinned");
@@ -211,7 +209,7 @@ export function ContentRevisionList({
                     <span className="truncate">{rev.title || "(untitled)"}</span>
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    {formatDateTime(rev.created_at, dateFormat)}
+                    {formatDateTime(rev.created_at)}
                     {rev.editor_member_names.length > 0
                       ? ` · ${rev.editor_member_names.join(", ")}`
                       : ""}
@@ -328,7 +326,7 @@ export function ContentRevisionList({
             <DialogTitle>
               {previewing?.rev.title ||
                 (previewing
-                  ? `Revision from ${formatDateTime(previewing.rev.created_at, dateFormat)}`
+                  ? `Revision from ${formatDateTime(previewing.rev.created_at)}`
                   : "Revision")}
             </DialogTitle>
           </DialogHeader>

--- a/web/src/components/edit-front-dialog.tsx
+++ b/web/src/components/edit-front-dialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { useUpdateFront } from "@/hooks/use-fronts";
 import type { Front } from "@/types/api";
 import { Button } from "@/components/ui/button";
@@ -16,21 +17,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MemberSelect } from "@/components/member-select";
 
-function toLocalInput(iso: string | null): string {
-  if (!iso) return "";
-  // datetime-local wants YYYY-MM-DDTHH:mm in the browser's local zone.
-  const d = new Date(iso);
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-    d.getHours(),
-  )}:${pad(d.getMinutes())}`;
-}
-
-function fromLocalInput(value: string): string | null {
-  if (!value) return null;
-  return new Date(value).toISOString();
-}
-
 export function EditFrontDialog({
   front,
   onOpenChange,
@@ -42,6 +28,9 @@ export function EditFrontDialog({
   onSaved?: () => void;
 }) {
   const updateFront = useUpdateFront();
+  // datetime-local values are rendered/parsed in the display timezone, so the
+  // times a user reads elsewhere match the times they edit here.
+  const { toDateTimeLocal, fromDateTimeLocal, timeZone } = useDateFormatters();
   const [error, setError] = useState("");
 
   // Reinit the form on the open transition without useEffect (lint
@@ -67,8 +56,8 @@ export function EditFrontDialog({
     setDraft({
       fromFrontId: front.id,
       memberIds: front.member_ids,
-      startedAt: toLocalInput(front.started_at),
-      endedAt: toLocalInput(front.ended_at),
+      startedAt: toDateTimeLocal(front.started_at),
+      endedAt: toDateTimeLocal(front.ended_at),
       reopen: false,
       customStatus: front.custom_status ?? "",
     });
@@ -105,21 +94,21 @@ export function EditFrontDialog({
       custom_status?: string | null;
     } = {};
 
-    const originalStartedAt = toLocalInput(front.started_at);
-    const originalEndedAt = toLocalInput(front.ended_at);
+    const originalStartedAt = toDateTimeLocal(front.started_at);
+    const originalEndedAt = toDateTimeLocal(front.ended_at);
     const originalCustomStatus = front.custom_status ?? "";
     const originalMemberIds = [...front.member_ids].sort();
     const draftMemberIds = [...draft.memberIds].sort();
 
     if (draft.startedAt !== originalStartedAt) {
-      const iso = fromLocalInput(draft.startedAt);
+      const iso = fromDateTimeLocal(draft.startedAt);
       if (iso) body.started_at = iso;
     }
     // Reopen flag wins: explicit clear.
     if (draft.reopen) {
       body.ended_at = null;
     } else if (draft.endedAt !== originalEndedAt) {
-      body.ended_at = fromLocalInput(draft.endedAt);
+      body.ended_at = fromDateTimeLocal(draft.endedAt);
     }
     if (draft.customStatus !== originalCustomStatus) {
       body.custom_status = draft.customStatus.trim() || null;
@@ -199,8 +188,8 @@ export function EditFrontDialog({
         </div>
 
         <p className="text-xs text-muted-foreground">
-          Times are in your device's local timezone, in the date format your
-          browser uses.
+          Times are in {timeZone ?? "your device's local timezone"}. The
+          picker's date format follows your browser.
         </p>
 
         {front?.ended_at && (

--- a/web/src/components/front-audit-history.tsx
+++ b/web/src/components/front-audit-history.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 
 import { listFrontAudit } from "@/lib/fronts";
 import { useMembers } from "@/hooks/use-members";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatDateTime } from "@/lib/utils";
 import type { FrontSnapshot } from "@/types/api";
 
 function memberNames(
@@ -23,6 +23,7 @@ function diff(
   before: FrontSnapshot,
   after: FrontSnapshot,
   members: Map<string, { display_name: string | null; name: string }>,
+  formatDateTime: (d: string | null | undefined) => string,
 ): { label: string; from: string; to: string }[] {
   const rows: { label: string; from: string; to: string }[] = [];
 
@@ -63,6 +64,7 @@ function diff(
 }
 
 export function FrontAuditHistory({ frontId }: { frontId: string }) {
+  const { formatDateTime } = useDateFormatters();
   const { data: events, isLoading } = useQuery({
     queryKey: ["fronts", frontId, "audit"],
     queryFn: () => listFrontAudit(frontId),
@@ -86,7 +88,7 @@ export function FrontAuditHistory({ frontId }: { frontId: string }) {
   return (
     <ul className="space-y-3">
       {events.map((ev) => {
-        const changes = diff(ev.before, ev.after, members);
+        const changes = diff(ev.before, ev.after, members, formatDateTime);
         return (
           <li
             key={ev.id}

--- a/web/src/components/journal-entry-card.tsx
+++ b/web/src/components/journal-entry-card.tsx
@@ -1,9 +1,9 @@
 import { Link } from "react-router";
 import { Card, CardContent } from "@/components/ui/card";
 import { PendingDeleteBadge } from "@/components/pending-delete-badge";
-import { formatDateTime } from "@/lib/date-format";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { cn } from "@/lib/utils";
-import type { DateFormat, JournalEntry, Member } from "@/types/api";
+import type { JournalEntry, Member } from "@/types/api";
 
 const SNIPPET_CHARS = 180;
 
@@ -20,15 +20,14 @@ function snippet(body: string): string {
 export function JournalEntryCard({
   entry,
   memberLookup,
-  dateFormat = "ymd",
 }: {
   entry: JournalEntry;
   memberLookup?: Map<string, Member>;
-  dateFormat?: DateFormat;
 }) {
+  const { formatDateTime } = useDateFormatters();
   const member = entry.member_id ? memberLookup?.get(entry.member_id) : null;
   const titleDisplay =
-    entry.title || `Entry from ${formatDateTime(entry.created_at, dateFormat)}`;
+    entry.title || `Entry from ${formatDateTime(entry.created_at)}`;
   const authors = entry.author_member_names.length > 0
     ? entry.author_member_names.join(", ")
     : "account";
@@ -45,7 +44,7 @@ export function JournalEntryCard({
           <div className="flex flex-wrap items-baseline justify-between gap-2">
             <p className="font-medium truncate">{titleDisplay}</p>
             <span className="text-xs text-muted-foreground shrink-0">
-              {formatDateTime(entry.created_at, dateFormat)}
+              {formatDateTime(entry.created_at)}
             </span>
           </div>
           <p className="text-xs text-muted-foreground">

--- a/web/src/components/notifications/activation-link-modal.tsx
+++ b/web/src/components/notifications/activation-link-modal.tsx
@@ -1,6 +1,7 @@
 import { Copy, ExternalLink } from "lucide-react";
 import { toast } from "sonner";
 
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -24,8 +25,8 @@ export function ActivationLinkModal({
   expiresAt: string | null;
   channelName: string;
 }) {
+  const { formatDateTime } = useDateFormatters();
   if (!url) return null;
-  const expires = expiresAt ? new Date(expiresAt) : null;
 
   function copy() {
     if (!url) return;
@@ -43,9 +44,9 @@ export function ActivationLinkModal({
           <DialogDescription>
             One-time activation link. We won't show it again, so copy it now and
             relay it to the recipient out-of-band (chat, signal, in-person).
-            {expires && (
+            {expiresAt && (
               <>
-                {" "}Expires <strong>{expires.toLocaleString()}</strong>.
+                {" "}Expires <strong>{formatDateTime(expiresAt)}</strong>.
               </>
             )}
           </DialogDescription>

--- a/web/src/components/notifications/receiving-list.tsx
+++ b/web/src/components/notifications/receiving-list.tsx
@@ -5,6 +5,7 @@ import {
   useReceiving,
   useUnsubscribeReceiving,
 } from "@/hooks/use-notifications";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import type { ReceivingChannelView } from "@/types/api";
 
 import { destinationLabel } from "./destination-meta";
@@ -72,6 +73,7 @@ function ReceivingRow({
   channel: ReceivingChannelView;
   onUnsubscribe: (channelId: string) => void;
 }) {
+  const { formatDateTime } = useDateFormatters();
   const state =
     channel.destination_state === "disabled" && channel.paused_by_sender
       ? PAUSED_BY_SENDER_LABEL
@@ -98,7 +100,7 @@ function ReceivingRow({
             {channel.last_delivered_at && (
               <>
                 {" · last delivery "}
-                {new Date(channel.last_delivered_at).toLocaleString()}
+                {formatDateTime(channel.last_delivered_at)}
               </>
             )}
           </p>

--- a/web/src/components/pending-delete-badge.tsx
+++ b/web/src/components/pending-delete-badge.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { Clock } from "lucide-react";
 
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { cn } from "@/lib/utils";
 
 /** Compact "Pending delete - finalises in Nd" badge for list items whose
@@ -15,19 +16,16 @@ export function PendingDeleteBadge({
   finalizeAt: string | null | undefined;
   className?: string;
 }) {
+  const { formatDate, formatDateTime } = useDateFormatters();
   if (!finalizeAt) return null;
   // Show the absolute finalize date - pure across renders (no Date.now in
   // the render path) and more informative anyway for a grace window of
   // days. The Settings -> Safety page shows the exact countdown.
-  const date = new Date(finalizeAt);
-  const label = date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
+  const label = formatDate(finalizeAt);
   return (
     <Link
       to="/settings/safety"
-      title={`Pending delete - finalises ${date.toLocaleString()}. Click to cancel.`}
+      title={`Pending delete - finalises ${formatDateTime(finalizeAt)}. Click to cancel.`}
       className={cn(
         "inline-flex items-center gap-1 rounded-full border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700 hover:bg-amber-500/20 dark:text-amber-400",
         className,

--- a/web/src/components/settings/account-activity-card.tsx
+++ b/web/src/components/settings/account-activity-card.tsx
@@ -3,6 +3,7 @@ import {
   getMyAccountActivity,
   type AccountActivityEvent,
 } from "@/lib/account-activity";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
@@ -38,6 +39,7 @@ function formatDetail(detail: Record<string, unknown> | null): string {
 }
 
 export function AccountActivityCard() {
+  const { formatDateTime } = useDateFormatters();
   const { data: events, isLoading } = useQuery({
     queryKey: ["account-activity", "me"],
     queryFn: () => getMyAccountActivity(),
@@ -77,7 +79,7 @@ export function AccountActivityCard() {
                     </span>
                   </div>
                   <span className="text-xs text-muted-foreground whitespace-nowrap">
-                    {new Date(e.created_at).toLocaleString()}
+                    {formatDateTime(e.created_at)}
                   </span>
                 </div>
                 {e.detail && Object.keys(e.detail).length > 0 && (

--- a/web/src/components/settings/active-sessions-card.tsx
+++ b/web/src/components/settings/active-sessions-card.tsx
@@ -6,11 +6,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { timeAgo } from "@/lib/utils";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Pencil } from "lucide-react";
 import { toast } from "sonner";
 
 export function ActiveSessionsCard() {
   const qc = useQueryClient();
+  const { formatDate } = useDateFormatters();
   const { data: sessions } = useQuery({
     queryKey: ["sessions"],
     queryFn: getSessions,
@@ -125,7 +127,7 @@ export function ActiveSessionsCard() {
               <p className="text-xs text-muted-foreground">
                 Last active {timeAgo(s.last_active_at)}
                 {s.last_active_ip && ` from ${s.last_active_ip}`}
-                {" · "}Created {new Date(s.created_at).toLocaleDateString()}
+                {" · "}Created {formatDate(s.created_at)}
                 {s.created_ip && ` from ${s.created_ip}`}
               </p>
             </div>

--- a/web/src/components/settings/admin-activity-card.tsx
+++ b/web/src/components/settings/admin-activity-card.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getMyAdminActivity, type UserAdminActivityEvent } from "@/lib/admin";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
@@ -20,6 +21,7 @@ function formatDiff(
 }
 
 export function AdminActivityCard() {
+  const { formatDateTime } = useDateFormatters();
   const { data: events, isLoading } = useQuery({
     queryKey: ["admin-activity", "me"],
     queryFn: () => getMyAdminActivity(),
@@ -62,7 +64,7 @@ export function AdminActivityCard() {
                     </span>
                   </div>
                   <span className="text-xs text-muted-foreground whitespace-nowrap">
-                    {new Date(e.created_at).toLocaleString()}
+                    {formatDateTime(e.created_at)}
                   </span>
                 </div>
                 {e.reason && (

--- a/web/src/components/settings/api-keys-card.tsx
+++ b/web/src/components/settings/api-keys-card.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useState, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { listApiKeys, createApiKey, revokeApiKey } from "@/lib/api-keys";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -137,6 +138,7 @@ function ScopeRow({
 
 export function ApiKeysCard() {
   const { user } = useAuth();
+  const { formatDate } = useDateFormatters();
   const qc = useQueryClient();
   const { data: keys } = useQuery({ queryKey: ["api-keys"], queryFn: listApiKeys });
   const revoke = useMutation({
@@ -299,9 +301,9 @@ export function ApiKeysCard() {
                     ))}
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Created {new Date(k.created_at).toLocaleDateString()}
-                    {k.last_used_at && ` · Last used ${new Date(k.last_used_at).toLocaleDateString()}`}
-                    {k.expires_at && ` · Expires ${new Date(k.expires_at).toLocaleDateString()}`}
+                    Created {formatDate(k.created_at)}
+                    {k.last_used_at && ` · Last used ${formatDate(k.last_used_at)}`}
+                    {k.expires_at && ` · Expires ${formatDate(k.expires_at)}`}
                   </p>
                 </div>
                 {revokeConfirmId === k.id ? (

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { showApiErrorToast } from "@/lib/api-errors";
 
 import { useAuth } from "@/hooks/use-auth";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import {
   createExportJob,
   exportData,
@@ -160,6 +161,7 @@ function StepUpDialog({
 
 export function DataExportCard() {
   const { user } = useAuth();
+  const { formatDateTime } = useDateFormatters();
   const qc = useQueryClient();
   const [syncing, setSyncing] = useState(false);
   const [mode, setMode] = useState<ExportMode | null>(null);
@@ -444,14 +446,14 @@ export function DataExportCard() {
                       <span className="text-xs text-muted-foreground">
                         {FORMAT_LABELS[j.format] ?? j.format}
                         {" · "}
-                        {new Date(j.requested_at).toLocaleString()}
+                        {formatDateTime(j.requested_at)}
                       </span>
                       <span className="text-xs">
                         <StatusBadge status={j.status} />{" "}
                         {j.status === "done" && j.expires_at && (
                           <span className="text-muted-foreground">
                             · {formatBytes(j.file_size_bytes)} · expires{" "}
-                            {new Date(j.expires_at).toLocaleString()}
+                            {formatDateTime(j.expires_at)}
                           </span>
                         )}
                         {j.status === "failed" && j.error && (

--- a/web/src/components/settings/delete-account-card.tsx
+++ b/web/src/components/settings/delete-account-card.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { requestAccountDeletion, cancelDeletion, getAuthConfig } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,6 +12,7 @@ import { ApiError } from "@/lib/api-client";
 
 export function DeleteAccountCard() {
   const { user, refreshUser } = useAuth();
+  const { formatDate } = useDateFormatters();
   const [password, setPassword] = useState("");
   const [totpCode, setTotpCode] = useState("");
   const [error, setError] = useState("");
@@ -54,9 +56,7 @@ export function DeleteAccountCard() {
   }
 
   if (isPending) {
-    const deletionDate = user?.deletion_scheduled_for
-      ? new Date(user.deletion_scheduled_for)
-      : null;
+    const deletionDate = user?.deletion_scheduled_for ?? null;
 
     return (
       <Card className="border-destructive/50">
@@ -69,9 +69,7 @@ export function DeleteAccountCard() {
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
             Your account is scheduled for permanent deletion
-            {deletionDate
-              ? ` on ${deletionDate.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" })}`
-              : ""}.
+            {deletionDate ? ` on ${formatDate(deletionDate)}` : ""}.
             All your data will be permanently removed.
           </p>
           <Button

--- a/web/src/components/settings/system-profile-card.tsx
+++ b/web/src/components/settings/system-profile-card.tsx
@@ -13,6 +13,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  AUTO_VALUE,
+  FOLLOW_ACCOUNT_VALUE,
+  TimezoneSelect,
+} from "@/components/timezone-select";
+import { useTimezone } from "@/hooks/use-timezone";
 import { dateFormatLabels } from "@/lib/date-format";
 import type { DateFormat, PrivacyLevel } from "@/types/api";
 import { toast } from "sonner";
@@ -48,8 +54,8 @@ function SystemSettingsForm({
   onSubmit,
   loading,
 }: {
-  initial: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format?: DateFormat };
-  onSubmit: (data: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format: DateFormat }) => void;
+  initial: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format?: DateFormat; timezone?: string | null };
+  onSubmit: (data: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format: DateFormat; timezone: string | null }) => void;
   loading: boolean;
 }) {
   const [name, setName] = useState(initial.name);
@@ -60,6 +66,7 @@ function SystemSettingsForm({
   const [color, setColor] = useState(initial.color ?? "");
   const [privacy, setPrivacy] = useState<PrivacyLevel>(initial.privacy);
   const [dateFormat, setDateFormat] = useState<DateFormat>(initial.date_format ?? "ymd");
+  const [timezone, setTimezone] = useState<string | null>(initial.timezone ?? null);
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -72,6 +79,7 @@ function SystemSettingsForm({
       color: color || null,
       privacy,
       date_format: dateFormat,
+      timezone,
     });
   }
 
@@ -172,11 +180,69 @@ function SystemSettingsForm({
               </SelectContent>
             </Select>
           </div>
+          <div className="space-y-2">
+            <Label htmlFor="system-timezone">Timezone</Label>
+            <TimezoneSelect
+              id="system-timezone"
+              value={timezone ?? AUTO_VALUE}
+              specialOptions={[
+                { value: AUTO_VALUE, label: "Automatic (device local)" },
+              ]}
+              onValueChange={(v) => setTimezone(v === AUTO_VALUE ? null : v)}
+            />
+            <p className="text-xs text-muted-foreground">
+              The timezone timestamps are shown in, synced across your devices.
+              "Automatic" uses each device's own clock. Saved with this form.
+            </p>
+          </div>
+          <DeviceTimezoneOverride />
           <Button type="submit" disabled={loading}>
             {loading ? "Saving..." : "Save"}
           </Button>
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * Per-device timezone override. Distinct from the account default above: this
+ * writes localStorage on this browser only, applies immediately (no Save), and
+ * never touches the synced account value - so a machine in another zone can pin
+ * its own without changing what other devices see.
+ */
+function DeviceTimezoneOverride() {
+  const { deviceOverride, setDeviceOverride, resolvedTimeZone } = useTimezone();
+
+  // Map the override state (null | "auto" | zone) onto the picker's sentinels.
+  const value =
+    deviceOverride === null
+      ? FOLLOW_ACCOUNT_VALUE
+      : deviceOverride === "auto"
+        ? AUTO_VALUE
+        : deviceOverride;
+
+  return (
+    <div className="space-y-2 rounded-md border p-3 bg-muted/20">
+      <Label htmlFor="device-timezone">On this device</Label>
+      <TimezoneSelect
+        id="device-timezone"
+        value={value}
+        specialOptions={[
+          { value: FOLLOW_ACCOUNT_VALUE, label: "Follow account default" },
+          { value: AUTO_VALUE, label: "Automatic (this device's clock)" },
+        ]}
+        onValueChange={(v) =>
+          setDeviceOverride(
+            v === FOLLOW_ACCOUNT_VALUE ? null : v === AUTO_VALUE ? "auto" : v,
+          )
+        }
+      />
+      <p className="text-xs text-muted-foreground">
+        Overrides the account timezone on this browser only, applied
+        immediately. Currently showing times in{" "}
+        {resolvedTimeZone ?? "this device's local zone"}.
+      </p>
+    </div>
   );
 }

--- a/web/src/components/settings/tags-manager-card.tsx
+++ b/web/src/components/settings/tags-manager-card.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTags, useCreateTag, useUpdateTag, useDeleteTag } from "@/hooks/use-tags";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { getMySystem } from "@/lib/systems";
 import { ColorDot } from "@/components/color-dot";
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,7 @@ import { Link } from "react-router";
 
 export function TagsManagerCard() {
   const { data: tags } = useTags();
+  const { formatDateTime } = useDateFormatters();
   const { data: system } = useQuery({
     queryKey: ["system", "me"],
     queryFn: getMySystem,
@@ -119,7 +121,7 @@ export function TagsManagerCard() {
                 }}
                 title={
                   t.pending_delete_at
-                    ? `Pending delete - finalises ${new Date(t.pending_delete_at).toLocaleString()}. Click to cancel in Safety.`
+                    ? `Pending delete - finalises ${formatDateTime(t.pending_delete_at)}. Click to cancel in Safety.`
                     : undefined
                 }
               >

--- a/web/src/components/settings/trusted-devices-card.tsx
+++ b/web/src/components/settings/trusted-devices-card.tsx
@@ -6,11 +6,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { timeAgo } from "@/lib/utils";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Pencil } from "lucide-react";
 import { toast } from "sonner";
 
 export function TrustedDevicesCard() {
   const qc = useQueryClient();
+  const { formatDate } = useDateFormatters();
   const { data: devices } = useQuery({
     queryKey: ["trusted-devices"],
     queryFn: getTrustedDevices,
@@ -138,7 +140,7 @@ export function TrustedDevicesCard() {
                   ? `Last used ${timeAgo(d.last_used_at)}`
                   : "Not yet used"}
                 {d.last_used_ip && ` from ${d.last_used_ip}`}
-                {" · "}Expires {new Date(d.expires_at).toLocaleDateString()}
+                {" · "}Expires {formatDate(d.expires_at)}
               </p>
             </div>
             <Button

--- a/web/src/components/settings/uploaded-files-card.tsx
+++ b/web/src/components/settings/uploaded-files-card.tsx
@@ -9,6 +9,7 @@ import {
   type UploadedFileInfo,
 } from "@/lib/files";
 import { getMySystem } from "@/lib/systems";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { isDeleteQueued, type DestructiveConfirm } from "@/types/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -62,6 +63,7 @@ function ReferenceItem({ reference }: { reference: FileReference }) {
 
 export function UploadedFilesCard() {
   const qc = useQueryClient();
+  const { formatDate, formatDateTime } = useDateFormatters();
   const { data: files, isLoading } = useQuery({
     queryKey: ["files", "list"],
     queryFn: listFiles,
@@ -82,7 +84,7 @@ export function UploadedFilesCard() {
       if (isDeleteQueued(result)) {
         qc.invalidateQueries({ queryKey: ["system-safety"] });
         toast.success(
-          `Image scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+          `Image scheduled for deletion - cancellable in Settings until ${formatDate(result.finalize_after)}.`,
         );
       } else {
         toast.success("File deleted");
@@ -120,7 +122,7 @@ export function UploadedFilesCard() {
                   )}
                   title={
                     f.pending_delete_at
-                      ? `Pending delete - finalises ${new Date(f.pending_delete_at).toLocaleString()}. Open to manage.`
+                      ? `Pending delete - finalises ${formatDateTime(f.pending_delete_at)}. Open to manage.`
                       : undefined
                   }
                 >

--- a/web/src/components/timezone-select.tsx
+++ b/web/src/components/timezone-select.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * Shared IANA timezone picker. A short "Common" group of friendly, indicative
+ * names (e.g. "Eastern Time (US & Canada)") sits first, each mapped to the
+ * canonical city zone so DST is handled correctly (Eastern follows EST/EDT, UK
+ * follows GMT/BST, etc.). Below it is the full IANA list from
+ * `Intl.supportedValuesOf`, with the truly fixed / no-DST zones ("EST", "MST",
+ * "HST", "Etc/GMT+5", ...) appended so the "a zone that never shifts" case stays
+ * reachable. Every value offered is a real IANA zone the backend accepts, and
+ * each zone appears exactly once (common zones are not repeated in the full
+ * list) so the trigger shows the friendly label.
+ *
+ * `specialOptions` renders caller-defined entries at the very top carrying
+ * opaque sentinel values - e.g. "Automatic" for the account default, or "Follow
+ * account default" + "Automatic (this device)" for a device override. The
+ * caller maps those sentinels to whatever they mean in its tier. `AUTO_VALUE` /
+ * `FOLLOW_ACCOUNT_VALUE` are provided for the common cases.
+ */
+
+// Shared sentinels for the special (non-zone) options. Chosen to never collide
+// with a real IANA zone name.
+export const AUTO_VALUE = "__auto__";
+export const FOLLOW_ACCOUNT_VALUE = "__follow__";
+
+// Friendly shortcuts for the most-reached zones, each mapped to a canonical
+// city zone so DST is observed correctly where the region uses it. Shown first;
+// these zones are excluded from the full list below so each appears once.
+const COMMON_ZONES: { label: string; zone: string }[] = [
+  { label: "UTC", zone: "UTC" },
+  { label: "Eastern Time (US & Canada)", zone: "America/New_York" },
+  { label: "Central Time (US & Canada)", zone: "America/Chicago" },
+  { label: "Mountain Time (US & Canada)", zone: "America/Denver" },
+  { label: "Pacific Time (US & Canada)", zone: "America/Los_Angeles" },
+  { label: "Alaska Time", zone: "America/Anchorage" },
+  { label: "Hawaii Time", zone: "Pacific/Honolulu" },
+  { label: "UK / Ireland (London)", zone: "Europe/London" },
+  { label: "Central European (Paris, Berlin)", zone: "Europe/Paris" },
+  { label: "Eastern European (Athens, Helsinki)", zone: "Europe/Athens" },
+  { label: "India (Kolkata)", zone: "Asia/Kolkata" },
+  { label: "China (Shanghai)", zone: "Asia/Shanghai" },
+  { label: "Japan (Tokyo)", zone: "Asia/Tokyo" },
+  { label: "Australia Eastern (Sydney)", zone: "Australia/Sydney" },
+];
+
+// Fixed-offset / no-DST zones + pure UTC offsets, not returned by
+// Intl.supportedValuesOf. Kept reachable in the full list for the "never
+// shifts" case; all verified backend-valid. (The cryptic DST-combo names like
+// "EST5EDT" are deliberately omitted - the Common group's city zones cover that
+// with correct DST.)
+const FIXED_EXTRAS = [
+  "GMT",
+  "EST",
+  "MST",
+  "HST",
+  ...Array.from({ length: 12 }, (_, i) => `Etc/GMT+${i + 1}`),
+  ...Array.from({ length: 14 }, (_, i) => `Etc/GMT-${i + 1}`),
+];
+
+function allZones(): string[] {
+  const common = new Set(COMMON_ZONES.map((c) => c.zone));
+  try {
+    const canonical =
+      (
+        Intl as unknown as { supportedValuesOf?: (k: string) => string[] }
+      ).supportedValuesOf?.("timeZone") ?? [];
+    const merged = new Set<string>([...canonical, ...FIXED_EXTRAS]);
+    // Common zones live in the Common group only; a Select value must be unique.
+    for (const z of common) merged.delete(z);
+    return [...merged].sort();
+  } catch {
+    return FIXED_EXTRAS.filter((z) => !common.has(z)).sort();
+  }
+}
+
+export function TimezoneSelect({
+  value,
+  onValueChange,
+  specialOptions,
+  id,
+}: {
+  value: string;
+  onValueChange: (v: string) => void;
+  /** Leading non-zone options (sentinel value + label), rendered above the
+   *  zone groups. */
+  specialOptions?: { value: string; label: string }[];
+  id?: string;
+}) {
+  const zones = useMemo(() => allZones(), []);
+
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger id={id}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent className="max-h-72">
+        {specialOptions?.length ? (
+          <>
+            {specialOptions.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+            <SelectSeparator />
+          </>
+        ) : null}
+        <SelectGroup>
+          <SelectLabel>Common</SelectLabel>
+          {COMMON_ZONES.map((c) => (
+            <SelectItem key={c.zone} value={c.zone}>
+              {c.label}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+        <SelectGroup>
+          <SelectLabel>All time zones</SelectLabel>
+          {zones.map((z) => (
+            <SelectItem key={z} value={z}>
+              {z}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/web/src/hooks/use-custom-fields.ts
+++ b/web/src/hooks/use-custom-fields.ts
@@ -8,6 +8,7 @@ import {
   type DestructiveConfirm,
 } from "@/types/api";
 import * as api from "@/lib/custom-fields";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { memberKeys } from "./use-members";
 
 export const fieldKeys = {
@@ -47,6 +48,7 @@ export function useUpdateField() {
 
 export function useDeleteField() {
   const qc = useQueryClient();
+  const { formatDate } = useDateFormatters();
   return useMutation({
     mutationFn: ({
       id,
@@ -60,7 +62,7 @@ export function useDeleteField() {
       if (isDeleteQueued(result)) {
         qc.invalidateQueries({ queryKey: ["system-safety"] });
         toast.success(
-          `Field scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+          `Field scheduled for deletion - cancellable in Settings until ${formatDate(result.finalize_after)}.`,
         );
       } else {
         toast.success("Field deleted");

--- a/web/src/hooks/use-date-formatters.ts
+++ b/web/src/hooks/use-date-formatters.ts
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getAccessToken } from "@/lib/api-client";
+import {
+  dateTimeLocalToIso as rawDateTimeLocalToIso,
+  formatBirthday as rawFormatBirthday,
+  formatDate as rawFormatDate,
+  formatDateTime as rawFormatDateTime,
+  toDateTimeLocalValue as rawToDateTimeLocalValue,
+} from "@/lib/date-format";
+import { getMySystem } from "@/lib/systems";
+import type { DateFormat } from "@/types/api";
+
+import { browserTimeZone, useTimezone } from "./use-timezone";
+
+/**
+ * The blessed way to format dates in a component: returns formatters already
+ * bound to the account's `date_format` and the resolved display timezone, so
+ * call sites don't thread either through by hand and can't accidentally render
+ * in the browser's zone. Both underlying queries share the ["system","me"] key
+ * and dedupe with the rest of the app.
+ */
+export function useDateFormatters() {
+  const { resolvedTimeZone } = useTimezone();
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+    staleTime: 5 * 60 * 1000,
+    enabled: getAccessToken() !== null,
+  });
+  const dateFormat: DateFormat = system?.date_format ?? "ymd";
+
+  return useMemo(() => {
+    // Concrete zone for datetime-local conversion: the resolved preference, or
+    // the browser's own zone when "automatic".
+    const inputZone = resolvedTimeZone ?? browserTimeZone();
+    return {
+      dateFormat,
+      /** Resolved display zone; undefined = browser-local ("automatic"). */
+      timeZone: resolvedTimeZone,
+      formatDate: (d: string | null | undefined) =>
+        rawFormatDate(d, dateFormat, resolvedTimeZone),
+      formatDateTime: (
+        d: string | null | undefined,
+        opts?: { stamp?: boolean },
+      ) => rawFormatDateTime(d, dateFormat, resolvedTimeZone, opts),
+      formatBirthday: (d: string | null | undefined) =>
+        rawFormatBirthday(d, dateFormat),
+      /** Stored UTC ISO -> datetime-local input value, in the display zone. */
+      toDateTimeLocal: (iso: string | null | undefined) =>
+        rawToDateTimeLocalValue(iso, inputZone),
+      /** datetime-local input value -> UTC ISO, interpreted in the display zone. */
+      fromDateTimeLocal: (value: string) =>
+        rawDateTimeLocalToIso(value, inputZone),
+    };
+  }, [dateFormat, resolvedTimeZone]);
+}

--- a/web/src/hooks/use-fronts.ts
+++ b/web/src/hooks/use-fronts.ts
@@ -12,6 +12,7 @@ import {
   type FrontUpdate,
 } from "@/types/api";
 import * as api from "@/lib/fronts";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 
 export const frontKeys = {
   all: ["fronts"] as const,
@@ -86,6 +87,7 @@ export function useUpdateFront() {
 
 export function useDeleteFront() {
   const qc = useQueryClient();
+  const { formatDate } = useDateFormatters();
   return useMutation({
     mutationFn: ({
       id,
@@ -100,7 +102,7 @@ export function useDeleteFront() {
       if (isDeleteQueued(result)) {
         qc.invalidateQueries({ queryKey: ["system-safety"] });
         toast.success(
-          `Front entry scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+          `Front entry scheduled for deletion - cancellable in Settings until ${formatDate(result.finalize_after)}.`,
         );
       } else {
         toast.success("Front deleted");

--- a/web/src/hooks/use-groups.ts
+++ b/web/src/hooks/use-groups.ts
@@ -8,6 +8,7 @@ import {
   type GroupUpdate,
 } from "@/types/api";
 import * as api from "@/lib/groups";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 
 export const groupKeys = {
   all: ["groups"] as const,
@@ -72,6 +73,7 @@ export function useUpdateGroup() {
 
 export function useDeleteGroup() {
   const qc = useQueryClient();
+  const { formatDate } = useDateFormatters();
   return useMutation({
     mutationFn: ({
       id,
@@ -85,7 +87,7 @@ export function useDeleteGroup() {
       if (isDeleteQueued(result)) {
         qc.invalidateQueries({ queryKey: ["system-safety"] });
         toast.success(
-          `Group scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+          `Group scheduled for deletion - cancellable in Settings until ${formatDate(result.finalize_after)}.`,
         );
       } else {
         toast.success("Group deleted");

--- a/web/src/hooks/use-members.ts
+++ b/web/src/hooks/use-members.ts
@@ -7,6 +7,7 @@ import {
   type MemberUpdate,
 } from "@/types/api";
 import * as api from "@/lib/members";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 
 export const memberKeys = {
   all: ["members"] as const,
@@ -53,6 +54,7 @@ export function useUpdateMember() {
 
 export function useDeleteMember() {
   const qc = useQueryClient();
+  const { formatDate } = useDateFormatters();
   return useMutation({
     mutationFn: ({
       id,
@@ -66,7 +68,7 @@ export function useDeleteMember() {
       if (isDeleteQueued(result)) {
         qc.invalidateQueries({ queryKey: ["system-safety"] });
         toast.success(
-          `Member scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+          `Member scheduled for deletion - cancellable in Settings until ${formatDate(result.finalize_after)}.`,
         );
       } else {
         toast.success("Member deleted");

--- a/web/src/hooks/use-tags.ts
+++ b/web/src/hooks/use-tags.ts
@@ -13,6 +13,7 @@ import {
   type TagUpdate,
 } from "@/types/api";
 import * as api from "@/lib/tags";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 
 export const tagKeys = {
   all: ["tags"] as const,
@@ -89,6 +90,7 @@ export function useUpdateTag() {
 
 export function useDeleteTag() {
   const qc = useQueryClient();
+  const { formatDate } = useDateFormatters();
   return useMutation({
     mutationFn: ({
       id,
@@ -102,7 +104,7 @@ export function useDeleteTag() {
       if (isDeleteQueued(result)) {
         qc.invalidateQueries({ queryKey: ["system-safety"] });
         toast.success(
-          `Tag scheduled for deletion — cancellable in Settings until ${new Date(result.finalize_after).toLocaleDateString()}.`,
+          `Tag scheduled for deletion - cancellable in Settings until ${formatDate(result.finalize_after)}.`,
         );
       } else {
         toast.success("Tag deleted");

--- a/web/src/hooks/use-timezone.ts
+++ b/web/src/hooks/use-timezone.ts
@@ -1,0 +1,130 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { getAccessToken } from "@/lib/api-client";
+import { getMySystem, updateMySystem } from "@/lib/systems";
+
+/**
+ * Display-timezone preference. Two tiers, mirroring the theme system's
+ * "synced value + per-device override" shape but with the synced tier on the
+ * real, exported `System.timezone` column rather than the instance-local
+ * client-settings blob:
+ *
+ *   - Account default (`System.timezone`): syncs across the account's devices.
+ *     null = "automatic" (each device uses its own local clock). Set from any
+ *     device via PATCH /v1/systems/me.
+ *   - Device override (localStorage `sheaf_timezone`): shadows the account
+ *     value on this browser only and never writes back. Values: absent (follow
+ *     the account), "auto" (pin this device to its own clock even if the
+ *     account default is a fixed zone), or an IANA zone name.
+ *
+ * Resolution: device override > account default > browser-local. The resolved
+ * value is what `useDateFormatters` renders in; `undefined` means "the
+ * browser's own zone", which is exactly what "automatic" collapses to.
+ */
+
+const TZ_KEY = "sheaf_timezone";
+// Device-override sentinel: "follow this device's own clock", distinct from
+// "follow the account default" (which is the absence of any override).
+const AUTO = "auto";
+
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const cb of listeners) cb();
+}
+
+function getOverride(): string | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage.getItem(TZ_KEY);
+}
+
+function writeOverride(v: string | null) {
+  if (v === null) localStorage.removeItem(TZ_KEY);
+  else localStorage.setItem(TZ_KEY, v);
+  notify();
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** The browser/OS local IANA zone, e.g. "America/New_York". Falls back to
+ *  "UTC" where `Intl` can't resolve one. */
+export function browserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+export interface UseTimezoneResult {
+  /** IANA zone to render timestamps in, or `undefined` = the browser's local
+   *  clock. Feed straight into the date formatters. */
+  resolvedTimeZone: string | undefined;
+  /** The synced account default (`System.timezone`). null = automatic. */
+  accountTimeZone: string | null;
+  /** This device's local override: null = follow the account, "auto" = this
+   *  device's own clock, or a pinned IANA zone. */
+  deviceOverride: string | null;
+  /** True when this device follows the account default (no local override). */
+  synced: boolean;
+  /** Set the account-wide default (syncs to every device). */
+  setAccountTimeZone: (tz: string | null) => Promise<void>;
+  /** Set (or clear, with null) this device's local override. */
+  setDeviceOverride: (v: string | null) => void;
+}
+
+export function useTimezone(): UseTimezoneResult {
+  const queryClient = useQueryClient();
+  const deviceOverride = useSyncExternalStore(
+    subscribe,
+    getOverride,
+    () => null,
+  );
+
+  const { data: system } = useQuery({
+    queryKey: ["system", "me"],
+    queryFn: getMySystem,
+    staleTime: 5 * 60 * 1000,
+    enabled: getAccessToken() !== null,
+  });
+  const accountTimeZone = system?.timezone ?? null;
+
+  // Resolution: device override > account default > browser-local.
+  let resolvedTimeZone: string | undefined;
+  if (deviceOverride === AUTO) {
+    resolvedTimeZone = undefined;
+  } else if (deviceOverride) {
+    resolvedTimeZone = deviceOverride;
+  } else {
+    resolvedTimeZone = accountTimeZone ?? undefined;
+  }
+
+  const synced = deviceOverride === null;
+
+  const setAccountTimeZone = useCallback(
+    async (tz: string | null) => {
+      await updateMySystem({ timezone: tz });
+      queryClient.invalidateQueries({ queryKey: ["system", "me"] });
+    },
+    [queryClient],
+  );
+
+  const setDeviceOverride = useCallback((v: string | null) => {
+    writeOverride(v);
+  }, []);
+
+  return {
+    resolvedTimeZone,
+    accountTimeZone,
+    deviceOverride,
+    synced,
+    setAccountTimeZone,
+    setDeviceOverride,
+  };
+}

--- a/web/src/lib/date-format.ts
+++ b/web/src/lib/date-format.ts
@@ -1,5 +1,18 @@
 import { format, isValid, parse, parseISO } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import type { DateFormat } from "@/types/api";
+
+// This is the one blessed date/time formatter. Everything user-facing should
+// render through here (directly, or via the `useDateFormatters` hook which
+// binds the account date-format + the resolved display timezone) so a single
+// place controls both the day/month order and the timezone. Formatting a date
+// with raw `toLocaleDateString` / date-fns `format` elsewhere silently renders
+// in the browser's zone and dodges the timezone preference - see the lint
+// guard.
+//
+// `timeZone` is an IANA zone name. When omitted the formatter renders in the
+// browser's local zone (the historical behaviour), which is exactly what the
+// "automatic" preference resolves to.
 
 const formatStrings: Record<DateFormat, string> = {
   dmy: "dd/MM/yyyy",
@@ -21,13 +34,37 @@ const formatStringsWithTime: Record<DateFormat, string> = {
   ymd: "yyyy-MM-dd HH:mm",
 };
 
+function formatIn(date: Date, fmt: string, timeZone?: string): string {
+  return timeZone ? formatInTimeZone(date, timeZone, fmt) : format(date, fmt);
+}
+
+/**
+ * Short, DST-aware zone abbreviation for `date` in `timeZone` (or the
+ * browser's zone when omitted). Returns "EST"/"EDT" for zones that observe
+ * DST, "GMT-5" for fixed-offset zones, or "" if it can't be resolved. This is
+ * the stamp appended to absolute times so a rendered timestamp is never
+ * ambiguous about which clock it is in.
+ */
+export function zoneAbbrev(date: Date, timeZone?: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "short",
+    }).formatToParts(date);
+    return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
+  } catch {
+    return "";
+  }
+}
+
 export function formatDate(
   dateStr: string | null | undefined,
   dateFormat: DateFormat = "ymd",
+  timeZone?: string,
 ): string {
   if (!dateStr) return "";
   try {
-    return format(parseISO(dateStr), formatStrings[dateFormat]);
+    return formatIn(parseISO(dateStr), formatStrings[dateFormat], timeZone);
   } catch {
     return dateStr;
   }
@@ -36,10 +73,19 @@ export function formatDate(
 export function formatDateTime(
   dateStr: string | null | undefined,
   dateFormat: DateFormat = "ymd",
+  timeZone?: string,
+  opts?: { stamp?: boolean },
 ): string {
   if (!dateStr) return "";
+  // Absolute times carry their zone by default so they're unambiguous; pass
+  // `{ stamp: false }` for the rare spot where the zone is already implied.
+  const stamp = opts?.stamp ?? true;
   try {
-    return format(parseISO(dateStr), formatStringsWithTime[dateFormat]);
+    const d = parseISO(dateStr);
+    const base = formatIn(d, formatStringsWithTime[dateFormat], timeZone);
+    if (!stamp) return base;
+    const abbr = zoneAbbrev(d, timeZone);
+    return abbr ? `${base} ${abbr}` : base;
   } catch {
     return dateStr;
   }
@@ -52,6 +98,9 @@ export function formatDateTime(
  * `MM-DD` (when the member opted out of a birth year). Each is rendered in
  * the user's chosen order - with the year for a full date, month/day only
  * for a year-less one. Falls back to the raw string if it does not parse.
+ *
+ * Birthdays are calendar dates, not instants, so they are timezone-neutral by
+ * construction and take no `timeZone` argument.
  */
 export function formatBirthday(
   dateStr: string | null | undefined,
@@ -77,3 +126,41 @@ export const dateFormatLabels: Record<DateFormat, string> = {
   mdy: "MM/DD/YYYY",
   ymd: "YYYY-MM-DD",
 };
+
+// ---------------------------------------------------------------------------
+// <input type="datetime-local"> conversion, timezone-aware.
+//
+// A datetime-local input holds a bare wall-clock string (YYYY-MM-DDTHH:mm) with
+// no zone. To keep entry consistent with display, we render/parse that
+// wall-clock in the SAME zone timestamps are displayed in, not the browser's.
+// `timeZone` must be a concrete IANA zone (callers pass the resolved zone,
+// falling back to the browser's); the `useDateFormatters` hook binds it for you.
+// ---------------------------------------------------------------------------
+
+/** Stored UTC ISO -> the wall-clock value to put in a datetime-local input,
+ *  as it reads in `timeZone`. */
+export function toDateTimeLocalValue(
+  iso: string | null | undefined,
+  timeZone: string,
+): string {
+  if (!iso) return "";
+  try {
+    return formatInTimeZone(parseISO(iso), timeZone, "yyyy-MM-dd'T'HH:mm");
+  } catch {
+    return "";
+  }
+}
+
+/** A datetime-local input's wall-clock value -> a UTC ISO string, interpreting
+ *  the wall-clock as being in `timeZone`. Returns null for empty/invalid. */
+export function dateTimeLocalToIso(
+  value: string,
+  timeZone: string,
+): string | null {
+  if (!value) return null;
+  try {
+    return fromZonedTime(value, timeZone).toISOString();
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -5,24 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  })
-}
-
-export function formatDateTime(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  })
-}
-
 export function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B"
   const units = ["B", "KB", "MB", "GB"]

--- a/web/src/routes/admin/announcements.tsx
+++ b/web/src/routes/admin/announcements.tsx
@@ -23,6 +23,7 @@ import {
   type Announcement,
 } from "@/lib/announcements";
 import { timeAgo } from "@/lib/utils";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import {
   Plus,
   Trash2,
@@ -33,25 +34,6 @@ import {
   AlertTriangle,
   AlertOctagon,
 } from "lucide-react";
-
-// A datetime-local <input> works in the browser's local zone; the API
-// stores/returns ISO (UTC) strings. Convert between the two.
-function isoToLocalInput(iso: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return "";
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-    d.getHours(),
-  )}:${pad(d.getMinutes())}`;
-}
-
-function localInputToIso(local: string): string | null {
-  if (!local) return null;
-  const d = new Date(local);
-  if (isNaN(d.getTime())) return null;
-  return d.toISOString();
-}
 
 const severityIcons = {
   info: Info,
@@ -68,6 +50,7 @@ const severityColors = {
 
 function AnnouncementRow({ announcement }: { announcement: Announcement }) {
   const qc = useQueryClient();
+  const { formatDate, formatDateTime } = useDateFormatters();
   const [editing, setEditing] = useState(false);
   const [confirming, setConfirming] = useState(false);
 
@@ -130,15 +113,15 @@ function AnnouncementRow({ announcement }: { announcement: Announcement }) {
           {announcement.body}
         </p>
         <div className="mt-1 flex items-center gap-3 text-[11px] text-muted-foreground">
-          <span title={new Date(announcement.created_at).toLocaleString()}>
+          <span title={formatDateTime(announcement.created_at)}>
             Created {timeAgo(announcement.created_at)}
           </span>
           {announcement.starts_at && (
-            <span>Starts: {new Date(announcement.starts_at).toLocaleDateString()}</span>
+            <span>Starts: {formatDate(announcement.starts_at)}</span>
           )}
           {announcement.expires_at && (
             <span>
-              Expires: {new Date(announcement.expires_at).toLocaleString()}
+              Expires: {formatDateTime(announcement.expires_at)}
             </span>
           )}
         </div>
@@ -211,6 +194,7 @@ function EditAnnouncementForm({
   onDone: () => void;
 }) {
   const qc = useQueryClient();
+  const { toDateTimeLocal, fromDateTimeLocal } = useDateFormatters();
   const [title, setTitle] = useState(announcement.title);
   const [body, setBody] = useState(announcement.body);
   const [severity, setSeverity] = useState<string>(announcement.severity);
@@ -219,7 +203,7 @@ function EditAnnouncementForm({
     announcement.visible_while_logged_out,
   );
   const [expiresAt, setExpiresAt] = useState(
-    isoToLocalInput(announcement.expires_at),
+    toDateTimeLocal(announcement.expires_at),
   );
 
   const save = useMutation({
@@ -231,7 +215,7 @@ function EditAnnouncementForm({
         dismissible,
         visible_while_logged_out: visibleWhileLoggedOut,
         ...(expiresAt
-          ? { expires_at: localInputToIso(expiresAt) }
+          ? { expires_at: fromDateTimeLocal(expiresAt) }
           : { clear_expires_at: true }),
       }),
     onSuccess: () => {
@@ -332,6 +316,7 @@ function EditAnnouncementForm({
 }
 
 function CreateAnnouncementForm({ onCreated }: { onCreated: () => void }) {
+  const { fromDateTimeLocal } = useDateFormatters();
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [severity, setSeverity] = useState("info");
@@ -347,7 +332,7 @@ function CreateAnnouncementForm({ onCreated }: { onCreated: () => void }) {
         severity,
         dismissible,
         visible_while_logged_out: visibleWhileLoggedOut,
-        expires_at: localInputToIso(expiresAt),
+        expires_at: fromDateTimeLocal(expiresAt),
       }),
     onSuccess: () => {
       setTitle("");

--- a/web/src/routes/admin/approvals.tsx
+++ b/web/src/routes/admin/approvals.tsx
@@ -13,6 +13,7 @@ import {
   type PendingUser,
 } from "@/lib/admin";
 import { timeAgo } from "@/lib/utils";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Check, X } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 
@@ -26,6 +27,7 @@ function ApprovalRow({
   onToggleSelected: (checked: boolean) => void;
 }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const [confirming, setConfirming] = useState<"approve" | "reject" | null>(null);
 
   const approve = useMutation({
@@ -62,7 +64,7 @@ function ApprovalRow({
         {user.signup_ip ?? "—"}
       </td>
       <td className="py-3 pr-4 text-xs text-muted-foreground">
-        <span title={new Date(user.created_at).toLocaleString()}>
+        <span title={formatDateTime(user.created_at)}>
           {timeAgo(user.created_at)}
         </span>
       </td>

--- a/web/src/routes/admin/audit.tsx
+++ b/web/src/routes/admin/audit.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getAdminAuditEvents, type AdminAuditEvent } from "@/lib/admin";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { PageHeader } from "@/components/page-header";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -45,6 +46,7 @@ function formatDiff(
 }
 
 export function AdminAuditPage() {
+  const { formatDateTime } = useDateFormatters();
   const [targetUserId, setTargetUserId] = useState("");
   const [action, setAction] = useState("");
   const [page, setPage] = useState(1);
@@ -126,7 +128,7 @@ export function AdminAuditPage() {
               {events?.map((e: AdminAuditEvent) => (
                 <tr key={e.id} className="border-b text-sm last:border-0">
                   <td className="py-2 px-3 align-top whitespace-nowrap">
-                    {new Date(e.created_at).toLocaleString()}
+                    {formatDateTime(e.created_at)}
                   </td>
                   <td className="py-2 px-3 align-top">
                     {e.admin_email ?? <span className="text-muted-foreground">deleted</span>}

--- a/web/src/routes/admin/invites.tsx
+++ b/web/src/routes/admin/invites.tsx
@@ -13,10 +13,12 @@ import {
   type InviteCode,
 } from "@/lib/admin";
 import { timeAgo } from "@/lib/utils";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Copy, Plus, Trash2 } from "lucide-react";
 
 function InviteRow({ invite }: { invite: InviteCode }) {
   const qc = useQueryClient();
+  const { formatDate, formatDateTime } = useDateFormatters();
   const [confirming, setConfirming] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -70,14 +72,14 @@ function InviteRow({ invite }: { invite: InviteCode }) {
       <td className="py-3 pr-4 text-xs text-muted-foreground">
         {invite.expires_at ? (
           <span className={isExpired ? "text-destructive" : ""}>
-            {isExpired ? "Expired" : new Date(invite.expires_at).toLocaleDateString()}
+            {isExpired ? "Expired" : formatDate(invite.expires_at)}
           </span>
         ) : (
           "Never"
         )}
       </td>
       <td className="py-3 pr-4 text-xs text-muted-foreground">
-        <span title={new Date(invite.created_at).toLocaleString()}>
+        <span title={formatDateTime(invite.created_at)}>
           {timeAgo(invite.created_at)}
         </span>
         {invite.created_by_email && (

--- a/web/src/routes/admin/security.tsx
+++ b/web/src/routes/admin/security.tsx
@@ -5,6 +5,7 @@ import {
   securityStuffingView,
   type SecurityEventRow,
 } from "@/lib/admin";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { PageHeader } from "@/components/page-header";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -25,6 +26,7 @@ function outcomeBadge(outcome: string) {
 }
 
 function EventsTable({ events }: { events: SecurityEventRow[] }) {
+  const { formatDateTime } = useDateFormatters();
   return (
     <Card>
       <CardContent className="p-0">
@@ -43,7 +45,7 @@ function EventsTable({ events }: { events: SecurityEventRow[] }) {
             {events.map((e) => (
               <tr key={e.id} className="border-b text-sm last:border-0">
                 <td className="py-2 px-3 align-top whitespace-nowrap">
-                  {new Date(e.created_at).toLocaleString()}
+                  {formatDateTime(e.created_at)}
                 </td>
                 <td className="py-2 px-3 align-top">{e.event_type}</td>
                 <td className="py-2 px-3 align-top">
@@ -175,6 +177,7 @@ function StuffingWatch({
 }: {
   onPickIp: (ip: string) => void;
 }) {
+  const { formatDateTime } = useDateFormatters();
   const [hours, setHours] = useState(24);
   const [minFailures, setMinFailures] = useState(10);
 
@@ -252,7 +255,7 @@ function StuffingWatch({
                     {o.failures}
                   </td>
                   <td className="py-2 px-3 align-top whitespace-nowrap text-xs text-muted-foreground">
-                    {new Date(o.last_seen).toLocaleString()}
+                    {formatDateTime(o.last_seen)}
                   </td>
                   <td className="py-2 px-3 align-top text-right">
                     <Button

--- a/web/src/routes/admin/users.tsx
+++ b/web/src/routes/admin/users.tsx
@@ -42,6 +42,7 @@ import {
   type ExplainAccountResponse,
   type RateLimitHistoryResponse,
 } from "@/lib/admin";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { ChevronDown, ChevronRight, Copy } from "lucide-react";
 
 function formatBytes(bytes: number): string {
@@ -53,6 +54,7 @@ function formatBytes(bytes: number): string {
 
 function SessionsSection({ userId }: { userId: string }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const [reason, setReason] = useState("");
   const [confirming, setConfirming] = useState<string | null>(null);
 
@@ -86,7 +88,7 @@ function SessionsSection({ userId }: { userId: string }) {
               {s.nickname ? `${s.nickname} · ` : ""}
               {s.user_agent ?? "(unknown UA)"} · {s.ip ?? "—"}
               {s.created_at
-                ? ` · ${new Date(s.created_at).toLocaleString()}`
+                ? ` · ${formatDateTime(s.created_at)}`
                 : ""}
             </span>
             {confirming === s.id ? (
@@ -137,6 +139,7 @@ function SessionsSection({ userId }: { userId: string }) {
 
 function ImportLogsSection({ userId }: { userId: string }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const [reason, setReason] = useState("");
   const [confirming, setConfirming] = useState<string | null>(null);
   const [openJobId, setOpenJobId] = useState<string | null>(null);
@@ -177,7 +180,7 @@ function ImportLogsSection({ userId }: { userId: string }) {
                 <span className="flex-1 truncate">
                   {j.source} · {j.status}
                   {j.created_at
-                    ? ` · ${new Date(j.created_at).toLocaleString()}`
+                    ? ` · ${formatDateTime(j.created_at)}`
                     : ""}
                   {j.last_error ? " · error" : ""}
                 </span>
@@ -282,6 +285,7 @@ function ImportLogsSection({ userId }: { userId: string }) {
 
 function SecurityEventsSection({ userId }: { userId: string }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const [reason, setReason] = useState("");
   const [confirming, setConfirming] = useState(false);
 
@@ -346,7 +350,7 @@ function SecurityEventsSection({ userId }: { userId: string }) {
         <ul className="space-y-0.5 font-mono">
           {data.events.map((e) => (
             <li key={e.id}>
-              {new Date(e.created_at).toLocaleString()} · {e.event_type} ·{" "}
+              {formatDateTime(e.created_at)} · {e.event_type} ·{" "}
               <span
                 className={
                   e.outcome === "success" || e.outcome === "sent"
@@ -369,6 +373,7 @@ function SecurityEventsSection({ userId }: { userId: string }) {
 }
 
 function RateLimitSection({ userId }: { userId: string }) {
+  const { formatDateTime } = useDateFormatters();
   const [showAll, setShowAll] = useState(false);
   const { data } = useQuery<RateLimitHistoryResponse>({
     queryKey: ["admin", "rate-limit-history", userId],
@@ -394,7 +399,7 @@ function RateLimitSection({ userId }: { userId: string }) {
       <ul className="space-y-0.5 font-mono">
         {shown.map((hit, i) => (
           <li key={i}>
-            {new Date(hit.at).toLocaleString()} · {hit.bucket} ({hit.scope}) ·{" "}
+            {formatDateTime(hit.at)} · {hit.bucket} ({hit.scope}) ·{" "}
             {hit.route}
             {hit.ip ? ` · ${hit.ip}` : ""}
           </li>
@@ -413,6 +418,7 @@ function RateLimitSection({ userId }: { userId: string }) {
 }
 
 function ExplainPanel({ userId }: { userId: string }) {
+  const { formatDateTime } = useDateFormatters();
   const [open, setOpen] = useState(false);
   const { data, isLoading } = useQuery<ExplainAccountResponse>({
     queryKey: ["admin", "explain", userId],
@@ -471,7 +477,7 @@ function ExplainPanel({ userId }: { userId: string }) {
                 <div>
                   <span className="text-muted-foreground">Last login:</span>{" "}
                   {data.last_login_at
-                    ? new Date(data.last_login_at).toLocaleString()
+                    ? formatDateTime(data.last_login_at)
                     : "never"}
                 </div>
                 <div>
@@ -504,7 +510,7 @@ function ExplainPanel({ userId }: { userId: string }) {
                   <ul className="space-y-0.5 font-mono">
                     {data.recent_admin_audit.slice(0, 5).map((row) => (
                       <li key={row.id}>
-                        {new Date(row.created_at).toLocaleString()} ·{" "}
+                        {formatDateTime(row.created_at)} ·{" "}
                         {row.action}
                         {row.reason ? ` — "${row.reason}"` : ""}
                       </li>
@@ -522,6 +528,7 @@ function ExplainPanel({ userId }: { userId: string }) {
 
 function UserActions({ user }: { user: AdminUser }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const [confirming, setConfirming] = useState<string | null>(null);
   const [newEmail, setNewEmail] = useState("");
   const [reason, setReason] = useState("");
@@ -596,7 +603,7 @@ function UserActions({ user }: { user: AdminUser }) {
       qc.invalidateQueries({ queryKey: ["admin", "explain", user.id] });
       toast.success(
         data.suspended_until
-          ? `Suspended until ${new Date(data.suspended_until).toLocaleString()}`
+          ? `Suspended until ${formatDateTime(data.suspended_until)}`
           : "Suspended indefinitely",
       );
       setConfirming(null);
@@ -1294,6 +1301,7 @@ function UserActions({ user }: { user: AdminUser }) {
 
 function UserRow({ user }: { user: AdminUser }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const [tier, setTier] = useState(user.tier);
   const [isAdmin, setIsAdmin] = useState(user.is_admin);
   const [canUploadImages, setCanUploadImages] = useState(user.can_upload_images);
@@ -1365,7 +1373,7 @@ function UserRow({ user }: { user: AdminUser }) {
                   user.suspended_reason
                     ? `Reason: ${user.suspended_reason}` +
                       (user.suspended_until
-                        ? ` (until ${new Date(user.suspended_until).toLocaleString()})`
+                        ? ` (until ${formatDateTime(user.suspended_until)})`
                         : " (indefinite)")
                     : "Suspended"
                 }

--- a/web/src/routes/fronts.tsx
+++ b/web/src/routes/fronts.tsx
@@ -31,7 +31,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { cn, formatDateTime, timeAgo } from "@/lib/utils";
+import { cn, timeAgo } from "@/lib/utils";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { getMySystem } from "@/lib/systems";
 import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import type { Front } from "@/types/api";
@@ -57,6 +58,7 @@ function isPageSize(v: unknown): v is (typeof HISTORY_PAGE_SIZES)[number] {
 
 export function FrontsPage() {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const { data: current, isLoading: currentLoading } = useCurrentFronts();
 
   // Saved defaults from client settings — only consulted when the URL
@@ -386,8 +388,8 @@ export function FrontsPage() {
                   <span>
                     {formatDateTime(front.started_at)}
                     {front.ended_at
-                      ? ` — ${formatDateTime(front.ended_at)}`
-                      : " — ongoing"}
+                      ? ` - ${formatDateTime(front.ended_at)}`
+                      : " - ongoing"}
                   </span>
                   <Button
                     size="sm"

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Loader2Icon } from "lucide-react";
 import { apiErrorMessage } from "@/lib/api-errors";
 import { getMemberLimit } from "@/lib/members";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -646,6 +647,7 @@ function SPImportFlow({ onBack }: { onBack: () => void }) {
 
 function PKImportFlow({ onBack }: { onBack: () => void }) {
   const navigate = useNavigate();
+  const { formatDate } = useDateFormatters();
   const [method, setMethod] = useState<PKMethod>("choose");
   const [step, setStep] = useState<Step>("upload");
   const [file, setFile] = useState<File | null>(null);
@@ -898,9 +900,9 @@ function PKImportFlow({ onBack }: { onBack: () => void }) {
               </div>
               {preview.earliest_switch && preview.latest_switch && (
                 <div className="col-span-2 text-xs text-muted-foreground">
-                  Switch range: {new Date(preview.earliest_switch).toLocaleDateString()}
+                  Switch range: {formatDate(preview.earliest_switch)}
                   {" "}to{" "}
-                  {new Date(preview.latest_switch).toLocaleDateString()}
+                  {formatDate(preview.latest_switch)}
                 </div>
               )}
             </CardContent>

--- a/web/src/routes/imports.tsx
+++ b/web/src/routes/imports.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import {
   type ImportJobStatus,
   type ImportJobSummary,
@@ -48,6 +49,7 @@ function countsSummary(counts: Record<string, number>): string {
 }
 
 function ImportRow({ job }: { job: ImportJobSummary }) {
+  const { formatDateTime } = useDateFormatters();
   return (
     <Link
       to={`/imports/${job.id}`}
@@ -61,7 +63,7 @@ function ImportRow({ job }: { job: ImportJobSummary }) {
         {countsSummary(job.counts)}
       </span>
       <span className="shrink-0 text-xs text-muted-foreground">
-        {new Date(job.created_at).toLocaleString()}
+        {formatDateTime(job.created_at)}
       </span>
     </Link>
   );

--- a/web/src/routes/journals.$id.tsx
+++ b/web/src/routes/journals.$id.tsx
@@ -26,7 +26,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMembers } from "@/hooks/use-members";
-import { formatDateTime } from "@/lib/date-format";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import {
   deleteJournal,
   getJournal,
@@ -37,7 +37,6 @@ import {
   updateJournal,
 } from "@/lib/journals";
 import { getSystemSafety } from "@/lib/system-safety";
-import { getMySystem } from "@/lib/systems";
 import { apiErrorMessage } from "@/lib/api-errors";
 import { isDeleteQueued } from "@/types/api";
 
@@ -52,15 +51,11 @@ export function JournalDetailPage() {
   const navigate = useNavigate();
   const qc = useQueryClient();
   const { data: members } = useMembers();
-  const { data: system } = useQuery({
-    queryKey: ["system", "me"],
-    queryFn: getMySystem,
-  });
+  const { formatDateTime } = useDateFormatters();
   const { data: safety } = useQuery({
     queryKey: ["system-safety"],
     queryFn: getSystemSafety,
   });
-  const dateFormat = system?.date_format ?? "ymd";
 
   const { data: entry, isLoading } = useQuery({
     queryKey: ["journal", entryId],
@@ -98,7 +93,7 @@ export function JournalDetailPage() {
 
   const member = entry.member_id ? members?.find((m) => m.id === entry.member_id) : null;
   const titleDisplay =
-    entry.title || `Entry from ${formatDateTime(entry.created_at, dateFormat)}`;
+    entry.title || `Entry from ${formatDateTime(entry.created_at)}`;
   const authors = entry.author_member_names.length > 0
     ? entry.author_member_names.join(", ")
     : "account";
@@ -149,12 +144,12 @@ export function JournalDetailPage() {
         {member ? (
           <>
             About <span className="font-medium">{member.display_name || member.name}</span>{" "}
-            · written by {authors} · {formatDateTime(entry.created_at, dateFormat)}
+            · written by {authors} · {formatDateTime(entry.created_at)}
           </>
         ) : (
           <>
             System-wide · written by {authors} ·{" "}
-            {formatDateTime(entry.created_at, dateFormat)}
+            {formatDateTime(entry.created_at)}
           </>
         )}
       </p>
@@ -181,7 +176,6 @@ export function JournalDetailPage() {
                 ["system-safety"],
               ]}
               emptyMessage="No revisions yet. Edits to this entry will appear here."
-              dateFormat={dateFormat}
             />
           </CardContent>
         </Card>

--- a/web/src/routes/journals.tsx
+++ b/web/src/routes/journals.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router";
 import {
   useInfiniteQuery,
   useMutation,
-  useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
@@ -23,7 +22,6 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCurrentFronts } from "@/hooks/use-fronts";
 import { useMembers } from "@/hooks/use-members";
 import { createJournal, listJournals } from "@/lib/journals";
-import { getMySystem } from "@/lib/systems";
 import type { JournalListResponse, Member } from "@/types/api";
 
 const PAGE_LIMIT = 25;
@@ -140,12 +138,6 @@ function JournalList({
   memberLookup: Map<string, Member>;
   members: Member[];
 }) {
-  const { data: system } = useQuery({
-    queryKey: ["system", "me"],
-    queryFn: getMySystem,
-  });
-  const dateFormat = system?.date_format ?? "ymd";
-
   const params = useMemo(() => {
     if (filter === "system") return { system_only: true, limit: PAGE_LIMIT };
     if (filter !== "all") return { member_id: filter, limit: PAGE_LIMIT };
@@ -191,7 +183,6 @@ function JournalList({
             key={entry.id}
             entry={entry}
             memberLookup={memberLookup}
-            dateFormat={dateFormat}
           />
         ))}
       </div>

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/hooks/use-members";
 import { useCustomFields, useMemberFieldValues, useSetMemberFieldValues } from "@/hooks/use-custom-fields";
 import { getMySystem } from "@/lib/systems";
-import { formatBirthday } from "@/lib/date-format";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { cn } from "@/lib/utils";
 import { PendingDeleteBadge } from "@/components/pending-delete-badge";
 import {
@@ -939,9 +939,8 @@ function MemberView({
 }) {
   const { data: fields } = useCustomFields();
   const { data: values } = useMemberFieldValues(member.id);
-  const { data: system } = useQuery({ queryKey: ["system", "me"], queryFn: getMySystem });
   const { data: safety } = useQuery({ queryKey: ["system-safety"], queryFn: getSystemSafety });
-  const dateFormat = system?.date_format ?? "ymd";
+  const { formatBirthday } = useDateFormatters();
   const [showRevisions, setShowRevisions] = useState(false);
 
   const fieldDisplay = useMemo(() => {
@@ -1033,7 +1032,7 @@ function MemberView({
               )}
               {member.birthday && (
                 <p className="text-sm text-muted-foreground">
-                  {formatBirthday(member.birthday, dateFormat)}
+                  {formatBirthday(member.birthday)}
                 </p>
               )}
               {member.pluralkit_id && (
@@ -1087,7 +1086,6 @@ function MemberView({
                   ["system-safety"],
                 ]}
                 emptyMessage="No bio revisions yet. Edits to the bio will appear here."
-                dateFormat={dateFormat}
               />
             </div>
           )}

--- a/web/src/routes/messages.tsx
+++ b/web/src/routes/messages.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { showApiErrorToast } from "@/lib/api-errors";
 
 import { useMembers } from "@/hooks/use-members";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { getCurrentFronts } from "@/lib/fronts";
 import { getMySystem } from "@/lib/systems";
 import {
@@ -220,6 +221,7 @@ function BoardView({
   members: Member[];
 }) {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const { data: system } = useQuery({
     queryKey: ["system", "me"],
     queryFn: getMySystem,
@@ -292,9 +294,9 @@ function BoardView({
       setDeleting(null);
       if (isDeleteQueued(resp)) {
         toast.success(
-          `Deletion queued. Will finalize after ${new Date(
+          `Deletion queued. Will finalize after ${formatDateTime(
             resp.finalize_after,
-          ).toLocaleString()} unless cancelled.`,
+          )} unless cancelled.`,
         );
       } else {
         toast.success("Deleted");
@@ -491,7 +493,6 @@ function BoardView({
       {historyFor && (
         <HistoryDialog
           message={historyFor}
-          dateFormat={system?.date_format ?? "ymd"}
           onClose={() => setHistoryFor(null)}
           onRestored={() => {
             setHistoryFor(null);
@@ -542,6 +543,7 @@ function MessageRow({
   onDelete: (cascade: boolean) => void;
   replyCount?: number;
 }) {
+  const { formatDateTime } = useDateFormatters();
   const author =
     msg.author_member_id !== null
       ? (memberById.get(msg.author_member_id)?.display_name ??
@@ -583,7 +585,7 @@ function MessageRow({
           )}
         </div>
         <span className="text-xs text-muted-foreground">
-          {new Date(msg.created_at).toLocaleString()}
+          {formatDateTime(msg.created_at)}
           {msg.updated_at && msg.updated_at !== msg.created_at && (
             <span className="ml-1 italic">(edited)</span>
           )}
@@ -771,12 +773,10 @@ function EditDialog({
 
 function HistoryDialog({
   message,
-  dateFormat,
   onClose,
   onRestored,
 }: {
   message: Message;
-  dateFormat: import("@/types/api").DateFormat;
   onClose: () => void;
   onRestored: () => void;
 }) {
@@ -810,7 +810,6 @@ function HistoryDialog({
             ["messages", "revisions", message.id],
           ]}
           emptyMessage="No revisions yet. Edits to this message will appear here."
-          dateFormat={dateFormat}
         />
       </DialogContent>
     </Dialog>

--- a/web/src/routes/polls.$pollId.tsx
+++ b/web/src/routes/polls.$pollId.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { showApiErrorToast } from "@/lib/api-errors";
 
 import { useMembers } from "@/hooks/use-members";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { getCurrentFronts } from "@/lib/fronts";
 import { getMySystem } from "@/lib/systems";
 import {
@@ -40,6 +41,7 @@ export function PollDetailPage() {
   const { pollId } = useParams<{ pollId: string }>();
   const navigate = useNavigate();
   const qc = useQueryClient();
+  const { formatDate, formatDateTime } = useDateFormatters();
 
   const { data: poll, isLoading } = useQuery({
     queryKey: ["poll", pollId],
@@ -82,9 +84,9 @@ export function PollDetailPage() {
       qc.invalidateQueries({ queryKey: ["polls"] });
       if (isDeleteQueued(resp)) {
         toast.success(
-          `Deletion queued. Will finalize after ${new Date(
+          `Deletion queued. Will finalize after ${formatDateTime(
             resp.finalize_after,
-          ).toLocaleString()} unless cancelled.`,
+          )} unless cancelled.`,
         );
       } else {
         toast.success("Poll deleted");
@@ -143,11 +145,11 @@ export function PollDetailPage() {
               <Badge variant="secondary">Closed</Badge>
             ) : (
               <span>
-                Closes {new Date(poll.closes_at).toLocaleString()}
+                Closes {formatDateTime(poll.closes_at)}
               </span>
             )}
             <span>
-              Auto-purges {new Date(poll.purges_at).toLocaleDateString()} (
+              Auto-purges {formatDate(poll.purges_at)} (
               {poll.retention_days}d after close)
             </span>
           </div>
@@ -423,6 +425,7 @@ function AuditCard({
   memberById: Map<string, Member>;
   options: { id: string; text: string }[];
 }) {
+  const { formatDateTime } = useDateFormatters();
   if (!isVisible) {
     return (
       <div className="rounded-md border p-4 text-sm text-muted-foreground">
@@ -468,7 +471,7 @@ function AuditCard({
               return (
                 <ContentRow
                   key={e.id}
-                  when={new Date(e.created_at).toLocaleString()}
+                  when={formatDateTime(e.created_at)}
                   action={e.action}
                   detail={
                     <span>

--- a/web/src/routes/polls.tsx
+++ b/web/src/routes/polls.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { Checkbox } from "@/components/ui/checkbox";
 import { isDeleteQueued } from "@/types/api";
 import type {
@@ -44,19 +45,6 @@ import type {
   PollKind,
   PollResultsVisibility,
 } from "@/types/api";
-
-function offsetLocal(msFromNow: number): string {
-  const d = new Date(Date.now() + msFromNow);
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-    d.getHours(),
-  )}:${pad(d.getMinutes())}`;
-}
-
-function defaultClosesAtLocal(): string {
-  // 24h from now, in datetime-local format the <input> needs.
-  return offsetLocal(24 * 60 * 60 * 1000);
-}
 
 function formatRelative(iso: string): string {
   const target = new Date(iso).getTime();
@@ -77,6 +65,7 @@ function formatRelative(iso: string): string {
 
 export function PollsPage() {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const { data: polls, isLoading } = useQuery({
     queryKey: ["polls"],
     queryFn: listPolls,
@@ -110,9 +99,9 @@ export function PollsPage() {
       setDeleting(null);
       if (isDeleteQueued(resp)) {
         toast.success(
-          `Deletion queued. Will finalize after ${new Date(
+          `Deletion queued. Will finalize after ${formatDateTime(
             resp.finalize_after,
-          ).toLocaleString()} unless cancelled.`,
+          )} unless cancelled.`,
         );
       } else {
         toast.success("Poll deleted");
@@ -262,11 +251,16 @@ function CreatePollDialog({
   serverConfig: import("@/types/api").PollServerConfig | null;
 }) {
   const qc = useQueryClient();
+  // datetime-local values render/parse in the display timezone (24h from now
+  // by default), matching how poll deadlines are shown everywhere else.
+  const { toDateTimeLocal, fromDateTimeLocal } = useDateFormatters();
   const [question, setQuestion] = useState("");
   const [description, setDescription] = useState("");
   const [kind, setKind] = useState<PollKind>("single_choice");
   const [visibility, setVisibility] = useState<PollResultsVisibility>("live");
-  const [closesAtLocal, setClosesAtLocal] = useState(defaultClosesAtLocal());
+  const [closesAtLocal, setClosesAtLocal] = useState(() =>
+    toDateTimeLocal(new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()),
+  );
   const [includeCustomFronts, setIncludeCustomFronts] = useState(false);
   const [restrictToFronters, setRestrictToFronters] = useState(false);
   const [retentionDays, setRetentionDays] = useState<number>(
@@ -280,7 +274,9 @@ function CreatePollDialog({
   // Computed once at dialog mount; the cap is a per-tier ceiling, not a
   // ticking clock, so a stale-by-a-few-seconds value is fine.
   const [closesAtMaxLocal] = useState<string | undefined>(() =>
-    maxClose ? offsetLocal(maxClose * 1000) : undefined,
+    maxClose
+      ? toDateTimeLocal(new Date(Date.now() + maxClose * 1000).toISOString())
+      : undefined,
   );
 
   const createMut = useMutation({
@@ -302,7 +298,11 @@ function CreatePollDialog({
 
   function submit() {
     if (!valid) return;
-    const closesAt = new Date(closesAtLocal).toISOString();
+    const closesAt = fromDateTimeLocal(closesAtLocal);
+    if (!closesAt) {
+      toast.error("A close time is required.");
+      return;
+    }
     createMut.mutate({
       question: question.trim(),
       description: description.trim() || null,

--- a/web/src/routes/reminders.tsx
+++ b/web/src/routes/reminders.tsx
@@ -4,6 +4,7 @@ import { Bell, Pause, Pencil, Play, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { useMembers } from "@/hooks/use-members";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { getMySystem } from "@/lib/systems";
 import { listAllChannels } from "@/lib/notifications";
 import {
@@ -60,6 +61,7 @@ function browserTz(): string {
 
 export function RemindersPage() {
   const qc = useQueryClient();
+  const { formatDateTime } = useDateFormatters();
   const { data: reminders, isLoading } = useQuery({
     queryKey: ["reminders"],
     queryFn: listReminders,
@@ -100,9 +102,9 @@ export function RemindersPage() {
       setDeleting(null);
       if (isDeleteQueued(resp)) {
         toast.success(
-          `Deletion queued. Will finalize after ${new Date(
+          `Deletion queued. Will finalize after ${formatDateTime(
             resp.finalize_after,
-          ).toLocaleString()} unless cancelled.`,
+          )} unless cancelled.`,
         );
       } else {
         toast.success("Reminder deleted");
@@ -219,12 +221,13 @@ function ReminderRow({
   onDelete: () => void;
   onToggle: (v: boolean) => void;
 }) {
+  const { formatDateTime } = useDateFormatters();
   const summary = useMemo(
     () => triggerSummary(reminder, memberById),
     [reminder, memberById],
   );
   const nextFire = reminder.next_fire_at
-    ? new Date(reminder.next_fire_at).toLocaleString()
+    ? formatDateTime(reminder.next_fire_at)
     : null;
   return (
     <div

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -71,6 +71,10 @@ export interface System {
   privacy: PrivacyLevel;
   delete_confirmation: DeleteConfirmation;
   date_format: DateFormat;
+  /** Account display timezone. null = "automatic" (each device renders in
+   *  its own local clock); otherwise an IANA zone name. This is the synced
+   *  account default; a per-device override may shadow it locally. */
+  timezone: string | null;
   replace_fronts_default: boolean;
   coalesce_contiguous_fronts: boolean;
   created_at: string;
@@ -86,6 +90,9 @@ export interface SystemUpdate {
   color?: string | null;
   privacy?: PrivacyLevel;
   date_format?: DateFormat;
+  /** Omit to leave unchanged; null sets "automatic"; a string must be a
+   *  valid IANA zone (the backend 422s an unknown zone). */
+  timezone?: string | null;
   replace_fronts_default?: boolean;
   coalesce_contiguous_fronts?: boolean;
 }


### PR DESCRIPTION
## What

Adds a global display-timezone preference so timestamps can render in a chosen zone instead of always following the browser's clock. It is a per-account setting (`System.timezone`) that a system's devices sync to, sitting alongside the existing `date_format` preference, with a per-device local override so a machine in another zone can pin its own without disturbing the account default. The default is "automatic", which preserves today's behaviour exactly: each device uses its own local time, and nothing visibly changes until a non-automatic zone is chosen.

## Backend

`System.timezone` is a nullable column (null = automatic) validated against the IANA tz database at both the API and the import boundary, so an unknown zone is a 422 rather than junk that clients then fail to format. It bundles the `tzdata` package so `zoneinfo` resolves the same set of zones in the slim runtime container as on a dev box (the base image does not reliably ship the system zone data). The field is threaded through the native export/import, the OpenPlural envelope (as an `extensions.sheaf` field), and both parity guards, so it round-trips on backup/restore and cannot silently fall out of either format.

## Web

A timezone-aware formatter (`date-fns-tz`) replaces the browser-local formatting path, and absolute times now carry a DST-aware zone stamp (for example `2026-07-11 13:37 EST`); relative times stay bare and birthdays stay zone-neutral. A `useTimezone` hook resolves the effective zone as device-override > account-default > browser, and a shared picker lists a short set of friendly common zones (Eastern Time, UK/Ireland, and so on, mapped to canonical city zones so DST is correct) followed by the full IANA list with the truly fixed no-DST zones still reachable. Every display site across the app plus the `datetime-local` entry widgets (front edit, poll close, announcement expiry) route through the formatter, so what you read matches what you edit. An eslint rule guards against new code formatting a date with `toLocale*` and dodging the preference, while leaving numeric `toLocaleString` alone.

## Testing

- Backend headless: validation + both parity guards + OpenPlural round-trip green.
- Backend behavioural: the full suite (all 9 server configs) passes, including the new API/export tests for the field.
- Web: `tsc`, `eslint` (including the new guard, verified to fire on a date and ignore a number), and a production build all green.

## Not in this PR

Server-side localisation of notification emails and other server-rendered timestamps is a deliberate follow-up; this change covers the stored preference and the entire web client. The portable export stays in UTC by design regardless.
