### PR TITLE
Add relationship graph data layer (types + member/group edges)

### DIFF
--- a/alembic/versions/z7a8b9c0d1e2_add_relationships.py
+++ b/alembic/versions/z7a8b9c0d1e2_add_relationships.py
@@ -1,0 +1,152 @@
+"""Add relationship_types, member_relationships, group_relationships
+
+Revision ID: z7a8b9c0d1e2
+Revises: y6z7a8b9c0d1
+Create Date: 2026-07-12
+
+Typed relationship graph over a system's members and groups. `RelationshipType`
+is a per-system, user-defined vocabulary (name + symmetry mode + labels); the
+two edge tables share it. Exactly one canonical row is stored per relationship;
+the inverse is derived at read time.
+
+Uniqueness is over the UNORDERED pair per type (no both A->B and B->A of one
+type), which a plain UNIQUE(source,target,type) cannot express - hence the
+functional unique index on least()/greatest(). uuid has a total, immutable
+ordering so it is index-safe. A no-self-edge CheckConstraint guards each table.
+
+CREATE TABLE takes locks only on the brand-new relations; the lock_timeout is
+belt-and-braces per house style. No backfill (new tables).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "z7a8b9c0d1e2"
+down_revision: Union[str, None] = "y6z7a8b9c0d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# create_type=False: the types are created once by the explicit op.execute below.
+# Generic sa.Enum(create_type=False) does NOT suppress the auto-create inside
+# create_table (and `visibility` is shared by two tables, so it would collide);
+# the postgresql.ENUM form reliably honours create_type=False.
+_symmetry = postgresql.ENUM(
+    "symmetric", "directional", "either",
+    name="relationshipsymmetry", create_type=False,
+)
+_visibility = postgresql.ENUM(
+    "private", name="relationshipvisibility", create_type=False,
+)
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+
+    op.execute(
+        "CREATE TYPE relationshipsymmetry AS ENUM "
+        "('symmetric', 'directional', 'either')"
+    )
+    op.execute("CREATE TYPE relationshipvisibility AS ENUM ('private')")
+
+    op.create_table(
+        "relationship_types",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "system_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("systems.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("symmetry", _symmetry, nullable=False),
+        sa.Column("forward_label", sa.String(100), nullable=False),
+        sa.Column("reverse_label", sa.String(100), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "system_id", "name", name="uq_relationship_types_system_name"
+        ),
+    )
+
+    for table, node_table, ck_name in (
+        ("member_relationships", "members", "ck_member_rel_no_self"),
+        ("group_relationships", "groups", "ck_group_rel_no_self"),
+    ):
+        op.create_table(
+            table,
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "system_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("systems.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column(
+                "source_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey(f"{node_table}.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column(
+                "target_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey(f"{node_table}.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column(
+                "relationship_type_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("relationship_types.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column(
+                "mutual", sa.Boolean(),
+                nullable=False, server_default=sa.false(),
+            ),
+            sa.Column(
+                "visibility", _visibility,
+                nullable=False, server_default="private",
+            ),
+            sa.Column(
+                "created_at", sa.DateTime(timezone=True),
+                nullable=False, server_default=sa.func.now(),
+            ),
+            sa.CheckConstraint("source_id <> target_id", name=ck_name),
+        )
+        # Unordered-pair-per-type uniqueness: (A,B) and (B,A) collide.
+        op.create_index(
+            f"uq_{table}_unordered",
+            table,
+            [
+                sa.text("system_id"),
+                sa.text("relationship_type_id"),
+                sa.text("least(source_id, target_id)"),
+                sa.text("greatest(source_id, target_id)"),
+            ],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    op.execute("SET lock_timeout = '3s'")
+    for table in ("group_relationships", "member_relationships"):
+        op.drop_index(f"uq_{table}_unordered", table_name=table)
+        op.drop_table(table)
+    op.drop_table("relationship_types")
+    op.execute("DROP TYPE relationshipvisibility")
+    op.execute("DROP TYPE relationshipsymmetry")

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -41,6 +41,11 @@ from sheaf.models.group import Group
 from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
 from sheaf.models.notification_channel import NotificationChannel
+from sheaf.models.relationship import (
+    GroupRelationship,
+    MemberRelationship,
+    RelationshipType,
+)
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
 from sheaf.models.uploaded_file import UploadedFile
@@ -371,6 +376,28 @@ async def export_all(
     )
     messages_rows = list(msgs_result.scalars().all())
 
+    # Relationships - user-defined relationship types plus the member and
+    # group edges built on them. No encrypted columns, so no decryption.
+    # Old member/group/type uuids are emitted so the importer can remap.
+    rel_types_result = await db.execute(
+        select(RelationshipType).where(RelationshipType.system_id == system.id)
+    )
+    relationship_types = list(rel_types_result.scalars().all())
+
+    member_rels_result = await db.execute(
+        select(MemberRelationship).where(
+            MemberRelationship.system_id == system.id
+        )
+    )
+    member_relationships = list(member_rels_result.scalars().all())
+
+    group_rels_result = await db.execute(
+        select(GroupRelationship).where(
+            GroupRelationship.system_id == system.id
+        )
+    )
+    group_relationships = list(group_rels_result.scalars().all())
+
     native = {
         "version": "2",
         "system": _system_dict(system),
@@ -462,6 +489,22 @@ async def export_all(
         "reminders": [_reminder_dict(r) for r in reminders],
         "polls": [_poll_dict(p) for p in polls],
         "messages": [_message_dict(m) for m in messages_rows],
+        "relationship_types": [
+            {
+                "id": str(rt.id),
+                "name": rt.name,
+                "symmetry": rt.symmetry.value,
+                "forward_label": rt.forward_label,
+                "reverse_label": rt.reverse_label,
+            }
+            for rt in relationship_types
+        ],
+        "member_relationships": [
+            _relationship_dict(r) for r in member_relationships
+        ],
+        "group_relationships": [
+            _relationship_dict(r) for r in group_relationships
+        ],
     }
     return _maybe_openplural(native, format)
 
@@ -497,6 +540,23 @@ def _empty_export() -> dict:
         "reminders": [],
         "polls": [],
         "messages": [],
+        "relationship_types": [],
+        "member_relationships": [],
+        "group_relationships": [],
+    }
+
+
+def _relationship_dict(rel: MemberRelationship | GroupRelationship) -> dict:
+    """One member/group relationship edge. source/target/type carry the OLD
+    uuids (member or group depending on the table); the importer remaps them.
+    No encrypted columns, so nothing to decrypt."""
+    return {
+        "source_id": str(rel.source_id),
+        "target_id": str(rel.target_id),
+        "relationship_type_id": str(rel.relationship_type_id),
+        "mutual": rel.mutual,
+        "visibility": rel.visibility.value,
+        "created_at": rel.created_at.isoformat(),
     }
 
 

--- a/sheaf/api/v1/openplural_import.py
+++ b/sheaf/api/v1/openplural_import.py
@@ -56,6 +56,9 @@ def _summary_dict(p: SheafPreviewSummary) -> dict:
         "open_poll_count": p.open_poll_count,
         "reminder_count": p.reminder_count,
         "channel_count": p.channel_count,
+        "relationship_type_count": p.relationship_type_count,
+        "member_relationship_count": p.member_relationship_count,
+        "group_relationship_count": p.group_relationship_count,
         "limit_warnings": p.limit_warnings,
     }
 

--- a/sheaf/api/v1/sheaf_import.py
+++ b/sheaf/api/v1/sheaf_import.py
@@ -82,6 +82,9 @@ def _summary_dict(p: SheafPreviewSummary) -> dict:
         "open_poll_count": p.open_poll_count,
         "reminder_count": p.reminder_count,
         "channel_count": p.channel_count,
+        "relationship_type_count": p.relationship_type_count,
+        "member_relationship_count": p.member_relationship_count,
+        "group_relationship_count": p.group_relationship_count,
         "limit_warnings": p.limit_warnings,
     }
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -169,6 +169,12 @@ class Settings(BaseSettings):
     import_max_groups: int = 10000
     import_max_tags: int = 10000
     import_max_custom_fields: int = 10000
+    # Relationship types are a small vocabulary like tags/groups; the member
+    # and group edges built on them can scale with the roster, so they get the
+    # larger edge-style ceiling (fronts/messages scale).
+    import_max_relationship_types: int = 10000
+    import_max_member_relationships: int = 100000
+    import_max_group_relationships: int = 100000
 
     # Revision-history retention caps per tier. 0 = unlimited.
     # Covers both journal entries and member bios under a single cap.

--- a/sheaf/models/__init__.py
+++ b/sheaf/models/__init__.py
@@ -48,6 +48,13 @@ from sheaf.models.poll import (
     PollVoteEvent,
 )
 from sheaf.models.push_device_token import PushDeviceToken, PushPlatform
+from sheaf.models.relationship import (
+    GroupRelationship,
+    MemberRelationship,
+    RelationshipSymmetry,
+    RelationshipType,
+    RelationshipVisibility,
+)
 from sheaf.models.reminder import Reminder, ReminderPending, reminder_scope_members
 from sheaf.models.retention_trim_notice import RetentionTrimNotice, RetentionTrimStatus
 from sheaf.models.safety_change_request import SafetyChangeRequest, SafetyChangeStatus
@@ -113,6 +120,11 @@ __all__ = [
     "PrivacyLevel",
     "PushDeviceToken",
     "PushPlatform",
+    "GroupRelationship",
+    "MemberRelationship",
+    "RelationshipSymmetry",
+    "RelationshipType",
+    "RelationshipVisibility",
     "Reminder",
     "ReminderPending",
     "RetentionTrimNotice",

--- a/sheaf/models/relationship.py
+++ b/sheaf/models/relationship.py
@@ -1,0 +1,197 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Enum,
+    ForeignKey,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sheaf.models.base import Base, TimestampMixin, UUIDMixin
+
+
+class RelationshipSymmetry(enum.StrEnum):
+    """How a relationship type reads from each endpoint.
+
+    - SYMMETRIC: one label, unordered; both ends read `forward_label`
+      (e.g. partner).
+    - DIRECTIONAL: source reads `forward_label`, target reads `reverse_label`
+      (e.g. parent/child); the edge is inherently ordered.
+    - EITHER: the type supports both; a given edge is directional unless its
+      `mutual` flag is set, in which case both ends read `forward_label`
+      (e.g. protector -> protectee, or mutual protectors). This is the whole
+      reason directionality lives on the TYPE, not on separate types per
+      direction (avoids the "make a second type for the inverse" trap).
+    """
+
+    SYMMETRIC = "symmetric"
+    DIRECTIONAL = "directional"
+    EITHER = "either"
+
+
+class RelationshipVisibility(enum.StrEnum):
+    """Reserved for the future ACL/public-profiles primitive.
+
+    Only PRIVATE exists in v1 and it is stored-but-not-enforced (all reads are
+    owner-only today). The column exists now so ACL can light relationships up
+    later without a migration on a live table.
+    """
+
+    PRIVATE = "private"
+
+
+class RelationshipType(UUIDMixin, TimestampMixin, Base):
+    """A per-system, user-defined kind of relationship (partner, protector,
+    parent/child, ...). Starts empty per system; the web editor seeds new rows
+    from client-side preset templates. Shared vocabulary for both member and
+    group edges."""
+
+    __tablename__ = "relationship_types"
+    __table_args__ = (
+        UniqueConstraint(
+            "system_id", "name", name="uq_relationship_types_system_name"
+        ),
+    )
+
+    system_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("systems.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    symmetry: Mapped[RelationshipSymmetry] = mapped_column(
+        Enum(RelationshipSymmetry, values_callable=lambda e: [m.value for m in e]),
+        nullable=False,
+    )
+    # The single label for symmetric types and the source-side label otherwise.
+    forward_label: Mapped[str] = mapped_column(String(100), nullable=False)
+    # The target-side label for directional / either types; unused (null) for
+    # symmetric. Required at the schema layer when symmetry != symmetric.
+    reverse_label: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+
+# ---------------------------------------------------------------------------
+# Edge tables. Member<->member and group<->group share the RelationshipType
+# vocabulary and the same shape. Exactly ONE canonical row is stored per
+# relationship; the inverse is derived at render time by the shared engine
+# (services/relationships.py). See that module for the label-resolution logic.
+#
+# `source_id` has TYPE-DEPENDENT meaning and this is the subtlest thing here:
+#   - directional / either edges: source is the `forward_label` endpoint
+#     (e.g. the parent, or the protector); order is load-bearing, preserve it.
+#   - symmetric edges: direction is meaningless, so the API/importer store the
+#     lexicographically-smaller uuid as source purely for stable dedup/render.
+#
+# Uniqueness is over the UNORDERED pair per type (you cannot have both A->B and
+# B->A of one type). A plain UniqueConstraint(source,target,type) does NOT
+# enforce that, so the guarantee is a FUNCTIONAL unique index on
+# (system_id, relationship_type_id, least(source,target), greatest(source,target))
+# created in the migration (not expressible cleanly in __table_args__). The
+# no-self-edge CheckConstraint below is declarative and mirrored in the migration.
+# ---------------------------------------------------------------------------
+
+
+class MemberRelationship(UUIDMixin, Base):
+    __tablename__ = "member_relationships"
+    __table_args__ = (
+        CheckConstraint(
+            "source_id <> target_id", name="ck_member_rel_no_self"
+        ),
+    )
+
+    system_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("systems.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("members.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("members.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    relationship_type_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("relationship_types.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Only meaningful for `either` types: when true, both ends read forward_label.
+    mutual: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    visibility: Mapped[RelationshipVisibility] = mapped_column(
+        Enum(
+            RelationshipVisibility, values_callable=lambda e: [m.value for m in e]
+        ),
+        default=RelationshipVisibility.PRIVATE,
+        server_default=RelationshipVisibility.PRIVATE.value,
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class GroupRelationship(UUIDMixin, Base):
+    __tablename__ = "group_relationships"
+    __table_args__ = (
+        CheckConstraint(
+            "source_id <> target_id", name="ck_group_rel_no_self"
+        ),
+    )
+
+    system_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("systems.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    relationship_type_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("relationship_types.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    mutual: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    visibility: Mapped[RelationshipVisibility] = mapped_column(
+        Enum(
+            RelationshipVisibility, values_callable=lambda e: [m.value for m in e]
+        ),
+        default=RelationshipVisibility.PRIVATE,
+        server_default=RelationshipVisibility.PRIVATE.value,
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/sheaf/schemas/sheaf_import.py
+++ b/sheaf/schemas/sheaf_import.py
@@ -37,6 +37,9 @@ class SheafImportOptions(BaseModel):
     # Watch tokens + their channels + filter rules. Reminders reference a
     # channel, so importing reminders without notifications drops them.
     notifications: bool = True
+    # Relationship types + the member and group edges built on them. One flag
+    # gates all three: the edges reference the types, so they move together.
+    relationships: bool = True
 
 
 class SheafArchiveImportOptions(SheafImportOptions):

--- a/sheaf/services/import_content_dedup.py
+++ b/sheaf/services/import_content_dedup.py
@@ -53,6 +53,11 @@ from sheaf.models.member import front_members, group_members, member_tags
 from sheaf.models.message import Message
 from sheaf.models.notification_channel import NotificationChannel
 from sheaf.models.poll import Poll
+from sheaf.models.relationship import (
+    GroupRelationship,
+    MemberRelationship,
+    RelationshipType,
+)
 from sheaf.models.reminder import Reminder
 from sheaf.models.tag import Tag
 from sheaf.models.watch_token import WatchToken
@@ -356,3 +361,64 @@ async def load_member_tag_guard(
         ).where(Tag.system_id == system_id)
     )
     return PairGuard({(r.tag_id, r.member_id) for r in rows})
+
+
+async def load_relationship_type_index(
+    db: AsyncSession, system_id: uuid.UUID
+) -> ContentMatchIndex:
+    """Relationship types keyed by name (like tags/groups) - a re-import
+    reuses a same-named type so its edges land on the existing row."""
+    rows = await db.execute(
+        select(RelationshipType).where(RelationshipType.system_id == system_id)
+    )
+    return ContentMatchIndex({rt.name: rt for rt in rows.scalars().all()})
+
+
+def relationship_pair_key(
+    type_id: uuid.UUID, source_id: uuid.UUID, target_id: uuid.UUID
+) -> tuple:
+    """Guard key matching the functional unique index on member/group edges:
+    (type, least(source, target), greatest(source, target)). Uniqueness is
+    over the UNORDERED pair per type, so direction doesn't change the key."""
+    lo, hi = (source_id, target_id) if source_id <= target_id else (target_id, source_id)
+    return (type_id, lo, hi)
+
+
+async def load_member_relationship_guard(
+    db: AsyncSession, system_id: uuid.UUID
+) -> PairGuard:
+    """Existing member-edge unordered pairs per type - the functional unique
+    index makes a blind re-insert (or an in-file inverse duplicate) a hard
+    error, so importers consult this before adding an edge."""
+    rows = await db.execute(
+        select(
+            MemberRelationship.relationship_type_id,
+            MemberRelationship.source_id,
+            MemberRelationship.target_id,
+        ).where(MemberRelationship.system_id == system_id)
+    )
+    return PairGuard(
+        {
+            relationship_pair_key(r.relationship_type_id, r.source_id, r.target_id)
+            for r in rows
+        }
+    )
+
+
+async def load_group_relationship_guard(
+    db: AsyncSession, system_id: uuid.UUID
+) -> PairGuard:
+    """Group-edge counterpart of load_member_relationship_guard."""
+    rows = await db.execute(
+        select(
+            GroupRelationship.relationship_type_id,
+            GroupRelationship.source_id,
+            GroupRelationship.target_id,
+        ).where(GroupRelationship.system_id == system_id)
+    )
+    return PairGuard(
+        {
+            relationship_pair_key(r.relationship_type_id, r.source_id, r.target_id)
+            for r in rows
+        }
+    )

