### PR TITLE
Fix same-key requests blocking while a front-change stream is open (api_keys row lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Holding a front-change stream open no longer blocks other requests that use the same API key.** Authenticating a request recorded the key's `last_used_at` inside the request's own database transaction. On a long-lived request like an SSE stream that transaction stays open for the whole connection, so the write held a row lock on the key and any concurrent request using the same key blocked on it until it timed out (a 500). The `last_used_at` write is now committed immediately in its own transaction, so it never holds a lock. (Follow-up to the 1.3.2 stream connection-pool fix.)
+
 ## [1.3.2] - 2026-07-24
 
 ### Fixed

--- a/sheaf/auth/dependencies.py
+++ b/sheaf/auth/dependencies.py
@@ -60,10 +60,29 @@ async def get_current_user(
         request.state.api_key_id = api_key.id
         request.state.auth_method = "api_key"
 
-        # Fire-and-forget last_used_at update
+        # last_used_at is a fire-and-forget metric write, done in its own
+        # short-lived, immediately-committed session rather than by dirtying
+        # the request-session `api_key`. On a long-lived request (an SSE
+        # stream) the request transaction stays open for the whole connection,
+        # so an UPDATE flushed into it would hold a write lock on the api_keys
+        # row for the entire stream and block every other request using the
+        # same key, timing them out (statement_timeout) to a 500.
         from datetime import UTC, datetime
 
-        api_key.last_used_at = datetime.now(UTC)
+        from sqlalchemy import update
+
+        from sheaf.database import async_session_factory
+
+        try:
+            async with async_session_factory() as _touch_db:
+                await _touch_db.execute(
+                    update(ApiKey)
+                    .where(ApiKey.id == api_key.id)
+                    .values(last_used_at=datetime.now(UTC))
+                )
+                await _touch_db.commit()
+        except Exception:
+            pass  # best-effort: never fail authentication on a metric write
 
         user_id = api_key.user_id
 

--- a/tests/test_front_stream.py
+++ b/tests/test_front_stream.py
@@ -285,6 +285,35 @@ def test_integration_stream_sends_snapshot_then_front_change(auth_client: httpx.
         assert member in change["data"]["after"]
 
 
+def test_integration_stream_does_not_block_same_key_requests(auth_client: httpx.Client):
+    """Regression: holding a stream open must not block other requests that use
+    the SAME API key.
+
+    get_current_user used to bump api_keys.last_used_at in the request session,
+    which stays open for the whole stream - so the UPDATE held a write lock on
+    the api_keys row, and a concurrent request with the same key blocked on it
+    to a statement-timeout 500. last_used_at is now written in a separate
+    committed session, so no lock is held. (The earlier snapshot+delta test
+    missed this because its concurrent request used a different credential.)
+    """
+    _create_member(auth_client, f"K-{uuid.uuid4().hex[:6]}")
+    key = _create_key(auth_client, ["fronts:read"])
+    headers = {"Authorization": f"Bearer {key}"}
+
+    with httpx.Client(base_url=BASE_URL) as stream_client, stream_client.stream(
+        "GET", "/v1/fronts/stream", headers=headers, timeout=15.0
+    ) as resp:
+        assert resp.status_code == 200
+        assert _read_sse_event(resp.iter_lines())["event"] == "snapshot"
+
+        # While the stream is held open, a request with the SAME key must not
+        # block on the api_keys row lock. Bounded tightly so the old lock-hold
+        # (statement_timeout) fails fast rather than hanging the suite.
+        with httpx.Client(base_url=BASE_URL) as poll_client:
+            r = poll_client.get("/v1/fronts", headers=headers, timeout=10.0)
+        assert r.status_code == 200, r.text
+
+
 def test_integration_stream_requires_fronts_read_scope(auth_client: httpx.Client):
     # A key with an unrelated scope must be rejected with 403.
     key = _create_key(auth_client, ["members:read"])


### PR DESCRIPTION
Fixes the actual cause of "hold a front-change stream open and other requests using the same API key start failing" - the bug that 1.3.2 was aimed at but did not resolve. This is v1.3.3 material.

## Root cause

`get_current_user` records `api_keys.last_used_at` by setting it on the key object in the **request's own database session**, which is committed only when the request ends. For a normal request that is milliseconds. For a long-lived request - an SSE stream - that transaction stays open for the entire connection, so the `UPDATE api_keys SET last_used_at ...` sits uncommitted and **holds a write lock on that key's row** the whole time the stream is open.

Any concurrent request authenticated with the **same key** then does its own `last_used_at` update, blocks on that row lock, and is canceled at the 30-second statement timeout - surfacing as a 500. Observed against `app.sheaf.sh`: open a stream, and `GET /v1/members` on the same key 500s with `QueryCanceledError: canceling statement due to statement timeout ... while updating tuple ... in relation "api_keys"`; close the stream and it recovers. It is per-key (a different key is unaffected), which is why an integration like Home Assistant - one key, streaming and polling at once - hit it consistently.

1.3.2 removed the *stream handler's* own `Depends(get_db)`, but `get_current_user` - a dependency on the same endpoint - brings in its own `get_db` session, and that is the session that held the lock. So 1.3.2 fixed a real pool-exhaustion-at-scale leak but not this.

## Fix

Write `last_used_at` in its own short-lived, immediately-committed session instead of dirtying the request-session key object. The lock is then held only for that tiny committed UPDATE, never for the life of the request, so a stream can no longer block same-key requests.

## Regression test

`test_integration_stream_does_not_block_same_key_requests` opens a stream and, while it is held open, makes a request with the **same** API key and asserts it succeeds. The earlier snapshot+delta test missed this because its concurrent request used a different credential, so it never contended on the key row.

## Known residual (not this PR)

`get_current_user` still holds a read-only connection for the stream's lifetime (one per stream). That does not block anything and does not affect the reported bug, but the broader "a streaming endpoint should not pin a request session" pattern is worth a proper follow-up (authenticate in a short-lived session). Filed as a note, not urgent.

Full test matrix green (9/9 configs).
