### PR TITLE
Build and publish images for preview branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 #
 on:
   push:
-    branches: [main]
+    # preview/** gets the full build+publish flow so a feature line can be
+    # deployed to a test instance before it is anywhere near a release. The
+    # release approval gate only ever applies to tags, so preview images
+    # publish once lint and tests pass, tagged with the commit sha and a
+    # sanitised branch-name tag (preview/foo -> preview-foo).
+    branches: [main, "preview/**"]
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -176,6 +181,7 @@ jobs:
           tags: |
             type=sha,format=long
             type=raw,value=head,enable={{is_default_branch}}
+            type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Pushes to preview/** branches now run the full docker build and publish flow once lint and tests pass, so a long-lived feature line can be deployed to a test instance without cutting a tag. The release approval gate is unaffected; it only ever gates tag pushes. Preview images carry the long commit sha and a sanitised branch-name tag (preview/foo becomes preview-foo); head, semver and latest stay main-and-release-only.

Since push builds use the workflow file on the pushed branch, a preview branch technically only needs this on itself; landing it on main means every future preview branch inherits it instead of each one carrying its own copy. Note the cost: a preview push builds all four images, both architectures.