### PR TITLE
Add all-in-one Docker image

### DIFF
--- a/.env.aio.example
+++ b/.env.aio.example
@@ -1,0 +1,48 @@
+# All-in-one Sheaf - minimal configuration.
+# Copy to .env, set AIO_DOMAIN, and:
+#   docker compose -f docker-compose.aio.yml up -d --build
+
+# --- HTTPS ------------------------------------------------------------------
+# Your public domain. Point its DNS at this host and publish ports 80 + 443;
+# Caddy fetches and renews a Let's Encrypt certificate automatically. Leave
+# unset for plain HTTP on port 80 (LAN, or behind your own TLS proxy).
+AIO_DOMAIN=
+
+# Optional: email for Let's Encrypt expiry notices.
+AIO_ACME_EMAIL=
+
+# Optional: while first setting up DNS, point at the LE *staging* endpoint to
+# dry-run issuance without hitting production rate limits, then remove it and
+# recreate so a real cert is issued.
+# AIO_ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory
+
+# --- Run from home (Cloudflare Tunnel) --------------------------------------
+# No public IP, CGNAT, or can't forward ports? Create a Cloudflare Tunnel in
+# the Zero Trust dashboard, route your public hostname to http://localhost:80,
+# and paste the tunnel token here. Cloudflare terminates TLS and connects
+# outbound to this box - no ports need forwarding, and AIO_DOMAIN/ACME above
+# are then unnecessary (set AIO_DOMAIN only so links/cookies use the public
+# host). Leave blank to expose directly instead.
+# CF_TUNNEL_TOKEN=
+
+# --- Secrets ----------------------------------------------------------------
+# The Postgres password and JWT key are generated on first start into the
+# `secrets` volume, and the encryption key into the app data volume. You do
+# NOT need to set them - but you MUST back up those volumes (see
+# docs/SELFHOSTING.md "Backups"). To supply your own instead:
+# JWT_SECRET_KEY=
+# SHEAF_ENCRYPTION_KEY=
+
+# --- The rest ---------------------------------------------------------------
+# Everything in docs/SELFHOSTING.md applies. Common ones:
+# SHEAF_ADMIN_EMAILS=you@example.com
+# REGISTRATION_MODE=open        # open | approval | invite | closed
+# EMAIL_BACKEND=none            # none | smtp | ses | sendgrid
+# EMAIL_VERIFICATION=off        # off | required (needs EMAIL_BACKEND != none)
+
+# --- Opt out of the bundled services ----------------------------------------
+# Point these off-box to use external Postgres / Redis / object storage; the
+# bundled equivalents are then skipped (redis) or simply unused (db container).
+# DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/sheaf
+# REDIS_URL=redis://host:6379/0
+# STORAGE_BACKEND=s3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,62 @@ jobs:
       - name: Run test suite
         run: ./run_tests.sh
 
