### PR TITLE
Field encryption: AAD-bound v2 format and rollout gates

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -293,6 +293,7 @@ currently engaged, else 0. Use it to alert on "shield-mode active for
 |---|---|---|
 | `sheaf_decrypt_failures_total` | counter | `field` |
 | `sheaf_field_decrypts_total` | counter | `version` |
+| `sheaf_field_decrypt_v1_rejected_total` | counter | - |
 | `sheaf_users_total` | gauge | - |
 | `sheaf_users_pending_delete` | gauge | - |
 | `sheaf_tier_limit_hits_total` | counter | `limit`, `tier` |
@@ -306,18 +307,30 @@ Tracks where users bump into per-tier caps. Useful for pricing and
 limit-adjustment decisions - a sustained `members{tier="free"}` rate
 suggests the free cap needs revisiting.
 
-`field` ∈ {email, totp_secret, recovery_codes, channel_config, other}.
+`field` ∈ {email, totp_secret, recovery_codes, channel_config, other,
+unlabelled}.
 
 Should always be zero. Pre-warmed at startup so an absence-alert can
 detect non-zero from the first scrape.
 
 `sheaf_field_decrypts_total` counts successful field decrypts by ciphertext
 format `version` ∈ {v1, v2}. v1 is the legacy no-AAD SecretBox format; v2 is
-the AAD-bound XChaCha20-Poly1305 format. During the migration v2 should climb
-and v1 fall as rows are rewritten; a v1 floor that never reaches zero flags
-cells no converted write path is touching. Decrypt *failures* (including an
-AAD mismatch from a relocated v2 ciphertext, which is an indistinguishable
-nacl CryptoError) still land on `sheaf_decrypt_failures_total`.
+the AAD-bound XChaCha20-Poly1305 format. This is a cumulative counter, so
+the migration signal is the *rate* of v1 reads trending toward zero as rows
+are rewritten - the totals never fall, and read volume cannot prove
+completeness (a dormant cell that is never read never shows here). The
+authoritative completeness signal is the re-encrypt sweep's remaining-v1
+count. After `FIELD_ENCRYPTION_ACCEPT_V1` is disabled, v1 reads fail closed
+and never reach this success counter - the rejection lands on
+`sheaf_field_decrypt_v1_rejected_total`, which counts reads of legacy v1
+ciphertext rejected under the cutoff. After migration that counter should
+be zero; a nonzero rate is an attempted legacy read or a v1 downgrade
+attack.
+Decrypt *failures* (including an AAD mismatch from a relocated v2
+ciphertext, which is an indistinguishable nacl CryptoError) land on
+`sheaf_decrypt_failures_total`; failure counting lives in `decrypt()`
+itself, labelled `unlabelled` when the call site does not use
+`decrypt_field`.
 
 ### Data shape
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -292,6 +292,7 @@ currently engaged, else 0. Use it to alert on "shield-mode active for
 | Metric | Type | Labels |
 |---|---|---|
 | `sheaf_decrypt_failures_total` | counter | `field` |
+| `sheaf_field_decrypts_total` | counter | `version` |
 | `sheaf_users_total` | gauge | - |
 | `sheaf_users_pending_delete` | gauge | - |
 | `sheaf_tier_limit_hits_total` | counter | `limit`, `tier` |
@@ -309,6 +310,14 @@ suggests the free cap needs revisiting.
 
 Should always be zero. Pre-warmed at startup so an absence-alert can
 detect non-zero from the first scrape.
+
+`sheaf_field_decrypts_total` counts successful field decrypts by ciphertext
+format `version` ∈ {v1, v2}. v1 is the legacy no-AAD SecretBox format; v2 is
+the AAD-bound XChaCha20-Poly1305 format. During the migration v2 should climb
+and v1 fall as rows are rewritten; a v1 floor that never reaches zero flags
+cells no converted write path is touching. Decrypt *failures* (including an
+AAD mismatch from a relocated v2 ciphertext, which is an indistinguishable
+nacl CryptoError) still land on `sheaf_decrypt_failures_total`.
 
 ### Data shape
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -52,6 +52,25 @@ class Settings(BaseSettings):
     # Encryption
     sheaf_encryption_key: str | None = None
     sheaf_data_dir: Path = Path("data")
+    # Two independent knobs stage the v1 -> v2 (AAD-bound) field-encryption
+    # rollout so it survives a rolling deployment and a rollback.
+    #
+    # WRITE side. False = keep writing legacy v1 even where a call site
+    # supplies an aad; True = write v2. It defaults False so the release that
+    # introduces v2-capable code is a pure BRIDGE: it reads both formats but
+    # still writes v1, so it is a safe rollback target for the *next* release
+    # (which flips this True and starts emitting v2 that only v2-capable code
+    # can read). Never ship the read support and the write flip in the same
+    # release for a fleet that rolls back.
+    field_encryption_write_v2: bool = False
+    # READ side. Accept legacy (v1, no-AAD) ciphertexts on read. While true, a
+    # DB-write attacker can downgrade any AAD-bound v2 cell by overwriting it
+    # with a preserved v1 ciphertext, so the context-binding integrity
+    # guarantee only fully holds once this is false. Flip to false when no
+    # legitimate v1 cells remain: immediately on a fresh install, or after the
+    # re-encrypt sweep reports zero remaining. With it false, any v1 token
+    # fails closed on read.
+    field_encryption_accept_v1: bool = True
 
     # Auth
     jwt_secret_key: str = "changeme-in-production"
@@ -920,6 +939,29 @@ def _validate_settings() -> None:
         problems.append("JWT_SECRET_KEY is set to the default value")
     if "changeme" in settings.database_url:
         problems.append("DATABASE_URL contains default password")
