### PR TITLE
Derive DATABASE_URL from POSTGRES_PASSWORD; fix compose-manager auth failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,20 @@
 # =============================================================================
 # Database
 # =============================================================================
+# Set a strong password. This is the ONLY thing you normally need to change
+# here: the app builds DATABASE_URL from it automatically (using the
+# POSTGRES_USER/HOST/PORT/DB defaults, which match the compose db service), so
+# it can't drift from what the database was created with.
 POSTGRES_PASSWORD=changeme-in-production
-DATABASE_URL=postgresql+asyncpg://sheaf:${POSTGRES_PASSWORD}@db:5432/sheaf
+
+# DATABASE_URL is optional. Leave it unset to use the derived value above; set
+# it only to point at an external database or use custom driver options, e.g.:
+# DATABASE_URL=postgresql+asyncpg://sheaf:yourpassword@db:5432/sheaf
+#
+# POSTGRES_USER=sheaf
+# POSTGRES_HOST=db
+# POSTGRES_PORT=5432
+# POSTGRES_DB=sheaf
 
 # =============================================================================
 # Redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Changed
+
+- **`DATABASE_URL` is now optional; the app derives it from `POSTGRES_PASSWORD`.** Previously the Postgres password had to be set in two places (`POSTGRES_PASSWORD` for the database, and embedded again in `DATABASE_URL` for the app), and the two defaults didn't even match - so a deploy that set one but not the other failed on startup with `password authentication failed for user "sheaf"`. Now setting `POSTGRES_PASSWORD` is enough: the app builds `DATABASE_URL` from it (URL-encoding the password) using the `POSTGRES_USER`/`POSTGRES_HOST`/`POSTGRES_PORT`/`POSTGRES_DB` parts, which match the bundled database, so the credential can't drift. The compose file also passes `POSTGRES_PASSWORD` to the app via interpolation, so it reaches the container even under stack managers that don't load a `.env` into it (OpenMediaVault's `sheaf.env`, Portainer, etc.), which was a common cause of that same startup failure. Set `DATABASE_URL` explicitly only for an external database or custom driver options. Existing deployments that set `DATABASE_URL` are unaffected.
+
 ## [1.3.0] - 2026-07-19
 
 ### Security

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,12 @@ services:
         required: false
     environment:
       SHEAF_PORT: "${SHEAF_PORT:-8000}"
+      # The app builds DATABASE_URL from POSTGRES_PASSWORD when DATABASE_URL is
+      # unset (see sheaf/config.py). Pass it here via interpolation - not only
+      # env_file - so the db credential reaches the app container even under
+      # compose managers that don't load a .env into it (OMV names its env file
+      # sheaf.env, Portainer stack env, etc.). Same value the db service reads.
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-changeme-in-production}"
     volumes:
       - appdata:/app/data
     depends_on:

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -90,8 +90,9 @@ Set in `.env`:
 JWT_SECRET_KEY=<generated>
 SHEAF_ENCRYPTION_KEY=<generated>
 POSTGRES_PASSWORD=<generated>
