### PR TITLE
Only move the latest image tag for stable release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,13 @@ jobs:
             type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          # latest=auto moves :latest only for a stable semver tag. The old
+          # raw rule fired on ANY v* tag, so the first v1.x.y-beta.N we ever
+          # cut would have repointed :latest for every deploy that pulls it.
+          # A prerelease (hyphenated) or malformed tag now gets only its own
+          # version tag, or nothing.
+          flavor: |
+            latest=auto
 
       - uses: docker/build-push-action@v6
         id: build


### PR DESCRIPTION
The docker metadata step applied :latest on any v* tag push, so the first prerelease tag we ever cut (a v1.x.y-beta.1 or -rc.1) would have silently repointed :latest for every deployment that pulls it. Switch to metadata-action's latest=auto flavor: latest moves only for a stable semver version, a hyphenated prerelease gets just its own version tag, and a tag that does not parse as semver gets no version tag at all. Stable release tags behave exactly as before. No behaviour change for branch or main pushes.