### PR TITLE
Add per-front detail (fronts[]) to the realtime front-change stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **The realtime front-change stream now carries per-front detail.** Each `snapshot` and `front_change` event gains a `fronts` array describing every currently-open front after the change - id, member ids, start time, custom status, and the per-member "fronting since" timestamp - mirroring `GET /v1/fronts/current`. A stream client (for example the Home Assistant integration) can now drive per-front state straight from the event instead of re-polling after each one, and can tell when a member joins a *new* front while already fronting elsewhere, which the existing before/after union lists could not express. The `fronting` / `before` / `after` fields are unchanged, so existing clients keep working. See docs/CLIENT_DESIGN.md.
+
 ## [1.3.4] - 2026-07-25
 
 ### Added

--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -388,13 +388,29 @@ On connect you get one `snapshot` event (apply as truth), then `front_change` ev
 
 ```
 event: snapshot
-data: {"system_id":"...","fronting":["<member_id>", ...],"event_id":"..."}
+data: {"system_id":"...","fronting":["<member_id>", ...],"fronts":[...],"event_id":"..."}
 
 event: front_change
-data: {"system_id":"...","before":[...],"after":[...],"changed_at":"<iso8601>","event_id":"...","emit_ts":<float>}
+data: {"system_id":"...","before":[...],"after":[...],"fronts":[...],"changed_at":"<iso8601>","event_id":"...","emit_ts":<float>}
 ```
 
-`fronting`/`before`/`after` are arrays of member-id strings (resolve names via the members API). `after` is the new authoritative fronting set. There is no replay buffer: SSE auto-reconnects and the server re-sends a fresh `snapshot`, so a reconnecting client is always correct (re-apply the snapshot rather than resuming from `Last-Event-ID`). Responses: `404` if the operator disabled the stream (`FRONT_STREAM_ENABLED`), `403` if the key lacks `fronts:read`, `429` if the account is over its concurrent-connection cap (back off and retry). Full contract: `sheaf-design-docs/realtime-front-stream.md`.
+`fronting`/`before`/`after` are arrays of member-id strings (resolve names via the members API). `after` is the new authoritative fronting set (the union of everyone fronting).
+
+`fronts` (on both events) is the full per-front composition AFTER the change, one element per currently-open front, so you can drive per-front state straight from the frame without re-polling `GET /v1/fronts/current`. It is the detail the union lists can't express: a member joining a *new* front while already fronting elsewhere shows up as a new `fronts` element even though their membership of the `after` union is unchanged. Each element mirrors the `GET /v1/fronts/current` shape, so the same parser works:
+
+```
+{
+  "id": "<front_id>",
+  "member_ids": ["<member_id>", ...],
+  "started_at": "<iso8601>",
+  "custom_status": "at work",           // or null
+  "member_since": {"<member_id>": "<iso8601>", ...}
+}
+```
+
+`member_since` is the per-member effective fronting-since timestamp (coalesced across contiguous fronts exactly as `/current` computes it). An empty `fronts` array means nobody is fronting.
+
+There is no replay buffer: SSE auto-reconnects and the server re-sends a fresh `snapshot`, so a reconnecting client is always correct (re-apply the snapshot rather than resuming from `Last-Event-ID`). Responses: `404` if the operator disabled the stream (`FRONT_STREAM_ENABLED`), `403` if the key lacks `fronts:read`, `429` if the account is over its concurrent-connection cap (back off and retry). Full contract: `sheaf-design-docs/realtime-front-stream.md`.
 
 ### Notes
 

--- a/sheaf/api/v1/front_stream.py
+++ b/sheaf/api/v1/front_stream.py
@@ -21,6 +21,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 
+from sheaf.api.v1.fronts import serialize_open_fronts_for_stream
 from sheaf.auth.dependencies import get_current_user
 from sheaf.auth.sessions import get_redis, get_session_user_id
 from sheaf.config import settings
