### PR TITLE
Fix OpenPlural import dropping inline-asset avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenPlural import now restores avatars carried inline.** An OpenPlural JSON export whose images ride inline on the asset records (the spec's `data_uri` / `data_base64` fields, or a `data:` URI a producer placed in the `uri` field) now has those avatars decoded and stored through the normal image pipeline, the same as an `.openplural.zip` bundle. Previously only bundled or genuinely external avatar URLs came through, so a bare JSON with inline images imported its members without their avatars.
+
 ## [1.2.3] - 2026-07-15
 
 ### Added

--- a/sheaf/services/openplural_import.py
+++ b/sheaf/services/openplural_import.py
@@ -24,8 +24,11 @@ of things that round-trip via ``extensions.sheaf.*``.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import io
 import zipfile
+from dataclasses import dataclass
 
 from sheaf.services.import_parsing import ImportPayloadError, expect_dict, safe_json_loads
 from sheaf.services.openplural_export import EXT_NS
@@ -98,19 +101,66 @@ def _birthday_to_native(b: object) -> str | None:
     return None
 
 
+def _b64decode(value: str) -> bytes | None:
+    """Strict base64 -> bytes, or None on malformed input."""
+    try:
+        return base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _decode_inline_asset(asset: dict) -> bytes | None:
+    """Decoded bytes for an asset that carries its payload inline, else None.
+
+    Per the OpenPlural Asset spec an asset populates at least one of
+    ``uri`` (external URL), ``data_base64``, or ``data_uri``
+    (``data:<mime>;base64,<...>``). This handles the two inline carriers,
+    plus the common producer slip of putting a ``data:`` URI in the
+    ``uri`` field. External ``http(s)`` URLs and bundle refs return None -
+    they are resolved elsewhere. An over-cap payload returns None (the
+    asset is skipped, surfaced later as a removed reference)."""
+    data_uri = asset.get("data_uri")
+    if not (isinstance(data_uri, str) and data_uri.startswith("data:")):
+        uri = asset.get("uri")
+        data_uri = uri if isinstance(uri, str) and uri.startswith("data:") else None
+
+    raw: bytes | None = None
+    if data_uri is not None:
+        b64 = data_uri.partition(";base64,")[2]
+        if b64:
+            raw = _b64decode(b64)
+    if raw is None:
+        data_b64 = asset.get("data_base64")
+        if isinstance(data_b64, str) and data_b64:
+            raw = _b64decode(data_b64)
+    if raw is None or len(raw) > _MAX_ASSET_DECOMPRESSED:
+        return None
+    return raw
+
+
 class _AssetMap:
     """asset id -> native image reference, built from the envelope's assets.
 
-    For a bare-JSON import the reference is the asset's ``uri`` (an
-    external URL the native importer treats like any other). For a bundle
-    it is still the ``uri`` (a ``/v1/files/<key>`` form), and the bare
-    storage key parsed from ``bundle_path`` is what the archive restore
-    keys its blobs by.
+    An asset resolves one of three ways:
+
+    * Inline bytes (``data_uri`` / ``data_base64``, or a ``data:`` URI a
+      producer put in ``uri``): decoded into :attr:`inline` and referenced
+      by a synthetic bare key (the asset id). A bare-JSON import with any
+      inline asset is routed through ``sheaf_archive_import`` so the bytes
+      go through the shared image pipeline (quota, EXIF strip, dimension
+      cap), exactly like a bundle.
+    * A bundle asset: the ``uri`` is a ``/v1/files/<key>`` form and the
+      bare storage key parsed from ``bundle_path`` is what the archive
+      restore keys its blobs by.
+    * An external ``http(s)`` ``uri``: passed through as a URL the native
+      importer treats like any other (fragile, per the spec).
     """
 
     def __init__(self, envelope: dict) -> None:
         self.by_id: dict[str, str] = {}
         self.bundle_keys: set[str] = set()
+        # Synthetic-key -> decoded bytes, for inline assets in a bare JSON.
+        self.inline: dict[str, bytes] = {}
         for a in envelope.get("assets", []) or []:
             if not isinstance(a, dict):
                 continue
@@ -119,7 +169,14 @@ class _AssetMap:
                 continue
             uri = a.get("uri")
             bundle_path = _ext(a).get("bundle_path")
-            if isinstance(uri, str) and uri:
+            raw = _decode_inline_asset(a)
+            if raw is not None:
+                # Self-contained inline bytes win over a fragile external
+                # URL. The asset id doubles as the synthetic storage key the
+                # inline-archive import restores under.
+                self.by_id[aid] = aid
+                self.inline[aid] = raw
+            elif isinstance(uri, str) and uri:
                 self.by_id[aid] = uri
             if isinstance(bundle_path, str) and bundle_path.startswith(_ASSET_PREFIX):
                 self.bundle_keys.add(bundle_path[len(_ASSET_PREFIX):])
@@ -130,13 +187,37 @@ class _AssetMap:
         return None
 
 
-def to_native(envelope: dict) -> dict:
+@dataclass
+class _InlineAssetArchive:
+    """A ``ParsedArchive``-compatible view over inline JSON asset bytes.
+
+    ``sheaf_archive_import.run_import`` only needs ``data`` / ``image_keys``
+    / ``read_image``; this serves the decoded bytes from memory instead of
+    a zip so a bare-JSON export with inline ``data_uri`` assets restores
+    through the same pipeline (quota, scrub-on-failure, unused-key discard)
+    as an ``.openplural.zip`` bundle.
+    """
+
+    data: dict
+    image_keys: set[str]
+    inline: dict[str, bytes]
+
+    def read_image(self, key: str) -> bytes | None:
+        if key not in self.image_keys:
+            return None
+        return self.inline.get(key)
+
+
+def to_native(envelope: dict, assets: _AssetMap | None = None) -> dict:
     """Translate an OpenPlural v0.1 envelope into the native export dict.
 
     Pure transform: no DB, no IO. Mirrors ``openplural_export.build_envelope``.
+    Pass a prebuilt ``assets`` map to reuse its inline-asset decode (the
+    JSON runner does, to route inline images through the archive path).
     """
     _check_version(envelope)
-    assets = _AssetMap(envelope)
+    if assets is None:
+        assets = _AssetMap(envelope)
 
     native: dict = {"version": "2"}
 
@@ -466,6 +547,25 @@ def parse_json(blob: bytes) -> dict:
     envelope = expect_dict(safe_json_loads(blob), descriptor="OpenPlural export")
     _check_version(envelope)
     return envelope
+
+
+def build_json_import(envelope: dict) -> tuple[dict, _InlineAssetArchive | None]:
+    """Translate a bare-JSON envelope for import.
+
+    Returns ``(native, inline_archive)``. When the file carries inline
+    image bytes (``data_uri`` / ``data_base64`` assets), ``inline_archive``
+    is a read_image-compatible view to hand to
+    ``sheaf_archive_import.run_import`` so the avatars restore through the
+    shared image pipeline; otherwise it is None and the caller uses the
+    plain ``sheaf_import.run_import`` path.
+    """
+    assets = _AssetMap(envelope)
+    native = to_native(envelope, assets=assets)
+    if assets.inline:
+        return native, _InlineAssetArchive(
+            data=native, image_keys=set(assets.inline), inline=assets.inline
+        )
+    return native, None
 
 
 def parse_bundle(blob: bytes):

--- a/sheaf/services/openplural_import_runner.py
+++ b/sheaf/services/openplural_import_runner.py
@@ -40,11 +40,11 @@ from sheaf.services.openplural_archive import (
     unpack_residual,
 )
 from sheaf.services.openplural_import import (
+    build_json_import,
     inherited_lineage,
     looks_like_zip,
     parse_bundle_async,
     parse_json,
-    to_native,
 )
 
 logger = logging.getLogger("sheaf.imports.openplural")
@@ -154,8 +154,6 @@ async def handle_openplural_file(job: ImportJob, db: AsyncSession) -> None:
 
 
 async def _run_json(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
-    from sheaf.services.sheaf_import import run_import as sheaf_run_import
-
     envelope = parse_json(blob)
     append_event(
         job,
@@ -164,7 +162,32 @@ async def _run_json(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
         message=f"parsed {len(blob)} bytes of OpenPlural JSON",
     )
     _note_lineage(job, envelope)
-    native = to_native(envelope)
+    native, inline_archive = build_json_import(envelope)
+
+    # A bare JSON that inlines its avatars (data_uri / data_base64 assets)
+    # restores them through the archive importer's image pipeline instead
+    # of the plain JSON path, which only keeps external avatar URLs.
+    if inline_archive is not None:
+        append_event(
+            job,
+            level="info",
+            stage="parse",
+            message=f"{len(inline_archive.image_keys)} inline asset(s) to restore",
+        )
+        await _run_archive(
+            job,
+            db,
+            inline_archive,
+            envelope,
+            missing_label=(
+                "inline asset could not be restored (unreadable or over the "
+                "per-asset size limit)"
+            ),
+        )
+        return
+
+    from sheaf.services.sheaf_import import run_import as sheaf_run_import
+
     options = parse_options(job.payload_metadata, SheafImportOptions)
     system = await load_user_system(db, job.user_id)
 
@@ -204,8 +227,6 @@ async def _run_json(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
 
 
 async def _run_bundle(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
-    from sheaf.services.sheaf_archive_import import run_import as archive_run_import
-
     parsed, envelope = await parse_bundle_async(blob)
     append_event(
         job,
@@ -217,6 +238,27 @@ async def _run_bundle(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
         ),
     )
     _note_lineage(job, envelope)
+    await _run_archive(
+        job,
+        db,
+        parsed,
+        envelope,
+        missing_label=(
+            "asset missing from the bundle (or over the per-asset size limit)"
+        ),
+    )
+
+
+async def _run_archive(
+    job: ImportJob, db: AsyncSession, parsed, envelope: dict, *, missing_label: str
+) -> None:
+    """Import a native dict whose images are restored from blobs (an
+    ``.openplural.zip`` bundle or an inline-asset bare JSON), delegating to
+    ``sheaf_archive_import`` for the image pipeline plus every section
+    guard. ``missing_label`` phrases the per-asset "couldn't restore this"
+    warning for the payload shape."""
+    from sheaf.services.sheaf_archive_import import run_import as archive_run_import
+
     options = parse_options(job.payload_metadata, SheafArchiveImportOptions)
     system = await load_user_system(db, job.user_id)
     user = await db.get(User, job.user_id)
@@ -252,10 +294,7 @@ async def _run_bundle(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
             job,
             level="warning",
             stage="images",
-            message=(
-                "asset missing from the bundle (or over the per-asset size "
-                f"limit); reference removed from: {sites}"[:500]
-            ),
+            message=f"{missing_label}; reference removed from: {sites}"[:500],
             record_ref=key[:200],
         )
     _preserve_residual(job, system, envelope)

--- a/tests/test_imports_openplural_runner.py
+++ b/tests/test_imports_openplural_runner.py
@@ -11,6 +11,7 @@ member-cap precheck, and the zip guards inherited from the archive path.
 
 from __future__ import annotations
 
+import base64
 import io
 import json
 import uuid
@@ -152,6 +153,88 @@ def test_bundle_round_trip_restores_avatar(auth_client: httpx.Client):
     iris = next(m for m in auth_client.get("/v1/members").json() if m["name"] == "OpIris")
     avatar_key = (iris["avatar_url"] or "").removeprefix("/v1/files/")
     assert avatar_key in files, iris["avatar_url"]
+
+
+def _inline_asset_envelope(*, carrier: str) -> bytes:
+    """A bare-JSON OpenPlural envelope from a foreign producer whose avatar
+    bytes ride inline on the asset (not in a bundle). ``carrier`` selects
+    where the bytes sit: ``uri_data`` (a ``data:`` URI a producer put in
+    the ``uri`` field, as pluralport does), ``data_uri`` (the spec field),
+    or ``data_base64``."""
+    b64 = base64.b64encode(_TINY_PNG).decode()
+    asset_id = str(uuid.uuid4())
+    asset: dict = {"id": asset_id, "kind": "avatar", "mime_type": "image/png"}
+    if carrier == "uri_data":
+        asset["uri"] = f"data:image/png;base64,{b64}"
+    elif carrier == "data_uri":
+        asset["data_uri"] = f"data:image/png;base64,{b64}"
+    else:
+        asset["data_base64"] = b64
+    env = {
+        "openplural_version": "0.1",
+        "exported_at": _EXPORTED_AT,
+        "producer": {"app": "Pluralport", "app_id": "pluralport"},
+        "systems": [{"id": "s1", "name": "OP System", "privacy": "public"}],
+        "members": [
+            {"id": "m1", "name": "OpIris", "avatar_asset_id": asset_id},
+            {"id": "m2", "name": "OpJay"},
+        ],
+        "assets": [asset],
+    }
+    return json.dumps(env).encode("utf-8")
+
+
+def _assert_inline_avatar_restored(client: httpx.Client, job_id: str) -> None:
+    final = wait_for_terminal(client, job_id)
+    assert final["status"] == "complete", final
+    assert final["counts"].get("images_imported", 0) == 1, final["counts"]
+    files = {f["key"] for f in _files_list(client)}
+    members = {m["name"]: m for m in client.get("/v1/members").json()}
+    iris_key = (members["OpIris"]["avatar_url"] or "").removeprefix("/v1/files/")
+    assert iris_key in files, members["OpIris"]["avatar_url"]
+    # The member with no avatar asset stays avatar-less.
+    assert not members["OpJay"]["avatar_url"]
+
+
+def test_json_inline_data_in_uri_restores_avatar(auth_client: httpx.Client):
+    """A bare JSON whose avatar is a ``data:`` URI stuffed in the asset
+    ``uri`` (pluralport's shape) decodes and stores it, instead of dropping
+    it as an unusable external URL."""
+    job = _post(auth_client, _inline_asset_envelope(carrier="uri_data"))
+    drive_import_runner()
+    _assert_inline_avatar_restored(auth_client, job["id"])
+
+
+def test_json_inline_data_uri_field_restores_avatar(auth_client: httpx.Client):
+    """The spec-correct inline carrier (``data_uri``) also restores."""
+    job = _post(auth_client, _inline_asset_envelope(carrier="data_uri"))
+    drive_import_runner()
+    _assert_inline_avatar_restored(auth_client, job["id"])
+
+
+def test_json_inline_data_base64_field_restores_avatar(auth_client: httpx.Client):
+    """The other spec inline carrier (``data_base64``) also restores."""
+    job = _post(auth_client, _inline_asset_envelope(carrier="data_base64"))
+    drive_import_runner()
+    _assert_inline_avatar_restored(auth_client, job["id"])
+
+
+def test_json_inline_asset_images_off_imports_member_without_avatar(
+    auth_client: httpx.Client,
+):
+    """With images disabled the member still imports; the inline avatar is
+    dropped rather than left as a broken synthetic key."""
+    job = _post(
+        auth_client,
+        _inline_asset_envelope(carrier="uri_data"),
+        options={"images": False},
+    )
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+    assert final["counts"].get("images_imported", 0) == 0, final["counts"]
+    iris = next(m for m in auth_client.get("/v1/members").json() if m["name"] == "OpIris")
+    assert not iris["avatar_url"], iris
 
 
 def test_preview_reports_counts_and_lineage(auth_client: httpx.Client):


### PR DESCRIPTION
An OpenPlural JSON export whose images ride inline on the asset records had those avatars silently dropped. The importer forwarded the asset's `uri` as an avatar URL, but when that `uri` is a `data:` URI (or the bytes are in the spec's `data_uri` / `data_base64` fields) the native avatar sanitiser rejects it, and the importer never read the inline-bytes fields at all. So only an `.openplural.zip` bundle or a genuinely external avatar URL came through; a bare JSON with inline images imported its members without avatars.

Surfaced by a real round-trip: an Ampersand system imported into pluralport and exported as OpenPlural v0.1, where the 7 members with avatars all had valid `avatar_asset_id`s pointing at assets whose bytes were inline `data:` URIs.

Fix: a bare JSON that carries inline asset bytes (the spec's `data_uri` / `data_base64`, or a `data:` URI a producer placed in `uri`) is now routed through the same `sheaf_archive_import` image pipeline an `.openplural.zip` bundle uses - decode, quota check, EXIF strip, dimension cap, scrub-on-failure - via a `read_image`-compatible view over the decoded bytes, instead of the plain JSON path. `_AssetMap` recognises the inline carriers and hands the importer a synthetic key backed by the decoded bytes; with images disabled the avatar is cleanly dropped rather than left as a broken key.

Adds four runner tests (the `data:`-in-`uri` producer shape, the spec `data_uri` and `data_base64` fields, and images-off) to the existing OpenPlural suite. Verified against the test stack: 14 OpenPlural runner tests pass (10 existing + 4 new), and the 46 OpenPlural export/parity/archive tests still pass. The wider round-trip diagnosis (polls and groups also not surviving pluralport -> Sheaf, which are format-boundary effects deferred to OpenPlural v0.2 rather than Sheaf bugs) is written up in the design-docs repo.