+  # Fast pre-checks for a tagged release, BEFORE the approval gate, so an
+  # obviously-bad tag (not on main, or a version mismatch) fails in seconds
+  # without bothering the approver.
+  preflight:
+    name: Release preflight
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # ancestor check needs full history
+
+      - name: Validate tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::tagged commit $GITHUB_SHA is not on main - merge first, then tag"
+            exit 1
+          fi
+
+      - name: Verify pyproject.toml version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PY=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')
+          if [ "$TAG" != "$PY" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${PY}"
+            exit 1
+          fi
+          echo "ok: tag ${GITHUB_REF_NAME} matches pyproject.toml ${PY}"
+
+  # Manual-approval gate for a tagged release, placed at the START of the
+  # release flow (right after preflight) so approval is not blocked behind the
+  # ~15-minute test run. Configure repo Settings -> Environments -> "release"
+  # with required reviewers. The build/publish jobs below wait on this for tag
+  # pushes; on a branch push it is skipped and they proceed normally.
+  approve-release:
+    name: Approve release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: echo "Release ${{ github.ref_name }} approved."
+
   docker:
     runs-on: ubuntu-latest
-    needs: [lint, test]
-    if: github.event_name == 'push'
+    needs: [lint, test, approve-release]
+    # Any push, once lint + test pass. A tag push additionally waits for the
+    # approval gate above; on a branch push approve-release is skipped, which
+    # the skipped-result check tolerates.
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success' &&
+      (needs.approve-release.result == 'success' || needs.approve-release.result == 'skipped')
     permissions:
       contents: read
       packages: write
@@ -90,23 +142,15 @@ jobs:
             image: sheaf-web
             dockerfile: Dockerfile.web
             build_args: ""
+          - name: sheaf-aio
+            image: sheaf-aio
+            dockerfile: Dockerfile.aio
+            build_args: ""
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # ancestor check on tag pushes needs full history
 
-      # Tag pushes must point at a commit already on main. GitHub's deployment
-      # branch policy is name-pattern only and can't enforce this; checking
-      # here means a v* tag pushed from an unmerged branch fails before any
-      # image is built or signed.
-      - name: Validate tag is on main
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::tagged commit $GITHUB_SHA is not on main — merge first, then tag"
-            exit 1
-          fi
+      # Tag validity (on main, version matches) is checked in the preflight
+      # job that gates this one on tag pushes, so no per-image check here.
 
       - uses: docker/setup-qemu-action@v3
 
@@ -214,30 +258,19 @@ jobs:
             --type custom \
             "$REF"
 
-  # Manual-approval gate for tag pushes. Image signing happens unconditionally
-  # in the docker job above; this job pauses for human approval before
-  # publishing the GitHub release page and uploading verifiable artefacts.
-  # Configure repo Settings → Environments → "release" with required reviewers.
+  # Publishes the GitHub release page + verifiable artefacts. The manual
+  # approval gate now runs up front (see the approve-release job), and preflight
+  # already checked the tag, so by the time this runs the release is approved
+  # and validated; it just needs the signed images from the docker job.
   release:
     name: Publish GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [docker]
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Verify pyproject.toml version matches tag
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PY=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')
-          if [ "$TAG" != "$PY" ]; then
-            echo "::error::tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${PY}"
-            exit 1
-          fi
-          echo "ok: tag ${GITHUB_REF_NAME} matches pyproject.toml ${PY}"
 
       - uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **All-in-one Docker image for small self-hosts.** A new `sheaf-aio` image bundles the backend, the web UI, and a Caddy reverse proxy (with automatic Let's Encrypt HTTPS) in one container, alongside Postgres. It generates its own secrets on first start, so a public HTTPS deploy is close to a one-liner: set your domain and `docker compose -f docker-compose.aio.yml up -d`. It can also run from home with no public IP or port-forwarding via a Cloudflare Tunnel (set `CF_TUNNEL_TOKEN`). A small redis is bundled (override with `REDIS_URL`); Postgres stays a separate container; storage defaults to the filesystem. Intended for small single-instance deployments - outgrow it and you move to the split `sheaf` + `sheaf-web` images. See docs/SELFHOSTING.md.
+
 ## [1.2.3] - 2026-07-15
 
 ### Added

--- a/Dockerfile.aio
+++ b/Dockerfile.aio
@@ -1,0 +1,106 @@
+# All-in-one Sheaf image: backend + web bundle + Caddy (auto-TLS) + a
+# bundled redis, supervised in one container. For SMALL single-instance
+# self-hosts that want a near one-liner deploy. Not horizontally scalable;
+# outgrow it -> move to the split sheaf + sheaf-web images. See
+# docs/SELFHOSTING.md ("Quick start (all-in-one)") and
+# ../sheaf-design-docs/aio-docker-image.md.
+#
+# Postgres is NOT in this image - it runs as a separate container (see
+# docker-compose.aio.yml). Redis IS bundled (transient state only), and is
+# skipped when REDIS_URL points at an external server.
+
+# --- Stage 1: build the web SPA --------------------------------------------
+FROM node:22-slim AS webbuild
+WORKDIR /build
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+ARG GIT_COMMIT=
+ARG GIT_TAG=
+ARG BUILD_TIME=
+ENV VITE_GIT_COMMIT=${GIT_COMMIT}
+ENV VITE_GIT_TAG=${GIT_TAG}
+ENV VITE_BUILD_TIME=${BUILD_TIME}
+RUN npm run build
+
+# --- Stage 2: the runtime image --------------------------------------------
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN addgroup --system sheaf && adduser --system --ingroup sheaf sheaf
+
+# redis-server (transient state), tini (PID 1 zombie reaper), curl (compose
+# healthcheck). Caddy is a static Go binary copied from its official image
+# (no libc dependency, so the alpine->debian copy is safe); redis is glibc
+# so it comes from debian apt.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends redis-server tini curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=caddy:2 /usr/bin/caddy /usr/bin/caddy
+# cloudflared for optional Cloudflare Tunnel mode (outbound-only ingress, no
+# port-forwarding). Also a static Go binary, so the copy is libc-independent.
+COPY --from=cloudflare/cloudflared:latest /usr/local/bin/cloudflared /usr/local/bin/cloudflared
+
+# --- Backend: install exactly what uv.lock pins ----------------------------
+# Kept in sync with Dockerfile.backend; same rationale (reproducible,
+# no dependency-tree re-resolution). supervisor rides along for process
+# supervision.
+COPY pyproject.toml uv.lock ./
+COPY sheaf/ sheaf/
+COPY alembic.ini .
+COPY alembic/ alembic/
+
+ARG PIP_INDEX_URL=
+ARG PIP_EXTRA_INDEX_URL=
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
+ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+
+RUN pip install --no-cache-dir uv \
+ && uv export --frozen --no-dev --no-emit-project --no-hashes \
+      --extra s3 --extra ses --extra smtp --extra sendgrid \
+      -o /tmp/requirements.lock.txt \
+ && pip install --no-cache-dir -r /tmp/requirements.lock.txt \
+ && pip install --no-cache-dir --no-deps . \
+ && pip install --no-cache-dir supervisor \
+ && pip uninstall -y uv \
+ && rm -f /tmp/requirements.lock.txt
+
+RUN mkdir -p /app/data /home/sheaf && chown sheaf:sheaf /app/data /home/sheaf
+RUN mkdir -p /var/run/prometheus-multiproc && chown sheaf:sheaf /var/run/prometheus-multiproc
+ENV PROMETHEUS_MULTIPROC_DIR=/var/run/prometheus-multiproc
+
+# --- AIO runtime: web bundle, Caddy, supervisor, entrypoints ---------------
+COPY --from=webbuild /build/dist /srv/web
+COPY docker/aio/Caddyfile /etc/caddy/Caddyfile
+COPY docker/aio/supervisord.conf /etc/supervisor/supervisord.conf
+# redis + cloudflared are available-but-not-active programs; the entrypoint
+# links each into conf.d only when it applies (bundled redis when no external
+# REDIS_URL; cloudflared when CF_TUNNEL_TOKEN is set).
+COPY docker/aio/redis.conf /etc/supervisor/available/redis.conf
+COPY docker/aio/cloudflared.conf /etc/supervisor/available/cloudflared.conf
+COPY docker/aio/entrypoint.sh /usr/local/bin/aio-entrypoint.sh
+COPY docker/aio/app-start.sh /usr/local/bin/aio-app-start.sh
+COPY docker/aio/init-secrets.sh /usr/local/bin/aio-init-secrets.sh
+RUN chmod +x /usr/local/bin/aio-entrypoint.sh /usr/local/bin/aio-app-start.sh \
+      /usr/local/bin/aio-init-secrets.sh \
+ && mkdir -p /etc/supervisor/available /etc/supervisor/conf.d
+
+ARG GIT_COMMIT=
+ARG GIT_TAG=
+ARG BUILD_TIME=
+ENV SHEAF_GIT_COMMIT=${GIT_COMMIT}
+ENV SHEAF_GIT_TAG=${GIT_TAG}
+ENV SHEAF_BUILD_TIME=${BUILD_TIME}
+LABEL org.opencontainers.image.revision=${GIT_COMMIT}
+LABEL org.opencontainers.image.version=${GIT_TAG}
+LABEL org.opencontainers.image.source=https://github.com/sheaf-project/sheaf
+
+# Caddy serves 80/443; uvicorn stays on loopback (never exposed directly).
+EXPOSE 80 443
+
+# tini as PID 1 reaps zombies; the entrypoint generates first-boot secrets
+# (when running the app) then execs supervisord, which runs redis + the
+# backend + Caddy. Runs as root so Caddy can bind 80/443; supervisord drops
+# each program to its own user.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/aio-entrypoint.sh"]

--- a/docker-compose.aio.yml
+++ b/docker-compose.aio.yml
@@ -1,0 +1,95 @@
+# All-in-one Sheaf: backend + web + Caddy (automatic HTTPS) + a bundled redis
+# in one container, with Postgres alongside. For small single-instance
+# self-hosts that want a near one-liner deploy. See docs/SELFHOSTING.md
+# ("Quick start (all-in-one)").
+#
+#   AIO_DOMAIN=sheaf.example.com docker compose -f docker-compose.aio.yml up -d --build
+#
+# Point that domain's DNS at this host and publish 80 + 443; Caddy fetches and
+# renews a Let's Encrypt certificate automatically. Leave AIO_DOMAIN unset for
+# plain HTTP on port 80 (LAN, or behind your own TLS proxy).
+#
+# Secrets (Postgres password, JWT key) are generated on first start into the
+# `secrets` volume; the encryption key is generated into `appdata`. Back up
+# BOTH volumes (and pgdata). To run a published image instead of building, set
+# `image:` on the app + init services to ghcr.io/sheaf-project/sheaf-aio:X.Y.Z
+# and drop their `build:` blocks.
+
+services:
+  # One-shot: generate the shared first-boot secrets before db/app start.
+  # No-op on subsequent runs (the files already exist).
+  init:
+    image: sheaf-aio:local
+    build:
+      context: .
+      dockerfile: Dockerfile.aio
+    command: ["generate-secrets"]
+    volumes:
+      - secrets:/secrets
+    restart: "no"
+
+  db:
+    image: postgres:16-alpine
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    environment:
+      POSTGRES_DB: sheaf
+      POSTGRES_USER: sheaf
+      POSTGRES_PASSWORD_FILE: /secrets/postgres_password
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - secrets:/secrets:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sheaf"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  app:
+    image: sheaf-aio:local
+    build:
+      context: .
+      dockerfile: Dockerfile.aio
+      args:
+        GIT_COMMIT: "${GIT_COMMIT:-}"
+        GIT_TAG: "${GIT_TAG:-}"
+        BUILD_TIME: "${BUILD_TIME:-}"
+        PIP_INDEX_URL: "${PIP_INDEX_URL:-}"
+        PIP_EXTRA_INDEX_URL: "${PIP_EXTRA_INDEX_URL:-}"
+    depends_on:
+      init:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+    ports:
+      - "${HTTP_PORT:-80}:80"
+      - "${HTTPS_PORT:-443}:443"
+    environment:
+      # Set AIO_DOMAIN for automatic HTTPS; leave unset for plain HTTP on :80.
+      AIO_DOMAIN: "${AIO_DOMAIN:-}"
+      AIO_ACME_EMAIL: "${AIO_ACME_EMAIL:-}"
+      AIO_ACME_CA: "${AIO_ACME_CA:-}"
+      # Cloudflare Tunnel: set this to run from home with no ports forwarded.
+      # When set, TLS is Cloudflare's job and no ports need publishing.
+      CF_TUNNEL_TOKEN: "${CF_TUNNEL_TOKEN:-}"
+      SHEAF_MODE: "${SHEAF_MODE:-selfhosted}"
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - appdata:/app/data
+      - secrets:/secrets:ro
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  appdata:
+  secrets:

--- a/docker/aio/Caddyfile
+++ b/docker/aio/Caddyfile
@@ -1,0 +1,43 @@
+# AIO front proxy. Serves the SPA, reverse-proxies the API to uvicorn on
+# loopback, and (when AIO_SITE_ADDRESS is a domain) provisions a Let's Encrypt
+# certificate automatically. The entrypoint sets AIO_SITE_ADDRESS to the
+# domain, or ":80" for plain HTTP. Cert/state storage is XDG_DATA_HOME
+# (/app/data), set on the Caddy program so certs survive a container recreate.
+
+{
+	# No runtime reconfiguration needed; keeps the admin API off localhost:2019.
+	admin off
+
+	# Automatic HTTPS. When AIO_SITE_ADDRESS is a domain, Caddy provisions and
+	# renews a certificate on its own - the reason this image uses Caddy. The
+	# ACME endpoint (AIO_ACME_CA) and optional contact email (AIO_ACME_EMAIL)
+	# are rendered by the entrypoint into acme.conf, so an unset email is simply
+	# omitted rather than emitting an empty (and invalid) `email` directive.
+	import /etc/caddy/acme.conf
+}
+
+{$AIO_SITE_ADDRESS::80} {
+	encode zstd gzip
+
+	# API + health check -> the backend on loopback. /metrics is deliberately
+	# NOT proxied: it is unauthenticated and stays in-container.
+	@backend path /v1/* /health
+	handle @backend {
+		reverse_proxy 127.0.0.1:8000
+	}
+
+	# Everything else -> the single-page app. Sheaf only sets security headers
+	# on its own /v1/* responses, so the SPA document needs them here (mirrors
+	# the reverse-proxy examples in docs/SELFHOSTING.md).
+	handle {
+		root * /srv/web
+		try_files {path} /index.html
+		file_server
+		header {
+			X-Frame-Options "DENY"
+			X-Content-Type-Options "nosniff"
+			Referrer-Policy "no-referrer"
+			Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+		}
+	}
+}

--- a/docker/aio/app-start.sh
+++ b/docker/aio/app-start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Backend program for the AIO image (run by supervisord as the sheaf user).
+# Mirrors the split backend image's CMD: clear stale prometheus multiproc
+# files, apply migrations, then run uvicorn on loopback (Caddy fronts it).
+set -e
+
+rm -f "${PROMETHEUS_MULTIPROC_DIR}"/*.db 2>/dev/null || true
+
+alembic upgrade head
+
+exec uvicorn sheaf.main:app \
+    --host 127.0.0.1 \
+    --port "${SHEAF_PORT:-8000}" \
+    --proxy-headers \
+    --forwarded-allow-ips="${FORWARDED_ALLOW_IPS:-127.0.0.1}"

--- a/docker/aio/cloudflared.conf
+++ b/docker/aio/cloudflared.conf
@@ -1,0 +1,17 @@
+[program:cloudflared]
+# Cloudflare Tunnel: an outbound-only connection to Cloudflare, which routes
+# your public hostname to Caddy on loopback:80. No inbound ports, no
+# port-forwarding, no static IP - the "run it from home" path. The tunnel is
+# token-managed: create it in the Cloudflare Zero Trust dashboard and point the
+# public hostname at http://localhost:80. The token is passed via TUNNEL_TOKEN
+# (env, not argv, so it stays out of the process list).
+command=/usr/local/bin/cloudflared tunnel --no-autoupdate run
+user=sheaf
+autorestart=true
+startsecs=5
+priority=25
+environment=TUNNEL_TOKEN="%(ENV_CF_TUNNEL_TOKEN)s",TUNNEL_METRICS="127.0.0.1:0"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/aio/entrypoint.sh
+++ b/docker/aio/entrypoint.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# All-in-one entrypoint. Runs as root (so Caddy can bind 80/443); supervisord
+# drops each program to its own user.
+#
+# Two modes:
+#   generate-secrets  -> the compose `init` service: create the shared
+#                        first-boot secrets if absent, then exit.
+#   (default)         -> the app service: wire runtime config from those
+#                        secrets, then exec supervisord (redis + backend + Caddy).
+set -e
+
+if [ "$1" = "generate-secrets" ]; then
+    exec /usr/local/bin/aio-init-secrets.sh
+fi
+
+# supervisord runs the app as the `sheaf` user but does NOT reset HOME (it stays
+# root's /root, which sheaf can't traverse). Point it at the sheaf-owned home so
+# libpq/asyncpg's ~/.postgresql client-cert lookup resolves cleanly instead of
+# EACCES, and cloudflared/etc. have a writable home. Inherited by every
+# supervised program.
+export HOME=/home/sheaf
+
+# JWT signing key: read the shared file the init service generated when the
+# operator didn't set one. Persisted, not regenerated - rotating it logs
+# everyone out.
+if [ -z "${JWT_SECRET_KEY:-}" ] && [ -f /secrets/jwt_secret ]; then
+    JWT_SECRET_KEY="$(cat /secrets/jwt_secret)"
+    export JWT_SECRET_KEY
+fi
+
+# Database URL: build it from the shared Postgres password unless the operator
+# supplied a full DATABASE_URL (e.g. pointing at an external database).
+if [ -z "${DATABASE_URL:-}" ] && [ -f /secrets/postgres_password ]; then
+    PW="$(cat /secrets/postgres_password)"
+    DATABASE_URL="postgresql+asyncpg://sheaf:${PW}@${POSTGRES_HOST:-db}:5432/sheaf"
+    export DATABASE_URL
+fi
+
+# Public base URL / cookie Secure flag + email links: derive from the domain
+# when set. Left alone if the operator set SHEAF_BASE_URL explicitly.
+if [ -z "${SHEAF_BASE_URL:-}" ] && [ -n "${AIO_DOMAIN:-}" ]; then
+    export SHEAF_BASE_URL="https://${AIO_DOMAIN}"
+fi
+
+# Ingress mode. Two ways to reach the box:
+#   1. Cloudflare Tunnel (CF_TUNNEL_TOKEN set): Cloudflare terminates TLS and
+#      connects OUT to us, so Caddy just serves plain HTTP on loopback:80 and
+#      cloudflared forwards to it. No inbound ports / port-forwarding needed -
+#      point the tunnel's public hostname at http://localhost:80 in the
+#      Cloudflare dashboard.
+#   2. Direct: a domain gets automatic HTTPS from Caddy (publish 80 + 443);
+#      no domain means plain HTTP on :80 (LAN / behind your own proxy).
+mkdir -p /etc/supervisor/conf.d
+if [ -n "${CF_TUNNEL_TOKEN:-}" ]; then
+    export AIO_SITE_ADDRESS=":80"
+    cp /etc/supervisor/available/cloudflared.conf /etc/supervisor/conf.d/cloudflared.conf
+else
+    rm -f /etc/supervisor/conf.d/cloudflared.conf 2>/dev/null || true
+    if [ -n "${AIO_DOMAIN:-}" ]; then
+        export AIO_SITE_ADDRESS="${AIO_DOMAIN}"
+    else
+        export AIO_SITE_ADDRESS=":80"
+    fi
+fi
+
+# ACME endpoint: production Let's Encrypt by default. Override AIO_ACME_CA to
+# the LE staging directory to dry-run cert issuance without hitting production
+# rate limits. Defaulted here (not just in compose) so a raw `docker run` also
+# gets a valid CA.
+export AIO_ACME_CA="${AIO_ACME_CA:-https://acme-v02.api.letsencrypt.org/directory}"
+
+# Render Caddy's ACME global options. The email line is emitted only when set:
+# an empty `email` directive is a Caddyfile parse error, so we omit it rather
+# than pass one through.
+{
+    echo "acme_ca ${AIO_ACME_CA}"
+    [ -n "${AIO_ACME_EMAIL:-}" ] && echo "email ${AIO_ACME_EMAIL}"
+    true
+} > /etc/caddy/acme.conf
+
+# Caddy proxies to uvicorn on loopback; trust it so X-Forwarded-For is read.
+export TRUSTED_PROXIES="${TRUSTED_PROXIES:-127.0.0.1}"
+export FORWARDED_ALLOW_IPS="${FORWARDED_ALLOW_IPS:-127.0.0.1}"
+
+# Redis: run the bundled instance unless REDIS_URL points at an external one.
+mkdir -p /etc/supervisor/conf.d
+if [ -z "${REDIS_URL:-}" ]; then
+    export REDIS_URL="redis://127.0.0.1:6379/0"
+    cp /etc/supervisor/available/redis.conf /etc/supervisor/conf.d/redis.conf
+else
+    rm -f /etc/supervisor/conf.d/redis.conf 2>/dev/null || true
+fi
+
+# A fresh named volume comes up root-owned; hand the data dir to the app user
+# (encryption key, uploaded files, Caddy cert storage live here).
+chown -R sheaf:sheaf /app/data 2>/dev/null || true
+
+exec supervisord -c /etc/supervisor/supervisord.conf

--- a/docker/aio/init-secrets.sh
+++ b/docker/aio/init-secrets.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Generate the shared first-boot secrets, if absent, into /secrets (a volume
+# shared with the db and app containers). Run once by the compose `init`
+# service before Postgres and the app start.
+#
+# Persisting these (rather than regenerating per boot) is the point: the JWT
+# key logs everyone out if it changes, and the Postgres password must stay
+# stable for the app to keep connecting. Set JWT_SECRET_KEY / DATABASE_URL
+# yourself to bypass this entirely.
+set -e
+
+mkdir -p /secrets
+
+gen() {
+    python -c "import secrets; print(secrets.token_hex(32))"
+}
+
+if [ ! -s /secrets/postgres_password ]; then
+    gen > /secrets/postgres_password
+    echo "aio-init: generated /secrets/postgres_password"
+fi
+if [ ! -s /secrets/jwt_secret ]; then
+    gen > /secrets/jwt_secret
+    echo "aio-init: generated /secrets/jwt_secret"
+fi
+
+# Read by root in both the db (Postgres entrypoint) and app (this image's
+# entrypoint) containers, so root-only is enough.
+chmod 0400 /secrets/postgres_password /secrets/jwt_secret 2>/dev/null || true
+echo "aio-init: secrets ready"

--- a/docker/aio/redis.conf
+++ b/docker/aio/redis.conf
@@ -1,0 +1,13 @@
+[program:redis]
+# Transient state only (sessions, step-up challenges, rate-limit counters,
+# presign cache). No persistence: a restart just re-authenticates users.
+# Bound to loopback; only the backend in this container talks to it.
+command=redis-server --bind 127.0.0.1 --port 6379 --save "" --appendonly no --maxmemory 256mb --maxmemory-policy allkeys-lru
+user=sheaf
+autorestart=true
+startsecs=2
+priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/aio/supervisord.conf
+++ b/docker/aio/supervisord.conf
@@ -1,0 +1,39 @@
+[supervisord]
+nodaemon=true
+user=root
+pidfile=/run/supervisord.pid
+logfile=/dev/stdout
+logfile_maxbytes=0
+loglevel=info
+
+# Bundled redis is dropped in here by the entrypoint only when REDIS_URL is
+# not pointed at an external server.
+[include]
+files = /etc/supervisor/conf.d/*.conf
+
+[program:app]
+command=/usr/local/bin/aio-app-start.sh
+user=sheaf
+directory=/app
+autorestart=true
+startsecs=5
+startretries=5
+priority=20
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:caddy]
+command=/usr/bin/caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+user=root
+autorestart=true
+startsecs=3
+priority=30
+# Persist ACME certs / state on the data volume so a container recreate does
+# not re-fetch (and risk Let's Encrypt rate limits).
+environment=XDG_DATA_HOME="/app/data",XDG_CONFIG_HOME="/app/data"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -10,7 +10,57 @@ cp .env.example .env
 docker compose up -d
 ```
 
-API at `http://localhost:8000`, docs at `http://localhost:8000/v1/docs`.
+API at `http://localhost:8000`, docs at `http://localhost:8000/v1/docs`. This compose serves the backend API only - you build/serve the frontend and terminate TLS yourself (see [Frontend](#frontend)). For a batteries-included single container, use the all-in-one image below.
+
+---
+
+## Quick start (all-in-one)
+
+For a small single-instance self-host, the **all-in-one image** bundles the backend, the web UI, and a Caddy reverse proxy (with automatic HTTPS) in one container, alongside a Postgres container. It generates its own secrets on first start, so a public HTTPS deploy is close to a one-liner:
+
+```bash
+cp .env.aio.example .env
+# set AIO_DOMAIN=sheaf.example.com in .env, and point that domain's DNS here
+docker compose -f docker-compose.aio.yml up -d --build
+```
+
+Publish ports 80 and 443; Caddy fetches and renews a Let's Encrypt certificate for `AIO_DOMAIN` automatically (that automatic-HTTPS path is why the image uses Caddy). Set `AIO_ACME_EMAIL` for expiry notices, or `AIO_ACME_CA` to the [LE staging endpoint](https://letsencrypt.org/docs/staging-environment/) to dry-run issuance first. Leave `AIO_DOMAIN` unset to serve plain HTTP on port 80 (LAN, or behind your own TLS proxy).
+
+### Run from home (Cloudflare Tunnel)
+
+No public IP, behind CGNAT, or can't forward ports? A Cloudflare Tunnel lets the box serve to the internet over an outbound-only connection - nothing to forward, and Cloudflare terminates TLS for you. The all-in-one image bundles `cloudflared`; you just supply a tunnel token. You need a domain whose DNS is managed by Cloudflare (a free plan is fine).
+
+1. In the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/): **Networks -> Tunnels -> Create a tunnel -> Cloudflared**. Name it, then copy the **tunnel token** it shows (the long string after `--token`).
+2. On the tunnel's **Public Hostname** tab, add a hostname: pick your subdomain + domain (e.g. `sheaf.example.com`), set **Type** to `HTTP` and **URL** to `localhost:80`. Save - Cloudflare creates the DNS record for you.
+3. In `.env`:
+
+   ```env
+   CF_TUNNEL_TOKEN=<the token from step 1>
+   AIO_DOMAIN=sheaf.example.com
+   ```
+
+   `AIO_DOMAIN` here just makes links and cookies use the public host; TLS is Cloudflare's job, so no Let's Encrypt or open ports are involved.
+4. Start it:
+
+   ```bash
+   docker compose -f docker-compose.aio.yml up -d --build
+   ```
+
+You do not need to publish or forward ports 80/443 at all in this mode - cloudflared dials out. Your instance is reachable at `https://sheaf.example.com` once the tunnel connects (a few seconds; check `docker compose -f docker-compose.aio.yml logs app | grep cloudflared`).
+
+Other tunnel providers (Tailscale Funnel, ngrok, etc.) work the same way if you run them alongside and point them at the container's port 80; only Cloudflare is bundled today.
+
+### What is bundled, and what is not
+
+- **In the app container:** the backend, the web UI, Caddy, and a small redis (transient session / rate-limit / cache state only; a restart just re-authenticates users). Point `REDIS_URL` at an external server to skip the bundled one.
+- **A separate container:** Postgres - its data must outlive the app. Point `DATABASE_URL` at an external database to drop the bundled one.
+- **Filesystem storage** on a volume by default; set `STORAGE_BACKEND=s3` for object storage.
+
+First-boot secrets (the Postgres password and JWT key) are generated into the `secrets` volume, and the encryption key into the app-data volume - you do not set them by hand. **Back up the `pgdata`, `appdata`, and `secrets` volumes** (see [Backups](#backups)); losing `secrets`/`appdata` is losing the ability to decrypt and to log in.
+
+Everything else in this guide applies to the all-in-one too - the same env vars, set in the `.env` next to `docker-compose.aio.yml`. The image builds from source by default; to run a published image, set `image: ghcr.io/sheaf-project/sheaf-aio:X.Y.Z` on the `app` and `init` services and drop their `build:` blocks (see [Updating Sheaf](#updating-sheaf)).
+
+**Scope:** the all-in-one is for small deployments and is not horizontally scalable. If you outgrow it, move to the split `sheaf` + `sheaf-web` images with your own reverse proxy.
 
 ---
 
@@ -56,6 +106,76 @@ Sheaf refuses to start in `saas` mode if this is left at the default, and logs a
 - **Rotating it** requires re-encrypting the email ciphertext AND re-computing every `email_hash` row (see `alembic/versions/k1l2m3n4o5p6_rehash_email_blind_index.py` for the pattern). Don't rotate this casually.
 
 **If not set**, a key is auto-generated on first startup and saved to `data/encryption.key` inside the Docker volume. **Back this file up.** Prefer setting `SHEAF_ENCRYPTION_KEY` explicitly so the key isn't tied to a single volume.
+
+---
+
+## Updating Sheaf
+
+Sheaf runs its database migrations automatically: on every start the container runs `alembic upgrade head` before launching the app. Updating is therefore just "get the new version and recreate the app container" - there is no separate migration step to run by hand.
+
+### Published images
+
+CI publishes multi-arch (amd64 + arm64) images to the GitHub Container Registry on every tagged release and every push to `main`:
+
+| Image | Contents |
+|-------|----------|
+| `ghcr.io/sheaf-project/sheaf` | Backend: API, job runner, notification dispatcher, import runner |
+| `ghcr.io/sheaf-project/sheaf-web` | Prebuilt frontend (nginx serving the static SPA). Still needs your reverse proxy to route `/v1` to the backend and to add the SPA security headers - see [Frontend](#frontend). |
+
+Tags:
+
+| Tag | Meaning |
+|-----|---------|
+| `X.Y.Z` | An exact release, e.g. `1.2.3`. **Pin this in production.** |
+| `X.Y` | The latest patch on a minor line, e.g. `1.2`. |
+| `latest` | The newest tagged release. |
+| `head` | Tip of `main` - unreleased, may be unstable. |
+| `sha-<commit>` | An exact build, by full commit SHA. |
+
+The shipped `docker-compose.yml` builds the backend from source (`build:`) rather than pulling a published image. To run a published image instead, set `image: ghcr.io/sheaf-project/sheaf:X.Y.Z` on the `app` service and remove its `build:` block.
+
+### Before you update
+
+- **Back up first.** See [Backups](#backups) - at minimum the database and the encryption key. Migrations are applied forward on start and are not automatically reversed, so a clean rollback means restoring the pre-update database, not just re-pulling the old image.
+- **Read the [changelog](../CHANGELOG.md)** for the version you are moving to. Note anything under Security, and any migration that rewrites a large table (the entry will say so).
+
+### Update
+
+Building from source (the default compose file):
+
+```bash
+git pull
+docker compose build app
+docker compose up -d app       # recreates the container; migrations run on start
+docker compose logs -f app     # watch the "alembic upgrade" lines, then a clean boot
+```
+
+Running a pinned published image - bump the tag in your compose file, then:
+
+```bash
+docker compose pull app
+docker compose up -d app
+```
+
+If you also run the `sheaf-web` image, update it to the same version.
+
+### Verify
+
+`GET /v1/version` reports the running version, commit, and build time:
+
+```bash
+curl https://your-instance/v1/version
+```
+
+Confirm it matches what you deployed, and that the startup logs show migrations applied without error.
+
+### Rollback
+
+If an update misbehaves, roll back by restoring the pre-update **database backup** and running the **previous image tag** together - the two must match, because a newer migration may already have changed the schema and Sheaf does not auto-downgrade it. This is why the back-up-first step matters.
+
+### Multiple app replicas
+
+Migrations run on each container's start. Alembic takes a lock so concurrent starts cannot corrupt the schema, but to avoid a startup race, roll replicas one at a time (or scale to a single app process, update, then scale back up). Background work is already single-leader (see [Multi-instance deploys](#multi-instance-deploys)); this only concerns the migration step.
 
 ---
 
@@ -939,7 +1059,7 @@ CI publishes a separate variant built with `INCLUDE_DEV_TOOLS=true`:
 
 ```
 ghcr.io/sheaf-project/sheaf-devtools:head      # tip of main
-ghcr.io/sheaf-project/sheaf-devtools:vX.Y.Z    # pinned release
+ghcr.io/sheaf-project/sheaf-devtools:X.Y.Z     # pinned release (no leading "v")
 ghcr.io/sheaf-project/sheaf-devtools:latest    # latest release
 ```
 
@@ -1007,7 +1127,9 @@ The env vars are surfaced read-only via `GET /v1/auth/config`, alongside `TERMS_
 
 ## Frontend
 
-The Sheaf web frontend is a React SPA built with Vite. The Docker Compose setup serves the backend API only — you need to build and serve the frontend separately.
+The Sheaf web frontend is a React SPA built with Vite. The Docker Compose setup serves the backend API only - you build and serve the frontend separately, either from a local build (below) or from the prebuilt image.
+
+CI publishes a prebuilt frontend image, `ghcr.io/sheaf-project/sheaf-web` (nginx serving the static bundle; see [Updating Sheaf](#updating-sheaf) for the tag scheme). It saves the local `npm` build, but it is static-only: you still need the reverse proxy described below to route `/v1` to the backend and to add the SPA security headers. Build it yourself instead when you want to serve the bundle straight from your own nginx/Caddy.
 
 ### Building
 


### PR DESCRIPTION
Adds an optional all-in-one image (`sheaf-aio`) for small single-instance self-hosts, closing #208. Where the split `sheaf` + `sheaf-web` images assume you'll bring your own web stack and TLS, the all-in-one bundles the backend, the web UI, and a Caddy reverse proxy (with automatic Let's Encrypt HTTPS) in one container, supervised by supervisord under tini, alongside a Postgres container. It generates its own Postgres password and JWT key on first start into a shared `secrets` volume and auto-generates the encryption key, so a public HTTPS deploy is close to a one-liner: set `AIO_DOMAIN`, point its DNS at the box, publish 80/443, and `docker compose -f docker-compose.aio.yml up -d`.

Run-from-home path: no public IP, CGNAT, or can't forward ports? Set `CF_TUNNEL_TOKEN` and a bundled `cloudflared` connects outbound over a Cloudflare Tunnel, with Cloudflare terminating TLS; the entrypoint flips Caddy to plain HTTP automatically. Nothing to forward. Automatic HTTPS is the reason the image uses Caddy, and the SELFHOSTING quick-start covers the direct-HTTPS, Cloudflare-Tunnel, and plain-HTTP/LAN paths step by step.

What's bundled vs separate, all overridable: a small redis rides in the app container for transient session/rate-limit/cache state (set `REDIS_URL` to use an external one and the bundled one is skipped); Postgres is always a separate container so its data outlives the app (set `DATABASE_URL` to drop it); storage defaults to the filesystem on a volume (set `STORAGE_BACKEND=s3` for object storage). First-boot secrets live in the `secrets`/`appdata` volumes, which the docs flag for backup. Scope is deliberately small-single-instance and not horizontally scalable; outgrow it and you move to the split images.

CI: the tagged-release manual approval gate now runs at the front of the workflow. A fast `preflight` job (tag-on-main + version-match) then an `approve-release` job carrying the `release` environment means the approval prompt appears within seconds, in parallel with the test run, instead of after the ~15-minute suite. Normal PR/main CI is unchanged (the gate is skipped and the build proceeds). Adds `sheaf-aio` to the multi-arch image matrix.

Docs also gain a "Updating Sheaf" section that was previously missing entirely (published image names + tag scheme, the migrations-run-on-start behaviour, back-up-first, rollback semantics, multi-replica note), plus a `sheaf-web` prebuilt-image mention and a fix to the devtools image tag example (`X.Y.Z`, not `vX.Y.Z`, since metadata-action strips the leading `v`).

Testing: the image builds, and the full stack was smoke-tested end to end - first-boot secret generation, Postgres init from the shared password, migrations applied on start, uvicorn up, and Caddy serving the SPA and proxying `/v1` (health 200, `/v1/version` returns the running version). One bug was found and fixed in the process: supervisord's `user=` does not reset `HOME`, so asyncpg's libpq client-cert lookup hit root's unreadable home; the entrypoint now sets `HOME` for the supervised programs. The Cloudflare Tunnel path's conditional wiring is in place but was not live-tested against a real tunnel token. Design note in the design-docs repo (`aio-docker-image.md`).
