### PR TITLE
Fix SSE front-stream pinning a DB connection for the whole stream (pool exhaustion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **The realtime front-change stream no longer holds a database connection open for its whole lifetime.** The `GET /v1/fronts/stream` endpoint (added in 1.3.0) pinned a pooled Postgres connection (idle in a transaction) for as long as each stream stayed connected, so enough concurrent streams could exhaust the connection pool and make other requests hang until a stream closed. The stream now resolves what it needs up front and holds no database connection while it is open.
+
 ## [1.3.1] - 2026-07-24
 
 ### Security

--- a/sheaf/api/v1/front_stream.py
+++ b/sheaf/api/v1/front_stream.py
@@ -20,12 +20,11 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from sheaf.auth.dependencies import get_current_user
 from sheaf.auth.sessions import get_redis, get_session_user_id
 from sheaf.config import settings
-from sheaf.database import async_session_factory, get_db
+from sheaf.database import async_session_factory
 from sheaf.models.user import User
 from sheaf.observability.metrics import (
     realtime_connection_duration_seconds,
@@ -203,16 +202,18 @@ async def _stream(
         # state), never missed.
         reader = asyncio.create_task(_pubsub_reader(pubsub, queue, state))
 
-        # Snapshot in the generator's own DB session (the request session has
-        # closed by now) so the client is correct with no race, then deltas.
+        # Snapshot in a short-lived session CLOSED before we start yielding, so
+        # no DB connection is held while the stream is open. Building the whole
+        # snapshot first also means a slow client cannot pin the connection.
         async with async_session_factory() as db:
-            for sid in system_ids:
-                snap = build_snapshot_payload(
-                    sid, await snapshot_front_state(db, sid)
-                )
-                yield format_sse(
-                    json.dumps(snap), event="snapshot", id=snap["event_id"]
-                )
+            snapshots = [
+                build_snapshot_payload(sid, await snapshot_front_state(db, sid))
+                for sid in system_ids
+            ]
+        for snap in snapshots:
+            yield format_sse(
+                json.dumps(snap), event="snapshot", id=snap["event_id"]
+            )
 
         now = time.monotonic()
         next_heartbeat = now + heartbeat
@@ -292,7 +293,6 @@ async def _stream(
 async def stream_fronts(
     request: Request,
     user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
 ):
     """Open a Server-Sent Events stream of this account's front changes.
 
@@ -309,7 +309,14 @@ async def stream_fronts(
 
     _ensure_fronts_read_scope(request)
 
-    system_ids = await authorized_front_system_ids(user, db)
+    # Resolve the authorized systems in a SHORT-LIVED session closed before the
+    # StreamingResponse is returned. A `Depends(get_db)` session would be held
+    # for the ENTIRE stream lifetime: FastAPI tears down a yield-dependency only
+    # after the response finishes, and a stream finishes only when it closes, so
+    # the pooled Postgres connection would sit idle-in-transaction for the whole
+    # connection and eventually exhaust the pool, blocking every other request.
+    async with async_session_factory() as db:
+        system_ids = await authorized_front_system_ids(user, db)
     account_key = str(user.id)
     auth_ctx = _auth_context(request)
 

--- a/tests/test_front_stream.py
+++ b/tests/test_front_stream.py
@@ -228,6 +228,32 @@ def _read_sse_event(line_iter, *, skip_comments: bool = True) -> dict:
     raise AssertionError("stream ended before a complete SSE event arrived")
 
 
+def test_stream_handler_holds_no_request_lifetime_db_session():
+    """Regression: the SSE handler must NOT depend on `get_db`.
+
+    `get_db` is a yield-dependency, torn down only after the response finishes,
+    and a StreamingResponse finishes only when the stream closes. So a
+    request-scoped session would pin a pooled Postgres connection
+    idle-in-transaction for the entire stream and exhaust the pool, blocking
+    every other request that needs the DB (this shipped once). The handler must
+    resolve what it needs in a short-lived `async_session_factory()` session
+    instead. A future re-add of `Depends(get_db)` here fails this test.
+    """
+    import inspect
+
+    from sheaf.api.v1 import front_stream
+    from sheaf.database import get_db
+
+    deps = [
+        getattr(p.default, "dependency", None)
+        for p in inspect.signature(front_stream.stream_fronts).parameters.values()
+    ]
+    assert get_db not in deps, (
+        "stream_fronts depends on get_db; a request-lifetime DB session pins a "
+        "pooled connection for the whole stream. Use async_session_factory()."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Integration: snapshot + delta, scope, cap, disabled
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a bug in the realtime front-change stream (shipped in 1.3.0) where holding a stream open exhausts the database connection pool and makes other requests hang. This is v1.3.2 material.

## The bug

`GET /v1/fronts/stream` declared `db: AsyncSession = Depends(get_db)`. `get_db` is a `yield` dependency, and FastAPI tears a yield-dependency down only after the response finishes - and a `StreamingResponse` finishes only when the stream closes. So the single SELECT the handler runs (resolving the account's authorized systems) checked out a pooled Postgres connection and opened a transaction that then sat **idle-in-transaction for the entire lifetime of the stream**. Every open stream leaked one connection from the pool, which is shared with the request path and all the background loops. Enough concurrent streams and the pool is exhausted, so any request that needs the database blocks until a stream closes and frees a connection.

Reproduced against app.sheaf.sh (thanks to a clean bisection from the HA-integration work): open a stream, and a concurrent `GET /v1/members` times out; close the stream, and it recovers. Separate TCP connections and separate client sessions still blocked, ruling out anything client-side.

It affects any client that streams while making other requests - the mobile and web clients would hit it too once the pool is under pressure - so it is not HA-specific.

## The fix

- Resolve the authorized systems in a short-lived `async_session_factory()` session that is closed **before** the `StreamingResponse` is returned. No request-lifetime session, so no pinned connection.
- Build the connect snapshot fully within a short-lived session and close it before yielding, so a slow client can't pin the snapshot session either.

Net: the stream holds **no** database connection while it is open. The generator's periodic auth re-check already used its own short-lived session and is unchanged.

## Why the existing test missed it

The integration test already makes a concurrent request while streaming, but it passed because the default 30-connection pool isn't exhausted by a single held connection - the bug only bites once the pool is tight (many streams, or the SaaS's smaller per-replica pool). So a behavioural test is unreliable here. Instead, a structural regression test asserts the handler never re-adds a `Depends(get_db)` dependency, which is the exact mistake.

Ruff clean; front-stream unit + regression tests pass.
