### PR TITLE
Add Ampersand JSON importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Import from Ampersand.** You can now migrate an Ampersand system into Sheaf: on the Import page, choose Ampersand and upload the JSON export (Settings > Import/Export in Ampersand). It brings across members and custom fronts, custom fields, tags (and member roles), fronting history, journals, system notes, board messages with their polls, and reminders, and decodes the avatars embedded in the export. Each Ampersand system becomes a Sheaf group, with nested subsystems preserved. Ampersand features Sheaf has no equivalent for (the shared asset library, cosmetic name/avatar styling, per-front presence timelines, and journal comments) are skipped, with a note on the import's detail page explaining what was dropped.
+
 ## [1.2.2] - 2026-07-14
 
 ### Added

--- a/sheaf/api/v1/ampersand_import.py
+++ b/sheaf/api/v1/ampersand_import.py
@@ -1,0 +1,69 @@
+"""Ampersand import - preview endpoint.
+
+The actual import runs asynchronously through the unified job runner
+(POST /v1/imports/file). What's left here is the synchronous preview:
+parse an Ampersand export and return a summary of importable data.
+Preview writes nothing.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.auth.dependencies import get_current_user
+from sheaf.database import get_db
+from sheaf.models.system import System
+from sheaf.models.user import User
+from sheaf.schemas.ampersand_import import AmpersandPreviewSummary
+from sheaf.services.ampersand_import import preview
+from sheaf.services.front_retention import front_retention_preview_warning
+from sheaf.services.import_parsing import ImportPayloadError, safe_json_loads_async
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+MAX_IMPORT_SIZE = 100 * 1024 * 1024  # 100MB - Ampersand exports embed base64 images
+
+
+async def _get_user_system(user: User, db: AsyncSession) -> System:
+    result = await db.execute(select(System).where(System.user_id == user.id))
+    system = result.scalar_one_or_none()
+    if system is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="System not found"
+        )
+    return system
+
+
+async def _parse_upload(file: UploadFile) -> dict:
+    """Read and parse an Ampersand export JSON file."""
+    data = await file.read()
+    if len(data) > MAX_IMPORT_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Import file too large. Max 100MB.",
+        )
+    try:
+        return await safe_json_loads_async(data)
+    except ImportPayloadError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid JSON file.",
+        ) from exc
+
+
+@router.post("/ampersand/preview", response_model=AmpersandPreviewSummary)
+async def preview_import(
+    file: UploadFile,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Parse an Ampersand export file and return a summary of importable data."""
+    data = await _parse_upload(file)
+    summary = preview(data)
+    system = await _get_user_system(user, db)
+    retention_warning = front_retention_preview_warning(
+        system.front_retention_days, summary.front_history_count > 0
+    )
+    if retention_warning:
+        summary.limit_warnings.append(retention_warning)
+    return summary

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -7,6 +7,7 @@ from sheaf.api.v1 import (
     admin_emergency,
     admin_security,
     admin_small_actions,
+    ampersand_import,
     analytics,
     announcements,
     auth,
@@ -162,6 +163,10 @@ v1_router.include_router(
 )
 v1_router.include_router(
     prism_import.router,
+    dependencies=[Depends(require_scope("import:write"))],
+)
+v1_router.include_router(
+    ampersand_import.router,
     dependencies=[Depends(require_scope("import:write"))],
 )
 # Unified async-job import router. Replaces the per-source legacy

--- a/sheaf/models/import_job.py
+++ b/sheaf/models/import_job.py
@@ -39,6 +39,9 @@ class ImportJobSource(enum.StrEnum):
     # zip magic; both translate to the native shape and reuse the Sheaf
     # JSON / archive importers underneath.
     OPENPLURAL_FILE = "openplural_file"
+    # Ampersand JSON export ({revision, config, database}). Base64 images
+    # inline as data URIs; decoded + stored like the archive importers.
+    AMPERSAND_FILE = "ampersand_file"
 
 
 class ImportJobStatus(enum.StrEnum):

--- a/sheaf/schemas/ampersand_import.py
+++ b/sheaf/schemas/ampersand_import.py
@@ -1,0 +1,80 @@
+"""Pydantic models for Ampersand JSON data import.
+
+Ampersand (https://codeberg.org/Ampersand/app) exports a
+`{ revision, config, database }` JSON document; `database` is an object
+of per-table arrays. See `sheaf/services/ampersand_import.py` for the
+mapping and `../sheaf-design-docs/ampersand-import.md` for the format
+research note.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from sheaf.services.import_dedup import ImportConflictStrategy
+
+
+class AmpersandImportOptions(BaseModel):
+    """What to import from the Ampersand export.
+
+    Strict: a typo'd option key from a hand-rolled client 422s rather
+    than being silently ignored.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Members always import. The rest are toggleable; the heavy /
+    # content sections default on because an Ampersand export is a
+    # one-shot migration and the user expects their data to come across.
+    conflict_strategy: ImportConflictStrategy = ImportConflictStrategy.SKIP
+    member_ids: list[str] | None = Field(
+        None, max_length=10_000, description="Ampersand member UUIDs to import. None = all."
+    )
+    custom_fronts: bool = True
+    custom_fields: bool = True
+    tags: bool = True
+    # Ampersand systems become Sheaf groups (nested via `parent`).
+    groups: bool = True
+    front_history: bool = True
+    journals: bool = True
+    notes: bool = True
+    board_messages: bool = True
+    reminders: bool = True
+    # Decode + store the inline base64 avatars / covers. Off falls back
+    # to a text-only import (no images), which some users prefer.
+    images: bool = True
+
+
+class AmpersandPreviewSummary(BaseModel):
+    system_count: int = 0
+    member_count: int = 0
+    custom_front_count: int = 0
+    front_history_count: int = 0
+    tag_count: int = 0
+    custom_field_count: int = 0
+    journal_count: int = 0
+    note_count: int = 0
+    board_message_count: int = 0
+    poll_count: int = 0
+    reminder_count: int = 0
+    asset_count: int = 0
+    limit_warnings: list[str] = []
+
+
+class AmpersandImportResult(BaseModel):
+    members_imported: int = 0
+    custom_fronts_imported: int = 0
+    members_skipped: int = 0
+    members_updated: int = 0
+    groups_imported: int = 0
+    groups_skipped: int = 0
+    tags_imported: int = 0
+    custom_fields_imported: int = 0
+    custom_fields_skipped: int = 0
+    fronts_imported: int = 0
+    fronts_skipped: int = 0
+    journals_imported: int = 0
+    notes_imported: int = 0
+    messages_imported: int = 0
+    polls_imported: int = 0
+    reminders_imported: int = 0
+    images_imported: int = 0
+    warnings: list[str] = []

--- a/sheaf/schemas/imports.py
+++ b/sheaf/schemas/imports.py
@@ -45,6 +45,7 @@ class ImportFileCreateRequest(BaseModel):
         ImportJobSource.PLURALSPACE_FILE,
         ImportJobSource.PRISM_FILE,
         ImportJobSource.OPENPLURAL_FILE,
+        ImportJobSource.AMPERSAND_FILE,
     ]
     idempotency_key: uuid.UUID
     # Source-specific options as JSON string in the form field. Parsed