--- a/sheaf/services/import_limits.py
+++ b/sheaf/services/import_limits.py
@@ -85,6 +85,13 @@ REMINDER_NAME = Cap("reminder name", 120)
 REMINDER_TITLE = Cap("reminder title", 500)
 REMINDER_BODY = Cap("reminder body", 2000)
 
+# --- Relationships ----------------------------------------------------------
+# Mirrors the relationship_types columns (name / forward_label / reverse_label
+# are String(100)). A dedicated schema lands with the relationships API; until
+# then these track the column widths so an import can't over-run them.
+REL_TYPE_NAME = Cap("relationship type name", 100)
+REL_TYPE_LABEL = Cap("relationship type label", 100)
+
 
 @dataclass
 class ClampReport:
@@ -192,6 +199,9 @@ _ROW_CAP_LABELS: dict[str, str] = {
     "groups": "groups",
     "tags": "tags",
     "custom_fields": "custom fields",
+    "relationship_types": "relationship types",
+    "member_relationships": "member relationships",
+    "group_relationships": "group relationships",
 }
 
 

--- a/sheaf/services/openplural_export.py
+++ b/sheaf/services/openplural_export.py
@@ -61,6 +61,13 @@ _EXT_PASSTHROUGH_SECTIONS = (
     "revisions",
     "watch_tokens",
     "uploaded_files",
+    # OpenPlural v0.1 has no relationship core record, so the types and both
+    # edge tables ride the file-level extensions.sheaf.* passthrough (NOT the
+    # reserved top-level `relationships` key, which is for foreign preserved
+    # modules; see _merge_preserved).
+    "relationship_types",
+    "member_relationships",
+    "group_relationships",
 )
 
 

