### PR TITLE
Add relationships API (types, member/group edges, graph)

### DIFF
--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -110,6 +110,7 @@ _VALID_SCOPES = {
     "notifications:read", "notifications:write", "notifications:delete",
     "polls:read", "polls:write", "polls:delete",
     "messages:read", "messages:write", "messages:delete",
+    "relationships:read", "relationships:write", "relationships:delete",
     "import:write",
     "export:read",
     "admin:read", "admin:write",

--- a/sheaf/api/v1/relationships.py
+++ b/sheaf/api/v1/relationships.py
@@ -1,0 +1,541 @@
+import uuid
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_current_user, require_scope
+from sheaf.database import get_db
+from sheaf.files import resolve_avatar_url
+from sheaf.models.group import Group
+from sheaf.models.member import Member
+from sheaf.models.relationship import (
+    GroupRelationship,
+    MemberRelationship,
+    RelationshipSymmetry,
+    RelationshipType,
+)
+from sheaf.models.system import System
+from sheaf.models.user import User
+from sheaf.schemas.relationship import (
+    RelationshipEdgeCreate,
+    RelationshipEdgeRead,
+    RelationshipFromViewpoint,
+    RelationshipGraph,
+    RelationshipGraphEdge,
+    RelationshipGraphNode,
+    RelationshipTypeCreate,
+    RelationshipTypeRead,
+    RelationshipTypeUpdate,
+)
+from sheaf.services.members import member_plaintext
+from sheaf.services.relationships import (
+    canonicalize_pair,
+    endpoint_labels,
+    resolve_label,
+)
+
+router = APIRouter(tags=["relationships"])
+
+
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
+
+
+def _is_undirected(symmetry: RelationshipSymmetry, mutual: bool) -> bool:
+    return symmetry == RelationshipSymmetry.SYMMETRIC or (
+        symmetry == RelationshipSymmetry.EITHER and mutual
+    )
+
+
+async def _types_by_id(
+    db: AsyncSession, type_ids: set[uuid.UUID]
+) -> dict[uuid.UUID, RelationshipType]:
+    if not type_ids:
+        return {}
+    rows = await db.execute(
+        select(RelationshipType).where(RelationshipType.id.in_(type_ids))
+    )
+    return {t.id: t for t in rows.scalars().all()}
+
+
+# ---------------------------------------------------------------------------
+# Relationship types (the per-system vocabulary)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/relationship-types", response_model=list[RelationshipTypeRead])
+async def list_relationship_types(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    rows = await db.execute(
+        select(RelationshipType)
+        .where(RelationshipType.system_id == system.id)
+        .order_by(RelationshipType.name)
+    )
+    return list(rows.scalars().all())
+
+
+@router.post(
+    "/relationship-types",
+    response_model=RelationshipTypeRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_scope("relationships:write"))],
+)
+async def create_relationship_type(
+    body: RelationshipTypeCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    rt = RelationshipType(system_id=system.id, **body.model_dump())
+    db.add(rt)
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A relationship type with that name already exists",
+        ) from e
+    await db.refresh(rt)
+    return rt
+
+
+async def _get_type_in_system(
+    type_id: uuid.UUID, system: System, db: AsyncSession
+) -> RelationshipType:
+    row = await db.execute(
+        select(RelationshipType).where(
+            RelationshipType.id == type_id,
+            RelationshipType.system_id == system.id,
+        )
+    )
+    rt = row.scalar_one_or_none()
+    if rt is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Relationship type not found",
+        )
+    return rt
+
+
+@router.get(
+    "/relationship-types/{type_id}", response_model=RelationshipTypeRead
+)
+async def get_relationship_type(
+    type_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    return await _get_type_in_system(type_id, system, db)
+
+
+@router.patch(
+    "/relationship-types/{type_id}",
+    response_model=RelationshipTypeRead,
+    dependencies=[Depends(require_scope("relationships:write"))],
+)
+async def update_relationship_type(
+    type_id: uuid.UUID,
+    body: RelationshipTypeUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    rt = await _get_type_in_system(type_id, system, db)
+    update = body.model_dump(exclude_unset=True)
+    if rt.symmetry == RelationshipSymmetry.SYMMETRIC:
+        # reverse_label is meaningless for symmetric types; ignore any attempt.
+        update.pop("reverse_label", None)
+    elif "reverse_label" in update and (
+        not update["reverse_label"] or not update["reverse_label"].strip()
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="reverse_label cannot be empty for directional / either types",
+        )
+    for key, value in update.items():
+        setattr(rt, key, value)
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A relationship type with that name already exists",
+        ) from e
+    await db.refresh(rt)
+    return rt
+
+
+@router.delete(
+    "/relationship-types/{type_id}",
+    dependencies=[Depends(require_scope("relationships:delete"))],
+)
+async def delete_relationship_type(
+    type_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    # Deleting a type cascades its edges (DB FK). Low-stakes + reversible by
+    # re-adding, so no System Safety gate; the web client confirms first.
+    system = await _get_user_system(user, db)
+    rt = await _get_type_in_system(type_id, system, db)
+    await db.delete(rt)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Edges. Member and group endpoints share the shape; only the node table and
+# ORM model differ. One canonical row is stored; the per-node GET derives the
+# inverse via the shared engine.
+# ---------------------------------------------------------------------------
+
+
+async def _node_ids_in_system(
+    db: AsyncSession,
+    model: type[Member] | type[Group],
+    system: System,
+    ids: set[uuid.UUID],
+) -> set[uuid.UUID]:
+    rows = await db.execute(
+        select(model.id).where(model.id.in_(ids), model.system_id == system.id)
+    )
+    return set(rows.scalars().all())
+
+
+async def _create_edge(
+    body: RelationshipEdgeCreate,
+    *,
+    node_model: type[Member] | type[Group],
+    edge_model: type[MemberRelationship] | type[GroupRelationship],
+    node_label: str,
+    system: System,
+    db: AsyncSession,
+):
+    if body.source_id == body.target_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"A {node_label} cannot have a relationship with itself",
+        )
+    present = await _node_ids_in_system(
+        db, node_model, system, {body.source_id, body.target_id}
+    )
+    if len(present) != 2:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"source and target must both be {node_label}s in your system",
+        )
+    rt = await db.execute(
+        select(RelationshipType).where(
+            RelationshipType.id == body.relationship_type_id,
+            RelationshipType.system_id == system.id,
+        )
+    )
+    rtype = rt.scalar_one_or_none()
+    if rtype is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unknown relationship type",
+        )
+    src, tgt = canonicalize_pair(rtype.symmetry, body.source_id, body.target_id)
+    # `mutual` only means anything for `either` types; normalise it off otherwise.
+    mutual = body.mutual and rtype.symmetry == RelationshipSymmetry.EITHER
+    edge = edge_model(
+        system_id=system.id,
+        source_id=src,
+        target_id=tgt,
+        relationship_type_id=rtype.id,
+        mutual=mutual,
+        visibility=body.visibility,
+    )
+    db.add(edge)
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="That relationship already exists",
+        ) from e
+    await db.refresh(edge)
+    return edge
+
+
+async def _node_relationships(
+    node_id: uuid.UUID,
+    *,
+    node_model: type[Member] | type[Group],
+    edge_model: type[MemberRelationship] | type[GroupRelationship],
+    system: System,
+    db: AsyncSession,
+) -> list[RelationshipFromViewpoint]:
+    present = await _node_ids_in_system(db, node_model, system, {node_id})
+    if not present:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Not found"
+        )
+    rows = await db.execute(
+        select(edge_model).where(
+            edge_model.system_id == system.id,
+            or_(
+                edge_model.source_id == node_id,
+                edge_model.target_id == node_id,
+            ),
+        )
+    )
+    edges = list(rows.scalars().all())
+    types = await _types_by_id(db, {e.relationship_type_id for e in edges})
+    out: list[RelationshipFromViewpoint] = []
+    for e in edges:
+        t = types.get(e.relationship_type_id)
+        if t is None:
+            continue
+        label, direction = resolve_label(
+            symmetry=t.symmetry,
+            forward_label=t.forward_label,
+            reverse_label=t.reverse_label,
+            mutual=e.mutual,
+            source_id=e.source_id,
+            viewpoint_id=node_id,
+        )
+        other_id = e.target_id if e.source_id == node_id else e.source_id
+        out.append(
+            RelationshipFromViewpoint(
+                id=e.id,
+                relationship_type_id=t.id,
+                type_name=t.name,
+                other_id=other_id,
+                label=label,
+                direction=direction,
+                mutual=e.mutual,
+                visibility=e.visibility,
+            )
+        )
+    return out
+
+
+async def _delete_edge(
+    edge_id: uuid.UUID,
+    *,
+    edge_model: type[MemberRelationship] | type[GroupRelationship],
+    system: System,
+    db: AsyncSession,
+) -> Response:
+    row = await db.execute(
+        select(edge_model).where(
+            edge_model.id == edge_id, edge_model.system_id == system.id
+        )
+    )
+    edge = row.scalar_one_or_none()
+    if edge is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Relationship not found"
+        )
+    await db.delete(edge)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- Member edges ---
+
+
+@router.get(
+    "/members/{member_id}/relationships",
+    response_model=list[RelationshipFromViewpoint],
+)
+async def list_member_relationships(
+    member_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    return await _node_relationships(
+        member_id,
+        node_model=Member,
+        edge_model=MemberRelationship,
+        system=system,
+        db=db,
+    )
+
+
+@router.post(
+    "/member-relationships",
+    response_model=RelationshipEdgeRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_scope("relationships:write"))],
+)
+async def create_member_relationship(
+    body: RelationshipEdgeCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    return await _create_edge(
+        body,
+        node_model=Member,
+        edge_model=MemberRelationship,
+        node_label="member",
+        system=system,
+        db=db,
+    )
+
+
+@router.delete(
+    "/member-relationships/{edge_id}",
+    dependencies=[Depends(require_scope("relationships:delete"))],
+)
+async def delete_member_relationship(
+    edge_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    system = await _get_user_system(user, db)
+    return await _delete_edge(
+        edge_id, edge_model=MemberRelationship, system=system, db=db
+    )
+
+
+# --- Group edges ---
+
+
+@router.get(
+    "/groups/{group_id}/relationships",
+    response_model=list[RelationshipFromViewpoint],
+)
+async def list_group_relationships(
+    group_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    return await _node_relationships(
+        group_id,
+        node_model=Group,
+        edge_model=GroupRelationship,
+        system=system,
+        db=db,
+    )
+
+
+@router.post(
+    "/group-relationships",
+    response_model=RelationshipEdgeRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_scope("relationships:write"))],
+)
+async def create_group_relationship(
+    body: RelationshipEdgeCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+    return await _create_edge(
+        body,
+        node_model=Group,
+        edge_model=GroupRelationship,
+        node_label="group",
+        system=system,
+        db=db,
+    )
+
+
+@router.delete(
+    "/group-relationships/{edge_id}",
+    dependencies=[Depends(require_scope("relationships:delete"))],
+)
+async def delete_group_relationship(
+    edge_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    system = await _get_user_system(user, db)
+    return await _delete_edge(
+        edge_id, edge_model=GroupRelationship, system=system, db=db
+    )
+
+
+# ---------------------------------------------------------------------------
+# Whole-graph fetch for the viewer
+# ---------------------------------------------------------------------------
+
+
+@router.get("/relationships/graph", response_model=RelationshipGraph)
+async def relationship_graph(
+    scope: Literal["members", "groups"] = "members",
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    system = await _get_user_system(user, db)
+
+    nodes: list[RelationshipGraphNode] = []
+    if scope == "members":
+        rows = await db.execute(
+            select(Member).where(Member.system_id == system.id)
+        )
+        for m in rows.scalars().all():
+            name_pt, _ = member_plaintext(m)
+            nodes.append(
+                RelationshipGraphNode(
+                    id=m.id,
+                    name=m.display_name or name_pt,
+                    avatar_url=resolve_avatar_url(m.avatar_url),
+                    color=m.color,
+                )
+            )
+        edge_model: type[MemberRelationship] | type[GroupRelationship] = (
+            MemberRelationship
+        )
+    else:
+        rows = await db.execute(
+            select(Group).where(Group.system_id == system.id)
+        )
+        for g in rows.scalars().all():
+            nodes.append(
+                RelationshipGraphNode(id=g.id, name=g.name, color=g.color)
+            )
+        edge_model = GroupRelationship
+
+    edge_rows = await db.execute(
+        select(edge_model).where(edge_model.system_id == system.id)
+    )
+    edges_list = list(edge_rows.scalars().all())
+    types = await _types_by_id(db, {e.relationship_type_id for e in edges_list})
+    edges: list[RelationshipGraphEdge] = []
+    for e in edges_list:
+        t = types.get(e.relationship_type_id)
+        if t is None:
+            continue
+        src_label, tgt_label = endpoint_labels(
+            symmetry=t.symmetry,
+            forward_label=t.forward_label,
+            reverse_label=t.reverse_label,
+            mutual=e.mutual,
+        )
+        edges.append(
+            RelationshipGraphEdge(
+                id=e.id,
+                source_id=e.source_id,
+                target_id=e.target_id,
+                relationship_type_id=t.id,
+                type_name=t.name,
+                source_label=src_label,
+                target_label=tgt_label,
+                mutual=e.mutual,
+                directed=not _is_undirected(t.symmetry, e.mutual),
+            )
+        )
+    return RelationshipGraph(nodes=nodes, edges=edges)

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -28,6 +28,7 @@ from sheaf.api.v1 import (
     pluralspace_import,
     polls,
     prism_import,
+    relationships,
     reminders,
     retention,
     sheaf_import,
@@ -119,6 +120,10 @@ v1_router.include_router(
 v1_router.include_router(
     journals.router,
     dependencies=[Depends(require_scope("journals:read"))],
+)
+v1_router.include_router(
+    relationships.router,
+    dependencies=[Depends(require_scope("relationships:read"))],
 )
 v1_router.include_router(
     retention.router,

--- a/sheaf/schemas/relationship.py
+++ b/sheaf/schemas/relationship.py
@@ -1,0 +1,128 @@
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from sheaf.models.relationship import RelationshipSymmetry, RelationshipVisibility
+
+
+class RelationshipTypeCreate(BaseModel):
+    name: str = Field(max_length=100)
+    symmetry: RelationshipSymmetry
+    forward_label: str = Field(max_length=100)
+    reverse_label: str | None = Field(default=None, max_length=100)
+
+    @model_validator(mode="after")
+    def _reverse_label_rules(self) -> "RelationshipTypeCreate":
+        # Symmetric types read one label from both ends, so reverse_label is
+        # meaningless - drop it. Directional / either types need it.
+        if self.symmetry == RelationshipSymmetry.SYMMETRIC:
+            self.reverse_label = None
+        elif not self.reverse_label or not self.reverse_label.strip():
+            raise ValueError(
+                "reverse_label is required for directional and either types"
+            )
+        return self
+
+
+class RelationshipTypeUpdate(BaseModel):
+    # `symmetry` is intentionally immutable after creation: existing edges'
+    # stored orientation and `mutual` semantics depend on it (a symmetric type's
+    # edges are canonicalised with arbitrary source/target order), so flipping it
+    # would silently corrupt them. Name + labels are freely editable.
+    name: str | None = Field(default=None, max_length=100)
+    forward_label: str | None = Field(default=None, max_length=100)
+    reverse_label: str | None = Field(default=None, max_length=100)
+
+    @field_validator("name", "forward_label")
+    @classmethod
+    def _reject_explicit_null(cls, v):
+        # These back NOT-NULL columns; `null` only exists so model_fields_set
+        # can tell "omitted" from "supplied" for PATCH. Reject an explicit null.
+        if v is None:
+            raise ValueError("cannot be null")
+        return v
+
+
+class RelationshipTypeRead(BaseModel):
+    id: uuid.UUID
+    system_id: uuid.UUID
+    name: str
+    symmetry: RelationshipSymmetry
+    forward_label: str
+    reverse_label: str | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class RelationshipEdgeCreate(BaseModel):
+    """Create one relationship edge. `source_id`/`target_id` are member ids for
+    the member endpoint and group ids for the group endpoint. For directional /
+    either types source is the forward-label endpoint; for symmetric types order
+    does not matter (it is canonicalised server-side)."""
+
+    source_id: uuid.UUID
+    target_id: uuid.UUID
+    relationship_type_id: uuid.UUID
+    mutual: bool = False
+    visibility: RelationshipVisibility = RelationshipVisibility.PRIVATE
+
+
+class RelationshipEdgeRead(BaseModel):
+    id: uuid.UUID
+    source_id: uuid.UUID
+    target_id: uuid.UUID
+    relationship_type_id: uuid.UUID
+    mutual: bool
+    visibility: RelationshipVisibility
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# Direction as read from one endpoint's viewpoint (see services/relationships.py).
+Direction = Literal["none", "outgoing", "incoming"]
+
+
+class RelationshipFromViewpoint(BaseModel):
+    """One edge as it reads from a single member/group's perspective, used by
+    GET /members/{id}/relationships and /groups/{id}/relationships. A canonical
+    A<->B row surfaces in both A's and B's lists, each with the label + `other`
+    endpoint resolved for that viewer."""
+
+    id: uuid.UUID
+    relationship_type_id: uuid.UUID
+    type_name: str
+    other_id: uuid.UUID
+    label: str
+    direction: Direction
+    mutual: bool
+    visibility: RelationshipVisibility
+
+
+class RelationshipGraphNode(BaseModel):
+    id: uuid.UUID
+    name: str
+    avatar_url: str | None = None
+    color: str | None = None
+
+
+class RelationshipGraphEdge(BaseModel):
+    id: uuid.UUID
+    source_id: uuid.UUID
+    target_id: uuid.UUID
+    relationship_type_id: uuid.UUID
+    type_name: str
+    source_label: str
+    target_label: str
+    mutual: bool
+    # False for symmetric types and for mutual either-edges (undirected).
+    directed: bool
+
+
+class RelationshipGraph(BaseModel):
+    nodes: list[RelationshipGraphNode]
+    edges: list[RelationshipGraphEdge]

--- a/tests/test_relationships_api.py
+++ b/tests/test_relationships_api.py
@@ -1,0 +1,206 @@
+"""End-to-end coverage for the relationships API (Phase 2). Needs the docker
+stack (auth_client). Covers type CRUD, edge create/list/delete, the viewpoint
+label resolution (a canonical row read from both ends), symmetric
+canonicalisation, mutual normalisation, the graph endpoint, and the tenant /
+validation guards."""
+
+from __future__ import annotations
+
+import uuid as _uuid
+
+import httpx
+
+
+def _member(client: httpx.Client, name: str) -> str:
+    return client.post("/v1/members", json={"name": name}).json()["id"]
+
+
+def _group(client: httpx.Client, name: str) -> str:
+    return client.post("/v1/groups", json={"name": name}).json()["id"]
+
+
+def _type(client: httpx.Client, **body) -> str:
+    r = client.post("/v1/relationship-types", json=body)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+# --- Relationship types ----------------------------------------------------
+
+def test_create_type_symmetric_drops_reverse_label(auth_client: httpx.Client):
+    r = auth_client.post(
+        "/v1/relationship-types",
+        json={"name": "Partner", "symmetry": "symmetric",
+              "forward_label": "partner", "reverse_label": "ignored"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["reverse_label"] is None
+
+
+def test_directional_type_requires_reverse_label(auth_client: httpx.Client):
+    r = auth_client.post(
+        "/v1/relationship-types",
+        json={"name": "ParentNoRev", "symmetry": "directional",
+              "forward_label": "parent"},
+    )
+    assert r.status_code == 422
+
+
+def test_duplicate_type_name_conflicts(auth_client: httpx.Client):
+    body = {"name": "DupType", "symmetry": "symmetric", "forward_label": "x"}
+    assert auth_client.post("/v1/relationship-types", json=body).status_code == 201
+    assert auth_client.post("/v1/relationship-types", json=body).status_code == 409
+
+
+# --- Directional edges + viewpoint resolution ------------------------------
+
+def test_directional_edge_reads_from_both_viewpoints(auth_client: httpx.Client):
+    t = _type(auth_client, name="ParentChild", symmetry="directional",
+              forward_label="parent", reverse_label="child")
+    alice, bob = _member(auth_client, "Pc_Alice"), _member(auth_client, "Pc_Bob")
+    r = auth_client.post(
+        "/v1/member-relationships",
+        json={"source_id": alice, "target_id": bob, "relationship_type_id": t},
+    )
+    assert r.status_code == 201, r.text
+
+    a_view = auth_client.get(f"/v1/members/{alice}/relationships").json()
+    a_edge = next(e for e in a_view if e["relationship_type_id"] == t)
+    assert a_edge["label"] == "parent"
+    assert a_edge["direction"] == "outgoing"
+    assert a_edge["other_id"] == bob
+
+    b_view = auth_client.get(f"/v1/members/{bob}/relationships").json()
+    b_edge = next(e for e in b_view if e["relationship_type_id"] == t)
+    assert b_edge["label"] == "child"
+    assert b_edge["direction"] == "incoming"
+    assert b_edge["other_id"] == alice
+
+
+def test_either_edge_directional_and_mutual(auth_client: httpx.Client):
+    t = _type(auth_client, name="Protector", symmetry="either",
+              forward_label="protector", reverse_label="protectee")
+    a, b = _member(auth_client, "Pr_A"), _member(auth_client, "Pr_B")
+    c, d = _member(auth_client, "Pr_C"), _member(auth_client, "Pr_D")
+    # Directional: a protects b.
+    auth_client.post("/v1/member-relationships",
+                     json={"source_id": a, "target_id": b,
+                           "relationship_type_id": t, "mutual": False})
+    a_edge = next(e for e in auth_client.get(f"/v1/members/{a}/relationships").json()
+                  if e["relationship_type_id"] == t)
+    assert (a_edge["label"], a_edge["direction"]) == ("protector", "outgoing")
+    b_edge = next(e for e in auth_client.get(f"/v1/members/{b}/relationships").json()
+                  if e["relationship_type_id"] == t)
+    assert (b_edge["label"], b_edge["direction"]) == ("protectee", "incoming")
+    # Mutual: c and d protect each other; both read "protector".
+    auth_client.post("/v1/member-relationships",
+                     json={"source_id": c, "target_id": d,
+                           "relationship_type_id": t, "mutual": True})
+    for who in (c, d):
+        view = auth_client.get(f"/v1/members/{who}/relationships").json()
+        e = next(x for x in view if x["relationship_type_id"] == t)
+        assert (e["label"], e["direction"], e["mutual"]) == ("protector", "none", True)
+
+
+def test_mutual_ignored_on_non_either_type(auth_client: httpx.Client):
+    t = _type(auth_client, name="PartnerM", symmetry="symmetric",
+              forward_label="partner")
+    a, b = _member(auth_client, "Pm_A"), _member(auth_client, "Pm_B")
+    r = auth_client.post("/v1/member-relationships",
+                         json={"source_id": a, "target_id": b,
+                               "relationship_type_id": t, "mutual": True})
+    assert r.status_code == 201
+    assert r.json()["mutual"] is False  # normalised off for symmetric
+
+
+# --- Symmetric canonicalisation + dedup ------------------------------------
+
+def test_symmetric_inverse_is_duplicate(auth_client: httpx.Client):
+    t = _type(auth_client, name="PartnerDup", symmetry="symmetric",
+              forward_label="partner")
+    a, b = _member(auth_client, "Sd_A"), _member(auth_client, "Sd_B")
+    r1 = auth_client.post("/v1/member-relationships",
+                          json={"source_id": a, "target_id": b,
+                                "relationship_type_id": t})
+    assert r1.status_code == 201
+    # The inverse of the same pair+type must collide (unordered uniqueness).
+    r2 = auth_client.post("/v1/member-relationships",
+                          json={"source_id": b, "target_id": a,
+                                "relationship_type_id": t})
+    assert r2.status_code == 409
+
+
+# --- Validation guards -----------------------------------------------------
+
+def test_self_edge_rejected(auth_client: httpx.Client):
+    t = _type(auth_client, name="SelfT", symmetry="symmetric", forward_label="x")
+    a = _member(auth_client, "Self_A")
+    r = auth_client.post("/v1/member-relationships",
+                         json={"source_id": a, "target_id": a,
+                               "relationship_type_id": t})
+    assert r.status_code == 400
+
+
+def test_unknown_type_rejected(auth_client: httpx.Client):
+    a, b = _member(auth_client, "Ut_A"), _member(auth_client, "Ut_B")
+    r = auth_client.post("/v1/member-relationships",
+                         json={"source_id": a, "target_id": b,
+                               "relationship_type_id": str(_uuid.uuid4())})
+    assert r.status_code == 400
+
+
+def test_foreign_member_rejected(auth_client: httpx.Client):
+    t = _type(auth_client, name="ForeignT", symmetry="symmetric", forward_label="x")
+    a = _member(auth_client, "Fm_A")
+    r = auth_client.post("/v1/member-relationships",
+                         json={"source_id": a, "target_id": str(_uuid.uuid4()),
+                               "relationship_type_id": t})
+    assert r.status_code == 400
+
+
+# --- Group edges + graph + delete ------------------------------------------
+
+def test_group_edges_and_graph(auth_client: httpx.Client):
+    t = _type(auth_client, name="Allied", symmetry="symmetric", forward_label="allied")
+    g1, g2 = _group(auth_client, "Grp1"), _group(auth_client, "Grp2")
+    r = auth_client.post("/v1/group-relationships",
+                         json={"source_id": g1, "target_id": g2,
+                               "relationship_type_id": t})
+    assert r.status_code == 201, r.text
+    graph = auth_client.get("/v1/relationships/graph?scope=groups").json()
+    node_ids = {n["id"] for n in graph["nodes"]}
+    assert g1 in node_ids and g2 in node_ids
+    assert any(e["relationship_type_id"] == t for e in graph["edges"])
+    edge = next(e for e in graph["edges"] if e["relationship_type_id"] == t)
+    assert edge["directed"] is False
+    assert edge["source_label"] == "allied" and edge["target_label"] == "allied"
+
+
+def test_delete_edge_and_type(auth_client: httpx.Client):
+    t = _type(auth_client, name="DelT", symmetry="symmetric", forward_label="x")
+    a, b = _member(auth_client, "Del_A"), _member(auth_client, "Del_B")
+    edge_id = auth_client.post(
+        "/v1/member-relationships",
+        json={"source_id": a, "target_id": b, "relationship_type_id": t},
+    ).json()["id"]
+    assert auth_client.delete(f"/v1/member-relationships/{edge_id}").status_code == 204
+    assert auth_client.get(f"/v1/members/{a}/relationships").json() == [
+        e for e in auth_client.get(f"/v1/members/{a}/relationships").json()
+        if e["relationship_type_id"] != t
+    ]
+    # Recreate then delete the TYPE - the edge cascades away.
+    auth_client.post("/v1/member-relationships",
+                     json={"source_id": a, "target_id": b, "relationship_type_id": t})
+    assert auth_client.delete(f"/v1/relationship-types/{t}").status_code == 204
+    remaining = auth_client.get(f"/v1/members/{a}/relationships").json()
+    assert all(e["relationship_type_id"] != t for e in remaining)
+
+
+def test_symmetry_immutable_on_update(auth_client: httpx.Client):
+    t = _type(auth_client, name="ImmT", symmetry="symmetric", forward_label="x")
+    # symmetry is not an accepted update field; name/labels are.
+    r = auth_client.patch(f"/v1/relationship-types/{t}",
+                          json={"forward_label": "renamed"})
+    assert r.status_code == 200
+    assert r.json()["forward_label"] == "renamed"
+    assert r.json()["symmetry"] == "symmetric"


### PR DESCRIPTION
Second slice of the relationships feature, stacked on #201 (base is that branch; GitHub retargets this to `main` once #201 merges). This adds the v1 API on top of the data layer; the web UI and the d3-force graph viewer are the next PRs.

## Endpoints

New `relationships:read` / `relationships:write` / `relationships:delete` scopes gate a router registered with the read-gate plus per-write-endpoint gates. Relationship-type CRUD: `reverse_label` is required for directional / either types and dropped for symmetric, and `symmetry` is immutable after creation (existing edges' stored orientation and `mutual` semantics depend on it, so flipping it would silently corrupt them). Member and group edge create / delete, plus a per-node list endpoint (`GET /members/{id}/relationships`, `GET /groups/{id}/relationships`) that reads each canonical edge from that node's viewpoint through the shared engine, so an `A<->B` row surfaces in both A's and B's lists with the correct label and direction. A whole-graph endpoint (`GET /relationships/graph?scope=members|groups`) returns nodes plus edges with both end labels resolved, for the viewer.

## Safety and validation

Tenant-safe throughout: the system is resolved from the authenticated caller, and source, target, and type are all confirmed in-system before anything is written. Self-edges are rejected 400, unknown types 400, the unordered-pair collision surfaces as a clean 409, symmetric pairs are canonicalised before insert, and `mutual` is normalised off for non-either types. Deleting a type cascades its edges via the DB FK; that is low-stakes and reversible, so there is no System Safety category (the web client will confirm first).

## Verification

Endpoint tests cover viewpoint resolution from both ends, either-type directional vs mutual, the symmetric inverse-duplicate 409, group edges, the graph endpoint, and cascade on type delete. The full behavioural suite passes across all 9 server configs; ruff clean.