--- a/sheaf/services/ampersand_import.py
+++ b/sheaf/services/ampersand_import.py
@@ -1,0 +1,1142 @@
+"""Ampersand JSON data import service.
+
+Ampersand (https://codeberg.org/Ampersand/app) exports a
+``{ revision, config, database }`` JSON document; ``database`` is an
+object of per-table arrays (members, systems, customFields, tags,
+frontingEntries, journalPosts, notes, boardMessages, reminders, assets,
+filterQueries). Images (member/system ``image``/``cover``, asset
+``file``, journal ``cover``) arrive as inline base64 ``data:`` URIs.
+
+The mapping decisions live in ``../sheaf-design-docs/ampersand-import.md``
+(see the 2026-07-14 "Implementation decisions" section) and the
+per-app gap table in ``feature-gaps.md``. Headlines:
+
+- Every Ampersand ``System`` becomes a Sheaf ``Group`` (nested via
+  ``parent``); a member's ``system`` FK becomes group membership.
+- Each ``FrontingEntry`` becomes one single-member ``Front`` (no
+  overlap-coalescing).
+- ``role`` -> member Tag, ``age`` -> an auto-created "Age" custom field.
+- Inline images are decoded and pushed through the shared
+  ``store_imported_image`` pipeline; ``config`` (incl. the app-lock
+  password hash) is never touched.
+"""
+
+import base64
+import binascii
+import logging
+import re
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.crypto import blind_index, encrypt
+from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
+from sheaf.models.front import Front
+from sheaf.models.group import Group
+from sheaf.models.journal_entry import JournalEntry
+from sheaf.models.member import (
+    Member,
+    front_members,
+    group_members,
+    member_tags,
+)
+from sheaf.models.message import BoardKind, Message
+from sheaf.models.notification_channel import (
+    DestinationState,
+    DestinationType,
+    NotificationChannel,
+)
+from sheaf.models.poll import Poll, PollKind, PollOption, PollResultsVisibility, PollVote
+from sheaf.models.reminder import Reminder
+from sheaf.models.system import System
+from sheaf.models.tag import Tag
+from sheaf.models.user import User
+from sheaf.models.watch_token import WatchToken
+from sheaf.schemas.ampersand_import import (
+    AmpersandImportOptions,
+    AmpersandImportResult,
+    AmpersandPreviewSummary,
+)
+from sheaf.services import import_limits as il
+from sheaf.services.custom_fields import encrypt_field_value
+from sheaf.services.import_content_dedup import (
+    ContentMatchIndex,
+    front_key,
+    load_front_index,
+    load_group_index,
+    normalize_front_interval,
+)
+from sheaf.services.import_dedup import (
+    ImportConflictStrategy,
+    candidate_key,
+    count_new_members,
+    load_member_match_index,
+    resolve_member,
+)
+from sheaf.services.import_limits import ClampReport, clamp_str
+from sheaf.services.import_media import (
+    ImportImageError,
+    StoredImportImage,
+    store_imported_image,
+    user_can_upload_images,
+)
+from sheaf.services.member_limits import enforce_import_member_cap
+
+logger = logging.getLogger("sheaf.imports.ampersand")
+
+# Poll close window for imported polls. Ampersand board polls have no
+# close concept; import them "open" for a year like the PluralSpace /
+# Prism importers so a historical poll's votes aren't reaped by the
+# retention sweep the instant it lands (closes_at in the past + a short
+# retention would delete it).
+_POLL_OPEN_DAYS = 365
+_POLL_RETENTION_DAYS = 365
+
+
+# --- Parsing helpers --------------------------------------------------------
+
+
+def _database(data: dict) -> dict:
+    """The ``database`` object, or an empty dict for a malformed export."""
+    db = data.get("database")
+    return db if isinstance(db, dict) else {}
+
+
+def _coll(data: dict, name: str) -> list[dict]:
+    """A ``database`` collection as a list of dict rows; missing -> []."""
+    raw = _database(data).get(name)
+    if isinstance(raw, list):
+        return [r for r in raw if isinstance(r, dict)]
+    return []
+
+
+def _coerce_str(value: object) -> str | None:
+    """Plain string, or None for null / non-string. Never str()-quotes a
+    non-string so member content can't leak into an error via coercion."""
+    return value if isinstance(value, str) else None
+
+
+def _parse_iso(value: object) -> datetime | None:
+    """Parse an Ampersand ISO-8601 timestamp to an aware UTC datetime.
+
+    Ampersand serialises Dates via ``toISOString()`` (e.g.
+    ``2026-03-19T21:35:57.243Z``). ``fromisoformat`` handles the trailing
+    ``Z`` and milliseconds on 3.11+. Naive values are treated as UTC.
+    Missing / malformed -> None so one bad row can't crash the walk."""
+    s = _coerce_str(value)
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _normalize_color(color: object) -> str | None:
+    """Normalise a colour to '#rrggbb', or None. Handles 3/6/8-hex with or
+    without a leading '#'; 8-hex is treated as ARGB (drop the alpha byte)."""
+    if not isinstance(color, str):
+        return None
+    s = color.strip().lstrip("#")
+    if len(s) == 3:
+        s = f"{s[0] * 2}{s[1] * 2}{s[2] * 2}"
+    elif len(s) == 8:
+        s = s[2:]
+    if len(s) != 6 or not all(c in "0123456789abcdefABCDEF" for c in s):
+        return None
+    return f"#{s.lower()}"
+
+
+_DATA_URI_RE = re.compile(
+    r"^data:[\w/+.\-]*?(?:;[\w-]+=[\w-]+)*;base64,(?P<b64>.*)$",
+    re.DOTALL,
+)
+
+
+def _decode_data_uri(value: object) -> bytes | None:
+    """Decode a base64 ``data:`` URI to bytes, or None.
+
+    Only base64 payloads are handled (Ampersand always uses them via
+    ``toDataURI``). The image bytes are handed to ``store_imported_image``,
+    which sniffs the real format and re-encodes, so a lying mime type in
+    the URI is harmless. Bounded by the 100MB request-body cap upstream."""
+    s = _coerce_str(value)
+    if not s:
+        return None
+    m = _DATA_URI_RE.match(s.strip())
+    if not m:
+        return None
+    try:
+        return base64.b64decode(m.group("b64"), validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+
+# --- Preview ----------------------------------------------------------------
+
+
+def _count_polls(data: dict) -> int:
+    return sum(1 for b in _coll(data, "boardMessages") if isinstance(b.get("poll"), dict))
+
+
+def preview(data: dict) -> AmpersandPreviewSummary:
+    """Parse an Ampersand export and summarise importable data. No writes."""
+    members = _coll(data, "members")
+    real_members = [m for m in members if not m.get("isCustomFront")]
+    custom_fronts = [m for m in members if m.get("isCustomFront")]
+    journals = _coll(data, "journalPosts")
+    notes = _coll(data, "notes")
+    board = _coll(data, "boardMessages")
+
+    summary = AmpersandPreviewSummary(
+        system_count=len(_coll(data, "systems")),
+        member_count=len(real_members),
+        custom_front_count=len(custom_fronts),
+        front_history_count=len(_coll(data, "frontingEntries")),
+        tag_count=len(_coll(data, "tags")),
+        custom_field_count=len(_coll(data, "customFields")),
+        journal_count=len(journals),
+        note_count=len(notes),
+        board_message_count=len(board),
+        poll_count=_count_polls(data),
+        reminder_count=len(_coll(data, "reminders")),
+        asset_count=len(_coll(data, "assets")),
+    )
+    summary.limit_warnings = il.import_row_cap_warnings(
+        {
+            "groups": summary.system_count,
+            "tags": summary.tag_count,
+            "custom_fields": summary.custom_field_count,
+            "fronts": summary.front_history_count,
+            "journal_entries": summary.journal_count + summary.note_count,
+            "messages": summary.board_message_count,
+            "polls": summary.poll_count,
+        }
+    )
+    return summary
+
+
+# --- Import -----------------------------------------------------------------
+
+
+async def run_import(
+    data: dict,
+    options: AmpersandImportOptions,
+    system: System,
+    user: User,
+    db: AsyncSession,
+    stored_images: list[StoredImportImage],
+) -> AmpersandImportResult:
+    """Import an Ampersand export into the user's system.
+
+    ``stored_images`` is a caller-owned accumulator of blobs written to
+    storage; the runner scrubs it if the import fails, since storage
+    writes don't roll back with the DB transaction.
+    """
+    result = AmpersandImportResult()
+    warnings: list[str] = []
+    report = ClampReport()
+    dedupe = options.conflict_strategy != ImportConflictStrategy.CREATE
+
+    images_enabled = options.images
+    if options.images and not user_can_upload_images(user):
+        images_enabled = False
+        warnings.append(
+            "Image restore skipped: image uploads are not enabled for this "
+            "account. Members and journals imported without their avatars."
+        )
+
+    # --- Row caps (parse-bomb guard) -------------------------------------
+    il.enforce_import_row_caps(
+        {
+            "groups": len(_coll(data, "systems")) if options.groups else 0,
+            "tags": len(_coll(data, "tags")) if options.tags else 0,
+            "custom_fields": (
+                len(_coll(data, "customFields")) if options.custom_fields else 0
+            ),
+            "fronts": (
+                len(_coll(data, "frontingEntries")) if options.front_history else 0
+            ),
+            "journal_entries": (
+                (len(_coll(data, "journalPosts")) if options.journals else 0)
+                + (len(_coll(data, "notes")) if options.notes else 0)
+            ),
+            "messages": (
+                len(_coll(data, "boardMessages")) if options.board_messages else 0
+            ),
+            "polls": _count_polls(data) if options.board_messages else 0,
+        }
+    )
+
+    # --- Members + custom fronts (built as candidates first) -------------
+    amp_members = _coll(data, "members")
+    if options.member_ids is not None:
+        selected = set(options.member_ids)
+        amp_members = [m for m in amp_members if m.get("uuid") in selected]
+    if not options.custom_fronts:
+        amp_members = [m for m in amp_members if not m.get("isCustomFront")]
+
+    # Amp member uuid -> plaintext name, for journal author-name snapshots.
+    amp_id_to_name: dict[str, str] = {}
+    # Amp member uuid -> its Amp system uuid, for group membership wiring.
+    amp_id_to_system: dict[str, str] = {}
+    member_candidates: list[tuple[Member, dict]] = []
+    for amp_m in amp_members:
+        amp_id = _coerce_str(amp_m.get("uuid")) or ""
+        plaintext_name = clamp_str(
+            _coerce_str(amp_m.get("name")) or "unnamed", il.M_NAME, report=report
+        )
+        if amp_id:
+            amp_id_to_name[amp_id] = plaintext_name
+            sys_ref = _coerce_str(amp_m.get("system"))
+            if sys_ref:
+                amp_id_to_system[amp_id] = sys_ref
+        plaintext_desc = _coerce_str(amp_m.get("description"))
+        member = Member(
+            id=uuid.uuid4(),
+            system_id=system.id,
+            name=encrypt(plaintext_name),
+            name_hash=blind_index(plaintext_name),
+            description=encrypt(plaintext_desc) if plaintext_desc is not None else None,
+            pronouns=clamp_str(
+                _coerce_str(amp_m.get("pronouns")) or None, il.M_PRONOUNS, report=report
+            ),
+            color=_normalize_color(amp_m.get("color")),
+            is_custom_front=bool(amp_m.get("isCustomFront")),
+        )
+        created = _parse_iso(amp_m.get("dateCreated"))
+        if created:
+            member.created_at = created
+        if amp_m.get("isArchived"):
+            member.archived_at = _parse_iso(amp_m.get("dateCreated")) or datetime.now(UTC)
+        member_candidates.append((member, amp_m))
+
+    # Member cap: count only rows this run would CREATE, before any write.
+    index = await load_member_match_index(db, system.id)
+    new_count = count_new_members(
+        [candidate_key(m) for m, _ in member_candidates],
+        index=index,
+        strategy=options.conflict_strategy,
+    )
+    await enforce_import_member_cap(db, system, new_count)
+
+    # Resolve dispositions and add created rows.
+    amp_id_to_member: dict[str, Member] = {}
+    created_member_ids: set[uuid.UUID] = set()
+    for member, amp_m in member_candidates:
+        resolution = resolve_member(member, index=index, strategy=options.conflict_strategy)
+        amp_id = _coerce_str(amp_m.get("uuid")) or ""
+        if resolution.disposition == "created":
+            db.add(resolution.member)
+            created_member_ids.add(resolution.member.id)
+            if resolution.member.is_custom_front:
+                result.custom_fronts_imported += 1
+            else:
+                result.members_imported += 1
+        elif resolution.disposition == "updated":
+            result.members_updated += 1
+        else:
+            result.members_skipped += 1
+        if amp_id:
+            amp_id_to_member[amp_id] = resolution.member
+
+    await db.flush()
+
+    # Avatars: decode + store only for members we actually created, so a
+    # deduped-skip doesn't leave an orphaned blob.
+    if images_enabled:
+        for member, amp_m in member_candidates:
+            if member.id not in created_member_ids:
+                continue
+            raw = _decode_data_uri(amp_m.get("image"))
+            if raw is None:
+                continue
+            stored = await _store_avatar(raw, db, user, warnings)
+            if stored is not None:
+                stored_images.append(stored)
+                member.avatar_url = stored.key
+                result.images_imported += 1
+
+    # --- Systems -> groups -----------------------------------------------
+    if options.groups:
+        await _import_systems_as_groups(
+            data, system, db, amp_id_to_member, amp_id_to_system,
+            created_member_ids, result, warnings, report, dedupe,
+        )
+
+    # --- Tags (+ member.role) --------------------------------------------
+    if options.tags:
+        result.tags_imported += await _import_tags(
+            data, system, db, amp_id_to_member, created_member_ids, warnings, report
+        )
+
+    # --- Custom fields (+ member.age) ------------------------------------
+    if options.custom_fields:
+        await _import_custom_fields(
+            data, system, db, amp_id_to_member, created_member_ids, result, report
+        )
+
+    # --- Front history ----------------------------------------------------
+    if options.front_history:
+        await _import_fronts(data, system, db, amp_id_to_member, result, warnings, dedupe)
+
+    # --- Journals + notes -------------------------------------------------
+    if options.journals or options.notes:
+        await _import_journals(
+            data, system, db, user, amp_id_to_member, amp_id_to_name,
+            options, images_enabled, stored_images, result, warnings, report,
+        )
+
+    # --- Board messages + polls ------------------------------------------
+    if options.board_messages:
+        await _import_board(
+            data, system, db, amp_id_to_member, result, warnings, report
+        )
+
+    # --- Reminders (best-effort) -----------------------------------------
+    if options.reminders:
+        await _import_reminders(
+            data, system, db, amp_id_to_member, result, warnings, report
+        )
+
+    result.warnings = warnings + report.to_warnings()
+    return result
+
+
+async def _store_avatar(
+    raw: bytes, db: AsyncSession, user: User, warnings: list[str]
+) -> StoredImportImage | None:
+    """Store one decoded image as an avatar; None + a warning on rejection.
+
+    A ``quota_full`` rejection is terminal for images (the quota won't
+    free up mid-import), so it's surfaced once and further stores are the
+    caller's to stop - but since avatars are per-member and small, we just
+    warn and skip each."""
+    try:
+        return await store_imported_image(raw, db=db, user=user, purpose="avatar")
+    except ImportImageError as exc:
+        if exc.reason == "quota_full":
+            warnings.append("Some images were skipped: storage quota reached.")
+        elif exc.reason == "bad_format":
+            warnings.append("An image was skipped (unsupported format).")
+        else:
+            warnings.append("An image was skipped (rejected by the image normaliser).")
+        return None
+
+
+async def _import_systems_as_groups(
+    data: dict,
+    system: System,
+    db: AsyncSession,
+    amp_id_to_member: dict[str, Member],
+    amp_id_to_system: dict[str, str],
+    created_member_ids: set[uuid.UUID],
+    result: AmpersandImportResult,
+    warnings: list[str],
+    report: ClampReport,
+    dedupe: bool,
+) -> None:
+    """Each Ampersand system -> a Sheaf group; ``parent`` -> ``parent_id``.
+
+    Members join the group for their ``system`` FK. Group depth is clamped
+    to MAX_GROUP_DEPTH, reusing the native importer's reparent helper.
+    Group avatars don't exist, so system ``image`` is dropped."""
+    amp_systems = _coll(data, "systems")
+    if not amp_systems:
+        return
+
+    group_index = await load_group_index(db, system.id) if dedupe else ContentMatchIndex()
+    amp_sysid_to_group: dict[str, Group] = {}
+    created_group_ids: set[uuid.UUID] = set()
+    dropped_images = 0
+
+    # First pass: create groups (no parent links yet).
+    for amp_s in amp_systems:
+        amp_sid = _coerce_str(amp_s.get("uuid")) or ""
+        name = clamp_str(
+            _coerce_str(amp_s.get("name")) or "system", il.GROUP_NAME, report=report
+        )
+        existing = group_index.get(name) if dedupe else None
+        if existing is not None:
+            amp_sysid_to_group[amp_sid] = existing
+            result.groups_skipped += 1
+            continue
+        group = Group(
+            id=uuid.uuid4(),
+            system_id=system.id,
+            name=name,
+            description=_coerce_str(amp_s.get("description")),
+            color=_normalize_color(amp_s.get("color")),
+        )
+        db.add(group)
+        group_index.register(name, group)
+        created_group_ids.add(group.id)
+        amp_sysid_to_group[amp_sid] = group
+        result.groups_imported += 1
+        if amp_s.get("image"):
+            dropped_images += 1
+
+    await db.flush()
+
+    # Second pass: parent links (only on groups we created this run).
+    unresolved_parents = 0
+    for amp_s in amp_systems:
+        amp_sid = _coerce_str(amp_s.get("uuid")) or ""
+        group = amp_sysid_to_group.get(amp_sid)
+        if group is None or group.id not in created_group_ids:
+            continue
+        parent_ref = _coerce_str(amp_s.get("parent"))
+        if parent_ref:
+            parent = amp_sysid_to_group.get(parent_ref)
+            if parent is not None:
+                group.parent_id = parent.id
+            else:
+                unresolved_parents += 1
+
+    # Member -> group membership.
+    unknown_members = 0
+    seen_pairs: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    for amp_mid, sys_ref in amp_id_to_system.items():
+        member = amp_id_to_member.get(amp_mid)
+        group = amp_sysid_to_group.get(sys_ref)
+        if member is None or group is None:
+            if member is not None and group is None:
+                unknown_members += 1
+            continue
+        # Only associate members created this run (a deduped-skip member is
+        # already grouped as it was on the prior import).
+        if member.id not in created_member_ids:
+            continue
+        pair = (group.id, member.id)
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
+        await db.execute(
+            group_members.insert().values(group_id=group.id, member_id=member.id)
+        )
+
+    # Depth clamp, reusing the native importer's non-destructive reparent.
+    if created_group_ids:
+        from sheaf.api.v1.groups import MAX_GROUP_DEPTH
+        from sheaf.services.sheaf_import import correct_nesting_depth
+
+        await db.flush()
+        rows = await db.execute(
+            select(Group.id, Group.parent_id).where(Group.system_id == system.id)
+        )
+        parent_of = {gid: pid for gid, pid in rows.all()}
+        correction = correct_nesting_depth(parent_of, max_depth=MAX_GROUP_DEPTH)
+        moved = 0
+        for group in amp_sysid_to_group.values():
+            if group.id not in created_group_ids:
+                continue
+            if group.id in correction.moved or group.id in correction.cycle_broken:
+                group.parent_id = correction.parent_of[group.id]
+                moved += 1
+        if moved:
+            warnings.append(
+                f"{moved} imported group(s) exceeded the maximum nesting depth "
+                f"({MAX_GROUP_DEPTH}) or looped and were moved up to fit."
+            )
+
+    if dropped_images:
+        warnings.append(
+            f"Dropped {dropped_images} system image(s): Sheaf groups (which "
+            "Ampersand systems import as) have no avatar."
+        )
+    if unresolved_parents:
+        warnings.append(
+            f"Dropped {unresolved_parents} system parent link(s) that pointed at "
+            "a system not present in the export."
+        )
+    if unknown_members:
+        warnings.append(
+            f"{unknown_members} member(s) referenced a system not present in the "
+            "export; they were imported without a group."
+        )
+
+
+async def _import_tags(
+    data: dict,
+    system: System,
+    db: AsyncSession,
+    amp_id_to_member: dict[str, Member],
+    created_member_ids: set[uuid.UUID],
+    warnings: list[str],
+    report: ClampReport,
+) -> int:
+    """Import member-type tags + member.role, deduped by name (ci).
+
+    Ampersand tags are typed (member/journal/asset); only member tags map.
+    ``member.tags`` reference tag uuids; ``member.role`` is a free string
+    that also becomes a tag (SimplyPlural precedent)."""
+    existing = await db.execute(select(Tag).where(Tag.system_id == system.id))
+    tag_by_name: dict[str, Tag] = {t.name.lower(): t for t in existing.scalars().all()}
+    # Amp tag uuid -> Sheaf Tag, for member.tags[] references.
+    amp_tagid_to_tag: dict[str, Tag] = {}
+    created = 0
+
+    def _get_or_create(name: str) -> Tag:
+        nonlocal created
+        clamped = clamp_str(name, il.TAG_NAME, report=report) or name[: il.TAG_NAME.limit]
+        key = clamped.lower()
+        tag = tag_by_name.get(key)
+        if tag is None:
+            tag = Tag(id=uuid.uuid4(), system_id=system.id, name=clamped)
+            db.add(tag)
+            tag_by_name[key] = tag
+            created += 1
+        return tag
+
+    for amp_t in _coll(data, "tags"):
+        if amp_t.get("type") != "member":
+            continue
+        name = _coerce_str(amp_t.get("name"))
+        if not name:
+            continue
+        tag = _get_or_create(name)
+        amp_tid = _coerce_str(amp_t.get("uuid"))
+        if amp_tid:
+            amp_tagid_to_tag[amp_tid] = tag
+
+    await db.flush()
+
+    # Associate members with their tags + role.
+    seen: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    for amp_m in _coll(data, "members"):
+        amp_mid = _coerce_str(amp_m.get("uuid"))
+        member = amp_id_to_member.get(amp_mid) if amp_mid else None
+        if member is None or member.id not in created_member_ids:
+            continue
+        wanted: list[Tag] = []
+        for tref in amp_m.get("tags", []):
+            tag = amp_tagid_to_tag.get(_coerce_str(tref) or "")
+            if tag is not None:
+                wanted.append(tag)
+        role = _coerce_str(amp_m.get("role"))
+        if role and role.strip():
+            wanted.append(_get_or_create(role.strip()))
+        await db.flush()
+        for tag in wanted:
+            pair = (tag.id, member.id)
+            if pair in seen:
+                continue
+            seen.add(pair)
+            await db.execute(
+                member_tags.insert().values(tag_id=tag.id, member_id=member.id)
+            )
+    return created
+
+
+async def _import_custom_fields(
+    data: dict,
+    system: System,
+    db: AsyncSession,
+    amp_id_to_member: dict[str, Member],
+    created_member_ids: set[uuid.UUID],
+    result: AmpersandImportResult,
+    report: ClampReport,
+) -> None:
+    """Import customField defs (all TEXT) + per-member values, plus a
+    synthesised "Age" field from ``member.age``."""
+    existing = await db.execute(
+        select(CustomFieldDefinition).where(
+            CustomFieldDefinition.system_id == system.id
+        )
+    )
+    def_by_key: dict[tuple[str, str], CustomFieldDefinition] = {
+        (d.name, d.field_type.value if hasattr(d.field_type, "value") else d.field_type): d
+        for d in existing.scalars().all()
+    }
+    amp_fieldid_to_def: dict[str, CustomFieldDefinition] = {}
+
+    def _get_or_create_field(name: str, order: int) -> CustomFieldDefinition:
+        clamped = clamp_str(name, il.CF_NAME, report=report) or name[: il.CF_NAME.limit]
+        key = (clamped, FieldType.TEXT.value)
+        field_def = def_by_key.get(key)
+        if field_def is None:
+            field_def = CustomFieldDefinition(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                name=clamped,
+                field_type=FieldType.TEXT,
+                order=order,
+            )
+            db.add(field_def)
+            def_by_key[key] = field_def
+            result.custom_fields_imported += 1
+        else:
+            result.custom_fields_skipped += 1
+        return field_def
+
+    for idx, amp_f in enumerate(_coll(data, "customFields")):
+        name = _coerce_str(amp_f.get("name")) or f"field_{idx}"
+        field_def = _get_or_create_field(name, idx)
+        amp_fid = _coerce_str(amp_f.get("uuid"))
+        if amp_fid:
+            amp_fieldid_to_def[amp_fid] = field_def
+
+    # "Age" field, only if some member carries an age.
+    age_field: CustomFieldDefinition | None = None
+    if any(m.get("age") is not None for m in _coll(data, "members")):
+        age_field = _get_or_create_field("Age", len(amp_fieldid_to_def))
+
+    await db.flush()
+
+    # Values. member.customFields is {fieldUuid: value}; member.age is a
+    # number. Both keyed to the (field, member) UNIQUE, so guard the pair.
+    seen: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    for amp_m in _coll(data, "members"):
+        amp_mid = _coerce_str(amp_m.get("uuid"))
+        member = amp_id_to_member.get(amp_mid) if amp_mid else None
+        if member is None or member.id not in created_member_ids:
+            continue
+        pending: list[tuple[CustomFieldDefinition, str]] = []
+        cf = amp_m.get("customFields")
+        if isinstance(cf, dict):
+            for field_ref, raw_value in cf.items():
+                if raw_value is None:
+                    continue
+                field_def = amp_fieldid_to_def.get(field_ref)
+                if field_def is not None:
+                    pending.append((field_def, str(raw_value)))
+        age = amp_m.get("age")
+        if age is not None and age_field is not None and not isinstance(age, bool):
+            pending.append((age_field, str(age)))
+        for field_def, value in pending:
+            pair = (field_def.id, member.id)
+            if pair in seen:
+                continue
+            seen.add(pair)
+            db.add(
+                CustomFieldValue(
+                    id=uuid.uuid4(),
+                    field_id=field_def.id,
+                    member_id=member.id,
+                    value=encrypt_field_value({"v": value}),
+                )
+            )
+
+
+async def _import_fronts(
+    data: dict,
+    system: System,
+    db: AsyncSession,
+    amp_id_to_member: dict[str, Member],
+    result: AmpersandImportResult,
+    warnings: list[str],
+    dedupe: bool,
+) -> None:
+    """Each frontingEntry -> one single-member Front. No coalescing."""
+    front_index = await load_front_index(db, system.id) if dedupe else ContentMatchIndex()
+    missing_member = 0
+    bad_time = 0
+    for amp_f in _coll(data, "frontingEntries"):
+        member = amp_id_to_member.get(_coerce_str(amp_f.get("member")) or "")
+        if member is None:
+            missing_member += 1
+            continue
+        started = _parse_iso(amp_f.get("startTime"))
+        if started is None:
+            bad_time += 1
+            continue
+        ended = _parse_iso(amp_f.get("endTime"))
+        started, ended, _swapped = normalize_front_interval(started, ended)
+
+        if dedupe:
+            fkey = front_key(started, ended, {member.id})
+            if front_index.get(fkey) is not None:
+                result.fronts_skipped += 1
+                continue
+            front_index.register(fkey)
+
+        custom_status = _coerce_str(amp_f.get("customStatus"))
+        front = Front(
+            id=uuid.uuid4(),
+            system_id=system.id,
+            started_at=started,
+            ended_at=ended,
+            custom_status=encrypt(custom_status) if custom_status else None,
+        )
+        db.add(front)
+        await db.flush()
+        await db.execute(
+            front_members.insert().values(front_id=front.id, member_id=member.id)
+        )
+        result.fronts_imported += 1
+    if missing_member:
+        warnings.append(
+            f"Skipped {missing_member} fronting entries whose member wasn't "
+            "imported."
+        )
+    if bad_time:
+        warnings.append(
+            f"Skipped {bad_time} fronting entries with an unparseable start time."
+        )
+
+
+async def _import_journals(
+    data: dict,
+    system: System,
+    db: AsyncSession,
+    user: User,
+    amp_id_to_member: dict[str, Member],
+    amp_id_to_name: dict[str, str],
+    options: AmpersandImportOptions,
+    images_enabled: bool,
+    stored_images: list[StoredImportImage],
+    result: AmpersandImportResult,
+    warnings: list[str],
+    report: ClampReport,
+) -> None:
+    """journalPosts -> JournalEntry; system notes -> system-wide entries.
+
+    A single-member post also sets ``member_id``; multi/zero-member posts
+    are system-wide with the author snapshot populated. ``subtitle`` and
+    ``contentWarning`` fold into the body (Sheaf journals have neither
+    field); ``cover`` is stored to ``image_keys``. Journal ``comments`` are
+    dropped - Sheaf journals have no comment surface."""
+    dropped_comments = 0
+
+    if options.journals:
+        for amp_j in _coll(data, "journalPosts"):
+            member_objs = [
+                amp_id_to_member[mid]
+                for mid in (
+                    _coerce_str(r) for r in amp_j.get("members", [])
+                )
+                if mid and mid in amp_id_to_member
+            ]
+            author_names = [
+                amp_id_to_name[mid]
+                for mid in (_coerce_str(r) for r in amp_j.get("members", []))
+                if mid and mid in amp_id_to_name
+            ]
+            body_parts: list[str] = []
+            cw = _coerce_str(amp_j.get("contentWarning"))
+            if cw:
+                body_parts.append(f"> Content warning: {cw}")
+            subtitle = _coerce_str(amp_j.get("subtitle"))
+            if subtitle:
+                body_parts.append(f"*{subtitle}*")
+            body_parts.append(_coerce_str(amp_j.get("body")) or "")
+            body = "\n\n".join(p for p in body_parts if p)
+
+            image_keys: list[str] = []
+            if images_enabled:
+                raw = _decode_data_uri(amp_j.get("cover"))
+                if raw is not None:
+                    stored = await _store_avatar(raw, db, user, warnings)
+                    if stored is not None:
+                        stored_images.append(stored)
+                        image_keys.append(stored.key)
+                        result.images_imported += 1
+
+            j_title = _coerce_str(amp_j.get("title"))
+            entry = JournalEntry(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                member_id=member_objs[0].id if len(member_objs) == 1 else None,
+                title=(
+                    encrypt(clamp_str(j_title, il.JOURNAL_TITLE, report=report))
+                    if j_title
+                    else None
+                ),
+                body=encrypt(body),
+                visibility="system",
+                author_user_id=system.user_id,
+                author_member_ids=[str(m.id) for m in member_objs],
+                author_member_names=author_names,
+                image_keys=image_keys,
+            )
+            created = _parse_iso(amp_j.get("date"))
+            if created:
+                entry.created_at = created
+            db.add(entry)
+            result.journals_imported += 1
+            if amp_j.get("comments"):
+                dropped_comments += len(amp_j.get("comments") or [])
+
+    if options.notes:
+        for amp_n in _coll(data, "notes"):
+            title = _coerce_str(amp_n.get("title"))
+            content = _coerce_str(amp_n.get("content")) or ""
+            entry = JournalEntry(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                member_id=None,
+                title=(
+                    encrypt(clamp_str(title, il.JOURNAL_TITLE, report=report))
+                    if title
+                    else None
+                ),
+                body=encrypt(content),
+                visibility="system",
+                author_user_id=system.user_id,
+                author_member_ids=[],
+                author_member_names=[],
+                image_keys=[],
+            )
+            db.add(entry)
+            result.notes_imported += 1
+
+    if dropped_comments:
+        warnings.append(
+            f"Dropped {dropped_comments} journal comment(s): Sheaf journals have "
+            "no comment surface."
+        )
+
+
+async def _import_board(
+    data: dict,
+    system: System,
+    db: AsyncSession,
+    amp_id_to_member: dict[str, Member],
+    result: AmpersandImportResult,
+    warnings: list[str],
+    report: ClampReport,
+) -> None:
+    """boardMessages -> system-board Messages (+ comments as replies, polls).
+
+    Ampersand board posts have a title AND body: the title is prepended as
+    a bold line. ``members[0]`` is taken as the author. ``comments`` become
+    single-level replies to the post (Sheaf boards are single-level; the
+    inter-comment ``replyTo`` chain is flattened). Each post's ``poll``
+    imports as a closed-window Poll with per-voter votes."""
+    dropped_polls_no_options = 0
+    for amp_b in _coll(data, "boardMessages"):
+        members = [
+            amp_id_to_member[mid]
+            for mid in (_coerce_str(r) for r in amp_b.get("members", []))
+            if mid and mid in amp_id_to_member
+        ]
+        author = members[0] if members else None
+        title = _coerce_str(amp_b.get("title"))
+        raw_body = _coerce_str(amp_b.get("body")) or ""
+        body = f"**{title}**\n\n{raw_body}".strip() if title else raw_body
+        message = Message(
+            id=uuid.uuid4(),
+            system_id=system.id,
+            board_kind=BoardKind.SYSTEM.value,
+            board_member_id=None,
+            author_member_id=author.id if author else None,
+            body=encrypt(clamp_str(body, il.MESSAGE_BODY, report=report) or ""),
+        )
+        created = _parse_iso(amp_b.get("date"))
+        if created:
+            message.created_at = created
+        db.add(message)
+        await db.flush()
+        result.messages_imported += 1
+
+        # Comments -> replies to this post.
+        for amp_c in amp_b.get("comments") or []:
+            if not isinstance(amp_c, dict):
+                continue
+            c_author = amp_id_to_member.get(_coerce_str(amp_c.get("member")) or "")
+            c_body = _coerce_str(amp_c.get("comment")) or ""
+            reply = Message(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                board_kind=BoardKind.SYSTEM.value,
+                board_member_id=None,
+                author_member_id=c_author.id if c_author else None,
+                body=encrypt(clamp_str(c_body, il.MESSAGE_BODY, report=report) or ""),
+                parent_message_id=message.id,
+            )
+            c_created = _parse_iso(amp_c.get("date"))
+            if c_created:
+                reply.created_at = c_created
+            db.add(reply)
+            result.messages_imported += 1
+
+        # Poll.
+        poll_data = amp_b.get("poll")
+        if isinstance(poll_data, dict):
+            if await _import_poll(poll_data, system, db, amp_id_to_member, report):
+                result.polls_imported += 1
+            else:
+                dropped_polls_no_options += 1
+
+    if dropped_polls_no_options:
+        warnings.append(
+            f"Dropped {dropped_polls_no_options} poll(s) that had no options."
+        )
+
+
+async def _import_poll(
+    poll_data: dict,
+    system: System,
+    db: AsyncSession,
+    amp_id_to_member: dict[str, Member],
+    report: ClampReport,
+) -> bool:
+    """One Ampersand poll -> Poll + options + per-voter votes. Returns
+    False (no import) when the poll has no options. Per-vote ``reason``
+    freeform is dropped (Sheaf votes carry no freeform field)."""
+    entries = poll_data.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return False
+
+    now = datetime.now(UTC)
+    poll = Poll(
+        id=uuid.uuid4(),
+        system_id=system.id,
+        question=encrypt(clamp_str("Imported poll", il.POLL_QUESTION, report=report)),
+        description=None,
+        kind=(
+            PollKind.MULTI_CHOICE.value
+            if poll_data.get("multipleChoice")
+            else PollKind.SINGLE_CHOICE.value
+        ),
+        results_visibility=PollResultsVisibility.LIVE.value,
+        closes_at=now + timedelta(days=_POLL_OPEN_DAYS),
+        retention_days=_POLL_RETENTION_DAYS,
+    )
+    db.add(poll)
+    await db.flush()
+
+    # Options + invert per-option votes into per-voter option sets.
+    member_to_options: dict[uuid.UUID, list[uuid.UUID]] = {}
+    created_any = False
+    for position, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+        text = _coerce_str(entry.get("choice")) or f"Option {position + 1}"
+        option = PollOption(
+            id=uuid.uuid4(),
+            poll_id=poll.id,
+            text=encrypt(clamp_str(text, il.POLL_OPTION, report=report) or ""),
+            position=position,
+        )
+        db.add(option)
+        created_any = True
+        for vote in entry.get("votes") or []:
+            if not isinstance(vote, dict):
+                continue
+            voter = amp_id_to_member.get(_coerce_str(vote.get("member")) or "")
+            if voter is None:
+                continue
+            member_to_options.setdefault(voter.id, []).append(option.id)
+
+    if not created_any:
+        return False
+    await db.flush()
+
+    for member_id, option_ids in member_to_options.items():
+        db.add(
+            PollVote(
+                id=uuid.uuid4(),
+                poll_id=poll.id,
+                voted_as_member_id=member_id,
+                option_ids=option_ids,
+            )
+        )
+    return True
+
+
+async def _import_reminders(
+    data: dict,
+    system: System,
+    db: AsyncSession,
+    amp_id_to_member: dict[str, Member],
+    result: AmpersandImportResult,
+    warnings: list[str],
+    report: ClampReport,
+) -> None:
+    """Ampersand reminders -> automated (front-event) Sheaf reminders.
+
+    Sheaf reminders require a notification channel; Ampersand exports carry
+    none, so a single disabled placeholder channel is synthesised and all
+    imported reminders bind to it. The user re-enables it and sets a real
+    destination to make them fire. ``trigger`` fronting/fronted ->
+    start/stop; ``members[]`` fan out one reminder per member via
+    ``trigger_member_id`` (automated reminders trigger on a single member)."""
+    reminders = _coll(data, "reminders")
+    if not reminders:
+        return
+
+    channel = await _synthesise_reminder_channel(system, db)
+    made = 0
+    for amp_r in reminders:
+        title = _coerce_str(amp_r.get("title")) or "reminder"
+        message_body = _coerce_str(amp_r.get("message"))
+        trigger = _coerce_str(amp_r.get("trigger"))
+        trigger_event = "stop" if trigger == "fronted" else "start"
+        delay = amp_r.get("delay")
+        delay_seconds = (
+            int(delay) // 1000
+            if isinstance(delay, (int, float)) and not isinstance(delay, bool)
+            else None
+        )
+        enabled = bool(amp_r.get("active", True))
+
+        member_refs = [
+            amp_id_to_member[mid]
+            for mid in (_coerce_str(r) for r in amp_r.get("members", []) or [])
+            if mid and mid in amp_id_to_member
+        ]
+        # Fan out one automated reminder per targeted member; none -> a
+        # single "any member" reminder.
+        targets: list[Member | None] = member_refs if member_refs else [None]
+        for target in targets:
+            reminder = Reminder(
+                id=uuid.uuid4(),
+                system_id=system.id,
+                channel_id=channel.id,
+                name=clamp_str(title, il.REMINDER_NAME, report=report),
+                title=encrypt(clamp_str(title, il.REMINDER_TITLE, report=report) or ""),
+                body=(
+                    encrypt(clamp_str(message_body, il.REMINDER_BODY, report=report))
+                    if message_body
+                    else None
+                ),
+                enabled=enabled,
+                trigger_type="automated",
+                trigger_member_id=target.id if target else None,
+                trigger_event=trigger_event,
+                delay_seconds=delay_seconds,
+                scope="system",
+            )
+            db.add(reminder)
+            made += 1
+
+    result.reminders_imported += made
+    warnings.append(
+        f"Imported {made} reminder(s) bound to a disabled placeholder "
+        "notification channel ('Imported from Ampersand'). Set a real "
+        "destination and enable the channel to make them fire."
+    )
+
+
+async def _synthesise_reminder_channel(
+    system: System, db: AsyncSession
+) -> NotificationChannel:
+    """A single disabled webhook channel to satisfy the reminder FK.
+
+    Disabled + owner-paused so it never dispatches against its empty
+    config; the user configures a real destination post-import."""
+    token = WatchToken(
+        id=uuid.uuid4(),
+        system_id=system.id,
+        label="Imported from Ampersand",
+    )
+    db.add(token)
+    await db.flush()
+    channel = NotificationChannel(
+        id=uuid.uuid4(),
+        watch_token_id=token.id,
+        name="Imported from Ampersand",
+        destination_type=DestinationType.WEBHOOK.value,
+        destination_config={},
+        destination_state=DestinationState.DISABLED.value,
+        paused_by_sender=True,
+    )
+    db.add(channel)
+    await db.flush()
+    return channel

--- a/sheaf/services/ampersand_import_runner.py
+++ b/sheaf/services/ampersand_import_runner.py
@@ -1,0 +1,149 @@
+"""Async runner handler for Ampersand JSON file imports.
+
+Wrap-pattern handler: defensive parse + hard-failure surfacing + counts
++ warning-events land here; the per-record walk is in
+``ampersand_import.run_import``. Adds one concern the pure-JSON runners
+don't have - the importer writes image blobs to storage, which do NOT
+roll back with the DB transaction, so this handler scrubs any blob it
+wrote if the import raises (mirrors ``sheaf_archive_import``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sheaf.models.import_job import ImportJob, ImportJobSource
+from sheaf.models.user import User
+from sheaf.schemas.ampersand_import import AmpersandImportOptions
+from sheaf.services.ampersand_import import preview as amp_preview
+from sheaf.services.ampersand_import import run_import as amp_run_import
+from sheaf.services.import_media import StoredImportImage
+from sheaf.services.import_parsing import (
+    ImportPayloadError,
+    expect_dict,
+    parse_options,
+    safe_json_loads,
+)
+from sheaf.services.import_runner import (
+    append_event,
+    load_user_system,
+    register_handler,
+    update_counts,
+)
+from sheaf.services.import_storage import get_payload
+from sheaf.storage import get_storage
+
+logger = logging.getLogger("sheaf.imports.ampersand")
+
+
+async def handle_ampersand_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run an Ampersand-file import for a claimed ImportJob."""
+    if job.payload_storage_key is None:
+        raise ImportPayloadError(
+            "Ampersand file job has no payload - was the upload step skipped?"
+        )
+
+    blob = await get_payload(job.payload_storage_key)
+    if blob is None:
+        raise ImportPayloadError(
+            "Ampersand file payload missing from storage - "
+            "the blob may have been swept by orphan cleanup"
+        )
+
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=f"parsed {len(blob)} bytes of payload",
+    )
+
+    parsed = expect_dict(safe_json_loads(blob), descriptor="Ampersand export")
+
+    insum = amp_preview(parsed)
+    append_event(
+        job,
+        level="info",
+        stage="parse",
+        message=(
+            "export contained: "
+            f"{insum.member_count} members, "
+            f"{insum.custom_front_count} custom fronts, "
+            f"{insum.system_count} systems, "
+            f"{insum.front_history_count} fronting entries, "
+            f"{insum.tag_count} tags, "
+            f"{insum.custom_field_count} custom fields, "
+            f"{insum.journal_count} journal posts, "
+            f"{insum.note_count} notes, "
+            f"{insum.board_message_count} board messages, "
+            f"{insum.poll_count} polls, "
+            f"{insum.reminder_count} reminders, "
+            f"{insum.asset_count} assets"
+        ),
+    )
+
+    options = parse_options(job.payload_metadata, AmpersandImportOptions)
+    system = await load_user_system(db, job.user_id)
+    user = await db.scalar(select(User).where(User.id == job.user_id))
+    if user is None:  # pragma: no cover - job.user_id always resolves
+        raise ImportPayloadError("Import job user not found.")
+
+    stored_images: list[StoredImportImage] = []
+    try:
+        result = await amp_run_import(parsed, options, system, user, db, stored_images)
+    except Exception:
+        # Storage writes don't roll back with the DB; scrub what we wrote.
+        storage = get_storage()
+        for stored in stored_images:
+            try:
+                await storage.delete(stored.key)
+            except Exception:  # pragma: no cover - best-effort scrub
+                logger.warning(
+                    "could not scrub blob %s after failed Ampersand import",
+                    stored.key,
+                )
+        raise
+
+    update_counts(
+        job,
+        members_imported=result.members_imported,
+        custom_fronts_imported=result.custom_fronts_imported,
+        members_skipped=result.members_skipped,
+        members_updated=result.members_updated,
+        groups_imported=result.groups_imported,
+        groups_skipped=result.groups_skipped,
+        tags_imported=result.tags_imported,
+        custom_fields_imported=result.custom_fields_imported,
+        custom_fields_skipped=result.custom_fields_skipped,
+        fronts_imported=result.fronts_imported,
+        fronts_skipped=result.fronts_skipped,
+        journals_imported=result.journals_imported,
+        notes_imported=result.notes_imported,
+        messages_imported=result.messages_imported,
+        polls_imported=result.polls_imported,
+        reminders_imported=result.reminders_imported,
+        images_imported=result.images_imported,
+    )
+    for warning in result.warnings:
+        append_event(job, level="warning", stage="import", message=warning)
+    append_event(
+        job,
+        level="info",
+        stage="import",
+        message=(
+            f"imported {result.members_imported} members, "
+            f"{result.custom_fronts_imported} custom fronts, "
+            f"{result.groups_imported} groups, "
+            f"{result.fronts_imported} fronts, "
+            f"{result.journals_imported + result.notes_imported} journal entries, "
+            f"{result.messages_imported} board messages, "
+            f"{result.polls_imported} polls, "
+            f"{result.reminders_imported} reminders, "
+            f"{result.images_imported} images"
+        ),
+    )
+
+
+register_handler(ImportJobSource.AMPERSAND_FILE.value, handle_ampersand_file)

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -447,6 +447,7 @@ def _register_builtin_handlers() -> None:
     """
     # pk_import_runner registers both pluralkit_file and pluralkit_api.
     from sheaf.services import (
+        ampersand_import_runner,  # noqa: F401
         openplural_import_runner,  # noqa: F401
         pk_import_runner,  # noqa: F401
         pluralspace_import_runner,  # noqa: F401

--- a/tests/test_ampersand_import_unit.py
+++ b/tests/test_ampersand_import_unit.py
@@ -1,0 +1,110 @@
+"""Headless unit tests for the Ampersand importer's pure helpers.
+
+No DB / docker stack needed - these exercise the parsing, preview, and
+data-URI decode logic directly. The end-to-end runner behaviour lives in
+`test_imports_ampersand_runner.py` (needs the test stack).
+"""
+
+from __future__ import annotations
+
+import base64
+
+from sheaf.services.ampersand_import import (
+    _decode_data_uri,
+    _normalize_color,
+    _parse_iso,
+    preview,
+)
+
+_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x04\x00\x00\x00\x04"
+    b"\x08\x06\x00\x00\x00\xa9\xf1\x9e~\x00\x00\x00\x15IDATx\x9cc\xfc\xcf"
+    b"\xc0\xf0\x9f\x01\t01\xa0\x01\xc2\x02\x00\x83\xd1\x02\x06\x02\x90\xef"
+    b"X\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _data_uri(raw: bytes, mime: str = "image/png") -> str:
+    return f"data:{mime};base64," + base64.b64encode(raw).decode()
+
+
+def test_decode_data_uri_roundtrip():
+    assert _decode_data_uri(_data_uri(_PNG)) == _PNG
+    # A charset parameter before base64 is tolerated.
+    assert _decode_data_uri("data:image/png;charset=utf-8;base64,"
+                            + base64.b64encode(_PNG).decode()) == _PNG
+
+
+def test_decode_data_uri_rejects_non_data_uri():
+    assert _decode_data_uri("https://example.invalid/a.png") is None
+    assert _decode_data_uri("data:image/png,notbase64") is None
+    assert _decode_data_uri("data:image/png;base64,!!!not base64!!!") is None
+    assert _decode_data_uri(None) is None
+    assert _decode_data_uri(123) is None
+
+
+def test_normalize_color():
+    assert _normalize_color("#AABBCC") == "#aabbcc"
+    assert _normalize_color("aabbcc") == "#aabbcc"
+    assert _normalize_color("#abc") == "#aabbcc"
+    # 8-hex ARGB drops the alpha byte.
+    assert _normalize_color("#ff205c90") == "#205c90"
+    assert _normalize_color("not a color") is None
+    assert _normalize_color(None) is None
+
+
+def test_parse_iso():
+    dt = _parse_iso("2026-03-19T21:35:57.243Z")
+    assert dt is not None
+    assert dt.year == 2026 and dt.tzinfo is not None
+    assert _parse_iso("garbage") is None
+    assert _parse_iso(None) is None
+
+
+def test_preview_counts():
+    data = {
+        "revision": {"count": 1, "humanReadable": "0.3.0"},
+        "database": {
+            "systems": [{"uuid": "s1", "name": "A"}, {"uuid": "s2", "name": "B", "parent": "s1"}],
+            "members": [
+                {"uuid": "m1", "name": "One", "system": "s1"},
+                {"uuid": "m2", "name": "Away", "system": "s1", "isCustomFront": True},
+            ],
+            "frontingEntries": [
+                {"uuid": "f1", "member": "m1", "startTime": "2026-01-01T00:00:00Z"}
+            ],
+            "tags": [{"uuid": "t1", "name": "tag", "type": "member"}],
+            "customFields": [{"uuid": "c1", "name": "Species"}],
+            "journalPosts": [{"uuid": "j1", "members": ["m1"], "body": "hi"}],
+            "notes": [{"uuid": "n1", "title": "sticky", "content": "x"}],
+            "boardMessages": [
+                {
+                    "uuid": "b1",
+                    "members": ["m1"],
+                    "body": "post",
+                    "poll": {"multipleChoice": False, "entries": [{"choice": "a", "votes": []}]},
+                }
+            ],
+            "reminders": [{"uuid": "r1", "title": "t", "message": "m", "trigger": "fronting"}],
+            "assets": [{"uuid": "a1", "friendlyName": "img"}],
+        },
+    }
+    s = preview(data)
+    assert s.system_count == 2
+    assert s.member_count == 1
+    assert s.custom_front_count == 1
+    assert s.front_history_count == 1
+    assert s.tag_count == 1
+    assert s.custom_field_count == 1
+    assert s.journal_count == 1
+    assert s.note_count == 1
+    assert s.board_message_count == 1
+    assert s.poll_count == 1
+    assert s.reminder_count == 1
+    assert s.asset_count == 1
+
+
+def test_preview_handles_malformed_database():
+    assert preview({}).member_count == 0
+    assert preview({"database": None}).member_count == 0
+    assert preview({"database": {"members": "nope"}}).member_count == 0

--- a/tests/test_imports_ampersand_runner.py
+++ b/tests/test_imports_ampersand_runner.py
@@ -1,0 +1,295 @@
+"""End-to-end tests for the Ampersand JSON import runner.
+
+Builds an Ampersand-shape export inline (``{revision, config,
+database}``) with sanitised data and drives the runner. Covers the
+plumbing, the preview endpoint, and the mapping decisions worth locking
+in: systems -> nested groups, custom fronts, role -> tag, age -> custom
+field, inline data-URI avatars decoded + stored, board polls, and a
+synthesised reminder channel.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+
+import httpx
+
+from tests._import_runner_helpers import (
+    drive_import_runner,
+    set_member_limit,
+    wait_for_terminal,
+)
+
+# 4x4 RGBA PNG that survives a real decode through normalize_image.
+_TINY_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x04\x00\x00\x00\x04"
+    b"\x08\x06\x00\x00\x00\xa9\xf1\x9e~\x00\x00\x00\x15IDATx\x9cc\xfc\xcf"
+    b"\xc0\xf0\x9f\x01\t01\xa0\x01\xc2\x02\x00\x83\xd1\x02\x06\x02\x90\xef"
+    b"X\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_PNG_DATA_URI = "data:image/png;base64," + base64.b64encode(_TINY_PNG).decode()
+
+
+def _sample_data(*, member_count: int = 1, with_avatar: bool = True) -> dict:
+    """Build a sanitised Ampersand export payload.
+
+    One primary system with a nested child, `member_count` real members
+    (the first optionally carrying an inline avatar) plus one custom
+    front, a custom field + age, a member tag + role, a fronting entry, a
+    journal post, a note, a board message with a poll and a comment, and a
+    reminder.
+    """
+    sys_root = str(uuid.uuid4())
+    sys_child = str(uuid.uuid4())
+    field_id = str(uuid.uuid4())
+    tag_id = str(uuid.uuid4())
+
+    members = []
+    member_ids = []
+    for i in range(member_count):
+        mid = str(uuid.uuid4())
+        member_ids.append(mid)
+        m = {
+            "uuid": mid,
+            "name": f"Member{i}",
+            "system": sys_root,
+            "pronouns": "they/them",
+            "description": "a headmate",
+            "color": "#205c90",
+            "age": 20 + i,
+            "role": "protector",
+            "tags": [tag_id],
+            "isCustomFront": False,
+            "isPinned": False,
+            "isArchived": False,
+            "dateCreated": "2026-01-29T06:25:14.854Z",
+            "customFields": {field_id: "wolf"},
+        }
+        if with_avatar and i == 0:
+            m["image"] = _PNG_DATA_URI
+        members.append(m)
+
+    custom_front = {
+        "uuid": str(uuid.uuid4()),
+        "name": "Away",
+        "system": sys_root,
+        "isCustomFront": True,
+        "isPinned": False,
+        "isArchived": False,
+        "dateCreated": "2026-01-29T06:25:14.854Z",
+        "tags": [],
+    }
+
+    return {
+        "revision": {"count": 2404, "humanReadable": "0.3.0"},
+        "config": {
+            "appConfig": {"defaultSystem": sys_root},
+            "accessibilityConfig": {},
+            "securityConfig": {"password": "should-never-be-touched"},
+        },
+        "database": {
+            "systems": [
+                {"uuid": sys_root, "name": "Root system", "description": "d", "parent": None},
+                {"uuid": sys_child, "name": "Subsystem", "parent": sys_root},
+            ],
+            "members": [*members, custom_front],
+            "customFields": [{"uuid": field_id, "name": "Species", "priority": 1, "default": True}],
+            "tags": [
+                {"uuid": tag_id, "name": "cool", "type": "member", "color": "#205c90"},
+                {"uuid": str(uuid.uuid4()), "name": "journal-only", "type": "journal"},
+            ],
+            "frontingEntries": [
+                {
+                    "uuid": str(uuid.uuid4()),
+                    "member": member_ids[0],
+                    "startTime": "2026-02-01T10:00:00.000Z",
+                    "endTime": "2026-02-01T11:00:00.000Z",
+                    "isMainFronter": True,
+                    "customStatus": "busy",
+                }
+            ],
+            "journalPosts": [
+                {
+                    "uuid": str(uuid.uuid4()),
+                    "members": [member_ids[0]],
+                    "date": "2026-07-01T02:08:55.278Z",
+                    "title": "test journal",
+                    "subtitle": "a subtitle",
+                    "body": "journal body",
+                    "tags": [],
+                    "contentWarning": "heavy",
+                }
+            ],
+            "notes": [
+                {
+                    "uuid": str(uuid.uuid4()),
+                    "title": "sticky",
+                    "content": "note body",
+                    "priority": 1,
+                }
+            ],
+            "boardMessages": [
+                {
+                    "uuid": str(uuid.uuid4()),
+                    "members": [member_ids[0]],
+                    "title": "board title",
+                    "body": "board body",
+                    "date": "2026-07-01T02:00:00.000Z",
+                    "isPinned": True,
+                    "comments": [
+                        {
+                            "member": member_ids[0],
+                            "comment": "a comment",
+                            "date": "2026-07-01T02:05:00.000Z",
+                        }
+                    ],
+                    "poll": {
+                        "multipleChoice": False,
+                        "entries": [
+                            {"choice": "yes", "votes": [{"member": member_ids[0], "reason": "y"}]},
+                            {"choice": "no", "votes": []},
+                        ],
+                    },
+                }
+            ],
+            "reminders": [
+                {
+                    "uuid": str(uuid.uuid4()),
+                    "active": True,
+                    "title": "awoo",
+                    "message": "remember to awoo",
+                    "trigger": "fronting",
+                    "delay": 120000,
+                    "members": [member_ids[0]],
+                }
+            ],
+            "assets": [{"uuid": str(uuid.uuid4()), "friendlyName": "img", "tags": []}],
+            "filterQueries": [],
+        },
+    }
+
+
+def _post_file(
+    client: httpx.Client,
+    data: dict,
+    *,
+    idem_key: str | None = None,
+    options: dict | None = None,
+) -> dict:
+    form: dict[str, str] = {
+        "source": "ampersand_file",
+        "idempotency_key": idem_key or str(uuid.uuid4()),
+    }
+    if options is not None:
+        form["options"] = json.dumps(options)
+    payload = json.dumps(data).encode()
+    resp = client.post(
+        "/v1/imports/file",
+        files={"file": ("export.json", payload, "application/json")},
+        data=form,
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+# --- Preview --------------------------------------------------------------
+
+
+def test_preview_returns_summary(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/import/ampersand/preview",
+        files={"file": ("export.json", json.dumps(_sample_data()).encode(), "application/json")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["system_count"] == 2
+    assert body["member_count"] == 1
+    assert body["custom_front_count"] == 1
+    assert body["poll_count"] == 1
+    assert body["asset_count"] == 1
+
+
+def test_preview_rejects_non_json(auth_client: httpx.Client):
+    resp = auth_client.post(
+        "/v1/import/ampersand/preview",
+        files={"file": ("export.json", b"not json", "application/json")},
+    )
+    assert resp.status_code == 400
+
+
+# --- Full import ----------------------------------------------------------
+
+
+def test_full_import_maps_all_sections(auth_client: httpx.Client):
+    job = _post_file(auth_client, _sample_data())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+    c = final["counts"]
+    assert c["members_imported"] == 1
+    assert c["custom_fronts_imported"] == 1
+    assert c["groups_imported"] == 2
+    assert c["tags_imported"] >= 2  # "cool" tag + "protector" role
+    assert c["custom_fields_imported"] >= 2  # Species + synthesised Age
+    assert c["fronts_imported"] == 1
+    assert c["journals_imported"] == 1
+    assert c["notes_imported"] == 1
+    # Board post + its one comment = 2 messages.
+    assert c["messages_imported"] == 2
+    assert c["polls_imported"] == 1
+    assert c["reminders_imported"] == 1
+    assert c["images_imported"] == 1
+
+    # Roster grew: 1 member + 1 custom front.
+    members = auth_client.get("/v1/members").json()
+    fronts = [m for m in members if m.get("is_custom_front")]
+    assert len(fronts) == 1
+    imported = next(m for m in members if m["name"] == "Member0")
+    assert imported["avatar_url"]  # inline avatar was decoded + stored
+
+    # Systems became groups, and the child nests under the root.
+    groups = auth_client.get("/v1/groups").json()
+    by_name = {g["name"]: g for g in groups}
+    assert "Root system" in by_name and "Subsystem" in by_name
+    assert by_name["Subsystem"]["parent_id"] == by_name["Root system"]["id"]
+
+
+def test_images_option_off_skips_avatars(auth_client: httpx.Client):
+    job = _post_file(auth_client, _sample_data(), options={"images": False})
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+    assert final["counts"]["images_imported"] == 0
+    assert final["counts"]["members_imported"] == 1
+
+
+def test_member_cap_fails_job_before_writing(auth_client: httpx.Client):
+    set_member_limit(auth_client, 1)
+    try:
+        before = len(auth_client.get("/v1/members").json())
+        # 2 real members + 1 custom front = 3 new roster rows > cap of 1.
+        job = _post_file(auth_client, _sample_data(member_count=2))
+        drive_import_runner()
+        final = wait_for_terminal(auth_client, job["id"])
+        assert final["status"] == "failed", final
+        after = len(auth_client.get("/v1/members").json())
+        assert after == before  # nothing written
+    finally:
+        set_member_limit(auth_client, 0)
+
+
+def test_reimport_dedups_members(auth_client: httpx.Client):
+    data = _sample_data()
+    first = _post_file(auth_client, data)
+    drive_import_runner()
+    assert wait_for_terminal(auth_client, first["id"])["status"] == "complete"
+
+    second = _post_file(auth_client, data)
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, second["id"])
+    assert final["status"] == "complete", final
+    # Members match by name on the second pass; none re-created.
+    assert final["counts"]["members_imported"] == 0
+    assert final["counts"]["members_skipped"] >= 1

--- a/web/src/lib/ampersand-import.ts
+++ b/web/src/lib/ampersand-import.ts
@@ -1,0 +1,35 @@
+/**
+ * Ampersand import - preview call.
+ *
+ * The actual import is enqueued via lib/imports.ts (the async job
+ * runner). What's left here is the synchronous preview step.
+ */
+import { apiFetch } from "./api-client";
+
+export interface AmpersandPreviewSummary {
+  system_count: number;
+  member_count: number;
+  custom_front_count: number;
+  front_history_count: number;
+  tag_count: number;
+  custom_field_count: number;
+  journal_count: number;
+  note_count: number;
+  board_message_count: number;
+  poll_count: number;
+  reminder_count: number;
+  asset_count: number;
+  limit_warnings: string[];
+}
+
+export async function previewImport(
+  file: File,
+): Promise<AmpersandPreviewSummary> {
+  const form = new FormData();
+  form.append("file", file);
+  return apiFetch<AmpersandPreviewSummary>("/v1/import/ampersand/preview", {
+    method: "POST",
+    headers: {},
+    body: form,
+  });
+}

--- a/web/src/lib/imports.ts
+++ b/web/src/lib/imports.ts
@@ -17,7 +17,8 @@ export type ImportJobSource =
   | "sheaf_archive"
   | "pluralspace_file"
   | "prism_file"
-  | "openplural_file";
+  | "openplural_file"
+  | "ampersand_file";
 
 export type ImportJobStatus =
   | "pending"
@@ -80,6 +81,7 @@ export const SOURCE_LABELS: Record<ImportJobSource, string> = {
   pluralspace_file: "PluralSpace",
   prism_file: "Prism",
   openplural_file: "OpenPlural",
+  ampersand_file: "Ampersand",
 };
 
 const TERMINAL = new Set<ImportJobStatus>(["complete", "failed", "cancelled"]);

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -40,13 +40,26 @@ import {
   previewOpenpluralImport,
 } from "@/lib/openplural-import";
 import {
+  type AmpersandPreviewSummary,
+  previewImport as previewAmpersand,
+} from "@/lib/ampersand-import";
+import {
   createApiImport,
   createFileImport,
   newIdempotencyKey,
 } from "@/lib/imports";
 import { Input } from "@/components/ui/input";
 
-type Source = "choose" | "sheaf" | "sp" | "pk" | "tb" | "ps" | "prism" | "op";
+type Source =
+  | "choose"
+  | "sheaf"
+  | "sp"
+  | "pk"
+  | "tb"
+  | "ps"
+  | "prism"
+  | "op"
+  | "amp";
 // "importing" shows a brief spinner while the enqueue POST is in
 // flight; on success the flow navigates to /imports/:id, which owns
 // the running/done UI. There's no "done" step here any more.
@@ -84,6 +97,9 @@ export function ImportPage() {
       )}
       {source === "op" && (
         <OPImportFlow onBack={() => setSource("choose")} />
+      )}
+      {source === "amp" && (
+        <AmpersandImportFlow onBack={() => setSource("choose")} />
       )}
     </>
   );