--- a/sheaf/services/relationships.py
+++ b/sheaf/services/relationships.py
@@ -1,0 +1,90 @@
+"""Shared relationship-edge logic: the ONE source of truth for how a stored
+edge is read from each endpoint, and how a symmetric pair is canonicalised.
+
+Used by the member + group edge serializers, the graph endpoint, and the
+importer's canonicalisation. Mirrored in TypeScript at
+`web/src/lib/relationships.ts` - keep the two in lockstep; both are pinned by
+the same table-driven cases (`tests/test_relationships_engine.py`).
+
+Only ONE canonical row is ever stored per relationship; the inverse is derived
+here at read time. `source_id` is the `forward_label` endpoint for
+directional / either edges (order is load-bearing); for symmetric edges order
+is meaningless and `canonicalize_pair` normalises it so dedup + rendering are
+stable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from sheaf.models.relationship import RelationshipSymmetry
+
+# From a given member/group's point of view, an edge points away from them
+# (they are the source of a directional edge), toward them (they are the
+# target), or has no direction (symmetric, or an either-edge marked mutual).
+Direction = Literal["none", "outgoing", "incoming"]
+
+
+def _is_undirected(symmetry: RelationshipSymmetry, mutual: bool) -> bool:
+    return symmetry == RelationshipSymmetry.SYMMETRIC or (
+        symmetry == RelationshipSymmetry.EITHER and mutual
+    )
+
+
+def canonicalize_pair(
+    symmetry: RelationshipSymmetry,
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """Return (source, target) to store.
+
+    Symmetric edges are normalised so the smaller uuid is source, matching the
+    `least()/greatest()` functional unique index (Postgres uuid ordering and
+    Python `uuid.UUID` ordering agree, both being big-endian byte order).
+    Directional / either edges keep the caller's order - source is the
+    forward-label endpoint and must be preserved.
+    """
+    if symmetry == RelationshipSymmetry.SYMMETRIC and source_id > target_id:
+        return target_id, source_id
+    return source_id, target_id
+
+
+def resolve_label(
+    *,
+    symmetry: RelationshipSymmetry,
+    forward_label: str,
+    reverse_label: str | None,
+    mutual: bool,
+    source_id: uuid.UUID,
+    viewpoint_id: uuid.UUID,
+) -> tuple[str, Direction]:
+    """The (label, direction) this edge reads as from `viewpoint_id`'s side.
+
+    - undirected (symmetric, or either+mutual): forward_label, "none".
+    - otherwise: the source endpoint reads forward_label ("outgoing"), the
+      target endpoint reads reverse_label ("incoming"). reverse_label falls
+      back to forward_label defensively (schema requires it for these modes).
+    """
+    if _is_undirected(symmetry, mutual):
+        return forward_label, "none"
+    if viewpoint_id == source_id:
+        return forward_label, "outgoing"
+    return (reverse_label or forward_label), "incoming"
+
+
+def endpoint_labels(
+    *,
+    symmetry: RelationshipSymmetry,
+    forward_label: str,
+    reverse_label: str | None,
+    mutual: bool,
+) -> tuple[str, str]:
+    """(source_label, target_label) for an edge, independent of viewpoint.
+
+    Convenience for the graph endpoint, which labels both ends of each edge at
+    once. Undirected edges read forward_label on both ends.
+    """
+    if _is_undirected(symmetry, mutual):
+        return forward_label, forward_label
+    return forward_label, (reverse_label or forward_label)

--- a/sheaf/services/sheaf_archive_import_runner.py
+++ b/sheaf/services/sheaf_archive_import_runner.py
@@ -79,6 +79,7 @@ async def handle_sheaf_archive(job: ImportJob, db: AsyncSession) -> None:
         polls=options.polls,
         reminders=options.reminders,
         notifications=options.notifications,
+        relationships=options.relationships,
     )
 
     base = result.base
@@ -107,6 +108,12 @@ async def handle_sheaf_archive(job: ImportJob, db: AsyncSession) -> None:
         reminders_skipped=base.reminders_skipped,
         channels_imported=base.channels_imported,
         channels_skipped=base.channels_skipped,
+        relationship_types_imported=base.relationship_types_imported,
+        relationship_types_skipped=base.relationship_types_skipped,
+        member_relationships_imported=base.member_relationships_imported,
+        member_relationships_skipped=base.member_relationships_skipped,
+        group_relationships_imported=base.group_relationships_imported,
+        group_relationships_skipped=base.group_relationships_skipped,
         images_imported=result.images_imported,
     )
     for warning in result.warnings:

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -64,6 +64,13 @@ from sheaf.models.poll import (
     PollVoteAction,
     PollVoteEvent,
 )
+from sheaf.models.relationship import (
+    GroupRelationship,
+    MemberRelationship,
+    RelationshipSymmetry,
+    RelationshipType,
+    RelationshipVisibility,
+)
 from sheaf.models.reminder import Reminder, reminder_scope_members
 from sheaf.models.system import DateFormat, PrivacyLevel, System
 from sheaf.models.tag import Tag
@@ -82,16 +89,20 @@ from sheaf.services.import_content_dedup import (
     load_front_index,
     load_group_index,
     load_group_member_guard,
+    load_group_relationship_guard,
     load_journal_index,
+    load_member_relationship_guard,
     load_member_tag_guard,
     load_message_count_index,
     load_message_index,
     load_poll_index,
+    load_relationship_type_index,
     load_reminder_index,
     load_revision_index,
     load_tag_index,
     load_watch_token_index,
     normalize_front_interval,
+    relationship_pair_key,
 )
 from sheaf.services.import_dedup import (
     ImportConflictStrategy,
@@ -112,6 +123,7 @@ from sheaf.services.polls import (
     max_concurrent_open_for_tier,
     max_retention_days_for_tier,
 )
+from sheaf.services.relationships import canonicalize_pair
 from sheaf.timezones import is_valid_timezone
 
 logger = logging.getLogger("sheaf.import.sheaf")
@@ -135,6 +147,24 @@ def _field_type(val: object) -> FieldType:
     if isinstance(val, str) and val in _VALID_FIELD_TYPE:
         return FieldType(val)
     return FieldType.TEXT
+
+
+_VALID_SYMMETRY = {e.value for e in RelationshipSymmetry}
+_VALID_REL_VISIBILITY = {e.value for e in RelationshipVisibility}
+
+
+def _symmetry(val: object) -> RelationshipSymmetry:
+    # Untrusted enum string from the import file; default to the safest mode
+    # (symmetric needs no reverse_label) rather than raising mid-import.
+    if isinstance(val, str) and val in _VALID_SYMMETRY:
+        return RelationshipSymmetry(val)
+    return RelationshipSymmetry.SYMMETRIC
+
+
+def _rel_visibility(val: object) -> RelationshipVisibility:
+    if isinstance(val, str) and val in _VALID_REL_VISIBILITY:
+        return RelationshipVisibility(val)
+    return RelationshipVisibility.PRIVATE
 
 
 _VALID_DATE_FORMAT = {e.value for e in DateFormat}
@@ -461,6 +491,9 @@ class SheafPreviewSummary:
         self.open_poll_count: int = 0
         self.reminder_count: int = 0
         self.channel_count: int = 0
+        self.relationship_type_count: int = 0
+        self.member_relationship_count: int = 0
+        self.group_relationship_count: int = 0
         # Fields/lists that exceed the schema caps and would be shortened on
         # import (so the user can cancel or continue). Mirrors what
         # run_import's clamp pass would record.
@@ -492,6 +525,12 @@ class SheafImportResult:
         self.reminders_skipped: int = 0
         self.channels_imported: int = 0
         self.channels_skipped: int = 0
+        self.relationship_types_imported: int = 0
+        self.relationship_types_skipped: int = 0
+        self.member_relationships_imported: int = 0
+        self.member_relationships_skipped: int = 0
+        self.group_relationships_imported: int = 0
+        self.group_relationships_skipped: int = 0
         self.warnings: list[str] = []
 
 
@@ -587,6 +626,12 @@ def measure_native_payload(data: dict, report: ClampReport) -> None:
             s(rm.get("title"), il.REMINDER_TITLE)
             s(rm.get("body"), il.REMINDER_BODY)
 
+    for rt in _as_list(data.get("relationship_types")):
+        if isinstance(rt, dict):
+            s(rt.get("name"), il.REL_TYPE_NAME)
+            s(rt.get("forward_label"), il.REL_TYPE_LABEL)
+            s(rt.get("reverse_label"), il.REL_TYPE_LABEL)
+
 
 def preview(data: dict) -> SheafPreviewSummary:
     """Parse Sheaf export JSON and return a summary for user review."""
@@ -615,6 +660,9 @@ def preview(data: dict) -> SheafPreviewSummary:
     summary.channel_count = sum(
         len(t.get("channels", [])) for t in data.get("watch_tokens", [])
     )
+    summary.relationship_type_count = len(data.get("relationship_types", []))
+    summary.member_relationship_count = len(data.get("member_relationships", []))
+    summary.group_relationship_count = len(data.get("group_relationships", []))
 
     report = ClampReport()
     measure_native_payload(data, report)
@@ -628,6 +676,9 @@ def preview(data: dict) -> SheafPreviewSummary:
             "groups": summary.group_count,
             "tags": summary.tag_count,
             "custom_fields": summary.custom_field_count,
+            "relationship_types": summary.relationship_type_count,
+            "member_relationships": summary.member_relationship_count,
+            "group_relationships": summary.group_relationship_count,
         }
     )
     summary.limit_warnings += _group_depth_warnings(data.get("groups", []))
@@ -723,6 +774,7 @@ async def run_import(
     polls: bool = True,
     reminders: bool = True,
     notifications: bool = True,
+    relationships: bool = True,
     image_key_map: dict[str, str] | None = None,
     used_image_keys: set[str] | None = None,
 ) -> SheafImportResult:
@@ -1009,6 +1061,15 @@ async def run_import(
             "custom_fields": (
                 len(data.get("custom_fields", [])) if custom_fields else 0
             ),
+            "relationship_types": (
+                len(data.get("relationship_types", [])) if relationships else 0
+            ),
+            "member_relationships": (
+                len(data.get("member_relationships", [])) if relationships else 0
+            ),
+            "group_relationships": (
+                len(data.get("group_relationships", [])) if relationships else 0
+            ),
         }
     )
 
@@ -1272,6 +1333,91 @@ async def run_import(
                     f"{cycle_moved} group(s) had a looping parent reference and "
                     "were moved to the top level."
                 )
+
+    # --- Relationships (types + member/group edges) ---
+    # Types dedupe by name (like tags/groups). Edges resolve their endpoints
+    # and type through the old->new id maps built above (members always, groups
+    # only if that section ran); an edge whose endpoints or type didn't import
+    # is dropped, self-edges are skipped, and the pair guard - keyed on the
+    # unordered (type, endpoints) pair to match the functional unique index -
+    # drops a re-import or in-file inverse duplicate instead of hitting an
+    # IntegrityError. canonicalize_pair fixes the stored order for symmetric
+    # types so it lines up with that index.
+    if relationships:
+        rel_type_index = (
+            await load_relationship_type_index(db, system.id)
+            if dedupe
+            else ContentMatchIndex()
+        )
+        old_rtid_to_type: dict[str, RelationshipType] = {}
+        for rt_data in data.get("relationship_types", []):
+            old_rtid = rt_data.get("id", "")
+            name = clamp_str(
+                rt_data.get("name") or "relationship",
+                il.REL_TYPE_NAME,
+                report=report,
+            )
+            existing_type = rel_type_index.get(name) if dedupe else None
+            if existing_type is not None:
+                old_rtid_to_type[old_rtid] = existing_type
+                result.relationship_types_skipped += 1
+                continue
+            rtype = RelationshipType(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                name=name,
+                symmetry=_symmetry(rt_data.get("symmetry")),
+                forward_label=clamp_str(
+                    rt_data.get("forward_label") or name,
+                    il.REL_TYPE_LABEL,
+                    report=report,
+                ),
+                reverse_label=clamp_str(
+                    rt_data.get("reverse_label"), il.REL_TYPE_LABEL, report=report
+                ),
+            )
+            db.add(rtype)
+            rel_type_index.register(name, rtype)
+            old_rtid_to_type[old_rtid] = rtype
+            result.relationship_types_imported += 1
+
+        await db.flush()
+
+        member_rel_guard = (
+            await load_member_relationship_guard(db, system.id)
+            if dedupe
+            else PairGuard()
+        )
+        m_imp, m_skip = _import_relationship_edges(
+            db,
+            system,
+            data.get("member_relationships", []),
+            endpoint_map=old_id_to_member,
+            type_map=old_rtid_to_type,
+            model=MemberRelationship,
+            guard=member_rel_guard,
+        )
+        result.member_relationships_imported += m_imp
+        result.member_relationships_skipped += m_skip
+
+        group_rel_guard = (
+            await load_group_relationship_guard(db, system.id)
+            if dedupe
+            else PairGuard()
+        )
+        g_imp, g_skip = _import_relationship_edges(
+            db,
+            system,
+            data.get("group_relationships", []),
+            endpoint_map=old_gid_to_group,
+            type_map=old_rtid_to_type,
+            model=GroupRelationship,
+            guard=group_rel_guard,
+        )
+        result.group_relationships_imported += g_imp
+        result.group_relationships_skipped += g_skip
+
+        await db.flush()
 
     # --- Fronts ---
     if fronts:
@@ -1991,6 +2137,62 @@ async def run_import(
     # the per-record warnings in the job log.
     result.warnings = warnings + report.to_warnings()
     return result
+
+
+def _import_relationship_edges(
+    db: AsyncSession,
+    system: System,
+    edges: object,
+    *,
+    endpoint_map: dict,
+    type_map: dict,
+    model: type,
+    guard: PairGuard,
+) -> tuple[int, int]:
+    """Build member/group relationship edges, returning (imported, skipped).
+
+    Shared by both edge tables (they differ only in the endpoint map and ORM
+    model). For each edge: resolve the type and both endpoints through the
+    old->new maps, drop the edge if any didn't import, skip self-edges, then
+    canonicalize the pair for the type's symmetry and dedupe on the unordered
+    (type, endpoints) key (matching the functional unique index) so a
+    re-import or in-file inverse duplicate is skipped rather than raising.
+    ``db.add`` only; the caller flushes. Not a coroutine - it enqueues rows
+    on the session without awaiting.
+    """
+    imported = 0
+    skipped = 0
+    for e_data in _as_list(edges):
+        if not isinstance(e_data, dict):
+            continue
+        rtype = type_map.get(e_data.get("relationship_type_id"))
+        if rtype is None:
+            continue
+        source = endpoint_map.get(e_data.get("source_id"))
+        target = endpoint_map.get(e_data.get("target_id"))
+        if source is None or target is None:
+            continue
+        if source.id == target.id:
+            continue
+        src_id, tgt_id = canonicalize_pair(rtype.symmetry, source.id, target.id)
+        if not guard.add(relationship_pair_key(rtype.id, src_id, tgt_id)):
+            skipped += 1
+            continue
+        edge = model(
+            id=uuid.uuid4(),
+            system_id=system.id,
+            source_id=src_id,
+            target_id=tgt_id,
+            relationship_type_id=rtype.id,
+            mutual=bool(e_data.get("mutual", False)),
+            visibility=_rel_visibility(e_data.get("visibility")),
+        )
+        created = _parse_iso(e_data.get("created_at"))
+        if created:
+            edge.created_at = created
+        db.add(edge)
+        imported += 1
+    return imported, skipped
 
 
 def _trunc(val: str | None, max_len: int) -> str | None:

--- a/sheaf/services/sheaf_import_runner.py
+++ b/sheaf/services/sheaf_import_runner.py
@@ -76,6 +76,7 @@ async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
         polls=options.polls,
         reminders=options.reminders,
         notifications=options.notifications,
+        relationships=options.relationships,
     )
 
     update_counts(
@@ -103,6 +104,12 @@ async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
         reminders_skipped=result.reminders_skipped,
         channels_imported=result.channels_imported,
         channels_skipped=result.channels_skipped,
+        relationship_types_imported=result.relationship_types_imported,
+        relationship_types_skipped=result.relationship_types_skipped,
+        member_relationships_imported=result.member_relationships_imported,
+        member_relationships_skipped=result.member_relationships_skipped,
+        group_relationships_imported=result.group_relationships_imported,
+        group_relationships_skipped=result.group_relationships_skipped,
     )
     for warning in result.warnings:
         append_event(job, level="warning", stage="import", message=warning)
@@ -121,7 +128,10 @@ async def handle_sheaf_file(job: ImportJob, db: AsyncSession) -> None:
             f"{result.messages_imported} messages, "
             f"{result.polls_imported} polls, "
             f"{result.reminders_imported} reminders, "
-            f"{result.channels_imported} notification channels"
+            f"{result.channels_imported} notification channels, "
+            f"{result.relationship_types_imported} relationship types, "
+            f"{result.member_relationships_imported} member relationships, "
+            f"{result.group_relationships_imported} group relationships"
         ),
     )
 

--- a/tests/test_account_export_completeness.py
+++ b/tests/test_account_export_completeness.py
@@ -72,6 +72,19 @@ def test_export_version_bumped_to_2(auth_client: httpx.Client):
     assert export["version"] == "2"
 
 
+def test_export_includes_relationship_sections(auth_client: httpx.Client):
+    """The three relationship sections are always present as top-level lists,
+    even for a fresh system with no relationships."""
+    export = auth_client.get("/v1/export").json()
+    for key in (
+        "relationship_types",
+        "member_relationships",
+        "group_relationships",
+    ):
+        assert key in export, key
+        assert isinstance(export[key], list)
+
+
 # ---------------------------------------------------------------------------
 # Article 15: /v1/account/data
 # ---------------------------------------------------------------------------

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -50,6 +50,11 @@ from sheaf.models.notification_channel import NotificationChannel
 from sheaf.models.notification_channel_group_rule import NotificationChannelGroupRule
 from sheaf.models.notification_channel_member_rule import NotificationChannelMemberRule
 from sheaf.models.poll import Poll, PollOption, PollVote, PollVoteEvent
+from sheaf.models.relationship import (
+    GroupRelationship,
+    MemberRelationship,
+    RelationshipType,
+)
 from sheaf.models.reminder import Reminder
 from sheaf.models.system import System
 from sheaf.models.tag import Tag
@@ -317,6 +322,38 @@ CLASSIFICATION: dict[type, dict] = {
             "id": _SURROGATE_PK,
             "system_id": _TENANT_FK,
             "deleted_at": "soft-delete tombstone; deleted rows are not exported",
+        },
+    },
+    RelationshipType: {
+        "exported": {"name", "symmetry", "forward_label", "reverse_label"},
+        "excluded": {
+            "id": _SURROGATE_PK,
+            "system_id": _TENANT_FK,
+            "created_at": _ROW_CREATED,
+            "updated_at": _ROW_UPDATED,
+        },
+    },
+    MemberRelationship: {
+        # source_id/target_id/relationship_type_id carry the OLD uuids and are
+        # remapped onto the new member + type rows on import, exactly like
+        # CustomFieldValue.member_id.
+        "exported": {
+            "source_id", "target_id", "relationship_type_id", "mutual",
+            "visibility", "created_at",
+        },
+        "excluded": {
+            "id": _SURROGATE_PK,
+            "system_id": _TENANT_FK,
+        },
+    },
+    GroupRelationship: {
+        "exported": {
+            "source_id", "target_id", "relationship_type_id", "mutual",
+            "visibility", "created_at",
+        },
+        "excluded": {
+            "id": _SURROGATE_PK,
+            "system_id": _TENANT_FK,
         },
     },
 }

--- a/tests/test_imports_sheaf_runner.py
+++ b/tests/test_imports_sheaf_runner.py
@@ -78,6 +78,111 @@ def test_sheaf_runner_roundtrip_from_export(auth_client: httpx.Client):
     assert len([m for m in members if m["name"] == "RoundtripMember"]) == 1
 
 
+def test_sheaf_runner_roundtrips_relationships(auth_client: httpx.Client):
+    """Relationship types (symmetric / directional / either) and both member
+    and group edges import, and a re-export carries them back with correct
+    orientation + mutual. A second import must not duplicate any edge."""
+    export = {
+        "version": "2",
+        "system": {"name": "Rel System"},
+        "members": [
+            {"id": "m1", "name": "RelAlice"},
+            {"id": "m2", "name": "RelBob"},
+            {"id": "m3", "name": "RelCass"},
+        ],
+        "groups": [
+            {"id": "g1", "name": "RelGroupOne", "member_ids": []},
+            {"id": "g2", "name": "RelGroupTwo", "member_ids": []},
+        ],
+        "relationship_types": [
+            {
+                "id": "rt-sym", "name": "Partner", "symmetry": "symmetric",
+                "forward_label": "partner", "reverse_label": None,
+            },
+            {
+                "id": "rt-dir", "name": "Parent", "symmetry": "directional",
+                "forward_label": "parent", "reverse_label": "child",
+            },
+            {
+                "id": "rt-either", "name": "Protector", "symmetry": "either",
+                "forward_label": "protector", "reverse_label": "protectee",
+            },
+        ],
+        "member_relationships": [
+            {
+                "source_id": "m1", "target_id": "m2",
+                "relationship_type_id": "rt-sym", "mutual": False,
+                "visibility": "private",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            },
+            {
+                "source_id": "m1", "target_id": "m3",
+                "relationship_type_id": "rt-dir", "mutual": False,
+                "visibility": "private",
+                "created_at": "2026-01-02T00:00:00+00:00",
+            },
+            {
+                "source_id": "m2", "target_id": "m3",
+                "relationship_type_id": "rt-either", "mutual": True,
+                "visibility": "private",
+                "created_at": "2026-01-03T00:00:00+00:00",
+            },
+        ],
+        "group_relationships": [
+            {
+                "source_id": "g1", "target_id": "g2",
+                "relationship_type_id": "rt-sym", "mutual": False,
+                "visibility": "private",
+                "created_at": "2026-01-04T00:00:00+00:00",
+            },
+        ],
+        "fronts": [],
+        "tags": [],
+        "custom_fields": [],
+    }
+    job = _post_file(auth_client, payload=json.dumps(export).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    dump = auth_client.get("/v1/export").json()
+    types = {t["name"]: t for t in dump["relationship_types"]}
+    assert {"Partner", "Parent", "Protector"} <= set(types), types
+    assert types["Partner"]["symmetry"] == "symmetric"
+    assert types["Partner"]["reverse_label"] is None
+    assert types["Parent"]["symmetry"] == "directional"
+    assert types["Protector"]["symmetry"] == "either"
+
+    m_id = {m["name"]: m["id"] for m in dump["members"]}
+    type_id = {t["name"]: t["id"] for t in dump["relationship_types"]}
+
+    medges = dump["member_relationships"]
+    assert len(medges) == 3, medges
+
+    # Directional edge keeps its orientation: Alice (parent) -> Cass (child).
+    parent = [e for e in medges if e["relationship_type_id"] == type_id["Parent"]]
+    assert len(parent) == 1
+    assert parent[0]["source_id"] == m_id["RelAlice"]
+    assert parent[0]["target_id"] == m_id["RelCass"]
+
+    # The either-edge round-trips its mutual flag.
+    prot = [e for e in medges if e["relationship_type_id"] == type_id["Protector"]]
+    assert len(prot) == 1
+    assert prot[0]["mutual"] is True
+
+    assert len(dump["group_relationships"]) == 1
+
+    # Re-import the same export: dedup means nothing is duplicated.
+    job2 = _post_file(auth_client, payload=json.dumps(export).encode())
+    drive_import_runner()
+    final2 = wait_for_terminal(auth_client, job2["id"])
+    assert final2["status"] == "complete", final2
+    dump2 = auth_client.get("/v1/export").json()
+    assert len(dump2["member_relationships"]) == 3
+    assert len(dump2["group_relationships"]) == 1
+    assert len(dump2["relationship_types"]) == len(dump["relationship_types"])
+
+
 def test_sheaf_runner_roundtrips_notify_prefs_and_coalesce(auth_client: httpx.Client):
     """Per-member notify_on_front_* prefs and the system coalesce preference
     survive a re-import. The notify_on_front_member_ids cross-reference is

