### PR TITLE
Add an optional member created date system setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- **Optional "member created date" on member profiles.** A new per-system setting (Settings > System profile) shows when each member was added, on their profile. It is off by default and opt-in, since some systems want it and others would find it noise. The member's creation date was already available on the API; this only gates whether the web UI shows it.
+
 ## [1.3.4] - 2026-07-25
 
 ### Added

--- a/alembic/versions/b9c0d1e2f3a4_add_show_member_created_date.py
+++ b/alembic/versions/b9c0d1e2f3a4_add_show_member_created_date.py
@@ -1,0 +1,37 @@
+"""add show_member_created_date to systems
+
+Revision ID: b9c0d1e2f3a4
+Revises: a8b9c0d1e2f3
+Create Date: 2026-07-29
+
+Per-system display preference (opt-in, default off) controlling whether the
+web UI shows each member's created date on their profile. Purely a display
+toggle; the member's created_at is already exposed on the API.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b9c0d1e2f3a4"
+down_revision: str | None = "a8b9c0d1e2f3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "systems",
+        sa.Column(
+            "show_member_created_date",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("systems", "show_member_created_date")

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -601,6 +601,7 @@ def _system_dict(system: System) -> dict:
         # User-set system preferences. Re-import should restore these.
         "replace_fronts_default": system.replace_fronts_default,
         "coalesce_contiguous_fronts": system.coalesce_contiguous_fronts,
+        "show_member_created_date": system.show_member_created_date,
         "date_format": system.date_format.value,
         # NULL (auto) round-trips as null; a set zone as its IANA name.
         "timezone": system.timezone,

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -82,6 +82,13 @@ class System(UUIDMixin, TimestampMixin, Base):
     coalesce_contiguous_fronts: Mapped[bool] = mapped_column(
         Boolean, default=True, server_default="true", nullable=False
     )
+    # Display preference: show each member's created date on their profile.
+    # Off by default - some systems want it, others find it noise, so it is
+    # opt-in per system. Purely a display toggle: the member's created_at is
+    # always available (MemberRead.created_at); this only gates the UI.
+    show_member_created_date: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
 
     # System Safety — grace period + per-category toggles for destructive actions.
     # 0 days means no grace; paired with all category toggles off by default.

--- a/sheaf/schemas/system.py
+++ b/sheaf/schemas/system.py
@@ -49,6 +49,7 @@ class SystemUpdate(BaseModel):
     timezone: str | None = Field(default=None, max_length=64)
     replace_fronts_default: bool | None = None
     coalesce_contiguous_fronts: bool | None = None
+    show_member_created_date: bool | None = None
 
     @field_validator("avatar_url", mode="before")
     @classmethod
@@ -76,6 +77,7 @@ class SystemUpdate(BaseModel):
         "date_format",
         "replace_fronts_default",
         "coalesce_contiguous_fronts",
+        "show_member_created_date",
     )
     @classmethod
     def _reject_explicit_null(cls, v):
@@ -105,6 +107,7 @@ class SystemRead(BaseModel):
     timezone: str | None
     replace_fronts_default: bool
     coalesce_contiguous_fronts: bool
+    show_member_created_date: bool
     created_at: datetime
     updated_at: datetime
 

--- a/sheaf/services/openplural_export.py
+++ b/sheaf/services/openplural_export.py
@@ -191,6 +191,7 @@ def build_envelope(
             "timezone": sys_data.get("timezone"),
             "replace_fronts_default": sys_data.get("replace_fronts_default"),
             "coalesce_contiguous_fronts": sys_data.get("coalesce_contiguous_fronts"),
+            "show_member_created_date": sys_data.get("show_member_created_date"),
             "delete_confirmation": sys_data.get("delete_confirmation"),
             "safety": sys_data.get("safety"),
             "retention": sys_data.get("retention"),

--- a/sheaf/services/openplural_import.py
+++ b/sheaf/services/openplural_import.py
@@ -239,6 +239,7 @@ def to_native(envelope: dict, assets: _AssetMap | None = None) -> dict:
             "timezone": ext.get("timezone"),
             "replace_fronts_default": ext.get("replace_fronts_default"),
             "coalesce_contiguous_fronts": ext.get("coalesce_contiguous_fronts"),
+            "show_member_created_date": ext.get("show_member_created_date"),
             "delete_confirmation": ext.get("delete_confirmation"),
             "safety": ext.get("safety"),
             "retention": ext.get("retention"),

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -899,6 +899,10 @@ async def run_import(
                 system.coalesce_contiguous_fronts = bool(
                     sys_data["coalesce_contiguous_fronts"]
                 )
+            if "show_member_created_date" in sys_data:
+                system.show_member_created_date = bool(
+                    sys_data["show_member_created_date"]
+                )
             df = _date_format(sys_data.get("date_format"))
             if df is not None:
                 system.date_format = df

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -80,6 +80,7 @@ CLASSIFICATION: dict[type, dict] = {
             "name", "description", "note", "tag", "avatar_url", "color",
             "privacy", "delete_confirmation", "date_format", "timezone",
             "replace_fronts_default", "coalesce_contiguous_fronts",
+            "show_member_created_date",
             "auto_pin_first_revision", "safety_grace_period_days",
             "safety_applies_to_members", "safety_applies_to_groups",
             "safety_applies_to_tags", "safety_applies_to_fields",

--- a/tests/test_openplural_parity.py
+++ b/tests/test_openplural_parity.py
@@ -42,7 +42,8 @@ DISPOSITION: dict[str, dict[str, object]] = {
         # extensions.sheaf.* (note + prefs + the safety/retention blocks).
         "note": EXT, "date_format": EXT, "timezone": EXT,
         "replace_fronts_default": EXT,
-        "coalesce_contiguous_fronts": EXT, "delete_confirmation": EXT,
+        "coalesce_contiguous_fronts": EXT, "show_member_created_date": EXT,
+        "delete_confirmation": EXT,
         "auto_pin_first_revision": EXT,
         "safety_grace_period_days": EXT, "safety_applies_to_members": EXT,
         "safety_applies_to_groups": EXT, "safety_applies_to_tags": EXT,

--- a/tests/test_patch_null_rejection.py
+++ b/tests/test_patch_null_rejection.py
@@ -39,6 +39,34 @@ def test_systems_patch_rejects_null_replace_fronts_default(
     assert resp.status_code == 422
 
 
+def test_systems_patch_rejects_null_show_member_created_date(
+    auth_client: httpx.Client,
+):
+    resp = auth_client.patch(
+        "/v1/systems/me",
+        json={"show_member_created_date": None},
+    )
+    assert resp.status_code == 422
+
+
+def test_systems_show_member_created_date_round_trips(auth_client: httpx.Client):
+    """Opt-in display setting: defaults off, PATCH turns it on, and it reads
+    back on SystemRead."""
+    assert (
+        auth_client.get("/v1/systems/me").json()["show_member_created_date"]
+        is False
+    )
+    resp = auth_client.patch(
+        "/v1/systems/me", json={"show_member_created_date": True}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["show_member_created_date"] is True
+    assert (
+        auth_client.get("/v1/systems/me").json()["show_member_created_date"]
+        is True
+    )
+
+
 def test_systems_patch_rejects_null_privacy(auth_client: httpx.Client):
     resp = auth_client.patch("/v1/systems/me", json={"privacy": None})
     assert resp.status_code == 422

--- a/web/src/components/settings/system-profile-card.tsx
+++ b/web/src/components/settings/system-profile-card.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -54,8 +55,8 @@ function SystemSettingsForm({
   onSubmit,
   loading,
 }: {
-  initial: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format?: DateFormat; timezone?: string | null };
-  onSubmit: (data: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format: DateFormat; timezone: string | null }) => void;
+  initial: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format?: DateFormat; timezone?: string | null; show_member_created_date?: boolean };
+  onSubmit: (data: { name: string; description: string | null; note: string | null; tag: string | null; avatar_url: string | null; color: string | null; privacy: PrivacyLevel; date_format: DateFormat; timezone: string | null; show_member_created_date: boolean }) => void;
   loading: boolean;
 }) {
   const [name, setName] = useState(initial.name);
@@ -67,6 +68,9 @@ function SystemSettingsForm({
   const [privacy, setPrivacy] = useState<PrivacyLevel>(initial.privacy);
   const [dateFormat, setDateFormat] = useState<DateFormat>(initial.date_format ?? "ymd");
   const [timezone, setTimezone] = useState<string | null>(initial.timezone ?? null);
+  const [showMemberCreatedDate, setShowMemberCreatedDate] = useState<boolean>(
+    initial.show_member_created_date ?? false,
+  );
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -80,6 +84,7 @@ function SystemSettingsForm({
       privacy,
       date_format: dateFormat,
       timezone,
+      show_member_created_date: showMemberCreatedDate,
     });
   }
 
@@ -196,6 +201,25 @@ function SystemSettingsForm({
             </p>
           </div>
           <DeviceTimezoneOverride />
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="show-member-created-date"
+              checked={showMemberCreatedDate}
+              onCheckedChange={(v) => setShowMemberCreatedDate(v === true)}
+            />
+            <div>
+              <Label
+                htmlFor="show-member-created-date"
+                className="text-sm font-medium cursor-pointer"
+              >
+                Show member created dates
+              </Label>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Show when each member was added, on their profile. Saved with
+                this form.
+              </p>
+            </div>
+          </div>
           <Button type="submit" disabled={loading}>
             {loading ? "Saving..." : "Save"}
           </Button>

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -942,7 +942,8 @@ function MemberView({
   const { data: values } = useMemberFieldValues(member.id);
   const { data: allMembers } = useMembers();
   const { data: safety } = useQuery({ queryKey: ["system-safety"], queryFn: getSystemSafety });
-  const { formatBirthday } = useDateFormatters();
+  const { data: system } = useQuery({ queryKey: ["system", "me"], queryFn: getMySystem });
+  const { formatBirthday, formatDate } = useDateFormatters();
   const [showRevisions, setShowRevisions] = useState(false);
 
   const fieldDisplay = useMemo(() => {
@@ -1040,6 +1041,11 @@ function MemberView({
               {member.pluralkit_id && (
                 <p className="text-xs text-muted-foreground font-mono">
                   PK: {member.pluralkit_id}
+                </p>
+              )}
+              {system?.show_member_created_date && (
+                <p className="text-xs text-muted-foreground">
+                  Created {formatDate(member.created_at)}
                 </p>
               )}
             </div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -77,6 +77,7 @@ export interface System {
   timezone: string | null;
   replace_fronts_default: boolean;
   coalesce_contiguous_fronts: boolean;
+  show_member_created_date: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -95,6 +96,7 @@ export interface SystemUpdate {
   timezone?: string | null;
   replace_fronts_default?: boolean;
   coalesce_contiguous_fronts?: boolean;
+  show_member_created_date?: boolean;
 }
 
 export interface Member {


### PR DESCRIPTION
## Summary

A per-system display preference (off by default, opt-in) controlling whether the web UI shows each member's created date on their profile. One system asked for it; others may not want it, so it is a setting rather than always-on.

- New `show_member_created_date` boolean on the System model (default false) + migration `b9c0d1e2f3a4`; added to the system settings read/update schema (explicit `null` rejected like the other NOT-NULL prefs). The member `created_at` was already exposed on the API, so this only gates the UI.
- **Settings > System profile:** a "Show member created dates" checkbox next to the date-format / timezone preferences.
- **Member profile:** shows "Created &lt;date&gt;" (formatted with the system's date-format setting) only when the toggle is on.
- Round-trips through data export/import - both the native format and OpenPlural - the same as the other system display preferences.

## Tests

Explicit-null rejection + a settings round-trip (default off, PATCH on, reads back). The two export/import parity guards - native column classification and the OpenPlural disposition - are satisfied, and the field is wired through the actual export/import code (native + OpenPlural, both directions).

## Notes

- Contains a DB migration (`b9c0d1e2f3a4`): one nullable-false boolean column, default false. No data change.
- Full test suite green (rebuild). Backend and the whole frontend typecheck clean.
- No behaviour change when the setting is off, which is the default.