@@ -216,7 +217,11 @@ async def _stream(
         # snapshot first also means a slow client cannot pin the connection.
         async with async_session_factory() as db:
             snapshots = [
-                build_snapshot_payload(sid, await snapshot_front_state(db, sid))
+                build_snapshot_payload(
+                    sid,
+                    await snapshot_front_state(db, sid),
+                    fronts=await serialize_open_fronts_for_stream(db, sid),
+                )
                 for sid in system_ids
             ]
         for snap in snapshots:

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -235,6 +235,53 @@ async def _build_coalesced_member_since(
     return out
 
 
+async def serialize_open_fronts_for_stream(
+    db: AsyncSession, system_id: uuid.UUID
+) -> list[dict]:
+    """Serialise a system's currently-open fronts for the realtime SSE stream.
+
+    Mirrors the per-front shape GET /v1/fronts/current returns - id, member_ids,
+    started_at, decrypted custom_status, and the coalesced per-member
+    `member_since` map - so a stream client can drive per-front state straight
+    from the frame instead of re-polling. This is the detail the union
+    before/after member-id lists can't express (a member joining a new front
+    while already fronting elsewhere). Returns [] for an unknown system.
+
+    Ordered newest-first to match /current. The `member_since` walk-back reuses
+    `_build_coalesced_member_since`, so composition and timestamps are identical
+    to the REST view.
+    """
+    system = (
+        await db.execute(select(System).where(System.id == system_id))
+    ).scalar_one_or_none()
+    if system is None:
+        return []
+    result = await db.execute(
+        select(Front)
+        .options(selectinload(Front.members))
+        .where(Front.system_id == system_id, Front.ended_at.is_(None))
+        .order_by(Front.started_at.desc())
+    )
+    fronts = list(result.scalars().all())
+    since_map = await _build_coalesced_member_since(db, system, fronts)
+    return [
+        {
+            "id": str(f.id),
+            "member_ids": [str(m.id) for m in f.members],
+            "started_at": f.started_at.isoformat(),
+            "custom_status": (
+                decrypt(f.custom_status, aad=front_custom_status_aad(f.id))
+                if f.custom_status
+                else None
+            ),
+            "member_since": {
+                mid: ts.isoformat() for mid, ts in since_map[f.id][0].items()
+            },
+        }
+        for f in fronts
+    ]
+
+
 @router.get("", response_model=list[FrontRead])
 async def list_fronts(
     response: Response,
@@ -519,8 +566,14 @@ async def create_front(
     await db.commit()
     fronts_created_total.inc()
     # Realtime stream fast path: publish AFTER commit so a rolled-back switch
-    # can't emit a phantom event. Best-effort - never fails the request.
-    await publish_front_change(system.id, before_state, after_state)
+    # can't emit a phantom event. Best-effort - never fails the request. The
+    # per-front detail is resolved post-commit so it reflects the new state.
+    await publish_front_change(
+        system.id,
+        before_state,
+        after_state,
+        fronts=await serialize_open_fronts_for_stream(db, system.id),
+    )
     await db.refresh(front, ["members"])
     return _front_to_read(front)
 
@@ -666,7 +719,12 @@ async def update_front(
 
     await db.commit()
     # Realtime stream fast path: publish AFTER commit (see create_front).
-    await publish_front_change(system.id, before_state, after_state)
+    await publish_front_change(
+        system.id,
+        before_state,
+        after_state,
+        fronts=await serialize_open_fronts_for_stream(db, system.id),
+    )
     await db.refresh(front, ["members"])
     pending = await pending_finalize_after_by_target(
         db, system, PendingActionType.FRONT_DELETE

--- a/sheaf/services/front_stream.py
+++ b/sheaf/services/front_stream.py
@@ -178,10 +178,19 @@ def build_change_payload(
     changed_at: datetime,
     event_id: uuid.UUID,
     emit_ts: float,
+    fronts: list[dict] | None = None,
 ) -> dict:
     """The `front_change` event body. `emit_ts` is a wall-clock stamp used
     only to measure delivery lag at the client write; `changed_at` is the
-    human-facing transition time and doubles as the SSE `id:`."""
+    human-facing transition time and doubles as the SSE `id:`.
+
+    `before`/`after` carry only the union of fronting member ids (kept for
+    backwards compatibility). `fronts` carries the full per-front composition
+    AFTER the change - id, member_ids, started_at, custom_status, member_since -
+    so a client can tell "a member joined a new front" from the frame alone,
+    which the union lists can't express. Built by the caller (it needs a DB
+    session); serialize_open_fronts_for_stream in api/v1/fronts.py produces it.
+    """
     return {
         "system_id": str(system_id),
         "before": serialize_front_state(before),
@@ -189,16 +198,25 @@ def build_change_payload(
         "changed_at": changed_at.isoformat(),
         "event_id": str(event_id),
         "emit_ts": emit_ts,
+        "fronts": fronts or [],
     }
 
 
-def build_snapshot_payload(system_id: uuid.UUID, state: FrontState) -> dict:
+def build_snapshot_payload(
+    system_id: uuid.UUID, state: FrontState, *, fronts: list[dict] | None = None
+) -> dict:
     """The `snapshot` event body sent first on connect so the client is
-    correct with no race."""
+    correct with no race.
+
+    `fronting` is the union of fronting member ids (kept for compatibility).
+    `fronts` is the full per-front composition (same shape as in a
+    `front_change`), so a client gets a complete per-front baseline on every
+    connect/reconnect and can drive state from the stream alone."""
     return {
         "system_id": str(system_id),
         "fronting": serialize_front_state(state),
         "event_id": str(uuid.uuid4()),
+        "fronts": fronts or [],
     }
 
 
@@ -251,7 +269,11 @@ async def authorized_front_system_ids(
 # ---------------------------------------------------------------------------
 
 async def publish_front_change(
-    system_id: uuid.UUID, before: FrontState, after: FrontState
+    system_id: uuid.UUID,
+    before: FrontState,
+    after: FrontState,
+    *,
+    fronts: list[dict] | None = None,
 ) -> None:
     """Publish a front-change event to the per-system Redis channel.
 
@@ -259,6 +281,10 @@ async def publish_front_change(
     down Redis degrades the stream to nothing without failing the front
     switch. Call this AFTER `db.commit()` - a rolled-back switch must not
     emit a phantom event.
+
+    `fronts` is the post-change per-front composition (from
+    serialize_open_fronts_for_stream); the caller builds it because it needs a
+    DB session, and this runs after commit so it reflects the committed state.
     """
     payload = build_change_payload(
         system_id,
@@ -267,6 +293,7 @@ async def publish_front_change(
         changed_at=datetime.now(UTC),
         event_id=uuid.uuid4(),
         emit_ts=time.time(),
+        fronts=fronts,
     )
     try:
         r = await get_redis()

--- a/tests/test_front_stream.py
+++ b/tests/test_front_stream.py
@@ -171,8 +171,27 @@ def test_build_snapshot_payload_shape():
     payload = build_snapshot_payload(sid, _state(m))
     assert payload["system_id"] == str(sid)
     assert payload["fronting"] == [str(m)]
+    # per-front detail defaults to empty when not supplied
+    assert payload["fronts"] == []
     # event_id present and JSON-serializable
     assert "event_id" in payload
+    json.dumps(payload)
+
+
+def test_build_snapshot_payload_carries_fronts_detail():
+    sid = uuid.uuid4()
+    m = uuid.uuid4()
+    fronts = [
+        {
+            "id": "f1",
+            "member_ids": [str(m)],
+            "started_at": "2026-07-23T12:00:00+00:00",
+            "custom_status": None,
+            "member_since": {str(m): "2026-07-23T12:00:00+00:00"},
+        }
+    ]
+    payload = build_snapshot_payload(sid, _state(m), fronts=fronts)
+    assert payload["fronts"] == fronts
     json.dumps(payload)
 
 
@@ -184,6 +203,15 @@ def test_build_change_payload_shape_carries_system_id_and_both_states():
     after_m = uuid.uuid4()
     changed_at = datetime(2026, 7, 23, 12, 0, tzinfo=UTC)
     event_id = uuid.uuid4()
+    fronts = [
+        {
+            "id": "f1",
+            "member_ids": [str(after_m)],
+            "started_at": changed_at.isoformat(),
+            "custom_status": "at work",
+            "member_since": {str(after_m): changed_at.isoformat()},
+        }
+    ]
     payload = build_change_payload(
         sid,
         _state(before_m),
@@ -191,6 +219,7 @@ def test_build_change_payload_shape_carries_system_id_and_both_states():
         changed_at=changed_at,
         event_id=event_id,
         emit_ts=123.5,
+        fronts=fronts,
     )
     assert payload["system_id"] == str(sid)
     assert payload["before"] == [str(before_m)]
@@ -198,6 +227,16 @@ def test_build_change_payload_shape_carries_system_id_and_both_states():
     assert payload["changed_at"] == changed_at.isoformat()
     assert payload["event_id"] == str(event_id)
     assert payload["emit_ts"] == 123.5
+    # NEW: per-front detail is carried through verbatim
+    assert payload["fronts"] == fronts
+    # and defaults to [] when the caller omits it (back-compat)
+    assert (
+        build_change_payload(
+            sid, _state(before_m), _state(after_m),
+            changed_at=changed_at, event_id=event_id, emit_ts=1.0,
+        )["fronts"]
+        == []
+    )
     json.dumps(payload)
 
 
@@ -305,6 +344,58 @@ def test_integration_stream_sends_snapshot_then_front_change(auth_client: httpx.
         assert change["event"] == "front_change"
         assert change["data"]["system_id"] == snapshot["data"]["system_id"]
         assert member in change["data"]["after"]
+
+
+def test_integration_stream_frame_carries_per_front_detail(auth_client: httpx.Client):
+    # The fronts[] array carries per-front composition (id, member_ids,
+    # started_at, custom_status, member_since) so a client can tell "a member
+    # joined a new front" from the frame - which the before/after union lists
+    # can't express. Both the snapshot and every front_change carry it.
+    a = _create_member(auth_client, f"A-{uuid.uuid4().hex[:6]}")
+    b = _create_member(auth_client, f"B-{uuid.uuid4().hex[:6]}")
+    key = _create_key(auth_client, ["fronts:read", "fronts:write"])
+    headers = {"Authorization": f"Bearer {key}"}
+    _front_keys = {"id", "member_ids", "started_at", "custom_status", "member_since"}
+
+    with httpx.Client(base_url=BASE_URL) as stream_client, stream_client.stream(
+        "GET", "/v1/fronts/stream", headers=headers, timeout=15.0
+    ) as resp:
+        assert resp.status_code == 200
+        lines = resp.iter_lines()
+
+        snapshot = _read_sse_event(lines)
+        assert snapshot["event"] == "snapshot"
+        assert "fronts" in snapshot["data"]  # per-front baseline on connect
+
+        # Front A.
+        assert (
+            auth_client.post("/v1/fronts", json={"member_ids": [a]}).status_code
+            == 201
+        )
+        change = _read_sse_event(lines)
+        fronts = change["data"]["fronts"]
+        assert isinstance(fronts, list) and fronts
+        for f in fronts:
+            assert set(f) >= _front_keys
+        assert any(a in f["member_ids"] for f in fronts)
+
+        # Now front A + B: B joins the fronting composition.
+        assert (
+            auth_client.post(
+                "/v1/fronts", json={"member_ids": [a, b]}
+            ).status_code
+            == 201
+        )
+        change2 = _read_sse_event(lines)
+        fronts2 = change2["data"]["fronts"]
+        # Every fronting member in the union is accounted for across fronts[],
+        # and each front maps its members to a member_since timestamp.
+        detail_members = {m for f in fronts2 for m in f["member_ids"]}
+        assert detail_members == set(change2["data"]["after"])
+        assert b in detail_members
+        for f in fronts2:
+            for mid in f["member_ids"]:
+                assert mid in f["member_since"]
 
 
 def test_integration_stream_does_not_block_same_key_requests(auth_client: httpx.Client):


### PR DESCRIPTION
## Summary

The realtime front-change stream's `snapshot` and `front_change` events carried only the union of fronting member ids (`fronting` / `before` / `after`), so a stream client couldn't tell "a member joined a new front" from the stream alone - a switch from Alex to Alex + Sam leaves Alex's union membership unchanged. Clients (the Home Assistant integration) worked around this by re-polling `GET /v1/fronts/current` on every event.

This adds a `fronts` array to both events: the full per-front composition after the change, one element per currently-open front, mirroring `GET /v1/fronts/current` so the same parser works:

```
{
  "id": "<front_id>",
  "member_ids": ["<member_id>", ...],
  "started_at": "<iso8601>",
  "custom_status": "at work",   // or null
  "member_since": {"<member_id>": "<iso8601>", ...}
}
```

It is built at the publish site via a new `serialize_open_fronts_for_stream` helper that reuses the existing coalesced `member_since` walk-back, so composition and timestamps are identical to the REST view. The snapshot carries it too, so a client gets a full per-front baseline on every connect/reconnect. Empty array means nobody is fronting.

Backwards-compatible: the union `fronting` / `before` / `after` fields are unchanged and the new array defaults to empty, so existing clients keep working. Once this is out, the HA client can drive per-front state (and fire a "member joined a front" event) straight from the frame and drop the per-event reconcile poll at its own pace.

## Not changed

Webhook / notification-channel payloads and their redaction model, the union fields, auth, the connection cap, heartbeat cadence, Last-Event-ID behaviour.

## Tests

Payload unit tests (both events carry `fronts`, defaulting to `[]`) plus an integration test that drives a member joining a new front while already fronting and asserts the per-front detail and the `member_since` mapping. Full suite green (rebuild).

## Docs

`docs/CLIENT_DESIGN.md` SSE section updated. The design doc (`realtime-front-stream.md`, in the design-docs repo) is updated separately.

Purely additive, no migration.
