### PR TITLE
Field encryption: bind every call site to its cell (v2 AAD)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,6 +18,11 @@ services:
       REDIS_URL: redis://redis:6379/0
       JWT_SECRET_KEY: test-jwt-secret-not-for-production
       SHEAF_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      # Exercise the AAD-bound v2 write path (the post-bridge steady state)
+      # so the encryption relocation-attack tests write real v2 ciphertext.
+      # The write gate defaults off in production for a rollback-safe
+      # rollout; the test stack runs the enabled state on purpose.
+      FIELD_ENCRYPTION_WRITE_V2: "true"
       SHEAF_BASE_URL: "http://localhost:8001"
       SHEAF_MODE: "${SHEAF_MODE:-selfhosted}"
       ADMIN_AUTH_LEVEL: "${ADMIN_AUTH_LEVEL:-none}"

--- a/sheaf/api/v1/account.py
+++ b/sheaf/api/v1/account.py
@@ -20,8 +20,14 @@ from sheaf.auth.lockout import ensure_not_locked, record_login_failure
 from sheaf.auth.passwords import verify_password
 from sheaf.auth.sessions import list_user_sessions
 from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
+from sheaf.config import settings
 from sheaf.crypto import blind_index, decrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import (
+    pending_target_label_aad,
+    user_email_aad,
+    user_totp_secret_aad,
+)
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.activity_event import ActivityEvent
 from sheaf.models.api_key import ApiKey
@@ -151,7 +157,7 @@ async def get_account_data(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="TOTP code required",
             )
-        secret = decrypt(user.totp_secret)
+        secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
         totp_result = await check_code_once(user.id, secret, body.totp_code)
         if totp_result is not TotpCheck.OK:
             await record_login_failure(db, user, reason="totp_failures")
