### PR TITLE
Poll the rotation grace cache before treating a refresh replay as reuse

### DIFF
--- a/sheaf/api/v1/auth.py
+++ b/sheaf/api/v1/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import logging
@@ -1673,7 +1674,14 @@ async def refresh(
     consumed_sid = await consume_refresh_jti(jti)
     replay_token: str | None = None
     if consumed_sid is None:
-        replay_token = await get_cached_refresh_rotation(jti)
+        # A loser processed concurrently with the winner can land here
+        # after the winner's GETDEL but before its cache write, so poll
+        # the rotation cache briefly before treating this as theft.
+        for _ in range(8):
+            replay_token = await get_cached_refresh_rotation(jti)
+            if replay_token is not None:
+                break
+            await asyncio.sleep(0.25)
         if replay_token is None:
             await delete_session(sid)
             response.delete_cookie("sheaf_session")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -133,6 +133,65 @@ def test_refresh_concurrent_replay_does_not_kill_session(client: httpx.Client):
     assert me.status_code == 200, me.text
 
 
+def test_refresh_loser_in_flight_waits_for_winner_rotation(
+    client: httpx.Client, monkeypatch: pytest.MonkeyPatch
+):
+    """A loser can land in the gap after the winner's GETDEL but before
+    its rotation-cache write. The endpoint must poll the cache briefly
+    instead of reading that instant as reuse and deleting the session,
+    which took the winner's fresh token down with it (observed as
+    sporadic logouts on iOS when a background refresh raced the app)."""
+    import asyncio
+    import threading
+    import time
+
+    import jwt
+
+    from tests.test_shield_mode import _patch_redis_url_for_host, _reset_redis_singleton
+
+    email = f"refresh-inflight-{uuid.uuid4().hex[:8]}@sheaf.dev"
+    resp = client.post("/v1/auth/register", json={"email": email, "password": "securepassword"})
+    assert resp.status_code == 201
+    original_refresh_jwt = resp.json()["refresh_token"]
+    access = resp.json()["access_token"]
+    jti = jwt.decode(original_refresh_jwt, options={"verify_signature": False})["jti"]
+
+    _patch_redis_url_for_host(monkeypatch)
+
+    from sheaf.auth.sessions import cache_refresh_rotation, consume_refresh_jti
+
+    # Simulate the winner mid-flight: jti consumed, rotation not yet cached.
+    _reset_redis_singleton()
+    assert asyncio.run(consume_refresh_jti(jti)) is not None
+
+    result = {}
+
+    def fire():
+        result["resp"] = client.post(
+            "/v1/auth/refresh", json={"refresh_token": original_refresh_jwt}
+        )
+
+    t = threading.Thread(target=fire)
+    t.start()
+
+    # Let the loser start polling, then complete the winner's rotation.
+    time.sleep(0.6)
+    _reset_redis_singleton()
+    asyncio.run(cache_refresh_rotation(jti, "winner-rotated-refresh"))
+    t.join(timeout=10)
+
+    r = result["resp"]
+    assert r.status_code == 200, (
+        f"In-flight loser should pick up the winner's rotation, "
+        f"got {r.status_code}: {r.text}"
+    )
+    assert r.json()["refresh_token"] == "winner-rotated-refresh"
+
+    # The session survived the race.
+    me = client.get("/v1/auth/me", headers={"Authorization": f"Bearer {access}"})
+    assert me.status_code == 200, me.text
+
+
 def test_secondary_session_mints_independent_session(client: httpx.Client):
     """A primary device (phone) can mint a child session for a paired
     companion (watch). Both sessions exist concurrently in /sessions and


### PR DESCRIPTION
### Problem

The refresh rotation grace window only protects a loser that arrives after the
winner has fully finished. Two genuinely concurrent `/refresh` calls with the
same token can interleave so that the loser's GETDEL lands after the winner
consumed the jti but before the winner wrote its rotation to the cache. The
loser then sees no cache entry, takes the reuse-detection path, and deletes
the session, which also invalidates the token the winner just received.

On mobile this shows up as sporadic logouts when a background refresh races
the foreground app. Debug logs from an affected device:

```
16:56:23.723  Refresh OK, rotated ..old -> ..new
16:56:23.792  Refresh FAILED, HTTP 401, sent token ..old
16:56:24.592  Refresh FAILED, HTTP 401: Session revoked
```

The second line is the loser hitting the gap. The third is the client's
retry, which did find the grace cache, but by then the loser had already
deleted the session.

### Fix

When the jti GETDEL loses and no cached rotation exists yet, poll the
rotation cache for up to 2 seconds (8 attempts, 250 ms apart) before treating
the replay as reuse. A concurrent legitimate caller picks up the winner's
rotation once it lands; replay outside the grace window still burns the
session as before.

### Testing

- New test `test_refresh_loser_in_flight_waits_for_winner_rotation`
  reproduces the interleaving: it consumes the jti directly in Redis
  (simulating the winner mid-flight), fires the losing `/refresh`, writes the
  rotation cache 600 ms later, and asserts the loser replays the winner's
  rotation and the session survives.
- `tests/test_auth.py` against the compose test stack: 45 passed.
