### PR TITLE
Fix cross-device failure moving filesystem exports into place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Async data exports on filesystem storage no longer fail when the build directory and the exports directory are on different filesystems.** The export worker builds the zip in a temp directory (`/tmp` by default, which is frequently a separate tmpfs) and then moved it into `data/exports/` with a rename - which fails with "Invalid cross-device link" (EXDEV) when the two are on different filesystems, a common layout. The move now falls back to a copy when a rename can't cross the boundary (and is still a fast atomic rename when they share a filesystem).
+
 ## [1.2.3] - 2026-07-15
 
 ### Added

--- a/sheaf/services/export_storage.py
+++ b/sheaf/services/export_storage.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import uuid
 from functools import partial
 from pathlib import Path
@@ -142,10 +143,14 @@ async def put_path(
     """Persist a built export from a filesystem path.
 
     Avoids the bytes-in-RAM hop for big exports. On S3 we call
-    `upload_file` which transparently switches to multipart upload
-    once the file crosses ~8MB; on filesystem we rename the temp file
-    into place (same partition assumption — `tempfile` honours
-    `tmpdir` for cross-device safety).
+    `upload_file` which transparently switches to multipart upload once
+    the file crosses ~8MB. On filesystem we `shutil.move` the temp file
+    into place: an atomic rename when the build tmpdir and the exports
+    dir share a filesystem, falling back to copy-then-delete when they do
+    not. A plain rename raises EXDEV across devices - which is exactly the
+    default layout (build tmpdir on `/tmp`/tmpfs, exports on a data
+    volume). Point `export_build_tmp_dir` at the exports device to keep it
+    a fast rename for large exports.
     """
     if _is_s3():
         key = _key(user_id, job_id)
@@ -163,7 +168,7 @@ async def put_path(
         return key
     dest = _filesystem_path(user_id, job_id)
     dest.parent.mkdir(parents=True, exist_ok=True)
-    await _run(os.replace, source_path, str(dest))
+    await _run(shutil.move, source_path, str(dest))
     return str(dest)
 
 

--- a/tests/test_export_builder_streaming.py
+++ b/tests/test_export_builder_streaming.py
@@ -47,3 +47,41 @@ def test_streaming_export_cleans_up_tempfile_on_failure(monkeypatch):
         if f.startswith("sheaf-export-") and f.endswith(".zip")
     ]
     assert orphans == [], f"orphan tempfile(s) left behind: {orphans}"
+
+
+def test_put_path_survives_cross_device_rename(monkeypatch, tmp_path):
+    """When the build tmpdir and the exports dir are on different
+    filesystems, a plain rename raises EXDEV ("Invalid cross-device
+    link") - the default layout, with /tmp on tmpfs and exports on a data
+    volume. put_path must fall back to a copy rather than failing the
+    upload (regression: it used os.replace, which propagated EXDEV)."""
+    import errno
+    import uuid
+    from pathlib import Path
+
+    from sheaf.config import settings
+    from sheaf.services import export_storage
+
+    monkeypatch.setattr(settings, "storage_backend", "filesystem")
+    monkeypatch.setattr(settings, "sheaf_data_dir", tmp_path)
+
+    src = tmp_path / "build" / "sheaf-export-xyz.zip"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"zip-bytes")
+
+    def _exdev(*_args, **_kwargs):
+        raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+    # Simulate a genuine cross-device move: both rename syscalls fail.
+    # shutil.move (new) tries os.rename, catches EXDEV, and copies instead;
+    # os.replace (the old code) would just propagate it and fail the upload.
+    # Patching both means this fails on the old code AND exercises the new
+    # copy fallback (src/dest are actually same-device in the test).
+    monkeypatch.setattr(os, "rename", _exdev)
+    monkeypatch.setattr(os, "replace", _exdev)
+
+    user_id, job_id = uuid.uuid4(), uuid.uuid4()
+    location = asyncio.run(export_storage.put_path(user_id, job_id, str(src)))
+
+    assert Path(location).read_bytes() == b"zip-bytes"
+    assert not src.exists(), "tempfile should be consumed by the move"


### PR DESCRIPTION
The async export worker builds the zip in a temp directory (`export_build_tmp_dir`, `/tmp` by default) and then moved it into `data/exports/` with `os.replace`. `os.replace` is a rename, and a rename fails with EXDEV ("Invalid cross-device link") when the source and destination are on different filesystems - which is the common layout for a filesystem-storage self-host, with `/tmp` on tmpfs and the data volume elsewhere. The job failed at the upload step with `[Errno 18] Invalid cross-device link`.

The existing code assumed the two would share a filesystem (`export_build_tmp_dir` exists precisely to let an operator arrange that), but the default doesn't, and a plain rename has no fallback. This switches the filesystem `put_path` to `shutil.move`, which does a fast atomic rename when the tmpdir and exports dir share a filesystem and falls back to copy-then-delete when they don't. Operators who want to keep it a rename for large exports can still point `export_build_tmp_dir` at the exports device (documented in the updated docstring).

Adds a headless regression test that patches both rename syscalls to raise EXDEV, proving the move now succeeds via the copy fallback (and would have failed under the old `os.replace`). Scanned the rest of `sheaf/` - this `put_path` was the only rename-based move, so there are no other cross-device-vulnerable spots. Reported from a real filesystem-mode export.