+
+    if not settings.field_encryption_accept_v1:
+        # Deliberate and desirable once migration is done, but loud enough
+        # that an accidental flip (which fails every unmigrated cell closed)
+        # is traceable to this setting.
+        logger.warning(
+            "FIELD_ENCRYPTION_ACCEPT_V1=false: legacy v1 field ciphertexts "
+            "are rejected on read. Any cell not yet re-encrypted to the "
+            "AAD-bound v2 format will fail closed."
+        )
+    if not settings.field_encryption_write_v2 and not settings.field_encryption_accept_v1:
+        # Contradiction: this instance would write v1 (write_v2 off) but
+        # reject v1 on read (accept_v1 off), so it could not read back its
+        # own writes. This is guaranteed data loss on the next write, not a
+        # soft "insecure default", so hard-fail in every mode rather than
+        # deferring to the SaaS-only exit below.
+        logger.critical(
+            "REFUSING TO START: FIELD_ENCRYPTION_WRITE_V2=false with "
+            "FIELD_ENCRYPTION_ACCEPT_V1=false. The instance would write v1 "
+            "ciphertext it then refuses to read. Enable "
+            "FIELD_ENCRYPTION_WRITE_V2 to stop accepting v1."
+        )
+        sys.exit(1)
 
     if (
         settings.image_serving == "unsigned"

--- a/sheaf/crypto.py
+++ b/sheaf/crypto.py
@@ -41,6 +41,7 @@ import hashlib
 import hmac
 import os
 
+import nacl.exceptions
 import nacl.secret
 
 from sheaf.config import settings
@@ -92,16 +93,31 @@ def field_aad(table: str, column: str, pk) -> bytes:
 def encrypt(plaintext: str, *, aad: bytes | None = None) -> str:
     """Encrypt a string. Returns a URL-safe base64 token.
 
-    With `aad=None` this is the legacy v1 path: SecretBox, unprefixed
-    base64url, byte-for-byte identical to the pre-AAD behaviour. This path
-    stays until every call site passes an aad, at which point aad should
-    become mandatory and the v1 branch can go.
+    Which format is written depends on the aad AND the deployment's write
+    gate:
 
-    With an `aad`, this is v2: the Aead box under a fresh 24-byte nonce with
-    the aad as associated data, emitted as `"v2:" + base64url(nonce||ct||tag)`.
-    Pass `field_aad(table, column, pk)` so the ciphertext is bound to its cell.
+    - v2 (AAD-bound: Aead, `"v2:" + base64url(nonce||ct||tag)`) is written
+      only when an `aad` is supplied AND `FIELD_ENCRYPTION_WRITE_V2` is on.
+      Pass `field_aad(table, column, pk)` so the ciphertext binds to its cell.
+    - otherwise the legacy v1 path (SecretBox, unprefixed base64url,
+      byte-for-byte the pre-AAD behaviour) is written. This covers both a
+      call site that passes no aad and the bridge-release state where call
+      sites pass an aad but v2 writes are not yet enabled fleet-wide.
+
+    The write gate exists so the release that can *read* v2 ships before the
+    release that *writes* it, keeping a rolling deploy / rollback safe (see
+    `field_encryption_write_v2`). The v1 write path is refused only when
+    `FIELD_ENCRYPTION_ACCEPT_V1=false`, because writing a v1 token this
+    instance then refuses to read would be self-inflicted data loss (startup
+    validation already rejects write_v2=false + accept_v1=false; this guard
+    also covers a stray no-aad call under the cutoff).
     """
-    if aad is None:
+    if aad is None or not settings.field_encryption_write_v2:
+        if not settings.field_encryption_accept_v1:
+            raise ValueError(
+                "v1 encryption disabled: FIELD_ENCRYPTION_ACCEPT_V1=false "
+                "requires FIELD_ENCRYPTION_WRITE_V2=true and an aad"
+            )
         box = _get_box()
         nonce = os.urandom(nacl.secret.SecretBox.NONCE_SIZE)
         ct = box.encrypt(plaintext.encode(), nonce)
@@ -115,7 +131,7 @@ def encrypt(plaintext: str, *, aad: bytes | None = None) -> str:
     return _V2_PREFIX + base64.urlsafe_b64encode(ct).decode()
 
 
-def decrypt(token: str, *, aad: bytes | None = None) -> str:
+def decrypt(token: str, *, aad: bytes | None = None, field: str = "unlabelled") -> str:
     """Decrypt a token back to plaintext, dispatching on the format tag.
 
     A `v2:` token is decrypted with the Aead box and requires an `aad`: a v2
@@ -123,49 +139,71 @@ def decrypt(token: str, *, aad: bytes | None = None) -> str:
     falling through to any no-AAD path. A v1 (unprefixed) token uses the
     legacy SecretBox path; any `aad` passed for it is ignored, which is what
     lets a converted call site read old v1 rows during the dual-read window.
-    """
-    if token.startswith(_V2_PREFIX):
-        if aad is None:
-            raise ValueError("v2 ciphertext requires aad")
-        box = _get_aead_box()
-        raw = base64.urlsafe_b64decode(token[len(_V2_PREFIX):])
-        plaintext = box.decrypt(raw, aad).decode()
-        version = "v2"
-    else:
-        box = _get_box()
-        raw = base64.urlsafe_b64decode(token)
-        plaintext = box.decrypt(raw).decode()
-        version = "v1"
 
-    # Import here to avoid an import cycle (crypto is imported very early in
-    # the bootstrap path, before observability is ready).
+    The dual-read window is a real weakness, not just a convenience: while
+    v1 tokens are accepted, an attacker with DB write can DOWNGRADE any v2
+    cell by overwriting it with a preserved v1 ciphertext, whose plaintext
+    they chose by placement (the aad is never consulted). Setting
+    `FIELD_ENCRYPTION_ACCEPT_V1=false` closes this: v1 tokens then fail
+    closed. Only flip it once no legitimate v1 cells remain (fresh installs:
+    immediately; migrated installs: after the re-encrypt sweep reports zero).
+
+    Every failure is counted on `decrypt_failures_total` here, labelled by
+    `field` ("unlabelled" when the caller does not say - `decrypt_field` is
+    the field-labelling wrapper). An AAD mismatch (a relocated v2
+    ciphertext) surfaces as the same nacl CryptoError as key drift, so it
+    cannot be told apart at this layer; the failure counter is the alert
+    signal for both.
+    """
+    try:
+        if token.startswith(_V2_PREFIX):
+            if aad is None:
+                raise ValueError("v2 ciphertext requires aad")
+            box = _get_aead_box()
+            raw = base64.urlsafe_b64decode(token[len(_V2_PREFIX):])
+            plaintext = box.decrypt(raw, aad).decode()
+            version = "v2"
+        else:
+            if not settings.field_encryption_accept_v1:
+                # Count the rejection on its own dedicated counter (lazy
+                # import for the same bootstrap-cycle reason as below). After
+                # migration this should be zero; a nonzero rate is an
+                # attempted legacy read or a v1 downgrade attack.
+                from sheaf.observability.metrics import (
+                    field_decrypt_v1_rejected_total,
+                )
+                field_decrypt_v1_rejected_total.inc()
+                raise nacl.exceptions.CryptoError(
+                    "legacy v1 ciphertext rejected: FIELD_ENCRYPTION_ACCEPT_V1"
+                    " is disabled"
+                )
+            box = _get_box()
+            raw = base64.urlsafe_b64decode(token)
+            plaintext = box.decrypt(raw).decode()
+            version = "v1"
+    except Exception:
+        # Import here to avoid an import cycle (crypto is imported very
+        # early in the bootstrap path, before observability is ready).
+        from sheaf.observability.metrics import decrypt_failures_total
+        decrypt_failures_total.labels(field=field).inc()
+        raise
+
+    # Same lazy-import rationale as above.
     from sheaf.observability.metrics import field_decrypts_total
     field_decrypts_total.labels(version=version).inc()
     return plaintext
 
 
 def decrypt_field(token: str, field: str, *, aad: bytes | None = None) -> str:
-    """`decrypt()` wrapper that bumps the decrypt-failure metric on error.
+    """`decrypt()` with the failure metric labelled by `field`.
 
     `field` labels the failure so dashboards can answer "which field is
     drifting?" - should always be zero; non-zero indicates encryption-key
-    drift or storage corruption. `aad` is passed straight through to
-    `decrypt`. Re-raises the original exception so callers behave identically
-    to plain `decrypt()`.
-
-    An AAD mismatch (a relocated v2 ciphertext) surfaces as the same nacl
-    CryptoError as key drift, so it cannot be told apart at this layer and
-    gets no distinct label; this per-field failure counter stays the alert
-    signal for both.
+    drift, storage corruption, or a relocated ciphertext. Failure counting
+    itself lives in `decrypt()` (so unlabelled callers are counted too);
+    this wrapper only supplies the label.
     """
-    try:
-        return decrypt(token, aad=aad)
-    except Exception:
-        # Import here to avoid an import cycle (crypto is imported very
-        # early in the bootstrap path before observability is ready).
-        from sheaf.observability.metrics import decrypt_failures_total
-        decrypt_failures_total.labels(field=field).inc()
-        raise
+    return decrypt(token, aad=aad, field=field)
 
 
 _blind_index_key_cache: bytes | None = None

--- a/sheaf/crypto.py
+++ b/sheaf/crypto.py
@@ -1,9 +1,30 @@
 """Application-level field encryption and keyed lookup hashes.
 
-XChaCha20-Poly1305 via libsodium (PyNaCl) — 256-bit key, 192-bit nonce,
-AEAD construction with no padding oracle surface.
+Two on-disk ciphertext formats coexist, distinguished by a leading `v2:`
+tag on the token (base64url never contains `:`, so the prefix is an
+unambiguous discriminator):
 
-Ciphertext format: base64(nonce + ciphertext + tag)
+- Legacy v1 (unprefixed): `nacl.secret.SecretBox` = XSalsa20-Poly1305,
+  no associated data. Format `base64url(nonce||ciphertext||tag)`, 24-byte
+  nonce. The Poly1305 tag authenticates the bytes but not their location,
+  so a DB-write attacker can lift any v1 ciphertext into any other
+  encrypted cell and it still decrypts. Read-only path now; new writes on
+  converted call sites use v2.
+- v2 (`v2:` prefix): `nacl.secret.Aead` = XChaCha20-Poly1305-IETF with
+  associated data. Format `"v2:" + base64url(nonce||ciphertext||tag)`,
+  24-byte nonce. The associated data binds each ciphertext to the one cell
+  it belongs in: `sheaf-fe-v2|<table>|<column>|<pk>` (see `field_aad`). A
+  ciphertext relocated to a different row or column now fails to decrypt
+  (nacl CryptoError) instead of silently returning the wrong plaintext, so
+  a DB-write relocation attack fails closed.
+
+Both formats derive the same 256-bit key: `sha256(SHEAF_ENCRYPTION_KEY)`.
+
+Callers opt into v2 by passing `aad=field_aad(...)` to `encrypt`/`decrypt`.
+Until every call site is converted, `aad=None` preserves byte-for-byte v1
+behaviour; a v1 token still decrypts even if an (ignored) aad is passed,
+which is the dual-read window converted call sites rely on to read old
+rows.
 
 This module also owns two keyed hashes that are required for the app to
 function:
@@ -24,7 +45,12 @@ import nacl.secret
 
 from sheaf.config import settings
 
+# Marker prefix for v2 (AEAD-with-associated-data) tokens. base64url never
+# emits ':', so its presence at the front is an unambiguous format tag.
+_V2_PREFIX = "v2:"
+
 _box: nacl.secret.SecretBox | None = None
+_aead_box: nacl.secret.Aead | None = None
 
 
 def _get_box() -> nacl.secret.SecretBox:
@@ -37,31 +63,103 @@ def _get_box() -> nacl.secret.SecretBox:
     return _box
 
 
-def encrypt(plaintext: str) -> str:
-    """Encrypt a string. Returns URL-safe base64 token."""
-    box = _get_box()
-    nonce = os.urandom(nacl.secret.SecretBox.NONCE_SIZE)
-    ct = box.encrypt(plaintext.encode(), nonce)
-    return base64.urlsafe_b64encode(ct).decode()
+def _get_aead_box() -> nacl.secret.Aead:
+    """Lazily build the v2 AEAD box off the same derived key as `_get_box`.
+
+    `nacl.secret.Aead` wraps crypto_aead_xchacha20poly1305_ietf and, like
+    SecretBox, takes a 24-byte nonce and serialises to nonce||ct||tag.
+    """
+    global _aead_box
+    if _aead_box is None:
+        raw_key = settings.get_encryption_key()
+        derived = hashlib.sha256(raw_key).digest()
+        _aead_box = nacl.secret.Aead(derived)
+    return _aead_box
 
 
-def decrypt(token: str) -> str:
-    """Decrypt a token back to plaintext."""
-    box = _get_box()
-    raw = base64.urlsafe_b64decode(token)
-    return box.decrypt(raw).decode()
+def field_aad(table: str, column: str, pk) -> bytes:
+    """Canonical associated data binding one encrypted cell in place.
+
+    `table` and `column` are the physical Postgres identifiers, which are
+    `[a-z0-9_]` only, so `|` can never appear inside them and the fields are
+    unambiguous. `pk` is the row's UUID, stringified canonically via `str()`.
+    The fixed `sheaf-fe-v2` label gives domain separation from any other AEAD
+    use of this key and leaves room for a future v3.
+    """
+    return f"sheaf-fe-v2|{table}|{column}|{pk}".encode()
 
 
-def decrypt_field(token: str, field: str) -> str:
+def encrypt(plaintext: str, *, aad: bytes | None = None) -> str:
+    """Encrypt a string. Returns a URL-safe base64 token.
+
+    With `aad=None` this is the legacy v1 path: SecretBox, unprefixed
+    base64url, byte-for-byte identical to the pre-AAD behaviour. This path
+    stays until every call site passes an aad, at which point aad should
+    become mandatory and the v1 branch can go.
+
+    With an `aad`, this is v2: the Aead box under a fresh 24-byte nonce with
+    the aad as associated data, emitted as `"v2:" + base64url(nonce||ct||tag)`.
+    Pass `field_aad(table, column, pk)` so the ciphertext is bound to its cell.
+    """
+    if aad is None:
+        box = _get_box()
+        nonce = os.urandom(nacl.secret.SecretBox.NONCE_SIZE)
+        ct = box.encrypt(plaintext.encode(), nonce)
+        return base64.urlsafe_b64encode(ct).decode()
+
+    box = _get_aead_box()
+    nonce = os.urandom(nacl.secret.Aead.NONCE_SIZE)
+    # Aead.encrypt(plaintext, aad, nonce) returns an EncryptedMessage whose
+    # bytes are nonce||ct||tag when a nonce is supplied, mirroring SecretBox.
+    ct = box.encrypt(plaintext.encode(), aad, nonce)
+    return _V2_PREFIX + base64.urlsafe_b64encode(ct).decode()
+
+
+def decrypt(token: str, *, aad: bytes | None = None) -> str:
+    """Decrypt a token back to plaintext, dispatching on the format tag.
+
+    A `v2:` token is decrypted with the Aead box and requires an `aad`: a v2
+    read with no context is a programming error, so it raises rather than
+    falling through to any no-AAD path. A v1 (unprefixed) token uses the
+    legacy SecretBox path; any `aad` passed for it is ignored, which is what
+    lets a converted call site read old v1 rows during the dual-read window.
+    """
+    if token.startswith(_V2_PREFIX):
+        if aad is None:
+            raise ValueError("v2 ciphertext requires aad")
+        box = _get_aead_box()
+        raw = base64.urlsafe_b64decode(token[len(_V2_PREFIX):])
+        plaintext = box.decrypt(raw, aad).decode()
+        version = "v2"
+    else:
+        box = _get_box()
+        raw = base64.urlsafe_b64decode(token)
+        plaintext = box.decrypt(raw).decode()
+        version = "v1"
+
+    # Import here to avoid an import cycle (crypto is imported very early in
+    # the bootstrap path, before observability is ready).
+    from sheaf.observability.metrics import field_decrypts_total
+    field_decrypts_total.labels(version=version).inc()
+    return plaintext
+
+
+def decrypt_field(token: str, field: str, *, aad: bytes | None = None) -> str:
     """`decrypt()` wrapper that bumps the decrypt-failure metric on error.
 
     `field` labels the failure so dashboards can answer "which field is
-    drifting?" — should always be zero; non-zero indicates encryption-key
-    drift or storage corruption. Re-raises the original exception so
-    callers behave identically to plain `decrypt()`.
+    drifting?" - should always be zero; non-zero indicates encryption-key
+    drift or storage corruption. `aad` is passed straight through to
+    `decrypt`. Re-raises the original exception so callers behave identically
+    to plain `decrypt()`.
+
+    An AAD mismatch (a relocated v2 ciphertext) surfaces as the same nacl
+    CryptoError as key drift, so it cannot be told apart at this layer and
+    gets no distinct label; this per-field failure counter stays the alert
+    signal for both.
     """
     try:
-        return decrypt(token)
+        return decrypt(token, aad=aad)
     except Exception:
         # Import here to avoid an import cycle (crypto is imported very
         # early in the bootstrap path before observability is ready).

--- a/sheaf/encrypted_fields.py
+++ b/sheaf/encrypted_fields.py
@@ -12,6 +12,12 @@ enumerate their work from it. If you add an encrypted column, add its helper
 here and wire it into the sweep, or the column stays on the legacy format
 forever and blocks the v1 removal.
 
+The registry alone is NOT the whole sweep surface: `CIPHERTEXT_COPIES` below
+lists places that store a copy of some cell's ciphertext outside that cell
+(currently the front audit snapshots). A sweep driven only by the helpers
+would miss those copies and leave a v1 long tail that breaks when v1 reads
+are disabled.
+
 Conventions:
 
 - `pk` is the owning row's UUID. All encrypted columns live on single-UUID-PK
@@ -148,3 +154,24 @@ def pending_target_label_aad(pending_id) -> bytes:
 
 def pending_fronting_names_aad(pending_id) -> bytes:
     return field_aad("pending_actions", "fronting_member_names", pending_id)
+
+
+# Ciphertext COPIES stored outside their owning cell. Each entry is
+# (storage_table, storage_path, source_cell): the stored bytes are a copy of
+# the source cell's ciphertext and decrypt under the SOURCE cell's AAD (the
+# copy is same-cell by construction - e.g. an audit snapshot of front X's
+# custom_status decrypts under front_custom_status_aad(X), and X never
+# changes). The Phase 2 sweep must rewrite these alongside the registry
+# cells, or the Phase 3 remaining-v1 preflight must count them.
+CIPHERTEXT_COPIES = (
+    (
+        "front_audit_events",
+        "before_snapshot.custom_status_encrypted",
+        "fronts.custom_status",
+    ),
+    (
+        "front_audit_events",
+        "after_snapshot.custom_status_encrypted",
+        "fronts.custom_status",
+    ),
+)

--- a/sheaf/encrypted_fields.py
+++ b/sheaf/encrypted_fields.py
@@ -1,0 +1,150 @@
+"""Per-cell AAD helpers for field encryption - the encrypted-cell registry.
+
+Every encrypted column in the database has exactly one helper here that
+produces the AAD binding a ciphertext to its cell (see `crypto.field_aad`).
+Call sites must use these helpers rather than calling `field_aad` directly so
+the (table, column) pair for each cell is written once, in one reviewable
+place, and cannot drift between the encrypt and decrypt side of a field.
+
+This module is deliberately the complete inventory of encrypted cells: the
+Phase 2 re-encrypt sweep and the Phase 3 "cells remaining on v1" preflight
+enumerate their work from it. If you add an encrypted column, add its helper
+here and wire it into the sweep, or the column stays on the legacy format
+forever and blocks the v1 removal.
+
+Conventions:
+
+- `pk` is the owning row's UUID. All encrypted columns live on single-UUID-PK
+  tables. On INSERT paths the id does not exist until flush, so the call site
+  pre-allocates it (`row_id = uuid.uuid4()`) and passes the same value to both
+  the model constructor and the helper - the pattern import_jobs already uses.
+- JSON-embedded ciphertexts use a fixed logical column path (e.g.
+  `payload_metadata.encrypted_credential`). These strings are baked into the
+  AAD of stored rows: never rename them.
+- `content_revisions` ciphertexts are bound to the *revision* row's own id,
+  not the revised target, so revisions of the same entry are not mutually
+  swappable at the DB layer.
+"""
+
+from sheaf.crypto import field_aad
+
+# users
+
+def user_email_aad(user_id) -> bytes:
+    return field_aad("users", "email", user_id)
+
+
+def user_totp_secret_aad(user_id) -> bytes:
+    return field_aad("users", "totp_secret", user_id)
+
+
+def user_recovery_codes_aad(user_id) -> bytes:
+    return field_aad("users", "recovery_codes", user_id)
+
+
+# members
+
+def member_name_aad(member_id) -> bytes:
+    return field_aad("members", "name", member_id)
+
+
+def member_description_aad(member_id) -> bytes:
+    return field_aad("members", "description", member_id)
+
+
+def member_note_aad(member_id) -> bytes:
+    return field_aad("members", "note", member_id)
+
+
+# systems
+
+def system_note_aad(system_id) -> bytes:
+    return field_aad("systems", "note", system_id)
+
+
+def system_openplural_archive_aad(system_id) -> bytes:
+    return field_aad("systems", "openplural_archive", system_id)
+
+
+# fronts
+
+def front_custom_status_aad(front_id) -> bytes:
+    return field_aad("fronts", "custom_status", front_id)
+
+
+# journal_entries
+
+def journal_title_aad(entry_id) -> bytes:
+    return field_aad("journal_entries", "title", entry_id)
+
+
+def journal_body_aad(entry_id) -> bytes:
+    return field_aad("journal_entries", "body", entry_id)
+
+
+# content_revisions (bound to the revision row, see module docstring)
+
+def revision_title_aad(revision_id) -> bytes:
+    return field_aad("content_revisions", "title", revision_id)
+
+
+def revision_body_aad(revision_id) -> bytes:
+    return field_aad("content_revisions", "body", revision_id)
+
+
+# reminders
+
+def reminder_title_aad(reminder_id) -> bytes:
+    return field_aad("reminders", "title", reminder_id)
+
+
+def reminder_body_aad(reminder_id) -> bytes:
+    return field_aad("reminders", "body", reminder_id)
+
+
+# messages
+
+def message_body_aad(message_id) -> bytes:
+    return field_aad("messages", "body", message_id)
+
+
+# polls / poll_options
+
+def poll_question_aad(poll_id) -> bytes:
+    return field_aad("polls", "question", poll_id)
+
+
+def poll_description_aad(poll_id) -> bytes:
+    return field_aad("polls", "description", poll_id)
+
+
+def poll_option_text_aad(option_id) -> bytes:
+    return field_aad("poll_options", "text", option_id)
+
+
+# custom_field_values (ciphertext stored inside the JSONB `value`)
+
+def custom_field_value_aad(value_id) -> bytes:
+    return field_aad("custom_field_values", "value", value_id)
+
+
+# notification_channels
+
+def webhook_secret_aad(channel_id) -> bytes:
+    return field_aad("notification_channels", "webhook_secret_encrypted", channel_id)
+
+
+# import_jobs (ciphertext inside the payload_metadata JSONB; fixed logical path)
+
+def import_credential_aad(job_id) -> bytes:
+    return field_aad("import_jobs", "payload_metadata.encrypted_credential", job_id)
+
+
+# pending_actions
+
+def pending_target_label_aad(pending_id) -> bytes:
+    return field_aad("pending_actions", "target_label", pending_id)
+
+
+def pending_fronting_names_aad(pending_id) -> bytes:
+    return field_aad("pending_actions", "fronting_member_names", pending_id)

--- a/sheaf/models/content_revision.py
+++ b/sheaf/models/content_revision.py
@@ -51,8 +51,8 @@ class ContentRevision(UUIDMixin, Base):
     # Captured content as it was before the edit that produced this revision.
     # title and body are encrypted at application level — store ciphertext.
     # image_keys stays plaintext (orphan cleanup needs to read it without keys).
-    title: Mapped[str | None] = mapped_column(String, nullable=True)
-    body: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str | None] = mapped_column(String, nullable=True, info={"encrypted": True})
+    body: Mapped[str] = mapped_column(Text, nullable=False, info={"encrypted": True})
 
     image_keys: Mapped[list] = mapped_column(
         JSONB, nullable=False, default=list, server_default="[]"

--- a/sheaf/models/custom_field.py
+++ b/sheaf/models/custom_field.py
@@ -70,7 +70,7 @@ class CustomFieldValue(UUIDMixin, Base):
         index=True,
     )
 
-    value: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    value: Mapped[dict | None] = mapped_column(JSONB, nullable=True, info={"encrypted": True})
 
     # Relationships
     field_definition: Mapped["CustomFieldDefinition"] = relationship(back_populates="values")

--- a/sheaf/models/front.py
+++ b/sheaf/models/front.py
@@ -31,7 +31,7 @@ class Front(UUIDMixin, Base):
     # it's exactly the kind of contextual narrative that the field-level
     # encryption model is meant to protect, matching the precedent set by
     # bios and journal entries.
-    custom_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    custom_status: Mapped[str | None] = mapped_column(Text, nullable=True, info={"encrypted": True})
 
     # Row-creation timestamp, distinct from the front's real-world `started_at`.
     # This is *when the row landed in this database* (created or imported), so

--- a/sheaf/models/import_job.py
+++ b/sheaf/models/import_job.py
@@ -86,7 +86,9 @@ class ImportJob(UUIDMixin, TimestampMixin, Base):
     # Source-specific config: options dict, encrypted PK API token,
     # selected member ids, etc. Cleared on terminal state for any
     # credential-bearing fields.
-    payload_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    payload_metadata: Mapped[dict | None] = mapped_column(
+        JSONB, nullable=True, info={"encrypted": "json"}
+    )
 
     # Running tallies, e.g.
     # {"members_imported": N, "members_failed": M, "switches_imported": ...}.

--- a/sheaf/models/journal_entry.py
+++ b/sheaf/models/journal_entry.py
@@ -33,8 +33,8 @@ class JournalEntry(UUIDMixin, TimestampMixin, Base):
     # Encrypted at application level — store ciphertext.
     # title and body are encrypted; image_keys stays plaintext so orphan
     # cleanup and read-time URL rewrites don't require key access.
-    title: Mapped[str | None] = mapped_column(String, nullable=True)
-    body: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str | None] = mapped_column(String, nullable=True, info={"encrypted": True})
+    body: Mapped[str] = mapped_column(Text, nullable=False, info={"encrypted": True})
 
     # v1 only honors "system". "member_private" and "public" are reserved
     # for forward compatibility and rejected by the API schema.

--- a/sheaf/models/member.py
+++ b/sheaf/models/member.py
@@ -79,7 +79,7 @@ class Member(UUIDMixin, TimestampMixin, Base):
     # Encrypted at application level — store ciphertext.
     # Length is generous to accommodate the base64-encoded
     # nonce+ciphertext+tag for a 100-char plaintext.
-    name: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False, info={"encrypted": True})
     # Blind index on the *plaintext* name (keyed HMAC-SHA-256, normalised).
     # Used for exact-match lookups within a system (e.g. autocomplete dedup).
     # Not unique — duplicate names within a system are allowed.
@@ -88,7 +88,7 @@ class Member(UUIDMixin, TimestampMixin, Base):
     )
     display_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     # Encrypted at application level — store ciphertext.
-    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True, info={"encrypted": True})
     pronouns: Mapped[str | None] = mapped_column(String(100), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     # Wide header image for the member profile. Same storage/trust model as
@@ -124,7 +124,7 @@ class Member(UUIDMixin, TimestampMixin, Base):
     # no sub-records — overwriting clears the previous content with no
     # history. For "trigger list / fav drink / current med doses" type
     # quick reference. Soft-capped at ~5kb plaintext at the schema layer.
-    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True, info={"encrypted": True})
 
     # Per-member opt-in toggles for the on-front-start "new board
     # messages" prompt. Off by default — opt-in surface, not push.

--- a/sheaf/models/message.py
+++ b/sheaf/models/message.py
@@ -83,7 +83,7 @@ class Message(UUIDMixin, TimestampMixin, Base):
 
     # Body is markdown, encrypted at rest. Soft cap at 5000 plaintext
     # characters in the schema layer.
-    body: Mapped[str] = mapped_column(Text, nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False, info={"encrypted": True})
 
     # Soft delete: set when a message is removed. Reads filter on
     # `deleted_at IS NULL`. Hard delete happens via System Safety queue

--- a/sheaf/models/notification_channel.py
+++ b/sheaf/models/notification_channel.py
@@ -165,7 +165,9 @@ class NotificationChannel(UUIDMixin, TimestampMixin, Base):
     email_month_anchor: Mapped[date | None] = mapped_column(Date, nullable=True)
 
     # Webhook secret stored encrypted (HMAC needs cleartext at dispatch).
-    webhook_secret_encrypted: Mapped[str | None] = mapped_column(String, nullable=True)
+    webhook_secret_encrypted: Mapped[str | None] = mapped_column(
+        String, nullable=True, info={"encrypted": True}
+    )
 
     # Bookkeeping for debounce checks (last successful delivery).
     last_delivered_at: Mapped[datetime | None] = mapped_column(

--- a/sheaf/models/pending_action.py
+++ b/sheaf/models/pending_action.py
@@ -49,7 +49,7 @@ class PendingAction(UUIDMixin, Base):
     # land in any DB dump taken during the grace window. Text because
     # ciphertext is longer than the 200-char plaintext bound. Written via
     # encrypt() in queue_pending_action; decrypted defensively on read.
-    target_label: Mapped[str] = mapped_column(Text, nullable=False)
+    target_label: Mapped[str] = mapped_column(Text, nullable=False, info={"encrypted": True})
 
     requested_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
@@ -73,7 +73,9 @@ class PendingAction(UUIDMixin, Base):
     # decrypted member names. Stored as encrypt(json.dumps(list_of_names))
     # in a Text column. No server_default - the app sets the value on every
     # write and the encrypting migration backfills existing rows.
-    fronting_member_names: Mapped[str] = mapped_column(Text, nullable=False)
+    fronting_member_names: Mapped[str] = mapped_column(
+        Text, nullable=False, info={"encrypted": True}
+    )
 
     status: Mapped[str] = mapped_column(
         String(16),

--- a/sheaf/models/poll.py
+++ b/sheaf/models/poll.py
@@ -68,8 +68,8 @@ class Poll(UUIDMixin, TimestampMixin, Base):
     )
 
     # Encrypted at rest.
-    question: Mapped[str] = mapped_column(Text, nullable=False)
-    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    question: Mapped[str] = mapped_column(Text, nullable=False, info={"encrypted": True})
+    description: Mapped[str | None] = mapped_column(Text, nullable=True, info={"encrypted": True})
 
     kind: Mapped[str] = mapped_column(String(16), nullable=False)
     results_visibility: Mapped[str] = mapped_column(String(16), nullable=False)
@@ -121,7 +121,7 @@ class PollOption(UUIDMixin, Base):
         index=True,
     )
     # Encrypted at rest.
-    text: Mapped[str] = mapped_column(Text, nullable=False)
+    text: Mapped[str] = mapped_column(Text, nullable=False, info={"encrypted": True})
     position: Mapped[int] = mapped_column(Integer, nullable=False)
 
     poll: Mapped[Poll] = relationship(back_populates="options")

--- a/sheaf/models/reminder.py
+++ b/sheaf/models/reminder.py
@@ -76,8 +76,8 @@ class Reminder(UUIDMixin, TimestampMixin, Base):
     # title + body are encrypted at rest (matching the encryption discipline
     # used for member descriptions and journal entries — both are free-text
     # user content).
-    title: Mapped[str] = mapped_column(Text, nullable=False)
-    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    title: Mapped[str] = mapped_column(Text, nullable=False, info={"encrypted": True})
+    body: Mapped[str | None] = mapped_column(Text, nullable=True, info={"encrypted": True})
 
     enabled: Mapped[bool] = mapped_column(
         Boolean, default=True, nullable=False, server_default="true"

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -43,7 +43,7 @@ class System(UUIDMixin, TimestampMixin, Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Free-text scratchpad note. Same shape as Member.note: encrypted at
     # rest, lightweight, no revisions or System Safety integration.
-    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True, info={"encrypted": True})
     tag: Mapped[str | None] = mapped_column(String(8), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     color: Mapped[str | None] = mapped_column(String(7), nullable=True)
@@ -168,7 +168,9 @@ class System(UUIDMixin, TimestampMixin, Base):
     # Sheaf-in-the-middle round-trip does not silently drop it. Stored
     # encrypted (it can carry message bodies) and zlib-compressed; see
     # services/openplural_archive.py. NULL when nothing was preserved.
-    openplural_archive: Mapped[str | None] = mapped_column(Text, nullable=True)
+    openplural_archive: Mapped[str | None] = mapped_column(
+        Text, nullable=True, info={"encrypted": True}
+    )
 
     # Relationships
     user: Mapped["User"] = relationship(back_populates="system")

--- a/sheaf/models/user.py
+++ b/sheaf/models/user.py
@@ -34,17 +34,19 @@ class User(UUIDMixin, TimestampMixin, Base):
     __tablename__ = "users"
 
     # Encrypted at application level — store ciphertext
-    email: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False, info={"encrypted": True})
     # Blind index for lookups (keyed HMAC-SHA-256 of normalised email)
     email_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
 
     password_hash: Mapped[str] = mapped_column(String(128), nullable=False)
 
     # TOTP 2FA — encrypted at application level
-    totp_secret: Mapped[str | None] = mapped_column(String, nullable=True)
+    totp_secret: Mapped[str | None] = mapped_column(String, nullable=True, info={"encrypted": True})
     totp_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # Recovery codes — encrypted JSON array of hashed codes
-    recovery_codes: Mapped[str | None] = mapped_column(String, nullable=True)
+    recovery_codes: Mapped[str | None] = mapped_column(
+        String, nullable=True, info={"encrypted": True}
+    )
 
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -98,6 +98,7 @@ ShieldDirection = Literal["activated", "deactivated"]
 DecryptField = Literal[
     "email", "totp_secret", "recovery_codes", "channel_config", "other"
 ]
+FieldDecryptVersion = Literal["v1", "v2"]
 
 TierLimit = Literal[
     "members",
@@ -467,6 +468,14 @@ decrypt_failures_total = _C(
     "indicates key drift or corruption.",
     ["field"],
 )
+field_decrypts_total = _C(
+    "sheaf_field_decrypts_total",
+    "Successful field decrypts by ciphertext format version. Tracks the "
+    "v1 (no-AAD) -> v2 (AAD-bound) migration: v2 should climb and v1 fall "
+    "as rows are rewritten; a v1 floor that never reaches zero flags cells "
+    "no converted write path is touching.",
+    ["version"],
+)
 tier_limit_hits_total = _C(
     "sheaf_tier_limit_hits_total",
     "Quota-rejection callsites by limit category and account tier. "
@@ -824,6 +833,9 @@ def prewarm_metrics() -> None:
     # the absence alert can detect a non-zero rate as soon as it appears.
     for field in ("email", "totp_secret", "recovery_codes", "channel_config", "other"):
         decrypt_failures_total.labels(field=field).inc(0)
+
+    for version in ("v1", "v2"):
+        field_decrypts_total.labels(version=version).inc(0)
 
     auth_recovery_codes_used_total.inc(0)
     cf_shield_session_revocations_total.inc(0)

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -475,8 +475,9 @@ field_decrypts_total = _C(
     "counter, so the migration signal is the RATE of v1 reads trending to "
     "zero, not the total. Read volume cannot prove completeness (dormant "
     "cells are never read): the re-encrypt sweep's remaining-v1 count is "
-    "the completeness signal. Once FIELD_ENCRYPTION_ACCEPT_V1 is off, any "
-    "nonzero v1 rate here means a rejected legacy read (see failures).",
+    "the completeness signal. This counts only SUCCESSFUL decrypts; once "
+    "FIELD_ENCRYPTION_ACCEPT_V1 is off, rejected v1 reads never reach here "
+    "and are counted on field_decrypt_v1_rejected_total instead.",
     ["version"],
 )
 field_decrypt_v1_rejected_total = _C(

--- a/sheaf/observability/metrics.py
+++ b/sheaf/observability/metrics.py
@@ -96,7 +96,8 @@ PendingActionOutcome = Literal["completed", "cancelled", "errored"]
 ShieldDirection = Literal["activated", "deactivated"]
 
 DecryptField = Literal[
-    "email", "totp_secret", "recovery_codes", "channel_config", "other"
+    "email", "totp_secret", "recovery_codes", "channel_config", "other",
+    "unlabelled",
 ]
 FieldDecryptVersion = Literal["v1", "v2"]
 
@@ -470,11 +471,20 @@ decrypt_failures_total = _C(
 )
 field_decrypts_total = _C(
     "sheaf_field_decrypts_total",
-    "Successful field decrypts by ciphertext format version. Tracks the "
-    "v1 (no-AAD) -> v2 (AAD-bound) migration: v2 should climb and v1 fall "
-    "as rows are rewritten; a v1 floor that never reaches zero flags cells "
-    "no converted write path is touching.",
+    "Successful field decrypts by ciphertext format version. A cumulative "
+    "counter, so the migration signal is the RATE of v1 reads trending to "
+    "zero, not the total. Read volume cannot prove completeness (dormant "
+    "cells are never read): the re-encrypt sweep's remaining-v1 count is "
+    "the completeness signal. Once FIELD_ENCRYPTION_ACCEPT_V1 is off, any "
+    "nonzero v1 rate here means a rejected legacy read (see failures).",
     ["version"],
+)
+field_decrypt_v1_rejected_total = _C(
+    "sheaf_field_decrypt_v1_rejected_total",
+    "Reads of legacy v1 ciphertext rejected because "
+    "FIELD_ENCRYPTION_ACCEPT_V1 is disabled. After migration this should be "
+    "zero; a nonzero rate is an attempted legacy read or a v1 downgrade "
+    "attack.",
 )
 tier_limit_hits_total = _C(
     "sheaf_tier_limit_hits_total",
@@ -831,11 +841,16 @@ def prewarm_metrics() -> None:
 
     # decrypt_failures should always be zero; pre-touch each field so
     # the absence alert can detect a non-zero rate as soon as it appears.
-    for field in ("email", "totp_secret", "recovery_codes", "channel_config", "other"):
+    for field in (
+        "email", "totp_secret", "recovery_codes", "channel_config", "other",
+        "unlabelled",
+    ):
         decrypt_failures_total.labels(field=field).inc(0)
 
     for version in ("v1", "v2"):
         field_decrypts_total.labels(version=version).inc(0)
+
+    field_decrypt_v1_rejected_total.inc(0)
 
     auth_recovery_codes_used_total.inc(0)
     cf_shield_session_revocations_total.inc(0)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -19,6 +19,19 @@ _PK = uuid.uuid4()
 _AAD = crypto.field_aad("users", "email", _PK)
 
 
+@pytest.fixture(autouse=True)
+def _write_v2_on(monkeypatch):
+    """Exercise the steady-state v2 write path by default.
+
+    The production write gate (`field_encryption_write_v2`) defaults off so
+    the v2-capable release is a rollback-safe bridge; that staging is a
+    deployment concern, verified in the gate-specific tests below. Every
+    other test here is about the crypto layer's v2 behaviour, so it assumes
+    the enabled state. monkeypatch restores the default at teardown.
+    """
+    monkeypatch.setattr(crypto.settings, "field_encryption_write_v2", True)
+
+
 # ---------------------------------------------------------------------------
 # field_aad
 # ---------------------------------------------------------------------------
@@ -115,6 +128,107 @@ def test_v2_tampered_body_raises():
     tampered = "v2:" + base64.urlsafe_b64encode(bytes(raw)).decode()
     with pytest.raises(nacl.exceptions.CryptoError):
         crypto.decrypt(tampered, aad=_AAD)
+
+
+# ---------------------------------------------------------------------------
+# v1 cutoff (FIELD_ENCRYPTION_ACCEPT_V1=false)
+# ---------------------------------------------------------------------------
+
+def test_v1_rejected_when_accept_v1_disabled(monkeypatch):
+    # The dual-read window is also the downgrade-attack window: a DB writer
+    # can overwrite a v2 cell with a preserved v1 ciphertext and the aad is
+    # never consulted. The cutoff closes it: v1 tokens fail closed.
+    token = crypto.encrypt("legacy value")
+    monkeypatch.setattr(crypto.settings, "field_encryption_accept_v1", False)
+    with pytest.raises(
+        nacl.exceptions.CryptoError, match="legacy v1 ciphertext rejected"
+    ):
+        crypto.decrypt(token)
+
+
+def test_v2_still_reads_when_accept_v1_disabled(monkeypatch):
+    token = crypto.encrypt("bound", aad=_AAD)
+    monkeypatch.setattr(crypto.settings, "field_encryption_accept_v1", False)
+    assert crypto.decrypt(token, aad=_AAD) == "bound"
+
+
+def test_v1_encrypt_rejected_when_accept_v1_disabled(monkeypatch):
+    # Writing a v1 token the same instance can no longer read back would be
+    # self-inflicted data loss, so a no-aad encrypt fails fast instead.
+    monkeypatch.setattr(crypto.settings, "field_encryption_accept_v1", False)
+    with pytest.raises(ValueError, match="v1 encryption disabled"):
+        crypto.encrypt("new value")
+
+
+def test_v2_encrypt_still_works_when_accept_v1_disabled(monkeypatch):
+    monkeypatch.setattr(crypto.settings, "field_encryption_accept_v1", False)
+    token = crypto.encrypt("bound", aad=_AAD)
+    assert token.startswith("v2:")
+    assert crypto.decrypt(token, aad=_AAD) == "bound"
+
+
+# ---------------------------------------------------------------------------
+# write gate (FIELD_ENCRYPTION_WRITE_V2)
+# ---------------------------------------------------------------------------
+
+def test_write_gate_off_writes_v1_even_with_aad(monkeypatch):
+    # The bridge release: call sites already pass an aad, but until the write
+    # gate flips, writes stay v1 so a rollback target that only reads v1 is
+    # safe. The aad is accepted and ignored for the write.
+    monkeypatch.setattr(crypto.settings, "field_encryption_write_v2", False)
+    token = crypto.encrypt("bridge value", aad=_AAD)
+    assert not token.startswith("v2:")
+    # Still readable, and a converted call site reading it back passes its
+    # aad, which the v1 path ignores.
+    assert crypto.decrypt(token, aad=_AAD) == "bridge value"
+
+
+def test_write_gate_on_writes_v2(monkeypatch):
+    monkeypatch.setattr(crypto.settings, "field_encryption_write_v2", True)
+    token = crypto.encrypt("gated value", aad=_AAD)
+    assert token.startswith("v2:")
+
+
+# ---------------------------------------------------------------------------
+# v1 known-answer (frozen fixture)
+# ---------------------------------------------------------------------------
+
+# A v1 token FROZEN at generation time under a fixed key, so a serialization
+# regression in the legacy path (key derivation, base64 variant, nonce/ct
+# layout) cannot slip through while every round-trip test still passes.
+# Generated once in a fresh process (so the cached boxes derived from the
+# fixed key) via:
+#
+#   SHEAF_ENCRYPTION_KEY='frozen-v1-known-answer-key-2026-do-not-use-in-prod' \
+#     uv run python -c \
+#     "from sheaf import crypto; print(crypto.encrypt('frozen-v1-known-answer-plaintext'))"
+_KA_KEY = "frozen-v1-known-answer-key-2026-do-not-use-in-prod"
+_KA_PLAINTEXT = "frozen-v1-known-answer-plaintext"
+_KA_V1_TOKEN = (
+    "VWlVgmED6JofbwhFfLwBhYIO72I0WIfoTX5q6JMIEiBJgfrG2qpEXVn8"
+    "-mJNJiZgCyJguqvgoJy5OcArBAzlQidkgYAqB3h8"
+)
+
+
+@pytest.fixture
+def _known_answer_key(monkeypatch):
+    """Point crypto at the frozen key and drop the cached boxes.
+
+    `get_encryption_key()` returns `settings.sheaf_encryption_key.encode()`
+    when the setting is non-empty, so patching the attribute is enough - but
+    the module caches its SecretBox/Aead in `_box` / `_aead_box`, which must
+    be cleared or the boxes keep the previously derived key. monkeypatch
+    restores both the setting and the original cached box objects at
+    teardown, so the other tests keep their cached ephemeral key untouched.
+    """
+    monkeypatch.setattr(crypto.settings, "sheaf_encryption_key", _KA_KEY)
+    monkeypatch.setattr(crypto, "_box", None)
+    monkeypatch.setattr(crypto, "_aead_box", None)
+
+
+def test_v1_known_answer_frozen_token(_known_answer_key):
+    assert not _KA_V1_TOKEN.startswith("v2:")
+    assert crypto.decrypt(_KA_V1_TOKEN) == _KA_PLAINTEXT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,138 @@
+"""Headless unit tests for field encryption and its v1/v2 formats.
+
+No DB / docker stack needed - these exercise `sheaf.crypto` directly. The
+module derives its key from `sheaf.config.settings.get_encryption_key()`,
+which auto-generates an ephemeral key when SHEAF_ENCRYPTION_KEY is unset, so
+these round-trip tests are independent of which key is active.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import nacl.exceptions
+import pytest
+
+from sheaf import crypto
+
+_PK = uuid.uuid4()
+_AAD = crypto.field_aad("users", "email", _PK)
+
+
+# ---------------------------------------------------------------------------
+# field_aad
+# ---------------------------------------------------------------------------
+
+def test_field_aad_format_exact():
+    assert crypto.field_aad("users", "email", _PK) == (
+        f"sheaf-fe-v2|users|email|{_PK}".encode()
+    )
+
+
+def test_field_aad_differs_per_component():
+    base = crypto.field_aad("users", "email", _PK)
+    assert crypto.field_aad("systems", "email", _PK) != base  # table
+    assert crypto.field_aad("users", "phone", _PK) != base     # column
+    assert crypto.field_aad("users", "email", uuid.uuid4()) != base  # pk
+
+
+# ---------------------------------------------------------------------------
+# v1 (legacy, no aad)
+# ---------------------------------------------------------------------------
+
+def test_v1_roundtrip_no_prefix():
+    token = crypto.encrypt("hello world")
+    assert not token.startswith("v2:")
+    assert crypto.decrypt(token) == "hello world"
+
+
+def test_v1_empty_string_roundtrip():
+    token = crypto.encrypt("")
+    assert not token.startswith("v2:")
+    assert crypto.decrypt(token) == ""
+
+
+def test_v1_token_ignores_passed_aad():
+    # Dual-read window: a converted call site passes an aad but must still be
+    # able to read old v1 rows, which carry no associated data.
+    token = crypto.encrypt("legacy value")
+    assert crypto.decrypt(token, aad=_AAD) == "legacy value"
+
+
+# ---------------------------------------------------------------------------
+# v2 (AAD-bound)
+# ---------------------------------------------------------------------------
+
+def test_v2_roundtrip_has_prefix():
+    token = crypto.encrypt("hello world", aad=_AAD)
+    assert token.startswith("v2:")
+    assert crypto.decrypt(token, aad=_AAD) == "hello world"
+
+
+def test_v2_empty_string_roundtrip():
+    token = crypto.encrypt("", aad=_AAD)
+    assert token.startswith("v2:")
+    assert crypto.decrypt(token, aad=_AAD) == ""
+
+
+def test_v2_wrong_table_raises():
+    token = crypto.encrypt("secret", aad=_AAD)
+    wrong = crypto.field_aad("systems", "email", _PK)
+    with pytest.raises(nacl.exceptions.CryptoError):
+        crypto.decrypt(token, aad=wrong)
+
+
+def test_v2_wrong_column_raises():
+    token = crypto.encrypt("secret", aad=_AAD)
+    wrong = crypto.field_aad("users", "phone", _PK)
+    with pytest.raises(nacl.exceptions.CryptoError):
+        crypto.decrypt(token, aad=wrong)
+
+
+def test_v2_wrong_pk_raises():
+    token = crypto.encrypt("secret", aad=_AAD)
+    wrong = crypto.field_aad("users", "email", uuid.uuid4())
+    with pytest.raises(nacl.exceptions.CryptoError):
+        crypto.decrypt(token, aad=wrong)
+
+
+def test_v2_decrypt_without_aad_raises_valueerror():
+    # A v2 read with no context is a programming error and must NOT fall
+    # through to a no-AAD path.
+    token = crypto.encrypt("secret", aad=_AAD)
+    with pytest.raises(ValueError, match="v2 ciphertext requires aad"):
+        crypto.decrypt(token)
+
+
+def test_v2_tampered_body_raises():
+    import base64
+
+    token = crypto.encrypt("secret", aad=_AAD)
+    raw = bytearray(base64.urlsafe_b64decode(token[len("v2:"):]))
+    # Flip a byte inside the ciphertext/tag region (past the 24-byte nonce)
+    # to corrupt authentication without disturbing base64 padding.
+    raw[-1] ^= 0x01
+    tampered = "v2:" + base64.urlsafe_b64encode(bytes(raw)).decode()
+    with pytest.raises(nacl.exceptions.CryptoError):
+        crypto.decrypt(tampered, aad=_AAD)
+
+
+# ---------------------------------------------------------------------------
+# decrypt_field passthrough
+# ---------------------------------------------------------------------------
+
+def test_decrypt_field_passes_aad_through_success():
+    token = crypto.encrypt("via field", aad=_AAD)
+    assert crypto.decrypt_field(token, "email", aad=_AAD) == "via field"
+
+
+def test_decrypt_field_v1_still_works():
+    token = crypto.encrypt("legacy")
+    assert crypto.decrypt_field(token, "email") == "legacy"
+
+
+def test_decrypt_field_raises_on_wrong_aad():
+    token = crypto.encrypt("secret", aad=_AAD)
+    wrong = crypto.field_aad("users", "email", uuid.uuid4())
+    with pytest.raises(nacl.exceptions.CryptoError):
+        crypto.decrypt_field(token, "email", aad=wrong)

--- a/tests/test_encrypted_fields_registry.py
+++ b/tests/test_encrypted_fields_registry.py
@@ -88,14 +88,26 @@ def _resolve(table, logical):
     """Resolve a registry (table, logical_column) to a physical column.
 
     Returns (physical_column, None) on success or (None, reason) on failure.
-    Rule: exact column match, OR the logical name starts with
-    `physical_column + "."` and that physical column is marked
-    info={"encrypted": "json"}.
+    Rule: exact column match AND the column is marked exactly
+    info={"encrypted": True} (a "json"-marked column holds ciphertext at a
+    JSON *path*, so an exact-column helper on it is a mis-binding), OR the
+    logical name starts with `physical_column + "."` and that physical
+    column is marked info={"encrypted": "json"}. Requiring the strict marker
+    on the exact-match branch keeps the check two-way: a helper pointing at
+    a real but PLAINTEXT (or merely truthy-marked) column must fail, not
+    pass.
     """
     t = Base.metadata.tables.get(table)
     if t is None:
         return None, f"table {table!r} does not exist in Base.metadata"
     if logical in t.columns:
+        if t.columns[logical].info.get("encrypted") is not True:
+            return None, (
+                f"column {table}.{logical} exists but is not marked exactly "
+                f'info={{"encrypted": True}} - either the helper binds a '
+                f"plaintext or json-marked column, or the marker is missing "
+                f"in sheaf/models/"
+            )
         return logical, None
     if "." in logical:
         physical = logical.split(".", 1)[0]
@@ -153,6 +165,99 @@ def test_no_duplicate_registry_bindings():
             f"{table}.{column}; each cell must have exactly one helper."
         )
         seen[key] = fn_name