@@ -197,6 +213,24 @@ function SourcePicker({ onSelect }: { onSelect: (s: Source) => void }) {
             OpenPlural-compatible app. Upload the <code>.json</code>{" "}
             document, or the <code>.openplural.zip</code> bundle (the
             bundle restores avatars and embedded images too).
+          </p>
+        </CardContent>
+      </Card>
+      <Card
+        className="cursor-pointer hover:border-primary transition-colors"
+        onClick={() => onSelect("amp")}
+      >
+        <CardHeader>
+          <CardTitle className="text-base">Import from Ampersand</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Upload an Ampersand JSON export (Settings &gt; Import/Export).
+            Brings across members, custom fronts, custom fields, tags,
+            fronting history, journals, notes, board messages and polls,
+            and decodes the embedded avatars. Each Ampersand system becomes
+            a Sheaf group; the shared asset library and cosmetic name/avatar
+            styling have no Sheaf equivalent and are dropped.
           </p>
         </CardContent>
       </Card>
@@ -1905,6 +1939,217 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
 // exceed Sheaf's business caps and would be shortened on import. Amber
 // (not destructive) tone: the import still succeeds, data is just
 // clamped. Renders nothing when there's nothing to warn about.
+// ---------------------------------------------------------------------------
+// Ampersand import flow
+// ---------------------------------------------------------------------------
+
+function AmpersandImportFlow({ onBack }: { onBack: () => void }) {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>("upload");
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<AmpersandPreviewSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [idemKey] = useState(newIdempotencyKey);
+
+  const [conflictStrategy, setConflictStrategy] =
+    useState<ConflictStrategy>("skip");
+  const [customFronts, setCustomFronts] = useState(true);
+  const [tags, setTags] = useState(true);
+  const [customFields, setCustomFields] = useState(true);
+  const [groups, setGroups] = useState(true);
+  const [frontHistory, setFrontHistory] = useState(true);
+  const [journals, setJournals] = useState(true);
+  const [notes, setNotes] = useState(true);
+  const [boardMessages, setBoardMessages] = useState(true);
+  const [reminders, setReminders] = useState(true);
+  const [images, setImages] = useState(true);
+
+  async function handleFileSelect(e: ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+    setError(null);
+    try {
+      const p = await previewAmpersand(f);
+      setPreview(p);
+      setStep("preview");
+    } catch (err) {
+      setError(apiErrorMessage(err, "Failed to parse export"));
+    }
+  }
+
+  async function handleImport() {
+    if (!file) return;
+    setStep("importing");
+    setError(null);
+    try {
+      const job = await createFileImport({
+        source: "ampersand_file",
+        file,
+        idempotencyKey: idemKey,
+        options: {
+          conflict_strategy: conflictStrategy,
+          custom_fronts: customFronts,
+          tags,
+          custom_fields: customFields,
+          groups,
+          front_history: frontHistory,
+          journals,
+          notes,
+          board_messages: boardMessages,
+          reminders,
+          images,
+        },
+      });
+      navigate(`/imports/${job.id}`);
+    } catch (err) {
+      setError(apiErrorMessage(err, "Import failed"));
+      setStep("preview");
+    }
+  }
+
+  return (
+    <>
+      {error && <ErrorBanner message={error} />}
+
+      {step === "upload" && (
+        <Card className="max-w-lg">
+          <CardHeader>
+            <CardTitle className="text-base">Upload Ampersand export</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              In Ampersand, go to Settings &gt; Import/Export and export as
+              JSON (the third-party migration format). Upload the resulting{" "}
+              <code>.json</code> here.
+            </p>
+            <input
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileSelect}
+              className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+            />
+            <Button variant="outline" size="sm" onClick={onBack}>
+              Back
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "preview" && preview && (
+        <div className="grid gap-4 max-w-2xl">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Export summary</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-3 text-sm">
+              <div>Members: <strong>{preview.member_count}</strong></div>
+              <div>Custom fronts: <strong>{preview.custom_front_count}</strong></div>
+              <div>
+                Systems (as groups): <strong>{preview.system_count}</strong>
+              </div>
+              <div>Tags: <strong>{preview.tag_count}</strong></div>
+              <div>Custom fields: <strong>{preview.custom_field_count}</strong></div>
+              <div>Fronting entries: <strong>{preview.front_history_count}</strong></div>
+              <div>Journal posts: <strong>{preview.journal_count}</strong></div>
+              <div>Notes: <strong>{preview.note_count}</strong></div>
+              <div>Board messages: <strong>{preview.board_message_count}</strong></div>
+              <div>Polls: <strong>{preview.poll_count}</strong></div>
+              <div>Reminders: <strong>{preview.reminder_count}</strong></div>
+              {preview.asset_count > 0 && (
+                <div className="col-span-2 text-xs text-muted-foreground">
+                  {preview.asset_count} asset-library image
+                  {preview.asset_count === 1 ? "" : "s"} will be skipped:
+                  Sheaf has no shared asset library.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Import options</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Checkbox
+                label="Custom fronts"
+                checked={customFronts}
+                onChange={setCustomFronts}
+              />
+              <Checkbox
+                label="Systems as groups (nested)"
+                checked={groups}
+                onChange={setGroups}
+              />
+              <Checkbox
+                label="Tags (and member roles)"
+                checked={tags}
+                onChange={setTags}
+              />
+              <Checkbox
+                label="Custom fields (and member age)"
+                checked={customFields}
+                onChange={setCustomFields}
+              />
+              <Checkbox
+                label="Fronting history"
+                checked={frontHistory}
+                onChange={setFrontHistory}
+              />
+              <Checkbox
+                label="Journal posts"
+                checked={journals}
+                onChange={setJournals}
+              />
+              <Checkbox
+                label="Notes (as system journal entries)"
+                checked={notes}
+                onChange={setNotes}
+              />
+              <Checkbox
+                label="Board messages and polls"
+                checked={boardMessages}
+                onChange={setBoardMessages}
+              />
+              <Checkbox
+                label="Reminders (bound to a disabled placeholder channel)"
+                checked={reminders}
+                onChange={setReminders}
+              />
+              <Checkbox
+                label="Images (avatars and journal covers)"
+                checked={images}
+                onChange={setImages}
+              />
+
+              <ConflictStrategyField
+                value={conflictStrategy}
+                onChange={setConflictStrategy}
+              />
+
+              <p className="text-xs text-muted-foreground">
+                Members are matched by name; journals, notes, polls and
+                reminders are created fresh, so re-importing the same file
+                duplicates those. Import once into a fresh system for best
+                results.
+              </p>
+
+              <ImportLimitWarnings warnings={preview.limit_warnings} />
+
+              <ImportSubmit
+                incoming={preview.member_count}
+                onImport={handleImport}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {step === "importing" && <ImportingCard />}
+    </>
+  );
+}
+
 function ImportLimitWarnings({ warnings }: { warnings: string[] }) {
   if (warnings.length === 0) return null;
   return (


### PR DESCRIPTION
Adds an importer for Ampersand's JSON export, the third-party migration format Ampersand ships (Settings > Import/Export). Upstream asked us to support it and is winding down active development, so this is a one-shot migration path for people moving to Sheaf. Choose Ampersand on the Import page, upload the `.json`, review the summary, and enqueue; the async job runner handles the rest and the detail page shows per-record warnings.

Mapping: members and custom fronts; custom fields (all TEXT) plus a synthesised "Age" field from `member.age`; tags (member-type) plus `member.role` as a tag, matching the SimplyPlural precedent; each Ampersand system as a Sheaf group with `parent` nesting preserved (depth-clamped) and members joined to their system's group; one `Front` per fronting entry (no overlap-coalescing, since the currently-fronting walk already renders concurrent single-member fronts); journal posts and system notes as journal entries; board messages as system-board messages with their comments as replies and their polls as Poll/PollOption/PollVote; and reminders as automated front-event reminders. Inline base64 avatars and journal covers are decoded and stored through the shared `store_imported_image` pipeline (EXIF strip, dimension cap, quota, format sniff).

Importer safety pattern is followed throughout: the member cap and per-entity row caps are enforced before any write, JSON is parsed through the safe loader, user content is length-clamped and encrypted at rest, every row gets a fresh id with tenancy taken from the authenticated job, and the runner scrubs any image blob it wrote if the import fails (storage writes do not roll back with the DB transaction). The Ampersand `config` block, including the app-lock password hash, is never read.

Two decisions worth a reviewer's eye. Reminders require a notification channel that Ampersand exports do not carry, so a single disabled, owner-paused placeholder channel is synthesised and all imported reminders bind to it; the user enables it and sets a real destination to make them fire. And because Ampersand is a one-shot migration, members dedup by name across re-imports but journals, notes, polls, and reminders are create-only, so re-importing the same file duplicates those content sections; the preview and docs recommend importing once into a fresh system. Unmappable Ampersand data (the shared asset library, cosmetic name/avatar styling, per-front presence timelines, and journal comments) is dropped with warning events.

Testing: ruff, tsc, and eslint are clean. Six headless unit tests cover the parsing, preview, colour, and data-URI helpers. Six behavioural runner tests pass against the isolated test stack, exercising the full mapping (nested groups, custom fronts, tags and roles, fields and age, fronts, journals, notes, board messages with a comment, a poll, a reminder, and avatar decode-and-store), plus member-cap-fails-before-writing and re-import-dedups-members. The neighbouring importer and export/import parity suites still pass. The mapping decisions and format-signal gaps are documented in the design-docs repo (`ampersand-import.md`, `feature-gaps.md`, and a new OpenPlural adoption note).