@@ -206,7 +212,7 @@ async def get_account_data(
     # for both the suppression blind-index lookup AND the response body
     # (the user requesting their own data obviously already knows their
     # email, but dumping ciphertext would be misleading + useless).
-    plaintext_email = decrypt(user.email)
+    plaintext_email = decrypt(user.email, aad=user_email_aad(user.id))
 
     email_suppression_result = await db.execute(
         select(EmailSuppression).where(
@@ -386,7 +392,7 @@ async def get_account_data(
                 "id": str(a.id),
                 "action_type": a.action_type,
                 "target_id": str(a.target_id),
-                "target_label": _decrypt_pending_label(a.target_label),
+                "target_label": _decrypt_pending_label(a.target_label, a.id),
                 "requested_at": _iso(a.requested_at),
                 "finalize_after": _iso(a.finalize_after),
                 "status": a.status,
@@ -437,15 +443,25 @@ def _iso(value: datetime | None) -> str | None:
     return value.isoformat() if value else None
 
 
-def _decrypt_pending_label(value: str) -> str:
+def _decrypt_pending_label(value: str, pending_id) -> str:
     """Defensively decrypt a PendingAction.target_label for the data export.
 
     The column is encrypted at rest (see queue_pending_action). A row written
     by the old code during the deploy transition is still plaintext, so fall
     back to the stored value on any decrypt failure rather than exporting
     ciphertext or 500ing. Mirrors decrypt_text in sheaf/services/polls.py.
+
+    That fallback exists only for those pre-encryption rows and is
+    deliberately closed once FIELD_ENCRYPTION_ACCEPT_V1=false (no legacy
+    rows remain): returning the raw stored value would then be an
+    unauthenticated injection channel, so the export's unreadable-field
+    placeholder is substituted instead.
     """
     try:
-        return decrypt(value)
+        return decrypt(value, aad=pending_target_label_aad(pending_id))
     except Exception:
-        return value
+        if settings.field_encryption_accept_v1:
+            return value
+        # Same stand-in string the data export uses for an unreadable
+        # required text field (sheaf/api/v1/export.py).
+        return "[unreadable]"

--- a/sheaf/api/v1/admin.py
+++ b/sheaf/api/v1/admin.py
@@ -15,6 +15,7 @@ from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
 from sheaf.config import settings
 from sheaf.crypto import decrypt_field
 from sheaf.database import get_db
+from sheaf.encrypted_fields import user_email_aad, user_totp_secret_aad
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.admin_audit_event import AdminAuditAction, AdminAuditTargetType
 from sheaf.models.member import Member
@@ -118,7 +119,9 @@ async def verify_admin_step_up(
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="TOTP code required"
             )
-        totp_secret = decrypt_field(user.totp_secret, "totp_secret")
+        totp_secret = decrypt_field(
+            user.totp_secret, "totp_secret", aad=user_totp_secret_aad(user.id)
+        )
         totp_result = await check_code_once(user.id, totp_secret, body.totp_code)
         if totp_result is not TotpCheck.OK:
             await record_login_failure(db, user, reason="totp_failures")
@@ -266,7 +269,7 @@ async def list_users(
 
     def _decrypt_email(user: User) -> str:
         try:
-            return decrypt_field(user.email, "email")
+            return decrypt_field(user.email, "email", aad=user_email_aad(user.id))
         except Exception:
             return "<encrypted>"
 
@@ -389,7 +392,7 @@ async def update_user(
     )
 
     try:
-        email = decrypt_field(target.email, "email")
+        email = decrypt_field(target.email, "email", aad=user_email_aad(target.id))
     except Exception:
         email = "<encrypted>"
 
@@ -442,7 +445,7 @@ async def list_pending_approvals(
     users = []
     for user in result.scalars():
         try:
-            email = decrypt_field(user.email, "email")
+            email = decrypt_field(user.email, "email", aad=user_email_aad(user.id))
         except Exception:
             email = "<encrypted>"
         users.append(PendingUserRead(
@@ -487,7 +490,7 @@ async def approve_user(
 
     # Send approval notification email if configured
     try:
-        email = decrypt_field(target.email, "email")
+        email = decrypt_field(target.email, "email", aad=user_email_aad(target.id))
         from sheaf.config import settings as app_settings
 
         if app_settings.email_backend != "none":
@@ -536,7 +539,7 @@ async def reject_user(
 
     # Send rejection notification email if configured
     try:
-        email = decrypt_field(target.email, "email")
+        email = decrypt_field(target.email, "email", aad=user_email_aad(target.id))
         from sheaf.config import settings as app_settings
 
         if app_settings.email_backend != "none":
@@ -751,7 +754,9 @@ async def list_invites(
         )
         for uid, email_enc in users_result.all():
             try:
-                creators[uid] = decrypt_field(email_enc, "email")
+                creators[uid] = decrypt_field(
+                    email_enc, "email", aad=user_email_aad(uid)
+                )
             except Exception:
                 creators[uid] = "<encrypted>"
 
@@ -813,7 +818,7 @@ async def create_invite(
 
     admin_email: str | None = None
     try:
-        admin_email = decrypt_field(admin.email, "email")
+        admin_email = decrypt_field(admin.email, "email", aad=user_email_aad(admin.id))
     except Exception:
         admin_email = "<encrypted>"
 
@@ -1131,7 +1136,7 @@ async def admin_change_email(
             detail="Email already in use by another account",
         )
 
-    target.email = encrypt(normalized_email)
+    target.email = encrypt(normalized_email, aad=user_email_aad(target.id))
     target.email_hash = new_hash
     target.email_verified = True
     # Clear any pending verification tokens

--- a/sheaf/api/v1/admin_small_actions.py
+++ b/sheaf/api/v1/admin_small_actions.py
@@ -87,6 +87,7 @@ from sheaf.auth.sessions import (
 )
 from sheaf.crypto import decrypt_field
 from sheaf.database import get_db
+from sheaf.encrypted_fields import user_email_aad
 from sheaf.models.admin_audit_event import (
     AdminAuditAction,
     AdminAuditEvent,
@@ -175,7 +176,7 @@ async def explain_account(
         )
 
     try:
-        email = decrypt_field(target.email, "email")
+        email = decrypt_field(target.email, "email", aad=user_email_aad(target.id))
     except Exception:
         email = "<encrypted>"
 
@@ -590,7 +591,7 @@ async def bulk_approve(
                     if target is None:
                         continue
                     try:
-                        addr = decrypt_field(target.email, "email")
+                        addr = decrypt_field(target.email, "email", aad=user_email_aad(target.id))
                         await send_email(addr, subject, html, text)
                     except Exception:
                         logger.exception(
@@ -901,7 +902,7 @@ async def export_user_dossier(
         )
 
     try:
-        email = decrypt_field(target.email, "email")
+        email = decrypt_field(target.email, "email", aad=user_email_aad(target.id))
     except Exception:
         email = "<encrypted>"
 

--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -65,6 +65,11 @@ from sheaf.auth.trusted_devices import (
 from sheaf.config import SheafMode, read_custom_support_text, settings
 from sheaf.crypto import blind_index, decrypt, encrypt, hash_mail_token
 from sheaf.database import get_db
+from sheaf.encrypted_fields import (
+    user_email_aad,
+    user_recovery_codes_aad,
+    user_totp_secret_aad,
+)
 from sheaf.image_processing import animation_allowed
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.activity_event import ActivityAction
@@ -200,7 +205,9 @@ def _hash_recovery_code(code: str) -> str:
 def _store_recovery_codes(user: User, codes: list[str]) -> None:
     """Hash and store recovery codes as encrypted JSON."""
     hashed = [_hash_recovery_code(c) for c in codes]
-    user.recovery_codes = encrypt(json.dumps(hashed))
+    user.recovery_codes = encrypt(
+        json.dumps(hashed), aad=user_recovery_codes_aad(user.id)
+    )
 
 
 async def _check_recovery_code(db: AsyncSession, user: User, code: str) -> bool:
@@ -215,7 +222,9 @@ async def _check_recovery_code(db: AsyncSession, user: User, code: str) -> bool:
     if not old_blob:
         return False
     try:
-        hashed_codes = json.loads(decrypt(old_blob))
+        hashed_codes = json.loads(
+            decrypt(old_blob, aad=user_recovery_codes_aad(user.id))
+        )
     except Exception:
         return False
     code_hash = _hash_recovery_code(code)
@@ -223,7 +232,7 @@ async def _check_recovery_code(db: AsyncSession, user: User, code: str) -> bool:
         return False
 
     remaining = [c for c in hashed_codes if c != code_hash]
-    new_blob = encrypt(json.dumps(remaining))
+    new_blob = encrypt(json.dumps(remaining), aad=user_recovery_codes_aad(user.id))
 
     result = await db.execute(
         update(User)
@@ -366,8 +375,10 @@ async def register(
         else UserTier.SELF_HOSTED
     )
 
+    user_id = uuid.uuid4()
     user = User(
-        email=encrypt(body.email),
+        id=user_id,
+        email=encrypt(body.email, aad=user_email_aad(user_id)),
         email_hash=email_hash,
         password_hash=await hash_password(body.password),
         account_status=account_status,
@@ -525,7 +536,7 @@ async def resend_verification(
                 detail="Please wait before requesting another verification email",
             )
 
-    email = decrypt(user.email)
+    email = decrypt(user.email, aad=user_email_aad(user.id))
     await _send_verification_email(db, user, email)
     await db.commit()
     return {"sent": True}
@@ -577,7 +588,7 @@ async def revalidate_email(
                 detail="Please wait before requesting another verification email",
             )
 
-    email = decrypt(user.email)
+    email = decrypt(user.email, aad=user_email_aad(user.id))
     await _send_verification_email(db, user, email)
     await db.commit()
     return {"sent": True}
@@ -847,7 +858,7 @@ async def change_password(
                 detail="TOTP code required",
                 headers={"X-Sheaf-2FA": "required"},
             )
-        secret = decrypt(user.totp_secret)
+        secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
         totp_result = await check_code_once(user.id, secret, body.totp_code)
         if totp_result is not TotpCheck.OK and not await _check_recovery_code(
             db, user, body.totp_code
@@ -916,7 +927,7 @@ async def change_email(
     Other sessions are revoked, same as change-password.
     """
     new_email = body.new_email.strip().lower()
-    current_email = decrypt(user.email).strip().lower()
+    current_email = decrypt(user.email, aad=user_email_aad(user.id)).strip().lower()
     if new_email == current_email:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -941,7 +952,7 @@ async def change_email(
                 detail="TOTP code required",
                 headers={"X-Sheaf-2FA": "required"},
             )
-        secret = decrypt(user.totp_secret)
+        secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
         totp_result = await check_code_once(user.id, secret, body.totp_code)
         if totp_result is not TotpCheck.OK and not await _check_recovery_code(
             db, user, body.totp_code
@@ -961,7 +972,7 @@ async def change_email(
             detail="Email already in use",
         )
 
-    user.email = encrypt(new_email)
+    user.email = encrypt(new_email, aad=user_email_aad(user.id))
     user.email_hash = new_hash
     user.email_verified = False
     user.email_verification_token = None
@@ -1127,7 +1138,7 @@ async def login(
                     detail="TOTP code required",
                     headers={"X-Sheaf-2FA": "required"},
                 )
-            secret = decrypt(user.totp_secret)
+            secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
             # check_code_once consumes the code (anti-replay): a code
             # seen by a shoulder-surfer or proxy can't be reused at any
             # TOTP gate inside its validity window, and a replayed one is
@@ -1685,7 +1696,7 @@ async def get_me(user: User = Depends(get_current_user_allow_unverified)):
         )
     return UserRead(
         id=user.id,
-        email=decrypt(user.email),
+        email=decrypt(user.email, aad=user_email_aad(user.id)),
         totp_enabled=user.totp_enabled,
         is_admin=user.is_admin,
         tier=user.tier.value,
@@ -1743,7 +1754,7 @@ async def update_me(
         )
     return UserRead(
         id=user.id,
-        email=decrypt(user.email),
+        email=decrypt(user.email, aad=user_email_aad(user.id)),
         totp_enabled=user.totp_enabled,
         is_admin=user.is_admin,
         tier=user.tier.value,
@@ -1803,12 +1814,12 @@ async def totp_setup(
         )
 
     secret = generate_secret()
-    email = decrypt(user.email)
+    email = decrypt(user.email, aad=user_email_aad(user.id))
     uri = get_provisioning_uri(secret, email)
     recovery_codes = generate_recovery_codes()
 
     # Store encrypted secret and recovery codes (not yet enabled — needs verification)
-    user.totp_secret = encrypt(secret)
+    user.totp_secret = encrypt(secret, aad=user_totp_secret_aad(user.id))
     _store_recovery_codes(user, recovery_codes)
     await db.commit()
 
@@ -1835,7 +1846,7 @@ async def totp_verify(
             detail="Run /totp/setup first",
         )
 
-    secret = decrypt(user.totp_secret)
+    secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
     totp_result = await check_code_once(user.id, secret, body.code)
     if totp_result is not TotpCheck.OK:
         raise HTTPException(
@@ -1880,7 +1891,7 @@ async def totp_disable(
             detail="TOTP code required to disable 2FA",
         )
 
-    secret = decrypt(user.totp_secret)
+    secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
     totp_result = await check_code_once(user.id, secret, body.totp_code)
     if totp_result is not TotpCheck.OK and not await _check_recovery_code(
         db, user, body.totp_code
@@ -1938,7 +1949,7 @@ async def regenerate_recovery_codes(
 
     ensure_not_locked(user)
 
-    secret = decrypt(user.totp_secret)
+    secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
     totp_result = await check_code_once(user.id, secret, body.code)
     if totp_result is not TotpCheck.OK:
         await record_login_failure(db, user, reason="totp_failures")
@@ -2125,7 +2136,7 @@ async def request_account_deletion(
                 detail="TOTP code required",
                 headers={"X-Sheaf-2FA": "required"},
             )
-        totp_secret = decrypt(user.totp_secret)
+        totp_secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
         totp_result = await check_code_once(user.id, totp_secret, body.totp_code)
         if totp_result is not TotpCheck.OK and not await _check_recovery_code(
             db, user, body.totp_code
@@ -2149,7 +2160,7 @@ async def request_account_deletion(
             from sheaf.services.email import send_email
             from sheaf.services.email_templates import deletion_confirmation_email
 
-            email = decrypt(user.email)
+            email = decrypt(user.email, aad=user_email_aad(user.id))
             # Render the deadline in the account's display timezone (UTC when
             # "automatic") so a user west/east of UTC sees the correct local
             # calendar date rather than the UTC one. Month is spelled out, so

--- a/sheaf/api/v1/custom_fields.py
+++ b/sheaf/api/v1/custom_fields.py
@@ -40,7 +40,7 @@ def _value_read(v: CustomFieldValue) -> CustomFieldValueRead:
     return CustomFieldValueRead.model_validate({
         "field_id": v.field_id,
         "member_id": v.member_id,
-        "value": decrypt_field_value(v.value),
+        "value": decrypt_field_value(v.value, v.id),
     })
 
 router = APIRouter(tags=["custom fields"])
@@ -300,15 +300,16 @@ async def set_member_field_values(
             )
         )
         value = existing.scalar_one_or_none()
-        encrypted = encrypt_field_value(item.value)
         if value is not None:
-            value.value = encrypted
+            value.value = encrypt_field_value(item.value, value.id)
         else:
+            vid = uuid.uuid4()
             db.add(
                 CustomFieldValue(
+                    id=vid,
                     field_id=item.field_id,
                     member_id=member_id,
-                    value=encrypted,
+                    value=encrypt_field_value(item.value, vid),
                 )
             )
 

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -31,6 +31,18 @@ from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
 from sheaf.config import settings
 from sheaf.crypto import decrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import (
+    front_custom_status_aad,
+    member_note_aad,
+    message_body_aad,
+    poll_description_aad,
+    poll_option_text_aad,
+    poll_question_aad,
+    reminder_body_aad,
+    reminder_title_aad,
+    system_note_aad,
+    user_totp_secret_aad,
+)
 from sheaf.middleware.rate_limit import rate_limit
 from sheaf.models.activity_event import ActivityAction
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
@@ -63,7 +75,7 @@ router = APIRouter(prefix="/export", tags=["export"])
 logger = logging.getLogger("sheaf.export")
 
 
-def _safe_decrypt(value: str | None) -> str | None:
+def _safe_decrypt(value: str | None, aad: bytes) -> str | None:
     """Decrypt an encrypted field for the export, tolerating a single
     unreadable value instead of sinking the whole dump.
 
@@ -74,11 +86,15 @@ def _safe_decrypt(value: str | None) -> str | None:
     Returns None for a None input, or None when decryption fails. The
     warning lets an operator see it happened without leaking the field's
     plaintext or ciphertext into the logs.
+
+    `aad` is the per-cell associated data for the field (from a helper in
+    `sheaf.encrypted_fields`); it binds a v2 ciphertext to its row and is
+    ignored for legacy v1 tokens.
     """
     if value is None:
         return None
     try:
-        return decrypt(value)
+        return decrypt(value, aad=aad)
     except Exception:
         logger.warning(
             "An encrypted field could not be decrypted during export; "
@@ -416,7 +432,9 @@ async def export_all(
                 "emoji": m.emoji,
                 "is_custom_front": m.is_custom_front,
                 "privacy": m.privacy.value,
-                "note": _safe_decrypt(m.note) if m.note else None,
+                "note": (
+                    _safe_decrypt(m.note, member_note_aad(m.id)) if m.note else None
+                ),
                 "quick_switch_pin": m.quick_switch_pin,
                 "notify_on_front_global": m.notify_on_front_global,
                 "notify_on_front_self": m.notify_on_front_self,
@@ -435,7 +453,9 @@ async def export_all(
                 "ended_at": f.ended_at.isoformat() if f.ended_at else None,
                 "member_ids": [str(m.id) for m in f.members],
                 "custom_status": (
-                    _safe_decrypt(f.custom_status) if f.custom_status else None
+                    _safe_decrypt(f.custom_status, front_custom_status_aad(f.id))
+                    if f.custom_status
+                    else None
                 ),
             }
             for f in fronts
@@ -565,7 +585,11 @@ def _system_dict(system: System) -> dict:
         "id": str(system.id),
         "name": system.name,
         "description": system.description,
-        "note": _safe_decrypt(system.note) if system.note else None,
+        "note": (
+            _safe_decrypt(system.note, system_note_aad(system.id))
+            if system.note
+            else None
+        ),
         "tag": system.tag,
         "avatar_url": system.avatar_url,
         "color": system.color,
@@ -603,7 +627,9 @@ def _system_dict(system: System) -> dict:
         # OpenPlural import residual (foreign data Sheaf cannot model),
         # decrypted to a plain dict so it rides the portability export and
         # is re-merged on a Sheaf OpenPlural export. None when empty.
-        "openplural_archive": unpack_residual(system.openplural_archive) or None,
+        "openplural_archive": (
+            unpack_residual(system.openplural_archive, system_id=system.id) or None
+        ),
     }
 
 
@@ -735,8 +761,16 @@ def _reminder_dict(reminder) -> dict:
     pending queue) is omitted and the channel_id is just the original UUID
     so a re-import on a fresh instance won't resolve unless the channels
     were imported there too."""
-    title = _safe_decrypt(reminder.title) if reminder.title else ""
-    body = _safe_decrypt(reminder.body) if reminder.body else None
+    title = (
+        _safe_decrypt(reminder.title, reminder_title_aad(reminder.id))
+        if reminder.title
+        else ""
+    )
+    body = (
+        _safe_decrypt(reminder.body, reminder_body_aad(reminder.id))
+        if reminder.body
+        else None
+    )
     return {
         "id": str(reminder.id),
         "channel_id": str(reminder.channel_id),
@@ -778,7 +812,9 @@ def _message_dict(msg) -> dict:
         "parent_message_id": (
             str(msg.parent_message_id) if msg.parent_message_id else None
         ),
-        "body": _safe_decrypt(msg.body) if msg.body else "",
+        "body": (
+            _safe_decrypt(msg.body, message_body_aad(msg.id)) if msg.body else ""
+        ),
         "created_at": msg.created_at.isoformat(),
         "updated_at": msg.updated_at.isoformat(),
     }
@@ -791,8 +827,16 @@ def _poll_dict(poll) -> dict:
     they're meaningful again."""
     return {
         "id": str(poll.id),
-        "question": _safe_decrypt(poll.question) if poll.question else "",
-        "description": _safe_decrypt(poll.description) if poll.description else None,
+        "question": (
+            _safe_decrypt(poll.question, poll_question_aad(poll.id))
+            if poll.question
+            else ""
+        ),
+        "description": (
+            _safe_decrypt(poll.description, poll_description_aad(poll.id))
+            if poll.description
+            else None
+        ),
         "kind": poll.kind,
         "results_visibility": poll.results_visibility,
         "closes_at": poll.closes_at.isoformat(),
@@ -803,7 +847,11 @@ def _poll_dict(poll) -> dict:
         "options": [
             {
                 "id": str(opt.id),
-                "text": _safe_decrypt(opt.text) if opt.text else "",
+                "text": (
+                    _safe_decrypt(opt.text, poll_option_text_aad(opt.id))
+                    if opt.text
+                    else ""
+                ),
                 "position": opt.position,
             }
             for opt in sorted(poll.options, key=lambda o: o.position)
@@ -909,7 +957,7 @@ async def create_export_job(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="TOTP code required",
             )
-        secret = decrypt(user.totp_secret)
+        secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
         totp_result = await check_code_once(user.id, secret, body.totp_code)
         if totp_result is not TotpCheck.OK:
             await record_login_failure(db, user, reason="totp_failures")

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.crypto import decrypt, encrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import front_custom_status_aad
 from sheaf.middleware.rate_limit import check_front_switch_rate, write_rate_limit
 from sheaf.models.front import Front
 from sheaf.models.front_audit_event import FrontAuditEvent
@@ -102,7 +103,11 @@ def _front_to_read(
         started_at=front.started_at,
         ended_at=front.ended_at,
         member_ids=[m.id for m in front.members],
-        custom_status=decrypt(front.custom_status) if front.custom_status else None,
+        custom_status=(
+            decrypt(front.custom_status, aad=front_custom_status_aad(front.id))
+            if front.custom_status
+            else None
+        ),
         member_since=member_since,
         member_since_capped=member_since_capped or [],
         has_audit_history=has_audit_history,
@@ -488,10 +493,18 @@ async def create_front(
                     ),
                 )
 
+    # Pre-allocate the id (UUIDMixin's default only fires at flush) so the
+    # custom_status ciphertext binds to the row before insert.
+    front_id = uuid.uuid4()
     front = Front(
+        id=front_id,
         system_id=system.id,
         started_at=new_started_at,
-        custom_status=encrypt(body.custom_status) if body.custom_status else None,
+        custom_status=(
+            encrypt(body.custom_status, aad=front_custom_status_aad(front_id))
+            if body.custom_status
+            else None
+        ),
         members=members,
     )
     db.add(front)
@@ -520,9 +533,15 @@ def _front_snapshot_for_audit(front: Front) -> dict:
     }
 
 
-def _audit_snapshot_to_read(snapshot: dict) -> FrontSnapshot:
-    """Inverse of `_front_snapshot_for_audit` for the audit-list endpoint —
-    decrypts custom_status the same way the live front read does."""
+def _audit_snapshot_to_read(snapshot: dict, front_id: uuid.UUID) -> FrontSnapshot:
+    """Inverse of `_front_snapshot_for_audit` for the audit-list endpoint -
+    decrypts custom_status the same way the live front read does.
+
+    The snapshot stores a copy of the live front's custom_status ciphertext,
+    so it was bound to that front's cell; decrypt under the same
+    `front_custom_status_aad(front_id)`. v1 snapshots ignore the aad and still
+    read, which keeps pre-conversion audit rows legible.
+    """
     ciphertext = snapshot.get("custom_status_encrypted")
     return FrontSnapshot(
         started_at=datetime.fromisoformat(snapshot["started_at"]),
@@ -532,7 +551,11 @@ def _audit_snapshot_to_read(snapshot: dict) -> FrontSnapshot:
             else None
         ),
         member_ids=[uuid.UUID(m) for m in snapshot.get("member_ids", [])],
-        custom_status=decrypt(ciphertext) if ciphertext else None,
+        custom_status=(
+            decrypt(ciphertext, aad=front_custom_status_aad(front_id))
+            if ciphertext
+            else None
+        ),
     )
 
 
@@ -583,7 +606,9 @@ async def update_front(
 
     if "custom_status" in fields_set:
         front.custom_status = (
-            encrypt(body.custom_status) if body.custom_status else None
+            encrypt(body.custom_status, aad=front_custom_status_aad(front.id))
+            if body.custom_status
+            else None
         )
         has_explicit_change = True
 
@@ -734,8 +759,8 @@ async def list_front_audit(
             front_id=row.front_id,
             actor_user_id=row.actor_user_id,
             fronting_member_ids=[uuid.UUID(s) for s in (row.fronting_member_ids or [])],
-            before=_audit_snapshot_to_read(row.before_snapshot),
-            after=_audit_snapshot_to_read(row.after_snapshot),
+            before=_audit_snapshot_to_read(row.before_snapshot, row.front_id),
+            after=_audit_snapshot_to_read(row.after_snapshot, row.front_id),
             created_at=row.created_at,
         )
         for row in page

--- a/sheaf/api/v1/imports.py
+++ b/sheaf/api/v1/imports.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.auth.dependencies import get_current_user
 from sheaf.crypto import encrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import import_credential_aad
 from sheaf.models.import_job import ImportJob, ImportJobStatus
 from sheaf.models.user import User
 from sheaf.schemas.imports import (
@@ -216,7 +217,9 @@ async def create_file_import(
         if body.options is not None:
             metadata["options"] = body.options
         if credential:
-            metadata["encrypted_credential"] = encrypt(credential)
+            metadata["encrypted_credential"] = encrypt(
+                credential, aad=import_credential_aad(job_id)
+            )
 
     job = ImportJob(
         id=job_id,
@@ -270,11 +273,12 @@ async def create_api_import(
     if existing is not None:
         return ImportJobRead.model_validate(existing)
 
-    encrypted_token = encrypt(body.pk_token)
-
     # Explicit id so the post-commit race check can compare against it
-    # (the UUIDMixin default is only applied at flush time).
+    # (the UUIDMixin default is only applied at flush time) and so the
+    # credential ciphertext can be AAD-bound to the job row it lives on.
     new_id = uuid.uuid4()
+    encrypted_token = encrypt(body.pk_token, aad=import_credential_aad(new_id))
+
     job = ImportJob(
         id=new_id,
         user_id=user.id,

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -10,6 +10,11 @@ from sqlalchemy.orm import selectinload
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.crypto import blind_index, encrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import (
+    member_description_aad,
+    member_name_aad,
+    member_note_aad,
+)
 from sheaf.files import owned_avatar_url, owned_description_urls
 from sheaf.middleware.rate_limit import write_rate_limit
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
@@ -187,15 +192,21 @@ async def create_member(
     data["avatar_url"] = owned_avatar_url(data.get("avatar_url"), user.id)
     data["banner_url"] = owned_avatar_url(data.get("banner_url"), user.id)
     plaintext_description = owned_description_urls(plaintext_description, user.id)
+    # Pre-allocate the id (UUIDMixin's default only fires at flush) so the
+    # encrypted cells can be bound to the row before it is inserted.
+    member_id = uuid.uuid4()
     member = Member(
+        id=member_id,
         system_id=system.id,
-        name=encrypt(plaintext_name),
+        name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
         name_hash=blind_index(plaintext_name),
         description=(
-            encrypt(plaintext_description) if plaintext_description is not None else None
+            encrypt(plaintext_description, aad=member_description_aad(member_id))
+            if plaintext_description is not None
+            else None
         ),
         note=(
-            encrypt(plaintext_note)
+            encrypt(plaintext_note, aad=member_note_aad(member_id))
             if plaintext_note is not None and plaintext_note != ""
             else None
         ),
@@ -366,17 +377,21 @@ async def update_member(
         )
     for key, value in update_data.items():
         if key == "name":
-            member.name = encrypt(value)
+            member.name = encrypt(value, aad=member_name_aad(member.id))
             member.name_hash = blind_index(value)
         elif key == "description":
-            member.description = encrypt(value) if value is not None else None
+            member.description = (
+                encrypt(value, aad=member_description_aad(member.id))
+                if value is not None
+                else None
+            )
         elif key == "note":
             # Empty string clears the column. Notes are deliberately
             # overwrite-only; no revision capture here.
             if value is None or value == "":
                 member.note = None
             else:
-                member.note = encrypt(value)
+                member.note = encrypt(value, aad=member_note_aad(member.id))
         else:
             setattr(member, key, value)
     await db.commit()

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -142,7 +142,7 @@ async def _to_read(
         parent_message_id=msg.parent_message_id,
         parent_preview=parent_preview,
         parent_author_member_name=parent_author,
-        body=decrypt_body(msg.body),
+        body=decrypt_body(msg.body, msg.id),
         created_at=msg.created_at,
         updated_at=msg.updated_at,
         pending_delete_at=pending_delete_at,
@@ -188,7 +188,7 @@ async def _render_messages(
         if msg.parent_message_id is not None:
             parent = parents.get(msg.parent_message_id)
             if parent is not None and parent.deleted_at is None:
-                parent_preview = preview_for(decrypt_body(parent.body))
+                parent_preview = preview_for(decrypt_body(parent.body, parent.id))
                 parent_author = _name(parent.author_member_id)
         pending_at = (
             pending_delete_at_by_id.get(msg.id)
@@ -205,7 +205,7 @@ async def _render_messages(
             parent_message_id=msg.parent_message_id,
             parent_preview=parent_preview,
             parent_author_member_name=parent_author,
-            body=decrypt_body(msg.body),
+            body=decrypt_body(msg.body, msg.id),
             created_at=msg.created_at,
             updated_at=msg.updated_at,
             pending_delete_at=pending_at,
@@ -480,14 +480,15 @@ async def post_message(
                 detail="parent_message_id must reference a live message on the same board.",
             )
 
+    msg_id = uuid.uuid4()
     msg = Message(
-        id=uuid.uuid4(),
+        id=msg_id,
         system_id=system.id,
         board_kind=kind,
         board_member_id=board_member_id,
         author_member_id=body.author_member_id,
         parent_message_id=body.parent_message_id,
-        body=encrypt_body(body.body),
+        body=encrypt_body(body.body, msg_id),
     )
     db.add(msg)
     await db.commit()
@@ -519,7 +520,7 @@ async def edit_message(
     system = await _get_user_system(user, db)
     msg = await _get_owned_message(message_id, system, db)
 
-    current_plaintext = decrypt_body(msg.body)
+    current_plaintext = decrypt_body(msg.body, msg.id)
     if body.body == current_plaintext:
         return await _to_read(msg, db)
 
@@ -532,7 +533,7 @@ async def edit_message(
         title=None,
         body=current_plaintext,
     )
-    msg.body = encrypt_body(body.body)
+    msg.body = encrypt_body(body.body, msg.id)
     await db.commit()
     await db.refresh(msg)
     return await _to_read(msg, db)
@@ -851,7 +852,7 @@ def _summarise_message(msg: Message) -> str:
     target label. Decrypts a preview of the body."""
     from sheaf.services.messages import preview_for
 
-    body_pt = decrypt_body(msg.body)
+    body_pt = decrypt_body(msg.body, msg.id)
     return preview_for(body_pt) or "(empty message)"
 
 

--- a/sheaf/api/v1/notification_channels.py
+++ b/sheaf/api/v1/notification_channels.py
@@ -15,6 +15,7 @@ from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.config import settings
 from sheaf.crypto import encrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import webhook_secret_aad
 from sheaf.models.group import Group
 from sheaf.models.member import Member
 from sheaf.models.notification_channel import (
@@ -371,7 +372,9 @@ async def create_channel(
     )
 
     if body.destination_type == DestinationType.WEBHOOK.value and body.webhook_secret:
-        channel.webhook_secret_encrypted = encrypt(body.webhook_secret)
+        channel.webhook_secret_encrypted = encrypt(
+            body.webhook_secret, aad=webhook_secret_aad(channel.id)
+        )
 
     activation_url = None
     activation_expires = None
@@ -536,7 +539,9 @@ async def update_channel(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="webhook_secret only valid for webhook channels",
             )
-        channel.webhook_secret_encrypted = encrypt(body.webhook_secret)
+        channel.webhook_secret_encrypted = encrypt(
+            body.webhook_secret, aad=webhook_secret_aad(channel.id)
+        )
     # Re-check the pushover debounce floor against the merged config +
     # whichever debounce ends up applying after this PATCH. Either could
     # change independently — caller might raise debounce while keeping the

--- a/sheaf/api/v1/polls.py
+++ b/sheaf/api/v1/polls.py
@@ -19,6 +19,11 @@ from sqlalchemy.orm import selectinload
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.config import settings
 from sheaf.database import get_db
+from sheaf.encrypted_fields import (
+    poll_description_aad,
+    poll_option_text_aad,
+    poll_question_aad,
+)
 from sheaf.models.pending_action import PendingActionType
 from sheaf.models.poll import Poll, PollOption, PollVote, PollVoteEvent
 from sheaf.models.system import System
@@ -137,7 +142,7 @@ def _to_read(
     options = [
         PollOptionRead(
             id=opt.id,
-            text=decrypt_text(opt.text) or "",
+            text=decrypt_text(opt.text, poll_option_text_aad(opt.id)) or "",
             position=opt.position,
         )
         for opt in sorted(poll.options, key=lambda o: o.position)
@@ -165,8 +170,8 @@ def _to_read(
     return PollRead(
         id=poll.id,
         system_id=poll.system_id,
-        question=decrypt_text(poll.question) or "",
-        description=decrypt_text(poll.description),
+        question=decrypt_text(poll.question, poll_question_aad(poll.id)) or "",
+        description=decrypt_text(poll.description, poll_description_aad(poll.id)),
         kind=poll.kind,
         results_visibility=poll.results_visibility,
         closes_at=poll.closes_at,
@@ -294,11 +299,16 @@ async def create_poll(
                 ),
             )
 
+    poll_id = uuid.uuid4()
     poll = Poll(
-        id=uuid.uuid4(),
+        id=poll_id,
         system_id=system.id,
-        question=encrypt_text(body.question),
-        description=encrypt_text(body.description) if body.description else None,
+        question=encrypt_text(body.question, poll_question_aad(poll_id)),
+        description=(
+            encrypt_text(body.description, poll_description_aad(poll_id))
+            if body.description
+            else None
+        ),
         kind=body.kind,
         results_visibility=body.results_visibility,
         closes_at=body.closes_at,
@@ -307,10 +317,11 @@ async def create_poll(
         restrict_voting_to_fronters=body.restrict_voting_to_fronters,
     )
     for index, opt in enumerate(body.options):
+        opt_id = uuid.uuid4()
         poll.options.append(
             PollOption(
-                id=uuid.uuid4(),
-                text=encrypt_text(opt.text),
+                id=opt_id,
+                text=encrypt_text(opt.text, poll_option_text_aad(opt_id)),
                 position=index,
             )
         )
@@ -369,7 +380,10 @@ async def delete_poll(
             user=user,
             action_type=PendingActionType.POLL_DELETE,
             target_id=poll.id,
-            target_label=decrypt_text(poll.question) or "(unnamed poll)",
+            target_label=(
+                decrypt_text(poll.question, poll_question_aad(poll.id))
+                or "(unnamed poll)"
+            ),
         )
         await db.commit()
         await db.refresh(pending)

--- a/sheaf/api/v1/reminders.py
+++ b/sheaf/api/v1/reminders.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
+from sheaf.encrypted_fields import reminder_body_aad, reminder_title_aad
 from sheaf.middleware.rate_limit import write_rate_limit
 from sheaf.models.member import Member
 from sheaf.models.notification_channel import NotificationChannel
@@ -302,9 +303,10 @@ async def create_reminder(
         body.scope_member_ids, system, db
     )
 
-    title_ct, body_ct = encrypt_title_body(body.title, body.body)
+    reminder_id = uuid.uuid4()
+    title_ct, body_ct = encrypt_title_body(body.title, body.body, reminder_id)
     reminder = Reminder(
-        id=uuid.uuid4(),
+        id=reminder_id,
         system_id=system.id,
         channel_id=body.channel_id,
         name=body.name,
@@ -391,11 +393,14 @@ async def update_reminder(
 
     # Encrypt title/body when they change. Other fields just `setattr`.
     if "title" in update_data or "body" in update_data:
-        new_title = update_data.get("title", _decrypted(reminder.title) or "")
-        new_body = update_data.get(
-            "body", _decrypted(reminder.body)
+        new_title = update_data.get(
+            "title",
+            _decrypted(reminder.title, reminder_title_aad(reminder.id)) or "",
         )
-        title_ct, body_ct = encrypt_title_body(new_title, new_body)
+        new_body = update_data.get(
+            "body", _decrypted(reminder.body, reminder_body_aad(reminder.id))
+        )
+        title_ct, body_ct = encrypt_title_body(new_title, new_body, reminder.id)
         reminder.title = title_ct
         reminder.body = body_ct
         update_data.pop("title", None)
@@ -479,10 +484,10 @@ async def get_next_fire(
 # --- Internal helpers -----------------------------------------------------
 
 
-def _decrypted(ciphertext: str | None) -> str | None:
+def _decrypted(ciphertext: str | None, aad: bytes) -> str | None:
     from sheaf.crypto import decrypt
 
-    return decrypt(ciphertext) if ciphertext else None
+    return decrypt(ciphertext, aad=aad) if ciphertext else None
 
 
 def _reminder_dict(reminder: Reminder) -> dict:

--- a/sheaf/api/v1/system_safety.py
+++ b/sheaf/api/v1/system_safety.py
@@ -18,8 +18,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.api.v1.members import _get_user_system
 from sheaf.auth.dependencies import get_current_user, require_scope
+from sheaf.config import settings
 from sheaf.crypto import decrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import (
+    pending_fronting_names_aad,
+    pending_target_label_aad,
+)
 from sheaf.models.pending_action import PendingAction, PendingActionStatus
 from sheaf.models.safety_change_request import (
     SafetyChangeRequest,
@@ -97,20 +102,38 @@ def _pending_action_to_read(a: PendingAction) -> PendingActionRead:
     write path both landed) is still plaintext, so fall back to treating the
     stored value as plaintext rather than 500ing. Mirrors the tolerant
     pattern of `decrypt_text` in sheaf/services/polls.py.
+
+    The plaintext fallback exists only for those pre-encryption rows, so it
+    is deliberately closed once the operator sets
+    FIELD_ENCRYPTION_ACCEPT_V1=false (which declares no legacy rows remain):
+    returning the raw stored value would then be an unauthenticated injection
+    channel, so a placeholder is substituted instead.
     """
     try:
-        target_label = decrypt(a.target_label)
+        target_label = decrypt(a.target_label, aad=pending_target_label_aad(a.id))
     except Exception:
-        target_label = a.target_label
+        # "[unreadable]" is the same stand-in string the data export uses
+        # for an unreadable required text field (sheaf/api/v1/export.py).
+        target_label = (
+            a.target_label
+            if settings.field_encryption_accept_v1
+            else "[unreadable]"
+        )
 
     try:
-        fronting_member_names = json.loads(decrypt(a.fronting_member_names))
+        fronting_member_names = json.loads(
+            decrypt(a.fronting_member_names, aad=pending_fronting_names_aad(a.id))
+        )
     except Exception:
-        # Legacy plaintext row: the pre-migration JSONB list, now stored as a
-        # JSON-array string in the Text column. Parse it if we can, else [].
-        try:
-            fronting_member_names = json.loads(a.fronting_member_names)
-        except Exception:
+        if settings.field_encryption_accept_v1:
+            # Legacy plaintext row: the pre-migration JSONB list, now stored
+            # as a JSON-array string in the Text column. Parse it if we can,
+            # else [].
+            try:
+                fronting_member_names = json.loads(a.fronting_member_names)
+            except Exception:
+                fronting_member_names = []
+        else:
             fronting_member_names = []
 
     return PendingActionRead(

--- a/sheaf/api/v1/systems.py
+++ b/sheaf/api/v1/systems.py
@@ -8,6 +8,7 @@ from sheaf.auth.passwords import verify_password
 from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
 from sheaf.crypto import decrypt, encrypt
 from sheaf.database import get_db
+from sheaf.encrypted_fields import system_note_aad, user_totp_secret_aad
 from sheaf.files import owned_avatar_url, owned_description_urls
 from sheaf.models.system import DeleteConfirmation, System
 from sheaf.models.user import User
@@ -22,7 +23,9 @@ def _system_to_read(system: System) -> SystemRead:
     System.note is the only encrypted-at-rest field on System (description
     is plaintext for historical reasons), so we just patch it through here
     rather than building a parallel `decrypt_system_for_read` helper."""
-    plaintext_note = decrypt(system.note) if system.note else None
+    plaintext_note = (
+        decrypt(system.note, aad=system_note_aad(system.id)) if system.note else None
+    )
     return SystemRead.model_validate(
         {**system.__dict__, "note": plaintext_note}
     )
@@ -72,7 +75,7 @@ async def update_own_system(
             if value is None or value == "":
                 system.note = None
             else:
-                system.note = encrypt(value)
+                system.note = encrypt(value, aad=system_note_aad(system.id))
         else:
             setattr(system, key, value)
     await db.commit()
@@ -110,7 +113,7 @@ async def update_delete_confirmation(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="TOTP code required",
             )
-        secret = decrypt(user.totp_secret)
+        secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
         totp_result = await check_code_once(user.id, secret, body.totp_code)
         if totp_result is not TotpCheck.OK:
             await record_login_failure(db, user, reason="totp_failures")

--- a/sheaf/services/admin_audit.py
+++ b/sheaf/services/admin_audit.py
@@ -16,6 +16,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import decrypt
+from sheaf.encrypted_fields import user_email_aad
 from sheaf.models.admin_audit_event import (
     AdminAuditAction,
     AdminAuditEvent,
@@ -34,7 +35,7 @@ def _safe_decrypt_email(user: User) -> str | None:
     via admin_user_id + before_json attribution.
     """
     try:
-        return decrypt(user.email)
+        return decrypt(user.email, aad=user_email_aad(user.id))
     except Exception:
         return None
 

--- a/sheaf/services/ampersand_import.py
+++ b/sheaf/services/ampersand_import.py
@@ -32,6 +32,15 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
+from sheaf.encrypted_fields import (
+    front_custom_status_aad,
+    journal_body_aad,
+    journal_title_aad,
+    member_description_aad,
+    member_name_aad,
+    poll_option_text_aad,
+    poll_question_aad,
+)
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
 from sheaf.models.front import Front
 from sheaf.models.group import Group
@@ -83,6 +92,9 @@ from sheaf.services.import_media import (
     user_can_upload_images,
 )
 from sheaf.services.member_limits import enforce_import_member_cap
+from sheaf.services.messages import encrypt_body
+from sheaf.services.polls import encrypt_text
+from sheaf.services.reminders import encrypt_title_body
 
 logger = logging.getLogger("sheaf.imports.ampersand")
 
@@ -297,12 +309,17 @@ async def run_import(
             if sys_ref:
                 amp_id_to_system[amp_id] = sys_ref
         plaintext_desc = _coerce_str(amp_m.get("description"))
+        member_id = uuid.uuid4()
         member = Member(
-            id=uuid.uuid4(),
+            id=member_id,
             system_id=system.id,
-            name=encrypt(plaintext_name),
+            name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
             name_hash=blind_index(plaintext_name),
-            description=encrypt(plaintext_desc) if plaintext_desc is not None else None,
+            description=(
+                encrypt(plaintext_desc, aad=member_description_aad(member_id))
+                if plaintext_desc is not None
+                else None
+            ),
             pronouns=clamp_str(
                 _coerce_str(amp_m.get("pronouns")) or None, il.M_PRONOUNS, report=report
             ),
@@ -713,12 +730,13 @@ async def _import_custom_fields(
             if pair in seen:
                 continue
             seen.add(pair)
+            cfv_id = uuid.uuid4()
             db.add(
                 CustomFieldValue(
-                    id=uuid.uuid4(),
+                    id=cfv_id,
                     field_id=field_def.id,
                     member_id=member.id,
-                    value=encrypt_field_value({"v": value}),
+                    value=encrypt_field_value({"v": value}, cfv_id),
                 )
             )
 
@@ -756,12 +774,17 @@ async def _import_fronts(
             front_index.register(fkey)
 
         custom_status = _coerce_str(amp_f.get("customStatus"))
+        front_id = uuid.uuid4()
         front = Front(
-            id=uuid.uuid4(),
+            id=front_id,
             system_id=system.id,
             started_at=started,
             ended_at=ended,
-            custom_status=encrypt(custom_status) if custom_status else None,
+            custom_status=(
+                encrypt(custom_status, aad=front_custom_status_aad(front_id))
+                if custom_status
+                else None
+            ),
         )
         db.add(front)
         await db.flush()
@@ -838,16 +861,20 @@ async def _import_journals(
                         result.images_imported += 1
 
             j_title = _coerce_str(amp_j.get("title"))
+            entry_id = uuid.uuid4()
             entry = JournalEntry(
-                id=uuid.uuid4(),
+                id=entry_id,
                 system_id=system.id,
                 member_id=member_objs[0].id if len(member_objs) == 1 else None,
                 title=(
-                    encrypt(clamp_str(j_title, il.JOURNAL_TITLE, report=report))
+                    encrypt(
+                        clamp_str(j_title, il.JOURNAL_TITLE, report=report),
+                        aad=journal_title_aad(entry_id),
+                    )
                     if j_title
                     else None
                 ),
-                body=encrypt(body),
+                body=encrypt(body, aad=journal_body_aad(entry_id)),
                 visibility="system",
                 author_user_id=system.user_id,
                 author_member_ids=[str(m.id) for m in member_objs],
@@ -866,16 +893,20 @@ async def _import_journals(
         for amp_n in _coll(data, "notes"):
             title = _coerce_str(amp_n.get("title"))
             content = _coerce_str(amp_n.get("content")) or ""
+            entry_id = uuid.uuid4()
             entry = JournalEntry(
-                id=uuid.uuid4(),
+                id=entry_id,
                 system_id=system.id,
                 member_id=None,
                 title=(
-                    encrypt(clamp_str(title, il.JOURNAL_TITLE, report=report))
+                    encrypt(
+                        clamp_str(title, il.JOURNAL_TITLE, report=report),
+                        aad=journal_title_aad(entry_id),
+                    )
                     if title
                     else None
                 ),
-                body=encrypt(content),
+                body=encrypt(content, aad=journal_body_aad(entry_id)),
                 visibility="system",
                 author_user_id=system.user_id,
                 author_member_ids=[],
@@ -919,13 +950,16 @@ async def _import_board(
         title = _coerce_str(amp_b.get("title"))
         raw_body = _coerce_str(amp_b.get("body")) or ""
         body = f"**{title}**\n\n{raw_body}".strip() if title else raw_body
+        message_id = uuid.uuid4()
         message = Message(
-            id=uuid.uuid4(),
+            id=message_id,
             system_id=system.id,
             board_kind=BoardKind.SYSTEM.value,
             board_member_id=None,
             author_member_id=author.id if author else None,
-            body=encrypt(clamp_str(body, il.MESSAGE_BODY, report=report) or ""),
+            body=encrypt_body(
+                clamp_str(body, il.MESSAGE_BODY, report=report) or "", message_id
+            ),
         )
         created = _parse_iso(amp_b.get("date"))
         if created:
@@ -940,13 +974,17 @@ async def _import_board(
                 continue
             c_author = amp_id_to_member.get(_coerce_str(amp_c.get("member")) or "")
             c_body = _coerce_str(amp_c.get("comment")) or ""
+            reply_id = uuid.uuid4()
             reply = Message(
-                id=uuid.uuid4(),
+                id=reply_id,
                 system_id=system.id,
                 board_kind=BoardKind.SYSTEM.value,
                 board_member_id=None,
                 author_member_id=c_author.id if c_author else None,
-                body=encrypt(clamp_str(c_body, il.MESSAGE_BODY, report=report) or ""),
+                body=encrypt_body(
+                    clamp_str(c_body, il.MESSAGE_BODY, report=report) or "",
+                    reply_id,
+                ),
                 parent_message_id=message.id,
             )
             c_created = _parse_iso(amp_c.get("date"))
@@ -984,10 +1022,14 @@ async def _import_poll(
         return False
 
     now = datetime.now(UTC)
+    poll_id = uuid.uuid4()
     poll = Poll(
-        id=uuid.uuid4(),
+        id=poll_id,
         system_id=system.id,
-        question=encrypt(clamp_str("Imported poll", il.POLL_QUESTION, report=report)),
+        question=encrypt_text(
+            clamp_str("Imported poll", il.POLL_QUESTION, report=report),
+            poll_question_aad(poll_id),
+        ),
         description=None,
         kind=(
             PollKind.MULTI_CHOICE.value
@@ -1008,10 +1050,14 @@ async def _import_poll(
         if not isinstance(entry, dict):
             continue
         text = _coerce_str(entry.get("choice")) or f"Option {position + 1}"
+        option_id = uuid.uuid4()
         option = PollOption(
-            id=uuid.uuid4(),
+            id=option_id,
             poll_id=poll.id,
-            text=encrypt(clamp_str(text, il.POLL_OPTION, report=report) or ""),
+            text=encrypt_text(
+                clamp_str(text, il.POLL_OPTION, report=report) or "",
+                poll_option_text_aad(option_id),
+            ),
             position=position,
         )
         db.add(option)
@@ -1085,17 +1131,23 @@ async def _import_reminders(
         # single "any member" reminder.
         targets: list[Member | None] = member_refs if member_refs else [None]
         for target in targets:
-            reminder = Reminder(
-                id=uuid.uuid4(),
-                system_id=system.id,
-                channel_id=channel.id,
-                name=clamp_str(title, il.REMINDER_NAME, report=report),
-                title=encrypt(clamp_str(title, il.REMINDER_TITLE, report=report) or ""),
-                body=(
-                    encrypt(clamp_str(message_body, il.REMINDER_BODY, report=report))
+            reminder_id = uuid.uuid4()
+            enc_title, enc_body = encrypt_title_body(
+                clamp_str(title, il.REMINDER_TITLE, report=report) or "",
+                (
+                    clamp_str(message_body, il.REMINDER_BODY, report=report)
                     if message_body
                     else None
                 ),
+                reminder_id,
+            )
+            reminder = Reminder(
+                id=reminder_id,
+                system_id=system.id,
+                channel_id=channel.id,
+                name=clamp_str(title, il.REMINDER_NAME, report=report),
+                title=enc_title,
+                body=enc_body,
                 enabled=enabled,
                 trigger_type="automated",
                 trigger_member_id=target.id if target else None,

--- a/sheaf/services/custom_fields.py
+++ b/sheaf/services/custom_fields.py
@@ -11,29 +11,37 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from sheaf.config import settings
 from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import custom_field_value_aad
 from sheaf.models.custom_field import CustomFieldValue
 
 
-def encrypt_field_value(value: Any) -> str:
+def encrypt_field_value(value: Any, value_id) -> str:
     """JSON-serialise then encrypt a custom-field value."""
-    return encrypt(json.dumps(value))
+    return encrypt(json.dumps(value), aad=custom_field_value_aad(value_id))
 
 
-def decrypt_field_value(stored: Any) -> Any:
+def decrypt_field_value(stored: Any, value_id) -> Any:
     """Decrypt + JSON-decode a stored custom-field value.
 
     Returns None if the column was NULL. Stored ciphertext is always a string;
-    if we encounter a non-string (e.g. legacy plaintext rows from before
-    encryption), pass it through untouched as a defensive fallback.
+    a non-string is a legacy plaintext row from before encryption, passed
+    through untouched only while the v1 dual-read window is open. Once the
+    operator sets FIELD_ENCRYPTION_ACCEPT_V1=false they have declared no
+    legacy rows remain, so the passthrough is deliberately closed: returning
+    the raw stored value would be an unauthenticated injection channel, so it
+    becomes None (rendered the same as a NULL column by every caller).
     """
     if stored is None:
         return None
     if not isinstance(stored, str):
-        return stored
-    return json.loads(decrypt(stored))
+        if settings.field_encryption_accept_v1:
+            return stored
+        return None
+    return json.loads(decrypt(stored, aad=custom_field_value_aad(value_id)))
 
 
 def field_value_plaintext(v: CustomFieldValue) -> Any:
     """Return the decrypted, JSON-decoded plaintext for a value row."""
-    return decrypt_field_value(v.value)
+    return decrypt_field_value(v.value, v.id)

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sheaf.config import settings
 from sheaf.crypto import decrypt
 from sheaf.database import async_session_factory
+from sheaf.encrypted_fields import user_email_aad
 from sheaf.models.activity_event import ActivityAction, ActivityActorType
 from sheaf.models.export_job import ExportJob, ExportJobStatus
 from sheaf.models.uploaded_file import UploadedFile
@@ -202,7 +203,10 @@ async def _build(job_id: uuid.UUID) -> None:
 
     # Email notification — best-effort, don't fail the job on send error.
     try:
-        await _send_completion_email(user_email=decrypt(user.email), job_id=job.id)
+        await _send_completion_email(
+            user_email=decrypt(user.email, aad=user_email_aad(user.id)),
+            job_id=job.id,
+        )
     except Exception:  # noqa: BLE001
         logger.exception("Export completion email failed for job %s", job_id)
 

--- a/sheaf/services/file_cleanup.py
+++ b/sheaf/services/file_cleanup.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import decrypt
+from sheaf.encrypted_fields import member_description_aad
 from sheaf.files import _to_internal_key
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.journal_entry import JournalEntry
@@ -94,20 +95,23 @@ async def find_orphaned_files(
     for (avatar_url,) in result:
         referenced.update(_key_from_avatar(avatar_url))
 
-    # Member avatars, banners, and bios
+    # Member avatars, banners, and bios. Member.id is projected so the
+    # description ciphertext can be decrypted under its per-cell aad.
     result = await db.execute(
-        select(Member.avatar_url, Member.banner_url, Member.description)
+        select(Member.id, Member.avatar_url, Member.banner_url, Member.description)
         .join(System)
         .join(User)
         .where(User.id == user_id)
     )
-    for avatar_url, banner_url, description in result:
+    for member_id, avatar_url, banner_url, description in result:
         referenced.update(_key_from_avatar(avatar_url))
         referenced.update(_key_from_avatar(banner_url))
         # Member.description is encrypted at rest; decrypt for the markdown
         # scan. This runs in the app container which has the key.
         if description is not None:
-            description = decrypt(description)
+            description = decrypt(
+                description, aad=member_description_aad(member_id)
+            )
         referenced.update(_extract_keys_from_markdown(description))
 
     # Journal entries for this user's system. image_keys is pre-extracted

--- a/sheaf/services/front_history_export.py
+++ b/sheaf/services/front_history_export.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from sheaf.crypto import decrypt
+from sheaf.encrypted_fields import front_custom_status_aad
 from sheaf.models.front import Front
 from sheaf.models.system import System
 from sheaf.services.members import member_plaintext
@@ -73,7 +74,11 @@ async def load_front_history(db: AsyncSession, system: System) -> list[dict[str,
                 "started_at": f.started_at,
                 "ended_at": f.ended_at,
                 "members": names,
-                "custom_status": decrypt(f.custom_status) if f.custom_status else None,
+                "custom_status": (
+                    decrypt(f.custom_status, aad=front_custom_status_aad(f.id))
+                    if f.custom_status
+                    else None
+                ),
             }
         )
     return rows

--- a/sheaf/services/import_dedup.py
+++ b/sheaf/services/import_dedup.py
@@ -43,6 +43,12 @@ from dataclasses import dataclass, field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import (
+    member_description_aad,
+    member_name_aad,
+    member_note_aad,
+)
 from sheaf.models.member import Member
 
 
@@ -52,20 +58,21 @@ class ImportConflictStrategy(enum.StrEnum):
     UPDATE = "update"
 
 
-# Fields every importer always sets on a new Member, so UPDATE always
-# overwrites them. is_custom_front is deliberately NOT here: matching is
-# already scoped by it (a member only matches a member, a custom front
+# Plaintext fields every importer always sets on a new Member, so UPDATE
+# always overwrites them. is_custom_front is deliberately NOT here: matching
+# is already scoped by it (a member only matches a member, a custom front
 # only a custom front), so a match always agrees, and some importers
 # leave it None on the candidate (relying on the column server-default),
-# which would null out the existing row's NOT NULL column.
-_ALWAYS_OVERWRITE = ("name", "name_hash", "privacy")
-# Optional fields: UPDATE overwrites only when the candidate carries a
-# value, so a re-import never nulls a field the source format doesn't
-# model (e.g. PluralKit has no emoji, so a PK update must not wipe an
-# emoji the user set after the first import).
+# which would null out the existing row's NOT NULL column. The encrypted
+# `name` is handled separately (see `_ENCRYPTED_ALWAYS`); `name_hash` is a
+# blind index (not encrypted) and is copied verbatim.
+_ALWAYS_OVERWRITE = ("name_hash", "privacy")
+# Optional plaintext fields: UPDATE overwrites only when the candidate
+# carries a value, so a re-import never nulls a field the source format
+# doesn't model (e.g. PluralKit has no emoji, so a PK update must not wipe
+# an emoji the user set after the first import).
 _OVERWRITE_IF_SET = (
     "display_name",
-    "description",
     "pronouns",
     "avatar_url",
     "banner_url",
@@ -73,8 +80,19 @@ _OVERWRITE_IF_SET = (
     "birthday",
     "pluralkit_id",
     "emoji",
-    "note",
 )
+# Encrypted fields: their ciphertext is AAD-bound to the owning row's id, so
+# an UPDATE cannot copy the candidate's ciphertext onto the existing row -
+# it would stay bound to the candidate's id and become undecryptable on the
+# existing row. Each is decrypted under the candidate's AAD and re-encrypted
+# under the existing row's AAD instead (a legitimate cross-row move). `name`
+# is always re-bound; `description`/`note` only when the candidate carries a
+# value, mirroring the plaintext always/if-set split.
+_ENCRYPTED_ALWAYS = {"name": member_name_aad}
+_ENCRYPTED_IF_SET = {
+    "description": member_description_aad,
+    "note": member_note_aad,
+}
 
 
 @dataclass
@@ -130,6 +148,14 @@ class Resolution:
     disposition: str  # "created" | "skipped" | "updated"
 
 
+def _rebind(ciphertext: str, src_aad: bytes, dst_aad: bytes) -> str:
+    """Move an encrypted value between rows: decrypt under the source row's
+    AAD, re-encrypt under the destination's. A v1 candidate ciphertext still
+    decrypts (its AAD is ignored), so old rows re-bind cleanly and land on v2.
+    """
+    return encrypt(decrypt(ciphertext, aad=src_aad), aad=dst_aad)
+
+
 def _apply_update(existing: Member, candidate: Member) -> None:
     for fld in _ALWAYS_OVERWRITE:
         setattr(existing, fld, getattr(candidate, fld))
@@ -137,6 +163,26 @@ def _apply_update(existing: Member, candidate: Member) -> None:
         val = getattr(candidate, fld, None)
         if val is not None:
             setattr(existing, fld, val)
+    # Encrypted fields: re-bind the ciphertext from the candidate's AAD to the
+    # existing row's AAD rather than copying it (see the field-list comments).
+    for fld, aad_for in _ENCRYPTED_ALWAYS.items():
+        setattr(
+            existing,
+            fld,
+            _rebind(
+                getattr(candidate, fld),
+                aad_for(candidate.id),
+                aad_for(existing.id),
+            ),
+        )
+    for fld, aad_for in _ENCRYPTED_IF_SET.items():
+        val = getattr(candidate, fld, None)
+        if val is not None:
+            setattr(
+                existing,
+                fld,
+                _rebind(val, aad_for(candidate.id), aad_for(existing.id)),
+            )
 
 
 def resolve_member(

--- a/sheaf/services/jobs.py
+++ b/sheaf/services/jobs.py
@@ -386,6 +386,7 @@ async def _process_account_deletions(db: AsyncSession) -> dict:
 async def _send_deletion_reminders(db: AsyncSession) -> dict:
     """Send reminder emails to users with pending deletions."""
     from sheaf.crypto import decrypt
+    from sheaf.encrypted_fields import user_email_aad
     from sheaf.models.user import AccountStatus, User
     from sheaf.services.email import send_email
     from sheaf.services.email_templates import deletion_reminder_email
@@ -434,7 +435,7 @@ async def _send_deletion_reminders(db: AsyncSession) -> dict:
                 continue
             if days_remaining <= reminder_day:
                 try:
-                    email = decrypt(user.email)
+                    email = decrypt(user.email, aad=user_email_aad(user.id))
                     subject, html, text = deletion_reminder_email(
                         max(days_remaining, 0)
                     )

--- a/sheaf/services/journals.py
+++ b/sheaf/services/journals.py
@@ -15,6 +15,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import settings
 from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import (
+    journal_body_aad,
+    journal_title_aad,
+    member_description_aad,
+    member_name_aad,
+    revision_body_aad,
+    revision_title_aad,
+)
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.journal_entry import JournalEntry
 from sheaf.models.member import Member
@@ -194,8 +202,6 @@ async def capture_revision(
         effective_revision_caps(user, system)[0] if system is not None else 0
     )
 
-    enc_title = encrypt(title) if title is not None else None
-    enc_body = encrypt(body)
     image_keys = extract_image_keys(body)
 
     debounce_minutes = settings.revision_debounce_minutes
@@ -206,12 +212,17 @@ async def capture_revision(
             and latest.pinned_at is None
             and _within_debounce_window(latest.inserted_at, debounce_minutes)
         ):
-            # Replace the newest checkpoint in place. Reuse the same encrypt()
-            # calls as the append path so nothing plaintext is ever stored;
-            # image_keys stays the plaintext-extracted list, as today. Leave
-            # inserted_at untouched on purpose (see docstring).
-            latest.title = enc_title
-            latest.body = enc_body
+            # Replace the newest checkpoint in place. Encrypt bound to the
+            # existing revision row's own id (the cell being overwritten) so
+            # nothing plaintext is ever stored; image_keys stays the
+            # plaintext-extracted list, as today. Leave inserted_at untouched
+            # on purpose (see docstring).
+            latest.title = (
+                encrypt(title, aad=revision_title_aad(latest.id))
+                if title is not None
+                else None
+            )
+            latest.body = encrypt(body, aad=revision_body_aad(latest.id))
             latest.image_keys = image_keys
             latest.editor_member_ids = editor_ids
             latest.editor_member_names = editor_names
@@ -230,14 +241,23 @@ async def capture_revision(
     if existing_count == 0 and system is not None and system.auto_pin_first_revision:
         pinned_at = datetime.now(UTC)
 
+    # Append a new revision. Pre-allocate its id (UUIDMixin's default only
+    # fires at flush) so the ciphertext binds to this revision row, not the
+    # revised target.
+    rev_id = uuid.uuid4()
     revision = ContentRevision(
+        id=rev_id,
         target_type=target_type_str,
         target_id=target_id,
         user_id=user.id,
         editor_member_ids=editor_ids,
         editor_member_names=editor_names,
-        title=enc_title,
-        body=enc_body,
+        title=(
+            encrypt(title, aad=revision_title_aad(rev_id))
+            if title is not None
+            else None
+        ),
+        body=encrypt(body, aad=revision_body_aad(rev_id)),
         image_keys=image_keys,
         pinned_at=pinned_at,
     )
@@ -344,8 +364,16 @@ def unpin_revision_immediate(revision: ContentRevision) -> ContentRevision:
 
 def revision_plaintext(revision: ContentRevision) -> tuple[str | None, str]:
     """Decrypt a revision's title/body to plaintext."""
-    title = decrypt(revision.title) if revision.title is not None else None
-    body = decrypt(revision.body) if revision.body else ""
+    title = (
+        decrypt(revision.title, aad=revision_title_aad(revision.id))
+        if revision.title is not None
+        else None
+    )
+    body = (
+        decrypt(revision.body, aad=revision_body_aad(revision.id))
+        if revision.body
+        else ""
+    )
     return title, body
 
 
@@ -369,8 +397,14 @@ def decrypt_revision_for_read(revision: ContentRevision) -> dict:
 
 def entry_plaintext(entry: JournalEntry) -> tuple[str | None, str]:
     """Decrypt a journal entry's title/body to plaintext."""
-    title = decrypt(entry.title) if entry.title is not None else None
-    body = decrypt(entry.body) if entry.body else ""
+    title = (
+        decrypt(entry.title, aad=journal_title_aad(entry.id))
+        if entry.title is not None
+        else None
+    )
+    body = (
+        decrypt(entry.body, aad=journal_body_aad(entry.id)) if entry.body else ""
+    )
     return title, body
 
 
@@ -473,7 +507,10 @@ async def resolve_author_snapshot(
         # display_name is plaintext; name is ciphertext — decrypt for the
         # snapshot. Author-name snapshots are display strings, not lookups,
         # so we store them in plaintext (same as how they're shown to users).
-        names.append(member.display_name or decrypt(member.name))
+        names.append(
+            member.display_name
+            or decrypt(member.name, aad=member_name_aad(member.id))
+        )
     return ids, names
 
 
@@ -510,11 +547,19 @@ async def create_journal_entry(
         )
     else:
         author_ids, author_names = await snapshot_current_fronts(system.id, db)
+    # Pre-allocate the id (UUIDMixin's default only fires at flush) so the
+    # encrypted cells bind to the row before insert.
+    entry_id = uuid.uuid4()
     entry = JournalEntry(
+        id=entry_id,
         system_id=system.id,
         member_id=member_id,
-        title=encrypt(title) if title is not None else None,
-        body=encrypt(body),
+        title=(
+            encrypt(title, aad=journal_title_aad(entry_id))
+            if title is not None
+            else None
+        ),
+        body=encrypt(body, aad=journal_body_aad(entry_id)),
         visibility=visibility,
         author_user_id=user.id,
         author_member_ids=author_ids,
@@ -560,9 +605,9 @@ async def update_journal_entry(
             body=current_body,
         )
     if title is not None:
-        entry.title = encrypt(title)
+        entry.title = encrypt(title, aad=journal_title_aad(entry.id))
     if body is not None:
-        entry.body = encrypt(body)
+        entry.body = encrypt(body, aad=journal_body_aad(entry.id))
         entry.image_keys = extract_image_keys(body)
     if visibility is not None:
         entry.visibility = visibility
@@ -600,8 +645,12 @@ async def restore_journal_revision(
         body=current_body,
     )
     revision_title, revision_body = revision_plaintext(revision)
-    entry.title = encrypt(revision_title) if revision_title is not None else None
-    entry.body = encrypt(revision_body)
+    entry.title = (
+        encrypt(revision_title, aad=journal_title_aad(entry.id))
+        if revision_title is not None
+        else None
+    )
+    entry.body = encrypt(revision_body, aad=journal_body_aad(entry.id))
     entry.image_keys = extract_image_keys(revision_body)
     entry.updated_at = datetime.now(UTC)
     return entry
@@ -622,7 +671,9 @@ async def restore_member_bio_revision(
     revision rows themselves (the member table has no `image_keys` column).
     """
     current_description = (
-        decrypt(member.description) if member.description is not None else ""
+        decrypt(member.description, aad=member_description_aad(member.id))
+        if member.description is not None
+        else ""
     )
     await capture_revision(
         db=db,
@@ -634,5 +685,9 @@ async def restore_member_bio_revision(
         body=current_description,
     )
     _, revision_body = revision_plaintext(revision)
-    member.description = encrypt(revision_body) if revision_body else None
+    member.description = (
+        encrypt(revision_body, aad=member_description_aad(member.id))
+        if revision_body
+        else None
+    )
     return member

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -15,34 +15,47 @@ from __future__ import annotations
 from datetime import datetime
 
 from sheaf.crypto import blind_index, decrypt, encrypt
+from sheaf.encrypted_fields import (
+    member_description_aad,
+    member_name_aad,
+    member_note_aad,
+)
 from sheaf.models.member import Member
 from sheaf.schemas.member import MemberRead
 
 
 def member_name_plaintext(member: Member) -> str:
-    return decrypt(member.name)
+    return decrypt(member.name, aad=member_name_aad(member.id))
 
 
 def member_description_plaintext(member: Member) -> str | None:
     if member.description is None:
         return None
-    return decrypt(member.description)
+    return decrypt(member.description, aad=member_description_aad(member.id))
 
 
 def member_note_plaintext(member: Member) -> str | None:
     if member.note is None:
         return None
-    return decrypt(member.note)
+    return decrypt(member.note, aad=member_note_aad(member.id))
 
 
 def set_member_name(member: Member, plaintext: str) -> None:
-    """Encrypt + hash a new plaintext name onto a Member instance."""
-    member.name = encrypt(plaintext)
+    """Encrypt + hash a new plaintext name onto a Member instance.
+
+    The member must already carry its id (pre-allocated by the caller on an
+    insert path) so the ciphertext binds to the right cell.
+    """
+    member.name = encrypt(plaintext, aad=member_name_aad(member.id))
     member.name_hash = blind_index(plaintext)
 
 
 def set_member_description(member: Member, plaintext: str | None) -> None:
-    member.description = encrypt(plaintext) if plaintext is not None else None
+    member.description = (
+        encrypt(plaintext, aad=member_description_aad(member.id))
+        if plaintext is not None
+        else None
+    )
 
 
 def set_member_note(member: Member, plaintext: str | None) -> None:
@@ -52,7 +65,7 @@ def set_member_note(member: Member, plaintext: str | None) -> None:
     if plaintext is None or plaintext == "":
         member.note = None
     else:
-        member.note = encrypt(plaintext)
+        member.note = encrypt(plaintext, aad=member_note_aad(member.id))
 
 
 def decrypt_member_for_read(

--- a/sheaf/services/messages.py
+++ b/sheaf/services/messages.py
@@ -18,6 +18,11 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import (
+    member_name_aad,
+    message_body_aad,
+    revision_body_aad,
+)
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.member import Member
 from sheaf.models.message import BoardKind, Message, MessageReadState
@@ -29,14 +34,14 @@ from sheaf.schemas.message import BoardSummary
 # ---------------------------------------------------------------------------
 
 
-def encrypt_body(plaintext: str) -> str:
-    return encrypt(plaintext)
+def encrypt_body(plaintext: str, message_id) -> str:
+    return encrypt(plaintext, aad=message_body_aad(message_id))
 
 
-def decrypt_body(ciphertext: str | None) -> str:
+def decrypt_body(ciphertext: str | None, message_id) -> str:
     if not ciphertext:
         return ""
-    return decrypt(ciphertext)
+    return decrypt(ciphertext, aad=message_body_aad(message_id))
 
 
 # Body shown inline as "Replying to X: <preview>". Plaintext, truncated.
@@ -210,6 +215,7 @@ _BOARD_AGG_SQL = text(
         SELECT DISTINCT ON (m.board_kind, m.board_member_id)
                m.board_kind,
                m.board_member_id,
+               m.id AS last_message_id,
                m.body AS last_body
         FROM messages m
         WHERE m.system_id = :system_id AND m.deleted_at IS NULL
@@ -219,6 +225,7 @@ _BOARD_AGG_SQL = text(
            agg.board_member_id,
            agg.total_count,
            agg.last_at,
+           latest.last_message_id,
            latest.last_body,
            agg.unread_count,
            agg.has_read_state
@@ -255,11 +262,14 @@ async def board_summaries(
     )
     per_board: dict[
         tuple[str, uuid.UUID | None],
-        tuple[int, datetime | None, bytes | None, int, bool],
+        tuple[int, datetime | None, uuid.UUID | None, str | None, int, bool],
     ] = {}
-    for board_kind, board_member_id, total, last_at, last_body, unread, has_rs in agg_rows:
+    for (
+        board_kind, board_member_id, total, last_at,
+        last_msg_id, last_body, unread, has_rs,
+    ) in agg_rows:
         per_board[(board_kind, board_member_id)] = (
-            total, last_at, last_body, unread, has_rs,
+            total, last_at, last_msg_id, last_body, unread, has_rs,
         )
 
     members_result = await db.execute(
@@ -278,7 +288,9 @@ async def board_summaries(
             *((BoardKind.MEMBER.value, m.id) for m in members),
         }
         seen_keys = {
-            key for key, (_t, _la, _lb, _u, has_rs) in per_board.items() if has_rs
+            key
+            for key, (_t, _la, _mid, _lb, _u, has_rs) in per_board.items()
+            if has_rs
         }
         # Also consider boards that exist as read_state rows but have
         # no messages: the per_board aggregation only surfaces boards
@@ -316,13 +328,17 @@ async def board_summaries(
                 message_count=0,
                 unread_count=0,
             )
-        total, last_at, last_body, unread, has_rs = row
+        total, last_at, last_msg_id, last_body, unread, has_rs = row
         return BoardSummary(
             board_kind=key[0],
             board_member_id=key[1],
             member_name=member_name,
             last_message_at=last_at,
-            last_message_preview=preview_for(decrypt_body(last_body)) if last_body else None,
+            last_message_preview=(
+                preview_for(decrypt_body(last_body, last_msg_id))
+                if last_body
+                else None
+            ),
             message_count=total,
             # Caller has no read_state row yet → unread is 0 (baseline
             # was just established above; subsequent posts will count).
@@ -350,7 +366,11 @@ async def board_summaries(
 def display_name(member: Member) -> str:
     if member.display_name:
         return member.display_name
-    return decrypt(member.name) if member.name else "(unnamed)"
+    return (
+        decrypt(member.name, aad=member_name_aad(member.id))
+        if member.name
+        else "(unnamed)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -453,7 +473,7 @@ async def fetch_parent_preview(
     parent = await db.get(Message, parent_id)
     if parent is None or parent.deleted_at is not None:
         return None, None, parent_id
-    body_pt = decrypt_body(parent.body)
+    body_pt = decrypt_body(parent.body, parent.id)
     author_name: str | None = None
     if parent.author_member_id is not None:
         author = await db.get(Member, parent.author_member_id)
@@ -501,9 +521,9 @@ async def restore_message_revision(
     `restore_member_bio_revision`: capture the current body as a fresh
     revision, then overwrite `message.body` with the revision's content.
     """
-    from sheaf.services.journals import capture_revision, revision_plaintext
+    from sheaf.services.journals import capture_revision
 
-    current_body = decrypt_body(message.body)
+    current_body = decrypt_body(message.body, message.id)
     await capture_revision(
         db=db,
         target_type=ContentRevisionTarget.MESSAGE,
@@ -513,8 +533,14 @@ async def restore_message_revision(
         title=None,
         body=current_body,
     )
-    _, revision_body = revision_plaintext(revision)
-    message.body = encrypt_body(revision_body or "")
+    # The revision's stored body is bound to the revision row, so read it
+    # with the revision aad; the message side re-binds to the message row.
+    revision_body = (
+        decrypt(revision.body, aad=revision_body_aad(revision.id))
+        if revision.body
+        else ""
+    )
+    message.body = encrypt_body(revision_body, message.id)
     return message
 
 

--- a/sheaf/services/notifications/handlers.py
+++ b/sheaf/services/notifications/handlers.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import settings
 from sheaf.crypto import decrypt
+from sheaf.encrypted_fields import webhook_secret_aad
 from sheaf.models.notification_channel import (
     DestinationType,
     NotificationChannel,
@@ -243,7 +244,10 @@ async def _deliver_webhook(
     # cloud frontends.
     if fmt in ("json", "plaintext") and channel.webhook_secret_encrypted is not None:
         try:
-            secret = decrypt(channel.webhook_secret_encrypted)
+            secret = decrypt(
+                channel.webhook_secret_encrypted,
+                aad=webhook_secret_aad(channel.id),
+            )
         except Exception as exc:  # noqa: BLE001
             return permanent(f"webhook secret decryption failed: {exc}")
         timestamp = str(int(time.time()))

--- a/sheaf/services/openplural_archive.py
+++ b/sheaf/services/openplural_archive.py
@@ -28,6 +28,7 @@ import json
 import zlib
 
 from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import system_openplural_archive_aad
 
 # The reserved namespace Sheaf owns; everything else under file-level
 # `extensions` is foreign and gets preserved.
@@ -144,13 +145,19 @@ def merge_residual(existing: dict, incoming: dict) -> dict:
     return merged
 
 
-def pack_residual(residual: dict, *, max_bytes: int) -> tuple[str | None, str | None]:
+def pack_residual(
+    residual: dict, *, system_id, max_bytes: int
+) -> tuple[str | None, str | None]:
     """Compress + encrypt a residual for storage.
 
     Returns ``(token, warning)``. ``token`` is None when there is nothing
     to store or when the raw JSON exceeds ``max_bytes`` (in which case
     ``warning`` explains the drop). The size check is on the uncompressed
     JSON: it bounds what we are willing to retain, not the on-disk size.
+
+    ``system_id`` is the owning system's id; the ciphertext is AAD-bound to
+    the ``systems.openplural_archive`` cell so it cannot be relocated to
+    another system's row.
     """
     if not residual:
         return None, None
@@ -162,20 +169,26 @@ def pack_residual(residual: dict, *, max_bytes: int) -> tuple[str | None, str | 
             "(OPENPLURAL_MAX_PRESERVED_MB); it was not retained"
         )
     compressed = zlib.compress(raw, 9)
-    token = encrypt(base64.b64encode(compressed).decode("ascii"))
+    token = encrypt(
+        base64.b64encode(compressed).decode("ascii"),
+        aad=system_openplural_archive_aad(system_id),
+    )
     return token, None
 
 
-def unpack_residual(token: str | None) -> dict:
+def unpack_residual(token: str | None, *, system_id) -> dict:
     """Inverse of ``pack_residual``. Returns {} for NULL/empty/corrupt.
 
     Tolerant by design: a residual that fails to decode must never break
     an export. A corrupt blob yields an empty residual (the export is
-    simply missing the preserved data, not failed)."""
+    simply missing the preserved data, not failed). ``system_id`` supplies
+    the AAD for v2 tokens; a v1 token still decrypts with it ignored."""
     if not token:
         return {}
     try:
-        compressed = base64.b64decode(decrypt(token))
+        compressed = base64.b64decode(
+            decrypt(token, aad=system_openplural_archive_aad(system_id))
+        )
         data = json.loads(zlib.decompress(compressed))
     except Exception:  # noqa: BLE001 - corrupt archive must not break export
         return {}

--- a/sheaf/services/openplural_import_runner.py
+++ b/sheaf/services/openplural_import_runner.py
@@ -86,10 +86,10 @@ def _preserve_residual(job: ImportJob, system, envelope: dict) -> None:
     residual = extract_residual(envelope)
     if not residual:
         return
-    existing = unpack_residual(system.openplural_archive)
+    existing = unpack_residual(system.openplural_archive, system_id=system.id)
     merged = merge_residual(existing, residual)
     max_bytes = settings.openplural_max_preserved_mb * 1024 * 1024
-    token, warning = pack_residual(merged, max_bytes=max_bytes)
+    token, warning = pack_residual(merged, system_id=system.id, max_bytes=max_bytes)
     if warning:
         append_event(job, level="warning", stage="preserve", message=warning)
         return

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -34,6 +34,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
+from sheaf.encrypted_fields import member_description_aad, member_name_aad
 from sheaf.models.front import Front
 from sheaf.models.group import Group
 from sheaf.models.member import Member, front_members, group_members
@@ -214,15 +215,20 @@ def build_member(
 
     pk_hid = _clean_str(pk_m.get("id"))
 
+    member_id = uuid.uuid4()
     return Member(
-        id=uuid.uuid4(),
+        id=member_id,
         system_id=system_id,
-        name=encrypt(plaintext_name),
+        name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
         name_hash=blind_index(plaintext_name),
         display_name=clamp_str(
             _clean_str(pk_m.get("display_name")), il.M_DISPLAY_NAME, report=report
         ),
-        description=encrypt(plaintext_description) if plaintext_description else None,
+        description=(
+            encrypt(plaintext_description, aad=member_description_aad(member_id))
+            if plaintext_description
+            else None
+        ),
         pronouns=clamp_str(
             _clean_str(pk_m.get("pronouns")), il.M_PRONOUNS, report=report
         ),

--- a/sheaf/services/pk_import_runner.py
+++ b/sheaf/services/pk_import_runner.py
@@ -21,6 +21,7 @@ import logging
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import decrypt
+from sheaf.encrypted_fields import import_credential_aad
 from sheaf.models.import_job import ImportJob, ImportJobSource
 from sheaf.models.member import Member
 from sheaf.schemas.pk_import import PKImportOptions
@@ -291,7 +292,7 @@ async def handle_pluralkit_api(job: ImportJob, db: AsyncSession) -> None:
             "the token may have already been wiped by a prior run"
         )
     try:
-        token = decrypt(encrypted)
+        token = decrypt(encrypted, aad=import_credential_aad(job.id))
     except Exception as exc:
         raise ImportPayloadError(
             "could not decrypt the stored PluralKit token"

--- a/sheaf/services/pluralspace_import.py
+++ b/sheaf/services/pluralspace_import.py
@@ -66,6 +66,17 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
+from sheaf.encrypted_fields import (
+    front_custom_status_aad,
+    journal_body_aad,
+    journal_title_aad,
+    member_description_aad,
+    member_name_aad,
+    message_body_aad,
+    poll_description_aad,
+    poll_option_text_aad,
+    poll_question_aad,
+)
 from sheaf.models.custom_field import (
     CustomFieldDefinition,
     CustomFieldValue,
@@ -528,10 +539,11 @@ async def run_import(
         # uncapped, matching the create API; only `note` carries M_NOTE and
         # PluralSpace exports have no note-equivalent field to map.
         plaintext_description = _clean_str(m_data.get("description"))
+        member_id = uuid.uuid4()
         member = Member(
-            id=uuid.uuid4(),
+            id=member_id,
             system_id=system.id,
-            name=encrypt(plaintext_name),
+            name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
             name_hash=blind_index(plaintext_name),
             display_name=clamp_str(
                 _clean_str(m_data.get("display_name")),
@@ -539,7 +551,9 @@ async def run_import(
                 report=report,
             ),
             description=(
-                encrypt(plaintext_description) if plaintext_description else None
+                encrypt(plaintext_description, aad=member_description_aad(member_id))
+                if plaintext_description
+                else None
             ),
             pronouns=clamp_str(
                 _clean_str(m_data.get("pronouns")), il.M_PRONOUNS, report=report
@@ -1069,11 +1083,12 @@ async def _import_custom_fields(
         if not value_guard.add((field_id, member_id)):
             continue
         joined = "\n".join(values)
+        cfv_id = uuid.uuid4()
         cfv = CustomFieldValue(
-            id=uuid.uuid4(),
+            id=cfv_id,
             field_id=field_id,
             member_id=member_id,
-            value=encrypt_field_value(joined),
+            value=encrypt_field_value(joined, cfv_id),
         )
         db.add(cfv)
 
@@ -1141,12 +1156,17 @@ async def _import_fronts(
         if ftype and ftype != "front":
             unknown_types.add(ftype)
         comment = _clean_str(f_data.get("comment"))
+        front_id = uuid.uuid4()
         front = Front(
-            id=uuid.uuid4(),
+            id=front_id,
             system_id=system_id,
             started_at=started_at,
             ended_at=ended_at,
-            custom_status=encrypt(comment) if comment else None,
+            custom_status=(
+                encrypt(comment, aad=front_custom_status_aad(front_id))
+                if comment
+                else None
+            ),
         )
         db.add(front)
         await db.flush()
@@ -1238,12 +1258,13 @@ async def _import_journals(
                 continue
             journal_index.register(jkey)
 
+        entry_id = uuid.uuid4()
         entry = JournalEntry(
-            id=uuid.uuid4(),
+            id=entry_id,
             system_id=system.id,
             member_id=per_member_id,
-            title=encrypt(title) if title else None,
-            body=encrypt(body),
+            title=encrypt(title, aad=journal_title_aad(entry_id)) if title else None,
+            body=encrypt(body, aad=journal_body_aad(entry_id)),
             visibility="system",
             author_user_id=system.user_id,
             author_member_ids=author_ids,
@@ -1324,13 +1345,14 @@ async def _import_chat(
             author = member_name_to_member.get(author_name) if author_name else None
             if author_name and author is None:
                 missing_authors += 1
+            message_id = uuid.uuid4()
             message = Message(
-                id=uuid.uuid4(),
+                id=message_id,
                 system_id=system_id,
                 board_kind=BoardKind.SYSTEM.value,
                 board_member_id=None,
                 author_member_id=author.id if author else None,
-                body=encrypt(body),
+                body=encrypt(body, aad=message_body_aad(message_id)),
             )
             if created:
                 message.created_at = created
@@ -1415,11 +1437,16 @@ async def _import_polls(
             closes_at = base + timedelta(days=365)
             open_ended_count += 1
 
+        poll_row_id = uuid.uuid4()
         poll = Poll(
-            id=uuid.uuid4(),
+            id=poll_row_id,
             system_id=system_id,
-            question=encrypt(question),
-            description=encrypt(description) if description else None,
+            question=encrypt(question, aad=poll_question_aad(poll_row_id)),
+            description=(
+                encrypt(description, aad=poll_description_aad(poll_row_id))
+                if description
+                else None
+            ),
             kind=(
                 PollKind.MULTI_CHOICE.value
                 if allow_multi
@@ -1444,15 +1471,17 @@ async def _import_polls(
         for position, o_data in enumerate(options_in):
             if not isinstance(o_data, dict):
                 continue
+            option_row_id = uuid.uuid4()
             option = PollOption(
-                id=uuid.uuid4(),
+                id=option_row_id,
                 poll_id=poll.id,
                 text=encrypt(
                     clamp_str(
                         _clean_str(o_data.get("text")) or "",
                         il.POLL_OPTION,
                         report=report,
-                    )
+                    ),
+                    aad=poll_option_text_aad(option_row_id),
                 ),
                 position=position,
             )

--- a/sheaf/services/polls.py
+++ b/sheaf/services/polls.py
@@ -131,15 +131,15 @@ def validate_close_window(
 # ---------------------------------------------------------------------------
 
 
-def encrypt_text(plaintext: str) -> str:
-    return encrypt(plaintext)
+def encrypt_text(plaintext: str, aad: bytes) -> str:
+    return encrypt(plaintext, aad=aad)
 
 
-def decrypt_text(ciphertext: str | None) -> str | None:
+def decrypt_text(ciphertext: str | None, aad: bytes) -> str | None:
     if ciphertext is None:
         return None
     try:
-        return decrypt(ciphertext)
+        return decrypt(ciphertext, aad=aad)
     except Exception:
         logger.warning("poll content failed to decrypt; returning empty string")
         return ""

--- a/sheaf/services/prism_import.py
+++ b/sheaf/services/prism_import.py
@@ -73,6 +73,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.config import settings
 from sheaf.crypto import blind_index, encrypt
+from sheaf.encrypted_fields import (
+    journal_body_aad,
+    journal_title_aad,
+    member_description_aad,
+    member_name_aad,
+    message_body_aad,
+    poll_description_aad,
+    poll_option_text_aad,
+    poll_question_aad,
+)
 from sheaf.models.custom_field import (
     CustomFieldDefinition,
     CustomFieldValue,
@@ -418,14 +428,17 @@ async def run_import(
         display_name = _clean_str(m.get("displayName")) or _clean_str(
             m.get("pluralkitDisplayName")
         )
+        member_id = uuid.uuid4()
         member = Member(
-            id=uuid.uuid4(),
+            id=member_id,
             system_id=system.id,
-            name=encrypt(plaintext_name),
+            name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
             name_hash=blind_index(plaintext_name),
             display_name=clamp_str(display_name, il.M_DISPLAY_NAME, report=report),
             description=(
-                encrypt(plaintext_description) if plaintext_description else None
+                encrypt(plaintext_description, aad=member_description_aad(member_id))
+                if plaintext_description
+                else None
             ),
             pronouns=clamp_str(
                 _clean_str(m.get("pronouns")), il.M_PRONOUNS, report=report
@@ -882,11 +895,12 @@ async def _import_custom_fields(
             continue
         if not value_guard.add((field_def.id, handle.member.id)):
             continue
+        cfv_id = uuid.uuid4()
         cfv = CustomFieldValue(
-            id=uuid.uuid4(),
+            id=cfv_id,
             field_id=field_def.id,
             member_id=handle.member.id,
-            value=encrypt_field_value(raw_value),
+            value=encrypt_field_value(raw_value, cfv_id),
         )
         db.add(cfv)
         values_imported += 1
@@ -1008,12 +1022,13 @@ async def _import_notes(
                 skipped += 1
                 continue
             journal_index.register(jkey)
+        entry_id = uuid.uuid4()
         entry = JournalEntry(
-            id=uuid.uuid4(),
+            id=entry_id,
             system_id=system.id,
             member_id=handle.member.id if handle else None,
-            title=encrypt(title) if title else None,
-            body=encrypt(body),
+            title=encrypt(title, aad=journal_title_aad(entry_id)) if title else None,
+            body=encrypt(body, aad=journal_body_aad(entry_id)),
             visibility="system",
             author_user_id=system.user_id,
             author_member_ids=author_ids,
@@ -1111,11 +1126,16 @@ async def _import_polls(
             base = created_at or now
             closes_at = base + timedelta(days=365)
             open_ended += 1
+        poll_row_id = uuid.uuid4()
         poll = Poll(
-            id=uuid.uuid4(),
+            id=poll_row_id,
             system_id=system_id,
-            question=encrypt(question),
-            description=encrypt(description) if description else None,
+            question=encrypt(question, aad=poll_question_aad(poll_row_id)),
+            description=(
+                encrypt(description, aad=poll_description_aad(poll_row_id))
+                if description
+                else None
+            ),
             kind=(
                 PollKind.MULTI_CHOICE.value
                 if allow_multi
@@ -1158,10 +1178,11 @@ async def _import_polls(
             display_text = text
             if response_texts:
                 display_text = f"{text}\n---\n" + "\n".join(response_texts)
+            option_row_id = uuid.uuid4()
             option = PollOption(
-                id=uuid.uuid4(),
+                id=option_row_id,
                 poll_id=poll.id,
-                text=encrypt(display_text),
+                text=encrypt(display_text, aad=poll_option_text_aad(option_row_id)),
                 position=position,
             )
             db.add(option)
@@ -1314,13 +1335,14 @@ async def _import_conversations(
         author_handle = ps_id_to_handle.get(author_id) if author_id else None
         if author_id and author_handle is None:
             missing_author += 1
+        message_id = uuid.uuid4()
         message = Message(
-            id=uuid.uuid4(),
+            id=message_id,
             system_id=system_id,
             board_kind=BoardKind.SYSTEM.value,
             board_member_id=None,
             author_member_id=author_handle.member.id if author_handle else None,
-            body=encrypt(body),
+            body=encrypt(body, aad=message_body_aad(message_id)),
         )
         if ts:
             message.created_at = ts
@@ -1386,15 +1408,16 @@ async def _import_member_board_posts(
             body = f"[audience: {audience}] {body}".rstrip()
         if title:
             body = f"**{title}**\n\n{body}"
+        message_id = uuid.uuid4()
         message = Message(
-            id=uuid.uuid4(),
+            id=message_id,
             system_id=system_id,
             board_kind=(
                 BoardKind.MEMBER.value if target_handle else BoardKind.SYSTEM.value
             ),
             board_member_id=target_handle.member.id if target_handle else None,
             author_member_id=author_handle.member.id if author_handle else None,
-            body=encrypt(body),
+            body=encrypt(body, aad=message_body_aad(message_id)),
         )
         if written:
             message.created_at = written

--- a/sheaf/services/prism_import_runner.py
+++ b/sheaf/services/prism_import_runner.py
@@ -13,6 +13,7 @@ import logging
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import decrypt
+from sheaf.encrypted_fields import import_credential_aad
 from sheaf.models.import_job import ImportJob, ImportJobSource
 from sheaf.models.user import User
 from sheaf.schemas.prism_import import PrismImportOptions
@@ -50,7 +51,7 @@ async def handle_prism_file(job: ImportJob, db: AsyncSession) -> None:
             "with its decryption passphrase via the credential form field."
         )
     try:
-        passphrase = decrypt(encrypted_credential)
+        passphrase = decrypt(encrypted_credential, aad=import_credential_aad(job.id))
     except Exception as exc:  # noqa: BLE001 — Fernet raises InvalidToken
         raise ImportPayloadError(
             "stored passphrase ciphertext failed to decrypt; the job "

--- a/sheaf/services/reminders.py
+++ b/sheaf/services/reminders.py
@@ -48,6 +48,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import reminder_body_aad, reminder_title_aad
 from sheaf.models.front import Front
 from sheaf.models.notification_channel import (
     DestinationState,
@@ -71,8 +72,8 @@ _DOW_BITS = [1 << i for i in range(7)]
 # --- Helpers ---------------------------------------------------------------
 
 
-def _decrypt_or_none(value: str | None) -> str | None:
-    return decrypt(value) if value else None
+def _decrypt_or_none(value: str | None, aad: bytes) -> str | None:
+    return decrypt(value, aad=aad) if value else None
 
 
 def _zone(name: str | None) -> ZoneInfo:
@@ -185,8 +186,8 @@ def _reminder_payload(
     return {
         "kind": "reminder_single",
         "reminder_id": str(reminder.id),
-        "title": _decrypt_or_none(reminder.title) or "",
-        "body": _decrypt_or_none(reminder.body),
+        "title": _decrypt_or_none(reminder.title, reminder_title_aad(reminder.id)) or "",
+        "body": _decrypt_or_none(reminder.body, reminder_body_aad(reminder.id)),
         "scheduled_for": (
             scheduled_for.astimezone(UTC).isoformat()
             if scheduled_for is not None
@@ -219,8 +220,8 @@ def _digest_payload(
     return {
         "kind": "reminder_digest",
         "reminder_id": str(reminder.id),
-        "title": _decrypt_or_none(reminder.title) or "",
-        "body": _decrypt_or_none(reminder.body),
+        "title": _decrypt_or_none(reminder.title, reminder_title_aad(reminder.id)) or "",
+        "body": _decrypt_or_none(reminder.body, reminder_body_aad(reminder.id)),
         "missed_count": len(rows),
         "first_missed_at": rows[0].scheduled_for.astimezone(UTC).isoformat()
         if rows
@@ -558,16 +559,21 @@ def _channel_is_active(channel: NotificationChannel | None) -> bool:
 # --- Encryption helpers (used by API layer) -------------------------------
 
 
-def encrypt_title_body(title: str, body: str | None) -> tuple[str, str | None]:
+def encrypt_title_body(
+    title: str, body: str | None, reminder_id
+) -> tuple[str, str | None]:
     """Encrypt a reminder's title and body for storage."""
-    return encrypt(title), (encrypt(body) if body else None)
+    return (
+        encrypt(title, aad=reminder_title_aad(reminder_id)),
+        encrypt(body, aad=reminder_body_aad(reminder_id)) if body else None,
+    )
 
 
 def decrypt_for_read(reminder: Reminder) -> dict:
     """Build the decrypted, scope-resolved view used by the read API."""
     return {
-        "title": _decrypt_or_none(reminder.title) or "",
-        "body": _decrypt_or_none(reminder.body),
+        "title": _decrypt_or_none(reminder.title, reminder_title_aad(reminder.id)) or "",
+        "body": _decrypt_or_none(reminder.body, reminder_body_aad(reminder.id)),
         "scope_member_ids": [m.id for m in reminder.scope_members],
         "pending_count": len(reminder.pending),
         "next_fire_at": compute_next_fire(reminder),

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -36,6 +36,20 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
+from sheaf.encrypted_fields import (
+    front_custom_status_aad,
+    journal_body_aad,
+    journal_title_aad,
+    member_description_aad,
+    member_name_aad,
+    member_note_aad,
+    poll_description_aad,
+    poll_option_text_aad,
+    poll_question_aad,
+    revision_body_aad,
+    revision_title_aad,
+    system_note_aad,
+)
 from sheaf.models.content_revision import ContentRevision, ContentRevisionTarget
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
 from sheaf.models.front import Front
@@ -119,11 +133,14 @@ from sheaf.services.import_image_strip import (
 )
 from sheaf.services.import_limits import ClampReport, clamp_list, clamp_str
 from sheaf.services.member_limits import enforce_import_member_cap
+from sheaf.services.messages import encrypt_body
 from sheaf.services.polls import (
+    encrypt_text,
     max_concurrent_open_for_tier,
     max_retention_days_for_tier,
 )
 from sheaf.services.relationships import canonicalize_pair
+from sheaf.services.reminders import encrypt_title_body
 from sheaf.timezones import is_valid_timezone
 
 logger = logging.getLogger("sheaf.import.sheaf")
@@ -859,7 +876,11 @@ async def run_import(
                     il.SYS_NOTE,
                     report=report,
                 )
-                system.note = encrypt(note_val) if note_val else None
+                system.note = (
+                    encrypt(note_val, aad=system_note_aad(system.id))
+                    if note_val
+                    else None
+                )
             if sys_data.get("avatar_url") is not None:
                 # An avatar key like avatars/<old_user_id>/<uuid>.png points
                 # at the original account's storage; we can't fetch the
@@ -937,10 +958,14 @@ async def run_import(
                 )
 
                 merged = merge_residual(
-                    unpack_residual(system.openplural_archive), op_archive
+                    unpack_residual(
+                        system.openplural_archive, system_id=system.id
+                    ),
+                    op_archive,
                 )
                 token, _warn = pack_residual(
                     merged,
+                    system_id=system.id,
                     max_bytes=settings.openplural_max_preserved_mb * 1024 * 1024,
                 )
                 if token is not None:
@@ -978,21 +1003,25 @@ async def run_import(
             il.M_NOTE,
             report=report,
         )
+        member_id = uuid.uuid4()
         member = Member(
-            id=uuid.uuid4(),
+            id=member_id,
             system_id=system.id,
-            name=encrypt(plaintext_name),
+            name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
             name_hash=blind_index(plaintext_name),
             display_name=clamp_str(
                 m_data.get("display_name"), il.M_DISPLAY_NAME, report=report
             ),
             description=(
-                encrypt(plaintext_description)
+                encrypt(
+                    plaintext_description,
+                    aad=member_description_aad(member_id),
+                )
                 if plaintext_description is not None
                 else None
             ),
             note=(
-                encrypt(plaintext_note)
+                encrypt(plaintext_note, aad=member_note_aad(member_id))
                 if plaintext_note
                 else None
             ),
@@ -1217,11 +1246,12 @@ async def run_import(
                     continue
                 if not value_guard.add((field_def.id, member.id)):
                     continue
+                cfv_id = uuid.uuid4()
                 cfv = CustomFieldValue(
-                    id=uuid.uuid4(),
+                    id=cfv_id,
                     field_id=field_def.id,
                     member_id=member.id,
-                    value=encrypt_field_value(v_data.get("value")),
+                    value=encrypt_field_value(v_data.get("value"), cfv_id),
                 )
                 db.add(cfv)
 
@@ -1459,13 +1489,17 @@ async def run_import(
                 front_index.register(fkey)
 
             plaintext_status = f_data.get("custom_status")
+            front_id = uuid.uuid4()
             front = Front(
-                id=uuid.uuid4(),
+                id=front_id,
                 system_id=system.id,
                 started_at=started_at,
                 ended_at=ended_at,
                 custom_status=(
-                    encrypt(plaintext_status)
+                    encrypt(
+                        plaintext_status,
+                        aad=front_custom_status_aad(front_id),
+                    )
                     if isinstance(plaintext_status, str) and plaintext_status
                     else None
                 ),
@@ -1521,13 +1555,19 @@ async def run_import(
             title = clamp_str(
                 j_data.get("title"), il.JOURNAL_TITLE, report=report
             )
+            entry_id = uuid.uuid4()
             entry = JournalEntry(
-                id=uuid.uuid4(),
+                id=entry_id,
                 system_id=system.id,
                 member_id=member.id if member else None,
-                title=encrypt(title) if title else None,
+                title=(
+                    encrypt(title, aad=journal_title_aad(entry_id))
+                    if title
+                    else None
+                ),
                 body=encrypt(
-                    _resolve_md(j_data.get("body")) or ""
+                    _resolve_md(j_data.get("body")) or "",
+                    aad=journal_body_aad(entry_id),
                 ),
                 visibility=j_data.get("visibility") or "system",
                 # The original authoring account is meaningless on this
@@ -1592,8 +1632,9 @@ async def run_import(
                 continue
             revision_index.register(rkey)
         title = clamp_str(r_data.get("title"), il.JOURNAL_TITLE, report=report)
+        revision_id = uuid.uuid4()
         revision = ContentRevision(
-            id=uuid.uuid4(),
+            id=revision_id,
             target_type=target_type,
             target_id=target.id,
             user_id=system.user_id,
@@ -1604,9 +1645,14 @@ async def run_import(
                 )
             ],
             editor_member_names=_str_list(r_data.get("editor_member_names")),
-            title=encrypt(title) if title else None,
+            title=(
+                encrypt(title, aad=revision_title_aad(revision_id))
+                if title
+                else None
+            ),
             body=encrypt(
-                _resolve_md(r_data.get("body")) or ""
+                _resolve_md(r_data.get("body")) or "",
+                aad=revision_body_aad(revision_id),
             ),
             image_keys=_resolve_image_keys(
                 _str_list(r_data.get("image_keys"))
@@ -1659,19 +1705,21 @@ async def run_import(
                 continue
             old_author = msg_data.get("author_member_id")
             author = old_id_to_member.get(old_author) if old_author else None
+            message_id = uuid.uuid4()
             message = Message(
-                id=uuid.uuid4(),
+                id=message_id,
                 system_id=system.id,
                 board_kind=board_kind,
                 board_member_id=board_member.id if board_member else None,
                 author_member_id=author.id if author else None,
-                body=encrypt(
+                body=encrypt_body(
                     clamp_str(
                         _resolve_md(msg_data.get("body")),
                         il.MESSAGE_BODY,
                         report=report,
                     )
-                    or ""
+                    or "",
+                    message_id,
                 ),
             )
             if created:
@@ -1759,16 +1807,22 @@ async def run_import(
             description = clamp_str(
                 p_data.get("description"), il.POLL_DESCRIPTION, report=report
             )
+            poll_id = uuid.uuid4()
             poll = Poll(
-                id=uuid.uuid4(),
+                id=poll_id,
                 system_id=system.id,
-                question=encrypt(
+                question=encrypt_text(
                     clamp_str(
                         p_data.get("question"), il.POLL_QUESTION, report=report
                     )
-                    or ""
+                    or "",
+                    poll_question_aad(poll_id),
                 ),
-                description=encrypt(description) if description else None,
+                description=(
+                    encrypt_text(description, poll_description_aad(poll_id))
+                    if description
+                    else None
+                ),
                 kind=p_data.get("kind") or PollKind.SINGLE_CHOICE.value,
                 results_visibility=(
                     p_data.get("results_visibility")
@@ -1801,12 +1855,14 @@ async def run_import(
             for o_data in clamp_list(
                 p_data.get("options", []), il.POLL_OPTIONS_COUNT, report=report
             ):
+                option_id = uuid.uuid4()
                 option = PollOption(
-                    id=uuid.uuid4(),
+                    id=option_id,
                     poll_id=poll.id,
-                    text=encrypt(
+                    text=encrypt_text(
                         clamp_str(o_data.get("text"), il.POLL_OPTION, report=report)
-                        or ""
+                        or "",
+                        poll_option_text_aad(option_id),
                     ),
                     position=_coerce_int(
                         o_data.get("position"), default=0, minimum=0
@@ -2074,8 +2130,15 @@ async def run_import(
                 il.REMINDER_BODY,
                 report=report,
             )
+            reminder_id = uuid.uuid4()
+            enc_title, enc_body = encrypt_title_body(
+                clamp_str(rm_data.get("title"), il.REMINDER_TITLE, report=report)
+                or "",
+                body,
+                reminder_id,
+            )
             reminder = Reminder(
-                id=uuid.uuid4(),
+                id=reminder_id,
                 system_id=system.id,
                 channel_id=channel.id,
                 name=clamp_str(
@@ -2083,13 +2146,8 @@ async def run_import(
                     il.REMINDER_NAME,
                     report=report,
                 ),
-                title=encrypt(
-                    clamp_str(
-                        rm_data.get("title"), il.REMINDER_TITLE, report=report
-                    )
-                    or ""
-                ),
-                body=encrypt(body) if body else None,
+                title=enc_title,
+                body=enc_body,
                 enabled=bool(rm_data.get("enabled", True)),
                 trigger_type=rm_data.get("trigger_type") or "repeated",
                 trigger_member_id=trigger_member.id if trigger_member else None,

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -23,6 +23,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
+from sheaf.encrypted_fields import (
+    member_description_aad,
+    member_name_aad,
+    message_body_aad,
+)
 from sheaf.models.custom_field import CustomFieldDefinition, CustomFieldValue, FieldType
 from sheaf.models.front import Front
 from sheaf.models.group import Group
@@ -440,10 +445,11 @@ async def run_import(
         if sp_id:
             sp_id_to_name[sp_id] = plaintext_name
         plaintext_description = _coerce_str(sp_m.get("desc"))
+        member_id = uuid.uuid4()
         member = Member(
-            id=uuid.uuid4(),
+            id=member_id,
             system_id=system.id,
-            name=encrypt(plaintext_name),
+            name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
             name_hash=blind_index(plaintext_name),
             display_name=clamp_str(
                 _coerce_str(sp_m.get("displayName")) or None,
@@ -451,7 +457,7 @@ async def run_import(
                 report=report,
             ),
             description=(
-                encrypt(plaintext_description)
+                encrypt(plaintext_description, aad=member_description_aad(member_id))
                 if plaintext_description is not None
                 else None
             ),
@@ -481,13 +487,17 @@ async def run_import(
             if sp_id:
                 sp_id_to_name[sp_id] = plaintext_cf_name
             plaintext_cf_description = _coerce_str(sp_cf.get("desc"))
+            member_id = uuid.uuid4()
             member = Member(
-                id=uuid.uuid4(),
+                id=member_id,
                 system_id=system.id,
-                name=encrypt(plaintext_cf_name),
+                name=encrypt(plaintext_cf_name, aad=member_name_aad(member_id)),
                 name_hash=blind_index(plaintext_cf_name),
                 description=(
-                    encrypt(plaintext_cf_description)
+                    encrypt(
+                        plaintext_cf_description,
+                        aad=member_description_aad(member_id),
+                    )
                     if plaintext_cf_description is not None
                     else None
                 ),
@@ -636,11 +646,12 @@ async def run_import(
                     continue
                 if not value_guard.add((field_def.id, member.id)):
                     continue
+                cfv_id = uuid.uuid4()
                 cfv = CustomFieldValue(
-                    id=uuid.uuid4(),
+                    id=cfv_id,
                     field_id=field_def.id,
                     member_id=member.id,
-                    value=encrypt_field_value({"v": str(raw_value)}),
+                    value=encrypt_field_value({"v": str(raw_value)}, cfv_id),
                 )
                 db.add(cfv)
         if unknown_field_refs:
@@ -943,13 +954,14 @@ async def _import_messages(
         author = all_sp_to_member.get(sender) if sender else None
         if sender and author is None:
             missing_authors += 1
+        message_id = uuid.uuid4()
         message = Message(
-            id=uuid.uuid4(),
+            id=message_id,
             system_id=system.id,
             board_kind=BoardKind.SYSTEM.value,
             board_member_id=None,
             author_member_id=author.id if author else None,
-            body=encrypt(body),
+            body=encrypt(body, aad=message_body_aad(message_id)),
         )
         if created:
             message.created_at = created

--- a/sheaf/services/system_safety.py
+++ b/sheaf/services/system_safety.py
@@ -23,6 +23,12 @@ from sheaf.auth.lockout import ensure_not_locked, record_login_failure
 from sheaf.auth.passwords import verify_password
 from sheaf.auth.totp import TotpCheck, check_code_once, totp_error_detail
 from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import (
+    member_name_aad,
+    pending_fronting_names_aad,
+    pending_target_label_aad,
+    user_totp_secret_aad,
+)
 from sheaf.models.content_revision import ContentRevision
 from sheaf.models.custom_field import CustomFieldDefinition
 from sheaf.models.front import Front
@@ -187,7 +193,7 @@ async def verify_destructive_auth(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="TOTP code required",
             )
-        secret = decrypt(user.totp_secret)
+        secret = decrypt(user.totp_secret, aad=user_totp_secret_aad(user.id))
         totp_result = await check_code_once(user.id, secret, totp_code)
         if totp_result is not TotpCheck.OK:
             await record_login_failure(db, user, reason="totp_failures")
@@ -310,7 +316,10 @@ async def snapshot_current_fronts(
 
     return (
         [str(m.id) for m in members],
-        [m.display_name or decrypt(m.name) for m in members],
+        [
+            m.display_name or decrypt(m.name, aad=member_name_aad(m.id))
+            for m in members
+        ],
     )
 
 
@@ -344,16 +353,23 @@ async def queue_pending_action(
     # target_label and fronting_member_names hold decrypted user content, so
     # they are encrypted at rest here (the row is transient but lands in any
     # DB dump taken during the grace window). Read sites decrypt defensively.
+    # Pre-allocate the id (UUIDMixin's default only fires at flush) so the
+    # ciphertexts bind to the row before insert.
+    pending_id = uuid.uuid4()
     pending = PendingAction(
+        id=pending_id,
         system_id=system.id,
         action_type=action_type,
         target_id=target_id,
-        target_label=encrypt(target_label),
+        target_label=encrypt(target_label, aad=pending_target_label_aad(pending_id)),
         requested_at=now,
         requested_by_user_id=user.id,
         finalize_after=now + timedelta(days=system.safety_grace_period_days),
         fronting_member_ids=fronting_ids,
-        fronting_member_names=encrypt(json.dumps(fronting_names)),
+        fronting_member_names=encrypt(
+            json.dumps(fronting_names),
+            aad=pending_fronting_names_aad(pending_id),
+        ),
         status=PendingActionStatus.PENDING,
     )
     db.add(pending)

--- a/sheaf/services/tb_import.py
+++ b/sheaf/services/tb_import.py
@@ -34,6 +34,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.crypto import blind_index, encrypt
+from sheaf.encrypted_fields import member_description_aad, member_name_aad
 from sheaf.models.group import Group
 from sheaf.models.member import Member, group_members
 from sheaf.models.system import PrivacyLevel, System
@@ -245,15 +246,20 @@ def _build_member(
     plaintext_name = clamp_str(plaintext_name, il.M_NAME, report=report)
     plaintext_description = _clean_str(tupper.get("description"))
 
+    member_id = uuid.uuid4()
     return Member(
-        id=uuid.uuid4(),
+        id=member_id,
         system_id=system_id,
-        name=encrypt(plaintext_name),
+        name=encrypt(plaintext_name, aad=member_name_aad(member_id)),
         name_hash=blind_index(plaintext_name),
         display_name=clamp_str(
             _clean_str(tupper.get("nick")), il.M_DISPLAY_NAME, report=report
         ),
-        description=encrypt(plaintext_description) if plaintext_description else None,
+        description=(
+            encrypt(plaintext_description, aad=member_description_aad(member_id))
+            if plaintext_description
+            else None
+        ),
         pronouns=None,  # Tupperbox doesn't model pronouns.
         avatar_url=sanitize_external_avatar_url(_clean_str(tupper.get("avatar_url"))),
         color=None,  # Tupperbox doesn't model member colour.

--- a/tests/test_field_encryption_binding.py
+++ b/tests/test_field_encryption_binding.py
@@ -1,0 +1,437 @@
+"""Field-encryption AAD binding: relocation attacks must fail closed.
+
+Every v2 encrypted cell is bound to its (table, column, row-pk) via the
+associated data in `sheaf.crypto.field_aad` (see `sheaf.encrypted_fields`
+for the per-cell registry). The Poly1305 tag on a legacy v1 ciphertext
+authenticates the bytes but not where they live, so a DB-write attacker
+could lift a ciphertext out of one cell and drop it into another and it
+would still decrypt to attacker-chosen plaintext. v2 closes that: a
+ciphertext moved to a different row or column decrypts to a nacl
+CryptoError instead of the wrong plaintext.
+
+These tests drive that guarantee at the API level. Each one simulates the
+attacker with a raw SQL UPDATE against the test database (the same
+`_test_engine` direct-DB pattern the job-runner tests use), then reads the
+victim record back through the HTTP API and asserts the attacker's
+plaintext never comes back. Whether the read fails closed with a 5xx (the
+decrypt raises) or a tolerant path substitutes a placeholder is left open
+on purpose: the invariant under test is "no attacker-chosen plaintext is
+returned", not the specific error shape.
+
+The final test pins the dual-read window: an old, unprefixed v1 row still
+decrypts normally, so converting a call site to v2 does not orphan history
+written before the conversion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import httpx
+import pyotp
+from sqlalchemy import text
+
+BASE_URL = os.environ.get("SHEAF_TEST_URL", "http://localhost:8000")
+PASSWORD = "testpassword123"
+
+
+def _test_engine():
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from sheaf.config import settings
+
+    db_url = os.environ.get("SHEAF_TEST_DB_URL") or settings.database_url
+    return create_async_engine(db_url)
+
+
+def _run_sql(statement: str, **params) -> int:
+    """Run one UPDATE as the simulated DB-write attacker and commit it.
+
+    Uses a fresh engine per call and disposes it, matching the direct-DB
+    helpers in test_job_runner_rework.py so these tests stay self-contained.
+    Returns the statement's rowcount: every attacker-UPDATE call site asserts
+    it is 1, so a typo'd id/table that matches zero rows cannot let the test
+    pass vacuously (the "attack" would never have landed).
+    """
+
+    async def run() -> int:
+        engine = _test_engine()
+        try:
+            async with engine.begin() as conn:
+                result = await conn.execute(text(statement), params)
+                return result.rowcount
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _fetch_one(statement: str, **params):
+    """Run a single-row, single-column SELECT and return the value.
+
+    Used to read a victim cell back after a swap and prove the attacker's
+    ciphertext actually landed there before asserting the API refuses it.
+    """
+
+    async def run():
+        engine = _test_engine()
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(text(statement), params)
+                return result.scalar_one()
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _register(client: httpx.Client, email: str) -> str:
+    """Register a user on `client` and pin its bearer token. Returns user id."""
+    resp = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": PASSWORD},
+    )
+    assert resp.status_code == 201, resp.text
+    client.headers["Authorization"] = f"Bearer {resp.json()['access_token']}"
+    return client.get("/v1/auth/me").json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Same-column, cross-row swap (members.name)
+# ---------------------------------------------------------------------------
+
+
+def test_member_name_cross_row_swap_fails_closed(auth_client: httpx.Client):
+    """Attacker copies member A's `name` ciphertext onto victim member B's
+    row at the DB layer. A's name ciphertext is bound to A's pk, so reading
+    B back must not surface A's name: the swap decrypts to garbage (fail
+    closed) rather than handing B the attacker's plaintext."""
+    attacker_name = f"attacker-name-{uuid.uuid4().hex}"
+    victim_name = f"victim-name-{uuid.uuid4().hex}"
+
+    a = auth_client.post("/v1/members", json={"name": attacker_name}).json()
+    b = auth_client.post("/v1/members", json={"name": victim_name}).json()
+
+    assert _run_sql(
+        "UPDATE members SET name = (SELECT name FROM members WHERE id = :src) "
+        "WHERE id = :dst",
+        src=a["id"],
+        dst=b["id"],
+    ) == 1
+    # Prove the swap landed: B's stored cell now holds A's ciphertext.
+    assert _fetch_one(
+        "SELECT name FROM members WHERE id = :id", id=b["id"]
+    ) == _fetch_one("SELECT name FROM members WHERE id = :id", id=a["id"])
+
+    resp = auth_client.get(f"/v1/members/{b['id']}")
+    # Fail-closed (decrypt raises -> 5xx) or a placeholder both satisfy the
+    # guarantee: A's plaintext must not appear as B's name.
+    assert attacker_name not in resp.text, resp.text
+    if resp.status_code == 200:
+        assert resp.json()["name"] != attacker_name
+
+
+# ---------------------------------------------------------------------------
+# 2. Cross-row swap (journal_entries.body)
+# ---------------------------------------------------------------------------
+
+
+def test_journal_body_cross_row_swap_fails_closed(auth_client: httpx.Client):
+    """Attacker copies journal entry A's `body` ciphertext onto entry B.
+    The body ciphertext is bound to A's entry pk, so reading B back must
+    not return A's body text."""
+    attacker_body = f"attacker-body-{uuid.uuid4().hex}"
+    victim_body = f"victim-body-{uuid.uuid4().hex}"
+
+    a = auth_client.post("/v1/journals", json={"body": attacker_body}).json()
+    b = auth_client.post("/v1/journals", json={"body": victim_body}).json()
+
+    assert _run_sql(
+        "UPDATE journal_entries SET body = "
+        "(SELECT body FROM journal_entries WHERE id = :src) WHERE id = :dst",
+        src=a["id"],
+        dst=b["id"],
+    ) == 1
+    # Prove the swap landed: B's stored cell now holds A's ciphertext.
+    assert _fetch_one(
+        "SELECT body FROM journal_entries WHERE id = :id", id=b["id"]
+    ) == _fetch_one(
+        "SELECT body FROM journal_entries WHERE id = :id", id=a["id"]
+    )
+
+    resp = auth_client.get(f"/v1/journals/{b['id']}")
+    assert attacker_body not in resp.text, resp.text
+    if resp.status_code == 200:
+        assert resp.json()["body"] != attacker_body
+
+
+# ---------------------------------------------------------------------------
+# 3. TOTP-secret relocation is not an auth bypass (users.totp_secret)
+# ---------------------------------------------------------------------------
+
+
+def test_totp_secret_relocation_is_not_auth_bypass():
+    """The scenario the whole feature exists to close: an attacker with DB
+    write access lifts user A's enrolled `totp_secret` ciphertext onto
+    victim user B's row and flips B's `totp_enabled` flag, hoping to log in
+    as B using codes from a factor the attacker controls.
+
+    A's secret is bound to A's user pk, so when login decrypts B's
+    totp_secret under B's own AAD it fails closed instead of yielding A's
+    shared secret. A login as B carrying a currently-valid code from A's
+    factor must be rejected."""
+    with (
+        httpx.Client(base_url=BASE_URL) as attacker_c,
+        httpx.Client(base_url=BASE_URL) as victim_c,
+    ):
+        attacker_email = f"aad-totp-a-{uuid.uuid4().hex[:8]}@sheaf.dev"
+        victim_email = f"aad-totp-b-{uuid.uuid4().hex[:8]}@sheaf.dev"
+        attacker_id = _register(attacker_c, attacker_email)
+        victim_id = _register(victim_c, victim_email)
+
+        # Attacker enrols TOTP on their own account the normal way, which
+        # stores the secret as a v2 ciphertext bound to the attacker's pk.
+        setup = attacker_c.post(
+            "/v1/auth/totp/setup", json={"password": PASSWORD}
+        )
+        assert setup.status_code == 200, setup.text
+        attacker_totp = pyotp.TOTP(setup.json()["secret"])
+        verify = attacker_c.post(
+            "/v1/auth/totp/verify", json={"code": attacker_totp.now()}
+        )
+        assert verify.status_code == 204, verify.text
+
+        # DB-write attacker: relocate the secret onto the victim and enable
+        # the factor on the victim's account.
+        assert _run_sql(
+            "UPDATE users SET totp_secret = "
+            "(SELECT totp_secret FROM users WHERE id = :src), "
+            "totp_enabled = TRUE WHERE id = :dst",
+            src=attacker_id,
+            dst=victim_id,
+        ) == 1
+        # Prove the relocation landed before asserting login refuses it.
+        assert _fetch_one(
+            "SELECT totp_secret FROM users WHERE id = :id", id=victim_id
+        ) == _fetch_one(
+            "SELECT totp_secret FROM users WHERE id = :id", id=attacker_id
+        )
+
+        # Log in as the victim with a fresh, valid code from the attacker's
+        # factor. If the binding held, decrypt of the victim's totp_secret
+        # fails and login cannot succeed.
+        resp = victim_c.post(
+            "/v1/auth/login",
+            json={
+                "email": victim_email,
+                "password": PASSWORD,
+                "totp_code": attacker_totp.now(),
+            },
+        )
+        assert resp.status_code != 200, resp.text
+        assert "access_token" not in resp.text, resp.text
+
+
+# ---------------------------------------------------------------------------
+# 4. Legacy v1 rows still read (dual-read regression)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_v1_member_name_still_reads(auth_client: httpx.Client):
+    """Rows written before the v2 conversion carry unprefixed v1
+    ciphertexts with no AAD. The dual-read path must still decrypt them, or
+    converting a call site to v2 would orphan every pre-conversion row.
+
+    Simulate an old row by overwriting the name with a v1 token produced by
+    `encrypt(plaintext)` (no aad, no prefix), then read it back through the
+    API and confirm the plaintext returns intact."""
+    from sheaf.crypto import encrypt
+
+    legacy_name = f"legacy-v1-name-{uuid.uuid4().hex}"
+    member = auth_client.post(
+        "/v1/members", json={"name": f"placeholder-{uuid.uuid4().hex}"}
+    ).json()
+
+    # v1: unprefixed SecretBox token, exactly what old rows hold.
+    v1_token = encrypt(legacy_name)
+    assert not v1_token.startswith("v2:")
+    assert _run_sql(
+        "UPDATE members SET name = :ct WHERE id = :id",
+        ct=v1_token,
+        id=member["id"],
+    ) == 1
+    assert _fetch_one(
+        "SELECT name FROM members WHERE id = :id", id=member["id"]
+    ) == v1_token
+
+    resp = auth_client.get(f"/v1/members/{member['id']}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == legacy_name
+
+
+# ---------------------------------------------------------------------------
+# 5. Wrong-column swap (members.note -> members.description, same row)
+# ---------------------------------------------------------------------------
+
+
+def test_member_note_into_description_fails_closed(auth_client: httpx.Client):
+    """Same row, different column: attacker copies a member's `note`
+    ciphertext into that member's `description` cell. The AAD binds each
+    ciphertext to its column, so the note text must not resurface as the
+    description even though the row pk is unchanged."""
+    secret_note = f"secret-note-{uuid.uuid4().hex}"
+    member = auth_client.post(
+        "/v1/members",
+        json={
+            "name": f"note-holder-{uuid.uuid4().hex[:8]}",
+            "description": "an ordinary bio",
+            "note": secret_note,
+        },
+    ).json()
+
+    assert _run_sql(
+        "UPDATE members SET description = note WHERE id = :id",
+        id=member["id"],
+    ) == 1
+    # Prove the swap landed: the description cell now holds the note's
+    # ciphertext.
+    assert _fetch_one(
+        "SELECT description FROM members WHERE id = :id", id=member["id"]
+    ) == _fetch_one("SELECT note FROM members WHERE id = :id", id=member["id"])
+
+    resp = auth_client.get(f"/v1/members/{member['id']}")
+    assert secret_note not in resp.text, resp.text
+    if resp.status_code == 200:
+        assert resp.json()["description"] != secret_note
+
+
+# ---------------------------------------------------------------------------
+# 6. Webhook-secret relocation must not sign deliveries
+#    (notification_channels.webhook_secret_encrypted)
+# ---------------------------------------------------------------------------
+
+
+def _create_webhook_channel(
+    client: httpx.Client, *, name: str, secret: str
+) -> str:
+    """Create a webhook channel with a signing secret via the API; returns
+    the channel id. Mirrors the helper in test_notifications_api.py."""
+    sid = client.get("/v1/systems/me").json()["id"]
+    tok = client.post(
+        f"/v1/systems/{sid}/watch-tokens", json={"label": name}
+    ).json()
+    resp = client.post(
+        f"/v1/watch-tokens/{tok['id']}/channels",
+        json={
+            "name": name,
+            "destination_type": "webhook",
+            "destination_config": {"url": "https://example.com/webhook"},
+            "webhook_secret": secret,
+            "base_all_members": True,
+            "trigger_on_start": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["channel"]["id"]
+
+
+def test_webhook_secret_relocation_fails_closed(
+    auth_client: httpx.Client, monkeypatch
+):
+    """Attacker copies channel B's `webhook_secret_encrypted` ciphertext onto
+    channel A at the DB layer, hoping A's next delivery gets signed with a
+    secret of the attacker's choosing. B's secret is bound to B's channel pk,
+    so the delivery-side decrypt on A fails closed and the delivery is
+    dropped (permanent failure) before any signature is produced.
+
+    Drives `_deliver_webhook` directly with a DB-loaded channel (the same
+    in-process pattern as test_notifications_mobile_dispatch.py), with DNS
+    resolution stubbed and the HTTP client replaced by a sentinel that fails
+    the test if delivery ever reaches the network."""
+    from sheaf.services.notifications.safe_http import PinnedRequest
+
+    a_id = _create_webhook_channel(
+        auth_client, name="victim", secret="victim-secret"
+    )
+    b_id = _create_webhook_channel(
+        auth_client, name="donor", secret="donor-secret"
+    )
+
+    # DB-write attacker: relocate B's secret ciphertext onto A.
+    assert _run_sql(
+        "UPDATE notification_channels SET webhook_secret_encrypted = "
+        "(SELECT webhook_secret_encrypted FROM notification_channels "
+        "WHERE id = :src) WHERE id = :dst",
+        src=b_id,
+        dst=a_id,
+    ) == 1
+    assert _fetch_one(
+        "SELECT webhook_secret_encrypted FROM notification_channels "
+        "WHERE id = :id",
+        id=a_id,
+    ) == _fetch_one(
+        "SELECT webhook_secret_encrypted FROM notification_channels "
+        "WHERE id = :id",
+        id=b_id,
+    )
+
+    async def fake_resolve(url: str) -> PinnedRequest:
+        return PinnedRequest(url=url)
+
+    class _NoHttp:
+        async def __aenter__(self):
+            raise AssertionError(
+                "delivery reached the HTTP client: the relocated secret was "
+                "used instead of failing closed"
+            )
+
+        async def __aexit__(self, *exc) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "sheaf.services.notifications.handlers.resolve_pinned", fake_resolve
+    )
+    monkeypatch.setattr(
+        "sheaf.services.notifications.handlers.safe_client",
+        lambda timeout=10.0: _NoHttp(),
+    )
+
+    async def run():
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import (
+            AsyncSession,
+            create_async_engine,
+        )
+        from sqlalchemy.orm import sessionmaker
+
+        from sheaf.models.notification_channel import NotificationChannel
+        from sheaf.services.notifications.handlers import _deliver_webhook
+        from sheaf.services.notifications.payload import RenderedMessage
+
+        engine = _test_engine()
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        try:
+            async with async_session() as db:
+                channel = (
+                    await db.execute(
+                        select(NotificationChannel).where(
+                            NotificationChannel.id == uuid.UUID(a_id)
+                        )
+                    )
+                ).scalar_one()
+                return await _deliver_webhook(
+                    channel,
+                    RenderedMessage(title="hello", body="world"),
+                    event_id=str(uuid.uuid4()),
+                )
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(run())
+    assert result.ok is False
+    assert result.permanent, result
+    assert "secret decryption failed" in (result.error or ""), result

--- a/tests/test_import_dedup_unit.py
+++ b/tests/test_import_dedup_unit.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import uuid
 
+from sheaf.crypto import decrypt, encrypt
+from sheaf.encrypted_fields import member_name_aad
 from sheaf.models.member import Member
 from sheaf.services.import_dedup import (
     ImportConflictStrategy,
@@ -22,9 +24,16 @@ from sheaf.services.import_dedup import (
 
 
 def _m(name_hash: str, *, pk_id: str | None = None, is_cf: bool = False, **extra):
-    """A detached Member carrying just the attrs dedup reads."""
+    """A detached Member carrying just the attrs dedup reads.
+
+    The encrypted name is bound to the pre-allocated id, the same shape every
+    importer produces for real candidates, so _apply_update's re-bind path
+    runs against realistic rows.
+    """
+    mid = uuid.uuid4()
     return Member(
-        id=uuid.uuid4(),
+        id=mid,
+        name=encrypt(name_hash, aad=member_name_aad(mid)),
         name_hash=name_hash,
         pluralkit_id=pk_id,
         is_custom_front=is_cf,
@@ -105,6 +114,9 @@ def test_update_overwrites_set_fields_preserves_unset():
     assert existing.display_name == "new"      # candidate had a value -> overwrite
     assert existing.pronouns == "they/them"    # candidate None -> preserved
     assert existing.emoji == "star"            # candidate set -> filled in
+    # The candidate's encrypted name was re-bound to the existing row's AAD,
+    # not ciphertext-copied: it must decrypt under the existing id.
+    assert decrypt(existing.name, aad=member_name_aad(existing.id)) == "dup"
 
 
 def test_no_match_creates_and_registers_for_intra_batch():

--- a/tests/test_no_unbound_field_encryption.py
+++ b/tests/test_no_unbound_field_encryption.py
@@ -1,0 +1,80 @@
+"""Static guard: every sheaf.crypto encrypt/decrypt call site passes an aad.
+
+The write gate keeps writing v1 when no aad is supplied, so a future call
+that forgets `aad=` would silently persist an unbound v1 ciphertext even with
+FIELD_ENCRYPTION_WRITE_V2 on - exactly the regression the AAD binding exists
+to prevent, and one that no runtime test would catch (it just looks like a
+normal write). This walks the AST of every module under sheaf/ and fails if a
+call to a name imported from sheaf.crypto (`encrypt` / `decrypt` /
+`decrypt_field`) omits the `aad` keyword.
+
+Scope notes:
+- `sheaf/crypto.py` defines these functions and calls the nacl box directly;
+  `sheaf/services/prism_crypto.py` is a separate Fernet scheme. Neither is a
+  v2 AAD call site, so both are excluded.
+- Only calls to names actually imported from sheaf.crypto in that file are
+  checked (import alias respected), so an unrelated same-named function is
+  not flagged.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_SHEAF = pathlib.Path(__file__).resolve().parent.parent / "sheaf"
+_CHECKED = {"encrypt", "decrypt", "decrypt_field"}
+_EXCLUDE = {"crypto.py", "prism_crypto.py"}
+
+
+def _scan():
+    """Return (violations, total_checked_calls).
+
+    violations: (relpath, lineno, funcname) for a checked call missing aad.
+    total_checked_calls: how many checked calls were seen at all, so the test
+    can assert it actually scanned something rather than passing vacuously.
+    """
+    violations = []
+    total = 0
+    for path in _SHEAF.rglob("*.py"):
+        if path.name in _EXCLUDE:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+
+        # local-name -> original crypto function, honouring `import ... as`.
+        local: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "sheaf.crypto":
+                for alias in node.names:
+                    if alias.name in _CHECKED:
+                        local[alias.asname or alias.name] = alias.name
+        if not local:
+            continue
+
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in local
+            ):
+                total += 1
+                if not any(kw.arg == "aad" for kw in node.keywords):
+                    violations.append(
+                        (path.relative_to(_SHEAF.parent), node.lineno, node.func.id)
+                    )
+    return violations, total
+
+
+def test_all_field_encryption_calls_pass_aad():
+    violations, total = _scan()
+    assert not violations, (
+        "field-encryption call site(s) missing aad= (would write/expect an "
+        "unbound v1 ciphertext): "
+        + "; ".join(f"{p}:{ln} {fn}()" for p, ln, fn in violations)
+    )
+    # Guard against the scanner silently matching nothing (e.g. an import-name
+    # bug) and passing vacuously. There are ~150 such calls in the tree.
+    assert total > 100, (
+        f"only {total} sheaf.crypto call sites scanned; the guard is likely "
+        f"not matching correctly"
+    )

--- a/tests/test_openplural_archive.py
+++ b/tests/test_openplural_archive.py
@@ -5,6 +5,8 @@ size cap, merge, per-record detection, and re-merge on export.
 
 from __future__ import annotations
 
+import uuid
+
 from sheaf.services.openplural_archive import (
     extract_residual,
     has_per_record_foreign_extensions,
@@ -68,23 +70,26 @@ def test_extract_residual_empty_for_native_file():
 
 def test_pack_unpack_round_trip():
     res = extract_residual(_foreign_envelope())
-    token, warning = pack_residual(res, max_bytes=8 * 1024 * 1024)
+    system_id = uuid.uuid4()
+    token, warning = pack_residual(res, max_bytes=8 * 1024 * 1024, system_id=system_id)
     assert warning is None
     assert isinstance(token, str) and token
-    assert unpack_residual(token) == res
+    assert unpack_residual(token, system_id=system_id) == res
 
 
 def test_pack_respects_size_cap():
     big = {"extensions": {"prism": {"blob": "x" * 5000}}}
-    token, warning = pack_residual(big, max_bytes=1024)
+    token, warning = pack_residual(big, max_bytes=1024, system_id=uuid.uuid4())
     assert token is None
     assert warning is not None and "exceeds" in warning
 
 
 def test_pack_empty_is_noop():
-    assert pack_residual({}, max_bytes=1024) == (None, None)
-    assert unpack_residual(None) == {}
-    assert unpack_residual("not-a-real-token") == {}  # corrupt -> empty, no raise
+    system_id = uuid.uuid4()
+    assert pack_residual({}, max_bytes=1024, system_id=system_id) == (None, None)
+    assert unpack_residual(None, system_id=system_id) == {}
+    # corrupt -> empty, no raise
+    assert unpack_residual("not-a-real-token", system_id=system_id) == {}
 
 
 def test_merge_residual_unions_namespaces():

--- a/tests/test_revision_write_time.py
+++ b/tests/test_revision_write_time.py
@@ -313,11 +313,15 @@ def test_two_edits_within_window_collapse_to_one_revision(
     asyncio.run(_run())
 
     from sheaf.crypto import decrypt
+    from sheaf.encrypted_fields import revision_body_aad
 
     rows = _revisions_for(entry_id)
     assert len(rows) == 1
-    # The single revision holds the LATER outgoing content (encrypted at rest).
-    assert decrypt(rows[0]["body"]) == "outgoing-2"
+    # The single revision holds the LATER outgoing content (encrypted at rest,
+    # bound to the revision row that was replaced in place).
+    assert decrypt(
+        rows[0]["body"], aad=revision_body_aad(rows[0]["id"])
+    ) == "outgoing-2"
 
 
 def test_replace_does_not_move_inserted_at(client: httpx.Client, monkeypatch):
@@ -483,6 +487,7 @@ def test_pinned_most_recent_is_never_replaced(client: httpx.Client, monkeypatch)
     assert result["appended_new_row"]
 
     from sheaf.crypto import decrypt
+    from sheaf.encrypted_fields import revision_body_aad
 
     rows = _revisions_for(entry_id)
     assert len(rows) == 2
@@ -490,4 +495,6 @@ def test_pinned_most_recent_is_never_replaced(client: httpx.Client, monkeypatch)
     pinned_rows = [r for r in rows if r["pinned_at"] is not None]
     assert len(pinned_rows) == 1
     assert str(pinned_rows[0]["id"]) == result["pinned_id"]
-    assert decrypt(pinned_rows[0]["body"]) == "pinned-body"
+    assert decrypt(
+        pinned_rows[0]["body"], aad=revision_body_aad(pinned_rows[0]["id"])
+    ) == "pinned-body"

--- a/tests/test_system_safety.py
+++ b/tests/test_system_safety.py
@@ -170,6 +170,10 @@ def test_pending_action_content_encrypted_at_rest(client: httpx.Client):
     import json
 
     from sheaf.crypto import decrypt
+    from sheaf.encrypted_fields import (
+        pending_fronting_names_aad,
+        pending_target_label_aad,
+    )
 
     email, _ = _register(client)
     _set_system_safety_via_db(
@@ -192,11 +196,16 @@ def test_pending_action_content_encrypted_at_rest(client: httpx.Client):
     raw_label, raw_names = _read_pending_row_raw(pending_id)
     assert raw_label != "Victim Member"
     assert "Victim Member" not in raw_label
-    assert decrypt(raw_label) == "Victim Member"
+    assert (
+        decrypt(raw_label, aad=pending_target_label_aad(pending_id))
+        == "Victim Member"
+    )
 
     assert raw_names != "Alice"
     assert "Alice" not in raw_names
-    assert json.loads(decrypt(raw_names)) == ["Alice"]
+    assert json.loads(
+        decrypt(raw_names, aad=pending_fronting_names_aad(pending_id))
+    ) == ["Alice"]
 
     # Read endpoint returns the decrypted plaintext.
     pending = client.get("/v1/system/safety").json()["pending_actions"][0]


### PR DESCRIPTION
## What this is

Part 2 of 2 for field-encryption context binding. **Stacked on the machinery
PR (`feature/field-encryption-aad`) - review/merge that first.** This converts
every field-encryption call site to bind its ciphertext to its cell.

With the write gate at its default (off), this is the bridge state: reads both
formats, still writes v1. Flipping `FIELD_ENCRYPTION_WRITE_V2` on (a later
release) makes these same sites emit v2 that fails closed on relocation.

## In this PR

- **Every `encrypt`/`decrypt` site** across the API, services, and importers
  now passes `aad=<helper>(row_id)` from the registry (150 sites).
- **Insert paths pre-allocate the row UUID** so the ciphertext can bind to it
  (the ORM default only assigns at flush).
- **`capture_revision`** encrypts after the debounce-vs-append decision, bound
  to the row actually written, so revisions of one target are not mutually
  swappable.
- **Import dedup** re-binds a matched candidate's name/description/note to the
  existing row instead of copying ciphertext (which would become undecryptable
  under row-bound AAD).
- **Domain wrappers** thread row identity (message body by message id, poll
  text by an explicit aad, custom-field and reminder ids, the residual archive
  by system id); the board-summary aggregation carries the newest message id
  so the sidebar preview decrypts under the right row.
- **Legacy plaintext fallbacks** (custom fields, pending-action label and
  fronting names) are gated on `FIELD_ENCRYPTION_ACCEPT_V1`: under the cutoff
  they return fixed placeholders instead of the raw stored value.

## Tests

- `test_field_encryption_binding.py`: drives DB-level relocation attacks
  (cross-row, cross-column, totp-secret, webhook-secret) through the API and
  asserts each fails closed, plus a legacy-v1 dual-read case. Each attack
  asserts the swap actually landed before asserting the refusal.
- `test_no_unbound_field_encryption.py`: an AST guard that fails if any
  `sheaf.crypto` call site omits `aad=`, so a future no-aad call cannot
  silently write an unbound v1 ciphertext.
- Existing suites that pinned the old shapes are updated. Full test matrix
  green (9/9 configs); the test stack sets `FIELD_ENCRYPTION_WRITE_V2=true` to
  exercise real v2 writes.