+
+
+# The golden binding map: every AAD helper and the exact (table, logical
+# column) its body must bind. Deliberately a full literal, not derived from
+# the module under test: the set-based checks above cannot see a helper whose
+# BODY binds the wrong cell while the overall cell set stays intact (e.g.
+# member_name_aad returning the members.note AAD while member_note_aad
+# returns members.name). Changing any binding must be a conscious edit here,
+# because the (table, column) strings are baked into the AAD of stored rows.
+_GOLDEN_BINDINGS = {
+    "user_email_aad": ("users", "email"),
+    "user_totp_secret_aad": ("users", "totp_secret"),
+    "user_recovery_codes_aad": ("users", "recovery_codes"),
+    "member_name_aad": ("members", "name"),
+    "member_description_aad": ("members", "description"),
+    "member_note_aad": ("members", "note"),
+    "system_note_aad": ("systems", "note"),
+    "system_openplural_archive_aad": ("systems", "openplural_archive"),
+    "front_custom_status_aad": ("fronts", "custom_status"),
+    "journal_title_aad": ("journal_entries", "title"),
+    "journal_body_aad": ("journal_entries", "body"),
+    "revision_title_aad": ("content_revisions", "title"),
+    "revision_body_aad": ("content_revisions", "body"),
+    "reminder_title_aad": ("reminders", "title"),
+    "reminder_body_aad": ("reminders", "body"),
+    "message_body_aad": ("messages", "body"),
+    "poll_question_aad": ("polls", "question"),
+    "poll_description_aad": ("polls", "description"),
+    "poll_option_text_aad": ("poll_options", "text"),
+    "custom_field_value_aad": ("custom_field_values", "value"),
+    "webhook_secret_aad": ("notification_channels", "webhook_secret_encrypted"),
+    "import_credential_aad": (
+        "import_jobs", "payload_metadata.encrypted_credential",
+    ),
+    "pending_target_label_aad": ("pending_actions", "target_label"),
+    "pending_fronting_names_aad": ("pending_actions", "fronting_member_names"),
+}
+
+
+def test_registry_matches_golden_binding_map():
+    """Every helper binds exactly the golden (table, logical column) - both
+    directions: no helper missing from the map, no map entry without a
+    helper, and no helper whose body produces a different cell's AAD."""
+    actual = {
+        fn_name: (table, column)
+        for fn_name, table, column in _registry_bindings()
+    }
+    assert actual == _GOLDEN_BINDINGS, (
+        f"helpers not in golden map: {sorted(actual.keys() - _GOLDEN_BINDINGS.keys())}; "
+        f"golden entries without a helper: {sorted(_GOLDEN_BINDINGS.keys() - actual.keys())}; "
+        f"mis-bound: "
+        f"{ {k: (actual[k], _GOLDEN_BINDINGS[k]) for k in actual.keys() & _GOLDEN_BINDINGS.keys() if actual[k] != _GOLDEN_BINDINGS[k]} }. "
+        f"A binding change rewrites the AAD baked into stored rows - only "
+        f"edit the golden map as a conscious, reviewed decision."
+    )
+
+
+def test_registry_and_schema_sets_are_identical():
+    """The resolved registry cells and the marked schema columns are the
+    same set - a direct two-way comparison on top of the per-item checks,
+    so nothing can slip through an asymmetry between them."""
+    resolved = set()
+    for _fn_name, table, column in _registry_bindings():
+        physical, reason = _resolve(table, column)
+        assert physical is not None, reason
+        resolved.add((table, physical))
+    marked = {(table, column) for table, column, _marker in _schema_marked()}
+    assert resolved == marked, (
+        f"registry-only: {sorted(resolved - marked)}; "
+        f"schema-only: {sorted(marked - resolved)}"
+    )
+
+
+def test_ciphertext_copies_reference_real_marked_cells():
+    """CIPHERTEXT_COPIES (stored ciphertext copies outside their owning
+    cell, e.g. front audit snapshots) must point at real storage tables and
+    real marked source cells, so the Phase 2 sweep can trust the constant."""
+    for storage_table, storage_path, source_cell in (
+        encrypted_fields.CIPHERTEXT_COPIES
+    ):
+        assert storage_table in Base.metadata.tables, (
+            f"CIPHERTEXT_COPIES storage table {storage_table!r} does not exist"
+        )
+        storage_col = storage_path.split(".", 1)[0]
+        assert storage_col in Base.metadata.tables[storage_table].columns, (
+            f"CIPHERTEXT_COPIES storage column "
+            f"{storage_table}.{storage_col!r} does not exist"
+        )
+        src_table, src_column = source_cell.split(".", 1)
+        physical, reason = _resolve(src_table, src_column)
+        assert physical is not None, (
+            f"CIPHERTEXT_COPIES source cell {source_cell!r}: {reason}"
+        )
 
 
 def test_marked_tables_have_single_uuid_id_primary_key():

