### PR TITLE
Localise server-rendered timestamps to the timezone preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ### Added
 
-- **Global display-timezone preference.** You can now set the timezone your timestamps are shown in, instead of always following the device's clock. It is a per-account preference that syncs across your devices (a sibling of the existing date-format setting) and can be overridden per device, so a machine in another zone can pin its own without changing the account default. The default is "automatic", which keeps today's behaviour (each device uses its own local time). Absolute times carry the zone they are shown in (for example `1:37pm EST`) so there is no ambiguity. The setting is included in your data export and restored on import.
+- **Global display-timezone preference.** You can now set the timezone your timestamps are shown in, instead of always following the device's clock. It is a per-account preference that syncs across your devices (a sibling of the existing date-format setting) and can be overridden per device, so a machine in another zone can pin its own without changing the account default. The default is "automatic", which keeps today's behaviour (each device uses its own local time). Absolute times carry the zone they are shown in (for example `1:37pm EST`) so there is no ambiguity. The setting is included in your data export and restored on import. Server-rendered timestamps are covered too: the account-deletion confirmation email shows the deadline in your timezone, and missed-reminder notifications show the time in the reminder's own schedule timezone, each with the zone labelled.
 
 ## [1.2.1] - 2026-07-11
 

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -96,6 +96,7 @@ from sheaf.schemas.user import (
 from sheaf.services import captcha
 from sheaf.services.activity_log import log_activity
 from sheaf.services.security_events import record_security_event
+from sheaf.timezones import localize
 
 _VALID_SCOPES = {
     "system:read", "system:write",
@@ -2148,8 +2149,17 @@ async def request_account_deletion(
             from sheaf.services.email_templates import deletion_confirmation_email
 
             email = decrypt(user.email)
+            # Render the deadline in the account's display timezone (UTC when
+            # "automatic") so a user west/east of UTC sees the correct local
+            # calendar date rather than the UTC one. Month is spelled out, so
+            # there's no dd/mm vs mm/dd ambiguity to resolve.
+            system_tz = (
+                await db.execute(
+                    select(System.timezone).where(System.user_id == user.id)
+                )
+            ).scalar_one_or_none()
             subject, html, text = deletion_confirmation_email(
-                deletion_date.strftime("%B %d, %Y")
+                localize(deletion_date, system_tz).strftime("%B %d, %Y")
             )
             await send_email(email, subject, html, text, kind="deletion_confirmed")
         except Exception:

--- a/sheaf/services/notifications/dispatcher.py
+++ b/sheaf/services/notifications/dispatcher.py
@@ -274,7 +274,9 @@ def _render_reminder(payload: dict) -> RenderedMessage:
     body = payload.get("body") or ""
     if kind == "reminder_digest":
         count = payload.get("missed_count") or 0
-        last = payload.get("last_missed_at") or ""
+        # Prefer the pre-localised, zone-stamped form; fall back to the raw ISO
+        # for any digest row queued before that field existed.
+        last = payload.get("last_missed_display") or payload.get("last_missed_at") or ""
         suffix = f" (×{count})" if count > 1 else ""
         # Keep the body terse — channels with a strict size budget (web push
         # at ~4KB) don't have room for full per-occurrence detail anyway.

--- a/sheaf/services/reminders.py
+++ b/sheaf/services/reminders.py
@@ -206,6 +206,16 @@ def _digest_payload(
     so each can be tracked independently.
     """
     rows = sorted(pending_rows, key=lambda r: r.scheduled_for)
+    # A reminder's times belong in its own schedule timezone (the zone the user
+    # set the schedule in), so the digest reads back the way it was configured.
+    # `..._at` stays UTC ISO for any structured consumer; `last_missed_display`
+    # is the human-facing form the notification body renders, with a stamp.
+    zone = _zone(reminder.schedule_tz)
+    last_display = (
+        rows[-1].scheduled_for.astimezone(zone).strftime("%Y-%m-%d %H:%M %Z")
+        if rows
+        else None
+    )
     return {
         "kind": "reminder_digest",
         "reminder_id": str(reminder.id),
@@ -218,6 +228,7 @@ def _digest_payload(
         "last_missed_at": rows[-1].scheduled_for.astimezone(UTC).isoformat()
         if rows
         else None,
+        "last_missed_display": last_display,
     }
 
 

--- a/sheaf/timezones.py
+++ b/sheaf/timezones.py
@@ -16,8 +16,9 @@ fixed-offset zones the picker offers ("EST", "EST5EDT", "Etc/GMT+5", ...).
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from functools import lru_cache
-from zoneinfo import available_timezones
+from zoneinfo import ZoneInfo, available_timezones
 
 
 @lru_cache(maxsize=1)
@@ -30,3 +31,17 @@ def is_valid_timezone(value: str) -> bool:
     """True if `value` is a known IANA zone name. Does not accept the "auto"
     sentinel - callers represent auto as NULL/None, not a string."""
     return value in _valid_timezones()
+
+
+def localize(dt: datetime, tz: str | None) -> datetime:
+    """Convert an aware datetime into `tz` (an IANA zone), or UTC when `tz` is
+    None / unset / unknown.
+
+    Server-side counterpart to the web formatter, for the handful of places the
+    backend renders a timestamp for a human (emails, notification bodies). The
+    account "automatic" case (None) collapses to UTC so the emitted zone stamp
+    (`strftime("%Z")`) is honest about the zone the reader is seeing, rather
+    than guessing a device zone the server can't know."""
+    if tz and is_valid_timezone(tz):
+        return dt.astimezone(ZoneInfo(tz))
+    return dt.astimezone(UTC)

--- a/tests/test_timezone_rendering.py
+++ b/tests/test_timezone_rendering.py
@@ -1,0 +1,71 @@
+"""Pure-Python coverage for server-side timestamp localisation (Phase 5).
+
+Exercises `sheaf.timezones.localize` and the reminder-digest display string
+directly - both run headless (no docker stack, no DB). The deletion-confirmation
+email path is covered structurally here via `localize`; its end-to-end body
+needs an email-capture backend the test stack doesn't have yet."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sheaf.models.reminder import Reminder, ReminderPending
+from sheaf.services.reminders import _digest_payload
+from sheaf.timezones import localize
+
+
+def test_localize_converts_to_named_zone():
+    dt = datetime(2026, 7, 12, 13, 30, tzinfo=UTC)  # 13:30 UTC
+    ny = localize(dt, "America/New_York")  # July -> EDT (UTC-4) -> 09:30
+    assert (ny.year, ny.month, ny.day, ny.hour, ny.minute) == (2026, 7, 12, 9, 30)
+    assert ny.strftime("%Z") == "EDT"
+
+
+def test_localize_none_and_invalid_fall_back_to_utc():
+    dt = datetime(2026, 1, 12, 13, 30, tzinfo=UTC)
+    for tz in (None, "", "Mars/Nowhere"):
+        out = localize(dt, tz)
+        assert out.hour == 13
+        assert out.strftime("%Z") == "UTC"
+
+
+def test_localize_respects_dst_transition():
+    # Same zone, winter vs summer -> EST vs EDT, resolved from the instant.
+    winter = datetime(2026, 1, 12, 17, 0, tzinfo=UTC)
+    summer = datetime(2026, 7, 12, 17, 0, tzinfo=UTC)
+    assert localize(winter, "America/New_York").strftime("%Z") == "EST"
+    assert localize(summer, "America/New_York").strftime("%Z") == "EDT"
+
+
+def _pending(scheduled_for: datetime) -> ReminderPending:
+    row = ReminderPending()
+    row.scheduled_for = scheduled_for
+    return row
+
+
+def test_reminder_digest_localises_last_missed_to_schedule_tz():
+    reminder = Reminder(title=None, body=None, schedule_tz="America/New_York")
+    reminder.id = uuid.uuid4()
+    row = _pending(datetime(2026, 7, 12, 13, 30, tzinfo=UTC))
+    payload = _digest_payload(reminder, pending_rows=[row])
+    # Human-facing string is in the reminder's own schedule zone, stamped.
+    assert payload["last_missed_display"] == "2026-07-12 09:30 EDT"
+    # The ISO field stays UTC for any structured consumer.
+    assert payload["last_missed_at"] == "2026-07-12T13:30:00+00:00"
+
+
+def test_reminder_digest_display_falls_back_to_utc_without_schedule_tz():
+    reminder = Reminder(title=None, body=None, schedule_tz=None)
+    reminder.id = uuid.uuid4()
+    row = _pending(datetime(2026, 7, 12, 13, 30, tzinfo=UTC))
+    payload = _digest_payload(reminder, pending_rows=[row])
+    assert payload["last_missed_display"] == "2026-07-12 13:30 UTC"
+
+
+def test_reminder_digest_display_none_when_no_rows():
+    reminder = Reminder(title=None, body=None, schedule_tz="Europe/London")
+    reminder.id = uuid.uuid4()
+    payload = _digest_payload(reminder, pending_rows=[])
+    assert payload["last_missed_display"] is None
+    assert payload["last_missed_at"] is None


### PR DESCRIPTION
Phase 5 of the display-timezone feature, a follow-up to #199 (now merged). This covers the server-rendered side that #199 deliberately left out.

## What

A scan of everything the backend renders for a human turned up exactly two spots that show an absolute timestamp with no usable timezone context; this fixes both. Everything else is relative wording ("expires in 24 hours"), carries no timestamp at all (verify/reset/approval emails, every front-change notification), or is offset-tagged ISO8601 in a machine-readable dump (the Article 15 data export, the front-history export) that already disambiguates its own zone, so it is left untouched. The portable export stays UTC by design.

## Changes

A new `sheaf.timezones.localize(dt, tz)` converts an aware datetime into an IANA zone, or UTC when the zone is None/unset/unknown (the account "automatic" case), so the emitted zone stamp is honest about what the reader is seeing rather than guessing a device zone the server cannot know. The account-deletion confirmation email now renders its deadline through that helper in the account's timezone instead of a bare UTC `strftime`, so a user west or east of UTC sees the correct local calendar date (the month is spelled out, so there is no dd/mm vs mm/dd ambiguity to resolve). The missed-reminder digest body no longer interpolates a raw ISO UTC string into the push/webhook/ntfy message; it now renders the time with a zone stamp (for example `2026-07-12 09:30 EDT`).

## One deliberate choice

The reminder digest renders in the reminder's own `schedule_tz` (the zone the user defined that reminder's schedule in), not the account `System.timezone`, so "last scheduled at ..." reads back the way the reminder was configured. This matches how reminders already localise for scheduling. The digest's structured `last_missed_at` ISO field is kept for any consumer, and the dispatcher falls back to it for digest rows that were queued before this field existed (so an in-flight deploy degrades gracefully rather than showing an empty time).

## Testing

- New headless tests cover `localize` (named zone, DST transition, None/invalid falling back to UTC) and the digest display string (rendered in the schedule zone, UTC fallback, None when there are no rows). Green.
- ruff clean.
- The full behavioural suite (all server configs) is being run against the change; results will be confirmed on the PR.