--- a/tests/test_openplural_parity.py
+++ b/tests/test_openplural_parity.py
@@ -118,6 +118,12 @@ DISPOSITION: dict[str, dict[str, object]] = {
     "PollOption": "_all_ext",
     "PollVote": "_all_ext",
     "PollVoteEvent": "_all_ext",
+    # Relationship types + both edge tables carry verbatim under the file-level
+    # extensions.sheaf.<section> passthrough (OpenPlural v0.1 has no
+    # relationship core record).
+    "RelationshipType": "_all_ext",
+    "MemberRelationship": "_all_ext",
+    "GroupRelationship": "_all_ext",
 }
 
 

--- a/tests/test_relationships_engine.py
+++ b/tests/test_relationships_engine.py
@@ -1,0 +1,118 @@
+"""Pure-Python coverage for the relationship-edge engine
+(`sheaf.services.relationships`). Runs headless. These cases are the contract
+the TypeScript mirror (`web/src/lib/relationships.ts`) must match exactly -
+keep them in sync."""
+
+from __future__ import annotations
+
+import uuid
+
+from sheaf.models.relationship import RelationshipSymmetry as S
+from sheaf.services.relationships import (
+    canonicalize_pair,
+    endpoint_labels,
+    resolve_label,
+)
+
+# Two fixed uuids with a known order (A < B) so canonicalisation is testable.
+A = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
+B = uuid.UUID("00000000-0000-0000-0000-0000000000bb")
+assert A < B
+
+
+# --- canonicalize_pair -----------------------------------------------------
+
+def test_canonicalize_symmetric_orders_smaller_first():
+    assert canonicalize_pair(S.SYMMETRIC, B, A) == (A, B)
+    assert canonicalize_pair(S.SYMMETRIC, A, B) == (A, B)
+
+
+def test_canonicalize_directional_preserves_order():
+    # Direction is load-bearing; never reorder.
+    assert canonicalize_pair(S.DIRECTIONAL, B, A) == (B, A)
+    assert canonicalize_pair(S.EITHER, B, A) == (B, A)
+
+
+# --- resolve_label ---------------------------------------------------------
+
+def test_symmetric_both_sides_read_forward():
+    kw = dict(
+        symmetry=S.SYMMETRIC,
+        forward_label="partner",
+        reverse_label=None,
+        mutual=False,
+        source_id=A,
+    )
+    assert resolve_label(**kw, viewpoint_id=A) == ("partner", "none")
+    assert resolve_label(**kw, viewpoint_id=B) == ("partner", "none")
+
+
+def test_directional_source_vs_target():
+    kw = dict(
+        symmetry=S.DIRECTIONAL,
+        forward_label="parent",
+        reverse_label="child",
+        mutual=False,
+        source_id=A,  # A is the parent
+    )
+    assert resolve_label(**kw, viewpoint_id=A) == ("parent", "outgoing")
+    assert resolve_label(**kw, viewpoint_id=B) == ("child", "incoming")
+
+
+def test_either_directional_uses_forward_reverse():
+    kw = dict(
+        symmetry=S.EITHER,
+        forward_label="protector",
+        reverse_label="protectee",
+        mutual=False,
+        source_id=A,  # A protects B
+    )
+    assert resolve_label(**kw, viewpoint_id=A) == ("protector", "outgoing")
+    assert resolve_label(**kw, viewpoint_id=B) == ("protectee", "incoming")
+
+
+def test_either_mutual_both_sides_read_forward():
+    kw = dict(
+        symmetry=S.EITHER,
+        forward_label="protector",
+        reverse_label="protectee",
+        mutual=True,
+        source_id=A,
+    )
+    assert resolve_label(**kw, viewpoint_id=A) == ("protector", "none")
+    assert resolve_label(**kw, viewpoint_id=B) == ("protector", "none")
+
+
+def test_directional_missing_reverse_falls_back_to_forward():
+    # Schema requires reverse_label for directional, but the engine is defensive.
+    label, direction = resolve_label(
+        symmetry=S.DIRECTIONAL,
+        forward_label="parent",
+        reverse_label=None,
+        mutual=False,
+        source_id=A,
+        viewpoint_id=B,
+    )
+    assert label == "parent"
+    assert direction == "incoming"
+
+
+# --- endpoint_labels -------------------------------------------------------
+
+def test_endpoint_labels_all_modes():
+    assert endpoint_labels(
+        symmetry=S.SYMMETRIC, forward_label="partner", reverse_label=None,
+        mutual=False,
+    ) == ("partner", "partner")
+    assert endpoint_labels(
+        symmetry=S.DIRECTIONAL, forward_label="parent", reverse_label="child",
+        mutual=False,
+    ) == ("parent", "child")
+    assert endpoint_labels(
+        symmetry=S.EITHER, forward_label="protector", reverse_label="protectee",
+        mutual=False,
+    ) == ("protector", "protectee")
+    assert endpoint_labels(
+        symmetry=S.EITHER, forward_label="protector", reverse_label="protectee",
+        mutual=True,
+    ) == ("protector", "protector")