--- a/tests/test_encrypted_fields_registry.py
+++ b/tests/test_encrypted_fields_registry.py
@@ -1,0 +1,179 @@
+"""Drift guard between the DB schema and the encrypted-cell registry.
+
+Pure-unit: introspects `sheaf.encrypted_fields` and `Base.metadata` only,
+so it needs neither a database nor the encryption key. It fails loudly when
+the two inventories drift apart, which is the failure mode that silently
+leaves a column on the legacy (unbound) ciphertext format forever.
+
+Two sides are compared:
+
+- The *registry*: every public helper in `sheaf.encrypted_fields`, each of
+  which returns the AAD `sheaf-fe-v2|{table}|{column}|{pk}` for one cell.
+- The *schema*: every column whose `info` carries an `encrypted` marker
+  (`True`, or `"json"` for a ciphertext embedded inside a JSONB column).
+
+A logical JSON path like `payload_metadata.encrypted_credential` maps to the
+physical column `payload_metadata`, which must itself be marked
+`info={"encrypted": "json"}`.
+"""
+
+import inspect
+
+from sqlalchemy.dialects.postgresql import UUID
+
+from sheaf import encrypted_fields
+from sheaf.models import Base
+
+# A distinctive pk value we can look for in the last AAD field. Deliberately
+# not a real UUID and not containing '|' or '.', so a helper that hand-rolls
+# the AAD string instead of going through field_aad still round-trips it here.
+_SENTINEL_PK = "SENTINEL-PK-0000"
+
+_DESIGN_DOC = "sheaf-design-docs/field-encryption-context-binding.md"
+
+
+def _registry_helpers():
+    """Public AAD helpers defined in sheaf.encrypted_fields (not imports)."""
+    return [
+        fn
+        for name, fn in inspect.getmembers(encrypted_fields, inspect.isfunction)
+        if not name.startswith("_") and fn.__module__ == encrypted_fields.__name__
+    ]
+
+
+def _registry_bindings():
+    """Map each helper to the (table, logical_column) it binds.
+
+    Also asserts the AAD *shape* per helper, so a typo'd hand-rolled f-string
+    that bypasses field_aad is caught here rather than silently mis-binding.
+    """
+    bindings = []
+    for fn in _registry_helpers():
+        raw = fn(_SENTINEL_PK)
+        assert isinstance(raw, bytes), (
+            f"{fn.__name__} returned {type(raw).__name__}, expected bytes; "
+            f"AAD helpers must return the field_aad() byte string."
+        )
+        parts = raw.decode().split("|")
+        assert len(parts) == 4, (
+            f"{fn.__name__} produced AAD {raw!r} with {len(parts)} '|'-separated "
+            f"parts, expected exactly 4 (sheaf-fe-v2|table|column|pk). Use "
+            f"field_aad(table, column, pk) instead of a hand-rolled string."
+        )
+        label, table, column, pk = parts
+        assert label == "sheaf-fe-v2", (
+            f"{fn.__name__} produced AAD label {label!r}, expected 'sheaf-fe-v2'."
+        )
+        assert pk == _SENTINEL_PK, (
+            f"{fn.__name__} put {pk!r} in the pk position, expected the passed "
+            f"pk {_SENTINEL_PK!r}; the helper must pass its argument through as "
+            f"the row pk, not substitute a constant."
+        )
+        bindings.append((fn.__name__, table, column))
+    return bindings
+
+
+def _schema_marked():
+    """Every (table, column, marker) carrying an `encrypted` info marker."""
+    marked = []
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            marker = column.info.get("encrypted")
+            if marker:
+                marked.append((table.name, column.name, marker))
+    return marked
+
+
+def _resolve(table, logical):
+    """Resolve a registry (table, logical_column) to a physical column.
+
+    Returns (physical_column, None) on success or (None, reason) on failure.
+    Rule: exact column match, OR the logical name starts with
+    `physical_column + "."` and that physical column is marked
+    info={"encrypted": "json"}.
+    """
+    t = Base.metadata.tables.get(table)
+    if t is None:
+        return None, f"table {table!r} does not exist in Base.metadata"
+    if logical in t.columns:
+        return logical, None
+    if "." in logical:
+        physical = logical.split(".", 1)[0]
+        col = t.columns.get(physical)
+        if col is None:
+            return None, f"physical column {table}.{physical!r} does not exist"
+        if col.info.get("encrypted") != "json":
+            return None, (
+                f"column {table}.{physical} is not marked "
+                f'info={{"encrypted": "json"}}, so the JSON path {logical!r} '
+                f"cannot resolve to it"
+            )
+        return physical, None
+    return None, f"column {table}.{logical!r} does not exist"
+
+
+def test_registry_bindings_resolve_to_real_columns():
+    """Every registry helper binds a real (table, column) in the schema."""
+    for fn_name, table, column in _registry_bindings():
+        physical, reason = _resolve(table, column)
+        assert physical is not None, (
+            f"encrypted_fields.{fn_name} binds {table}.{column}, but {reason}. "
+            f"Fix the helper's table/column, or mark the column in sheaf/models/."
+        )
+
+
+def test_every_marked_column_has_a_registry_helper():
+    """Every schema-marked encrypted column is covered by a helper."""
+    bindings = _registry_bindings()
+    for table, column, marker in _schema_marked():
+        if marker == "json":
+            covered = any(
+                b_table == table and b_col.startswith(column + ".")
+                for _, b_table, b_col in bindings
+            )
+        else:
+            covered = any(
+                b_table == table and b_col == column
+                for _, b_table, b_col in bindings
+            )
+        assert covered, (
+            f"{table}.{column} is marked encrypted in sheaf/models/ but no helper "
+            f"in sheaf/encrypted_fields.py binds it. Add a helper and wire the cell "
+            f"into the re-encrypt sweep, or the column stays on the legacy format."
+        )
+
+
+def test_no_duplicate_registry_bindings():
+    """No two helpers bind the same (table, logical column)."""
+    seen = {}
+    for fn_name, table, column in _registry_bindings():
+        key = (table, column)
+        assert key not in seen, (
+            f"encrypted_fields.{fn_name} and encrypted_fields.{seen[key]} both bind "
+            f"{table}.{column}; each cell must have exactly one helper."
+        )
+        seen[key] = fn_name
+
+
+def test_marked_tables_have_single_uuid_id_primary_key():
+    """Marked columns' tables use the pk convention the AAD scheme assumes.
+
+    The registry passes a single UUID row id as the pk. If a marked table ever
+    has a composite or non-`id` primary key, the AAD scheme needs the
+    composite-pk extension described in the design doc.
+    """
+    marked_tables = {table for table, _column, _marker in _schema_marked()}
+    for table_name in sorted(marked_tables):
+        table = Base.metadata.tables[table_name]
+        pk_cols = list(table.primary_key.columns)
+        assert len(pk_cols) == 1 and pk_cols[0].name == "id", (
+            f"table {table_name} does not have a single-column primary key named "
+            f"'id' (found {[c.name for c in pk_cols]}); the field-encryption AAD "
+            f"scheme binds ciphertext to a single UUID id. Consult {_DESIGN_DOC} "
+            f"for the composite-pk extension before marking columns on this table."
+        )
+        pk = pk_cols[0]
+        assert isinstance(pk.type, UUID), (
+            f"table {table_name} primary key 'id' is {pk.type!r}, not a UUID; the "
+            f"AAD scheme stringifies a UUID row id as the pk. Consult {_DESIGN_DOC}."
+        )

