### PR TITLE
Bump nanoid to 3.3.17 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5973,9 +5973,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves Dependabot alert 76 (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, high).

`nanoid` before 3.3.17 loops indefinitely in `customAlphabet` / `customRandom` when called with `size=0`, a DoS if an app passes an unvalidated attacker-controlled size. Here it is a transitive build-time dependency (`vite` -> `postcss` -> `nanoid`), not code shipped to browsers, and nothing calls those functions with an attacker-controlled size, so real exposure is negligible - but the patch is free and clears the alert.

Lockfile-only bump 3.3.16 -> 3.3.17. The existing `^3.3.16` constraint already permits it, so there is no `package.json` change and no dependency-tree churn: only nanoid's `version` / `resolved` / `integrity` move. `npm ci` stays in sync.