-DATABASE_URL=postgresql+asyncpg://sheaf:${POSTGRES_PASSWORD}@db:5432/sheaf
 ```
+
+`DATABASE_URL` is optional - the app builds it from `POSTGRES_PASSWORD` (plus the `POSTGRES_USER`/`POSTGRES_HOST`/`POSTGRES_PORT`/`POSTGRES_DB` defaults, which match the bundled db container), so the password only lives in one place and can't drift from what the database was created with. Set `DATABASE_URL` explicitly only to point at an external database or use custom driver options.
 
 ### What each key does — and what happens if you lose or change it
 
@@ -106,6 +107,12 @@ Sheaf refuses to start in `saas` mode if this is left at the default, and logs a
 - **Rotating it** requires re-encrypting the email ciphertext AND re-computing every `email_hash` row (see `alembic/versions/k1l2m3n4o5p6_rehash_email_blind_index.py` for the pattern). Don't rotate this casually.
 
 **If not set**, a key is auto-generated on first startup and saved to `data/encryption.key` inside the Docker volume. **Back this file up.** Prefer setting `SHEAF_ENCRYPTION_KEY` explicitly so the key isn't tied to a single volume.
+
+### Compose managers that don't use a `.env` file
+
+Some stack managers keep the environment in a differently-named file: OpenMediaVault's compose plugin writes `sheaf.env`, Portainer keeps stack env in its own database, and so on. Sheaf's `docker-compose.yml` loads the app's config from a file literally named `.env`, so if your manager uses another name the app receives none of its env-file settings and falls back to defaults. The classic symptom on a brand-new stack is `password authentication failed for user "sheaf"`: Postgres was created with your `POSTGRES_PASSWORD`, but the app never saw it.
+
+The database password itself now reaches the app either way - it's also passed through compose interpolation, so `POSTGRES_PASSWORD` from your manager's env file lands in the container and `DATABASE_URL` is derived from it. But the rest of the file (admin emails, registration mode, email backend, your own `JWT_SECRET_KEY` / `SHEAF_ENCRYPTION_KEY`) still needs loading. Make that file available as `.env`: create a `.env` next to the compose file that is a copy or symlink of your manager's env file (`ln -s sheaf.env .env`), or point the app service's `env_file:` at it.
 
 ---
 

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from ipaddress import IPv4Network, IPv6Network, ip_network
 from pathlib import Path
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 logger = logging.getLogger("sheaf")
@@ -16,8 +16,34 @@ class SheafMode(StrEnum):
 
 
 class Settings(BaseSettings):
-    # Database
-    database_url: str = "postgresql+asyncpg://sheaf:changeme@db:5432/sheaf"
+    # Database. DATABASE_URL is optional: leave it unset and it is assembled
+    # from the POSTGRES_* parts below - the same env vars the db container
+    # reads - so the Postgres password only has to be set in ONE place and
+    # can't drift between the app and the database. Set DATABASE_URL
+    # explicitly to point at an external database or use a custom
+    # driver/options. The compose default password ("changeme-in-production")
+    # matches the db service so a bare deploy connects (and trips the
+    # insecure-default guard) instead of failing on a password mismatch.
+    database_url: str = ""
+    postgres_user: str = "sheaf"
+    postgres_password: str = "changeme-in-production"
+    postgres_host: str = "db"
+    postgres_port: int = 5432
+    postgres_db: str = "sheaf"
+
+    @model_validator(mode="after")
+    def _assemble_database_url(self):
+        """Derive DATABASE_URL from the POSTGRES_* parts when it wasn't set,
+        URL-encoding the password so special characters can't break the URL."""
+        if not self.database_url:
+            from urllib.parse import quote
+
+            pw = quote(self.postgres_password, safe="")
+            self.database_url = (
+                f"postgresql+asyncpg://{self.postgres_user}:{pw}"
+                f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
+            )
+        return self
 
     # Connection pool. Single-process asyncio app: one pool is shared by the
     # request path and every background loop (job runner, dispatcher, import

--- a/tests/test_config_database_url.py
+++ b/tests/test_config_database_url.py
@@ -1,0 +1,58 @@
+"""DATABASE_URL derivation from POSTGRES_* parts.
+
+`_env_file=None` disables reading the repo `.env` so these exercise the
+derivation logic against env vars and defaults only.
+"""
+
+from __future__ import annotations
+
+from sheaf.config import Settings
+
+
+def test_database_url_derived_from_postgres_password(monkeypatch):
+    """Unset DATABASE_URL is built from POSTGRES_PASSWORD, URL-encoded."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_PASSWORD", "p@ss:w/rd")
+
+    s = Settings(_env_file=None)
+
+    assert (
+        s.database_url
+        == "postgresql+asyncpg://sheaf:p%40ss%3Aw%2Frd@db:5432/sheaf"
+    )
+
+
+def test_explicit_database_url_is_used_verbatim(monkeypatch):
+    """An explicit DATABASE_URL wins; the POSTGRES_* parts are ignored."""
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://u:p@ext.example:5433/other"
+    )
+    monkeypatch.setenv("POSTGRES_PASSWORD", "ignored")
+
+    s = Settings(_env_file=None)
+
+    assert s.database_url == "postgresql+asyncpg://u:p@ext.example:5433/other"
+
+
+def test_database_url_honours_all_postgres_parts(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_USER", "app")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "secret")
+    monkeypatch.setenv("POSTGRES_HOST", "pg.internal")
+    monkeypatch.setenv("POSTGRES_PORT", "6543")
+    monkeypatch.setenv("POSTGRES_DB", "sheafdb")
+
+    s = Settings(_env_file=None)
+
+    assert s.database_url == "postgresql+asyncpg://app:secret@pg.internal:6543/sheafdb"
+
+
+def test_default_password_still_trips_insecure_guard(monkeypatch):
+    """A bare deploy derives the default password, which the derived URL
+    surfaces so the insecure-default check keeps firing."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+
+    s = Settings(_env_file=None)
+
+    assert "changeme" in s.database_url


### PR DESCRIPTION
Closes a recurring self-hosting footgun: a brand-new stack dying on `asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "sheaf"` even though the operator set their secrets. Two root causes, both fixed here.

First, the Postgres password had to be set in two places that could disagree: `POSTGRES_PASSWORD` (which the db container uses to initialise the role) and again embedded in `DATABASE_URL` (which the app connects with). Worse, the two defaults didn't match - the app's config default was `sheaf:changeme@db` while the compose db default was `changeme-in-production` - so a bare or half-configured deploy failed on a password mismatch rather than either working or tripping the insecure-default guard. `DATABASE_URL` is now optional: when it's unset the app assembles it from `POSTGRES_PASSWORD` plus the `POSTGRES_USER`/`POSTGRES_HOST`/`POSTGRES_PORT`/`POSTGRES_DB` parts (all defaulting to the bundled db's values), URL-encoding the password so special characters are safe. Setting `POSTGRES_PASSWORD` is now sufficient and the credential can't drift. The default password is aligned to `changeme-in-production` so a bare deploy connects and the `"changeme"` guard still fires.

Second, the specific case that surfaced this: a user running under OpenMediaVault's compose plugin, which keeps the stack environment in `sheaf.env`. Sheaf's compose loads the app's config from a file literally named `.env` (via `env_file:`), so with no `.env` present the app received none of its settings and fell back to defaults, while the db was created with the real `POSTGRES_PASSWORD` (which reaches the db through compose interpolation, not env_file). The compose file now also passes `POSTGRES_PASSWORD` to the app service via interpolation, so the db credential lands in the app container regardless of the env-file name, and combined with the derivation above the app comes up. A new SELFHOSTING section documents the general case (OMV, Portainer, and other managers that don't use `.env`) and how to load the rest of the config.

Existing deployments that set `DATABASE_URL` are unaffected - an explicit value is used verbatim. `.env.example` and the SELFHOSTING secrets section are updated to show `DATABASE_URL` as optional. Adds headless config tests (derivation with URL-encoding, explicit-URL-wins, all POSTGRES_* parts, and that the default password still trips the insecure-default guard); the config/engine import and the export-import parity guard both still pass.