--- a/tests/test_encrypted_fields_registry.py
+++ b/tests/test_encrypted_fields_registry.py
@@ -238,10 +238,42 @@ def test_registry_and_schema_sets_are_identical():
     )
 
 
+# Pinned exact expected contents of CIPHERTEXT_COPIES. Kept literal so that
+# deleting an entry (which would silently drop it from the Phase 2 sweep and
+# strand its ciphertext copies on v1) fails this test rather than passing
+# vacuously. Adding a new stored-ciphertext-copy site is a conscious edit here.
+_EXPECTED_CIPHERTEXT_COPIES = {
+    (
+        "front_audit_events",
+        "before_snapshot.custom_status_encrypted",
+        "fronts.custom_status",
+    ),
+    (
+        "front_audit_events",
+        "after_snapshot.custom_status_encrypted",
+        "fronts.custom_status",
+    ),
+}
+
+
+def test_ciphertext_copies_match_pinned_set():
+    """CIPHERTEXT_COPIES is exactly the pinned set - guards against a silent
+    deletion making the sweep-coverage test below vacuous."""
+    assert set(encrypted_fields.CIPHERTEXT_COPIES) == _EXPECTED_CIPHERTEXT_COPIES, (
+        "CIPHERTEXT_COPIES drifted from the pinned set. If you are adding or "
+        "removing a stored ciphertext copy, update _EXPECTED_CIPHERTEXT_COPIES "
+        "and the Phase 2 re-encrypt sweep together."
+    )
+
+
 def test_ciphertext_copies_reference_real_marked_cells():
     """CIPHERTEXT_COPIES (stored ciphertext copies outside their owning
     cell, e.g. front audit snapshots) must point at real storage tables and
     real marked source cells, so the Phase 2 sweep can trust the constant."""