### PR DESCRIPTION
First slice of the relationships feature: a typed relationship graph over a system's members and groups. This PR is the data layer only; the API and the web UI (including a graphical relationship map) land in follow-up PRs. It ships no user-visible surface on its own, and old exports without the new sections import unchanged.

## The design

Directionality is a property of the relationship TYPE, which is the point: a bidirectional relationship never needs two separate types (the shortcoming this design set out to avoid). A type is `symmetric` (one label, e.g. partner), `directional` (a forward and a reverse label, e.g. parent/child), or `either` (both, so a given edge is directional unless it is marked `mutual`, in which case both ends read the forward label, e.g. protector/protectee vs mutual protectors). Types are per-system and user-defined, and members and groups share the vocabulary.

## What's here

A new `RelationshipType` table plus `MemberRelationship` and `GroupRelationship` edge tables. Exactly one canonical row is stored per relationship and the inverse is derived at read time by a shared engine (`sheaf/services/relationships.py`, pinned by table-driven tests, and destined to be mirrored in TypeScript for the client renderers). Uniqueness is over the unordered pair per type, enforced by a functional unique index on `least()/greatest()` so `A->B` and `B->A` of one type collide; a check constraint forbids self-edges. Edges carry a `visibility` column (private-only, stored but not enforced) reserved for the coming access-control primitive. The full export/import round-trip is wired (old-id remap, symmetric-pair canonicalisation, pair-guard dedup matching the functional index), the three models are classified in both parity guards, and they ride the OpenPlural envelope as namespaced `extensions.sheaf` passthrough (not the reserved top-level key).

## Verification

The migration was run against real Postgres 16 and the functional index was proven to reject an inverse-duplicate while allowing a different type for the same pair. The shared engine has table-driven unit tests over all three symmetry modes. The full behavioural suite (all 9 server configs) passes, including a new export -> import round-trip test for types and edges, and both parity guards. ruff clean.