+    assert encrypted_fields.CIPHERTEXT_COPIES, (
+        "CIPHERTEXT_COPIES is empty; the front-audit snapshot copies must be "
+        "listed or the sweep will strand them on v1"
+    )
     for storage_table, storage_path, source_cell in (
         encrypted_fields.CIPHERTEXT_COPIES
     ):


### PR DESCRIPTION
## What this is

Part 1 of 2 for field-encryption context binding. This PR adds the machinery
only; **no call site is converted here, so it changes no behaviour on its
own.** The call-site conversion is the stacked follow-up PR.

Today each field is encrypted with `SecretBox` (XSalsa20-Poly1305) under one
key, with no associated data. The Poly1305 tag authenticates the bytes but not
*where* they live, so an actor with database write access can relocate an
intact ciphertext into any other encrypted cell and it still decrypts to the
attacker-chosen plaintext. This adds a versioned v2 format that binds each
ciphertext to its `(table, column, row-pk)` via AEAD associated data, so a
relocated ciphertext fails closed instead of decrypting in the wrong place.

## In this PR

- **v2 format** in `crypto.py`: `nacl.secret.Aead` (XChaCha20-Poly1305-IETF)
  alongside the legacy `SecretBox` path. v2 tokens carry a `v2:` prefix; the
  AAD is `sheaf-fe-v2|table|column|pk`. `decrypt` dual-reads both formats, so
  existing rows keep working with no data migration.
- **Two rollout flags** (`config.py`):
  - `FIELD_ENCRYPTION_WRITE_V2` (default off): write v2 only when a call site
    supplies an aad AND this is on, else v1. This makes the release that
    introduces v2-capable code a bridge (reads both, writes v1) and a safe
    rollback target for the release that later flips it on.
  - `FIELD_ENCRYPTION_ACCEPT_V1` (default on): when off, v1 reads fail closed
    and no-aad encrypts are refused, closing the dual-read downgrade window.
  - Startup hard-fails the incoherent `write_v2=off + accept_v1=off` combo in
    every mode.
- **Encrypted-cell registry** (`encrypted_fields.py`): one AAD helper per
  encrypted column, plus `CIPHERTEXT_COPIES` for stored ciphertext copies (the
  front-audit snapshots) the future re-encrypt sweep must also cover. Every
  encrypted model column gets an `info={"encrypted"}` marker.
- **Observability**: `sheaf_field_decrypts_total{version}` and
  `sheaf_field_decrypt_v1_rejected_total`; failure counting moved into
  `decrypt()` itself so every read path is covered.
- **Tests**: v1/v2 round-trips, wrong table/column/pk and tamper cases, the
  cutoff and write-gate behaviour, a frozen v1 known-answer token, and a
  schema-vs-registry drift guard with a pinned golden binding map.

## Not in scope here

The ~100 call-site conversions, the legacy-plaintext fallback gating, and the
relocation-attack integration tests are in the stacked follow-up PR. Rollout
sequencing (bridge release with the gate off, then a one-line flip) is
documented there.
