### PR TITLE
Fix front-coalesce query blow-up and statement_timeout coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Fronting since" no longer melts the database on a large imported history.** With coalesce-contiguous-fronts enabled, the walk that computes how far back a member's unbroken fronting run extends used a recursive query that, on an imported history whose switch boundaries share timestamps (PluralKit exports round to the second, so thousands do), could enumerate hundreds of millions of intermediate rows and spill tens of gigabytes into database temporary storage - one system's genuine imported history briefly took the whole database down this way. The walk is now a single sorted pass over the member's own front entries, with cost proportional to their history size, and returns the same answers. One deliberate refinement: fronts that *overlap* for the same member now count as one continuous run (previously the run only chained when one entry ended at the exact instant the next began), so a member fronting continuously across overlapping entries gets the earlier, correct "since". As a consequence the walk-back depth cap is gone; `member_since_capped` remains in the API for compatibility but is now always empty.
+- **The realtime front-change stream's database queries are now time-capped like every other request.** The stream endpoint builds its snapshots in self-managed database sessions, which silently missed the per-request statement timeout - so a pathological query from the stream path could run unboundedly (this is how the incident above kept filling the disk for 13 minutes after the same query on the normal endpoint had been cancelled at 30 seconds). Those sessions now carry the same timeout, and the cap is re-applied on every transaction, closing a second quiet gap where a mid-request commit dropped the timeout for the remainder of that request.
+
 ## [1.3.5] - 2026-08-09
 
 ### Security

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -108,6 +108,18 @@ Sheaf refuses to start in `saas` mode if this is left at the default, and logs a
 
 **If not set**, a key is auto-generated on first startup and saved to `data/encryption.key` inside the Docker volume. **Back this file up.** Prefer setting `SHEAF_ENCRYPTION_KEY` explicitly so the key isn't tied to a single volume.
 
+### Postgres safety limits (recommended)
+
+By default Postgres lets a single query spill unlimited temporary files to disk while it works. One runaway query can therefore fill the volume Postgres lives on and take the whole database down for every user - not just fail itself. Capping it turns that failure mode into "the one query errors out":
+
+```sql
+ALTER SYSTEM SET temp_file_limit = '2GB';   -- generous for a small instance
+ALTER SYSTEM SET log_temp_files = '64MB';   -- log any query spilling more than this
+SELECT pg_reload_conf();
+```
+
+Run once via `psql` against your database (for the bundled container: `docker compose exec db psql -U sheaf`). Pick a `temp_file_limit` well below the free space on the database volume. `log_temp_files` gives you a log line naming any unusually hungry query, which is the breadcrumb you want if something ever does hit the cap.
+
 ### Compose managers that don't use a `.env` file
 
 Some stack managers keep the environment in a differently-named file: OpenMediaVault's compose plugin writes `sheaf.env`, Portainer keeps stack env in its own database, and so on. Sheaf's `docker-compose.yml` loads the app's config from a file literally named `.env`, so if your manager uses another name the app receives none of its env-file settings and falls back to defaults. The classic symptom on a brand-new stack is `password authentication failed for user "sheaf"`: Postgres was created with your `POSTGRES_PASSWORD`, but the app never saw it.

--- a/sheaf/api/v1/front_stream.py
+++ b/sheaf/api/v1/front_stream.py
@@ -25,7 +25,7 @@ from sheaf.api.v1.fronts import serialize_open_fronts_for_stream
 from sheaf.auth.dependencies import get_current_user
 from sheaf.auth.sessions import get_redis, get_session_user_id
 from sheaf.config import settings
-from sheaf.database import async_session_factory
+from sheaf.database import request_session
 from sheaf.models.user import User
 from sheaf.observability.metrics import (
     realtime_connection_duration_seconds,
@@ -122,7 +122,7 @@ async def _recheck_auth(ctx: dict) -> tuple[bool, str | None]:
 
         from sheaf.models.api_key import ApiKey
 
-        async with async_session_factory() as db:
+        async with request_session() as db:
             row = await db.get(ApiKey, ctx["api_key_id"])
         if row is None:
             return False, "auth_revoked"
@@ -215,7 +215,7 @@ async def _stream(
         # Snapshot in a short-lived session CLOSED before we start yielding, so
         # no DB connection is held while the stream is open. Building the whole
         # snapshot first also means a slow client cannot pin the connection.
-        async with async_session_factory() as db:
+        async with request_session() as db:
             snapshots = [
                 build_snapshot_payload(
                     sid,
@@ -356,7 +356,7 @@ async def stream_fronts(
     # after the response finishes, and a stream finishes only when it closes, so
     # the pooled Postgres connection would sit idle-in-transaction for the whole
     # connection and eventually exhaust the pool, blocking every other request.
-    async with async_session_factory() as db:
+    async with request_session() as db:
         system_ids = await authorized_front_system_ids(user, db)
     account_key = str(user.id)
     auth_ctx = _auth_context(request)

--- a/sheaf/api/v1/fronts.py
+++ b/sheaf/api/v1/fronts.py
@@ -87,10 +87,11 @@ def _front_to_read(
     member — the literal-entry view used by history endpoints and any
     caller that doesn't want to pay for the walk-back.
 
-    `member_since_capped` lists member ids whose chain hit the
-    walk-back depth limit; the returned timestamp is a lower bound,
-    not the true chain start. Frontends should render those with a
-    "> X ago" prefix to be honest about precision.
+    `member_since_capped` is retained for API compatibility: the old
+    recursive walk-back could hit a depth limit and flag members whose
+    timestamp was only a lower bound. The set-based coalesce query has
+    no such cap, so this is now always empty; frontends that render a
+    "> X ago" prefix for flagged members simply never see one.
 
     `has_audit_history` reflects whether at least one FrontAuditEvent
     exists for this entry. Computed once per list call via a batch
@@ -141,49 +142,78 @@ async def _front_has_audit(db: AsyncSession, front_id: uuid.UUID) -> bool:
     return result.scalar_one_or_none() is not None
 
 
-# Walk-back depth cap: pathological cycles aside, real chains are
-# typically 1-3 entries. 500 is a generous bound that prevents a
-# corrupted-data edge case from running unbounded queries while still
-# covering anyone who switches every few minutes for many hours.
-# When the cap *is* hit, the response flags the affected member so the
-# UI can render "> X ago" instead of silently under-reporting. Easy to
-# raise later if the flag actually starts surfacing in real usage.
-_COALESCE_MAX_DEPTH = 500
-
-
-# Recursive CTE that walks every (seed_front, member) chain in
-# parallel. Replaces what was previously a per-(front, member) loop of
-# awaited single-row queries — fine for one open front with two
-# members on a brand-new system, ruinous for /current on a busy
-# system with coalesce_contiguous_fronts on. The CTE is bounded by
-# `_COALESCE_MAX_DEPTH` so a corrupted-data cycle can't run forever,
-# and we surface the cap-hit per member the same way the old code did.
+# Set-based gaps-and-islands "coalesce contiguous fronting" query.
+#
+# This replaced a recursive CTE that walked prev.ended_at == started_at
+# chains with UNION ALL. That formulation enumerates PATHS, not states:
+# on an imported history whose switch boundaries share timestamps
+# (PluralKit exports are second-rounded, so thousands collide), every
+# recursive step matches multiple predecessors and the intermediate set
+# grows multiplicatively per level. A depth cap bounds depth, not width.
+# On 2026-08-13 a genuine ~14k-front imported history detonated it into
+# ~19 GB of Postgres query temp, filling the data volume (see the
+# front-coalesce-query-scaling design doc). Path count is combinatorial;
+# table size is irrelevant.
+#
+# The rewrite computes each member's contiguous runs ("islands") in one
+# sorted window pass: a run breaks only where every earlier front's
+# reach (running MAX of ended_at, with an open front reaching infinity)
+# ends strictly before the next started_at. Cost is one sort of the
+# member's own fronts - O(n log n), no recursion, no width explosion.
+#
+# Contiguity is interval-merge: exact touches (ended_at == started_at)
+# chain exactly as before, and OVERLAPPING fronts for the same member -
+# the very shape that made the recursion branch - merge into one run.
+# Chain-reachability is a strict subset of interval-merge, so results
+# are identical wherever fronts don't overlap (all live-written data);
+# where they do, the merged run extends "since" through the overlap,
+# which is the correct reading of an unbroken fronting stretch.
 _COALESCED_SINCE_SQL = text(
     """
-    WITH RECURSIVE chain(seed_front_id, member_id, started_at, depth) AS (
-        SELECT f.id, fm.member_id, f.started_at, 0
+    WITH member_fronts AS (
+        SELECT fm.member_id,
+               f.id AS front_id,
+               f.started_at,
+               COALESCE(f.ended_at, 'infinity'::timestamptz) AS reach
         FROM fronts f
         JOIN front_members fm ON fm.front_id = f.id
-        WHERE f.id IN :seed_ids
-
-        UNION ALL
-
-        SELECT chain.seed_front_id, chain.member_id, prev.started_at,
-               chain.depth + 1
-        FROM chain
-        JOIN fronts prev
-            ON prev.system_id = :system_id
-            AND prev.ended_at = chain.started_at
-        JOIN front_members fm
-            ON fm.front_id = prev.id
-            AND fm.member_id = chain.member_id
-        WHERE chain.depth < :max_depth
+        WHERE f.system_id = :system_id
+          AND fm.member_id IN (
+              SELECT seed_fm.member_id
+              FROM front_members seed_fm
+              WHERE seed_fm.front_id IN :seed_ids
+          )
+    ),
+    runs AS (
+        SELECT member_id, front_id, started_at, reach,
+               MAX(reach) OVER (
+                   PARTITION BY member_id
+                   ORDER BY started_at, reach, front_id
+                   ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+               ) AS prev_reach
+        FROM member_fronts
+    ),
+    islands AS (
+        SELECT member_id, front_id, started_at,
+               SUM(CASE WHEN prev_reach IS NULL OR prev_reach < started_at
+                        THEN 1 ELSE 0 END)
+                   OVER (PARTITION BY member_id
+                         ORDER BY started_at, reach, front_id) AS island
+        FROM runs
+    ),
+    island_starts AS (
+        SELECT member_id, island, MIN(started_at) AS run_start
+        FROM islands
+        GROUP BY member_id, island
     )
-    SELECT seed_front_id, member_id,
-           MIN(started_at) AS earliest_started,
-           MAX(depth) AS deepest
-    FROM chain
-    GROUP BY seed_front_id, member_id
+    SELECT i.front_id AS seed_front_id,
+           i.member_id,
+           s.run_start AS earliest_started
+    FROM islands i
+    JOIN island_starts s
+        ON s.member_id = i.member_id
+        AND s.island = i.island
+    WHERE i.front_id IN :seed_ids
     """
 ).bindparams(bindparam("seed_ids", expanding=True))
 
@@ -194,8 +224,14 @@ async def _build_coalesced_member_since(
     """For each given front, build (since_map, capped_member_ids).
 
     When `system.coalesce_contiguous_fronts` is False, returns the
-    literal-entry view for each member with no capped members.
-    Otherwise walks back per member to find the earliest chain start.
+    literal-entry view for each member with no capped members. Otherwise
+    resolves each member's contiguous-run start via the gaps-and-islands
+    query above.
+
+    `capped_member_ids` is always empty now: the set-based query has no
+    depth cap to hit (the old recursive walk-back did). The tuple shape
+    is kept so the schema field `member_since_capped` stays present for
+    API compatibility; it simply never flags anyone.
     """
     out: dict[uuid.UUID, tuple[dict[str, datetime], list[str]]] = {}
     if not fronts:
@@ -220,18 +256,12 @@ async def _build_coalesced_member_since(
         {
             "seed_ids": [f.id for f in fronts],
             "system_id": system.id,
-            "max_depth": _COALESCE_MAX_DEPTH,
         },
     )
 
-    for seed_id, member_id, earliest, deepest in rows:
-        per_member, capped = out[seed_id]
+    for seed_id, member_id, earliest in rows:
+        per_member, _capped = out[seed_id]
         per_member[str(member_id)] = earliest
-        # depth==max_depth means the recursive step ran the last
-        # allowed iteration and may not have found the true chain
-        # start. Same semantics as the prior per-walk cap flag.
-        if deepest is not None and deepest >= _COALESCE_MAX_DEPTH:
-            capped.append(str(member_id))
 
     return out
 

--- a/sheaf/database.py
+++ b/sheaf/database.py
@@ -2,8 +2,9 @@ import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
-from sqlalchemy import event, text
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session as _SyncSession
 
 from sheaf.config import settings
 
@@ -16,9 +17,10 @@ from sheaf.config import settings
 # A connection-level cap would apply to every session drawn from the pool,
 # including the long-running background jobs (export builds, retention
 # sweeps, analytics) that legitimately outlast any request. Instead the
-# SHORT request cap is applied per-transaction inside get_db, and jobs stay
-# uncapped by default (opting into db_job_statement_timeout_ms via
-# job_session()). See _set_local_statement_timeout below.
+# SHORT request cap is applied per-transaction to sessions that opt in via
+# session.info (get_db, request_session), and jobs stay uncapped by default
+# (opting into db_job_statement_timeout_ms via job_session()). See the
+# after_begin listener below.
 engine = create_async_engine(
     settings.database_url,
     echo=False,
@@ -72,34 +74,73 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, executem
     )
 
 
-async def _set_local_statement_timeout(session: AsyncSession, timeout_ms: int) -> None:
-    """Apply a transaction-local Postgres statement_timeout to `session`.
+# Sessions opt into a Postgres statement_timeout by setting this key in
+# session.info; the after_begin listener below re-applies it at the start of
+# EVERY transaction the session opens. The previous design issued a single
+# SET LOCAL when the session was created, which silently evaporated at the
+# first mid-request commit (SET LOCAL is transaction-scoped), leaving the
+# rest of the request uncapped. The 2026-08-13 incident's variant of this
+# class - a request-tier session created outside get_db with no cap at all -
+# let one coalesce query spill 19 GB of query temp; see request_session().
+_TIMEOUT_INFO_KEY = "statement_timeout_ms"
 
-    A value <= 0 is a no-op (unlimited). SET LOCAL is scoped to the current
-    transaction, so the cap neither leaks to the next caller that checks out
-    this pooled connection nor bleeds past a commit. Postgres SET does not
-    accept bind parameters, so the value is formatted in directly - it comes
-    from a pydantic int setting, never user input, and is re-cast to int
-    here, so there is no injection surface.
+
+@event.listens_for(_SyncSession, "after_begin")
+def _apply_statement_timeout(session, transaction, connection) -> None:
+    """Apply the session's opted-in statement_timeout to each new transaction.
+
+    Registered on the Session class, so it fires for every session drawn from
+    the shared pool - but it is a no-op unless the session set
+    `info[_TIMEOUT_INFO_KEY]`, so background jobs that use
+    async_session_factory() directly stay uncapped as designed. SET LOCAL is
+    transaction-scoped, so nothing leaks to the next checkout of the pooled
+    connection. Postgres SET takes no bind parameters; the value is a pydantic
+    int setting (never user input) re-cast to int here, so there is no
+    injection surface.
     """
-    if timeout_ms <= 0:
+    timeout_ms = session.info.get(_TIMEOUT_INFO_KEY)
+    if not timeout_ms or timeout_ms <= 0:
         return
-    await session.execute(text(f"SET LOCAL statement_timeout = {int(timeout_ms)}"))
+    connection.exec_driver_sql(f"SET LOCAL statement_timeout = {int(timeout_ms)}")
 
 
 async def get_db() -> AsyncGenerator[AsyncSession]:
     async with async_session_factory() as session:
         # Bound the request path so a pathological O(history) query can't pin
-        # a pooled connection indefinitely. Applied per-transaction, so it
-        # never touches the background jobs, which use async_session_factory()
-        # / job_session() directly and legitimately run longer than a request.
-        await _set_local_statement_timeout(session, settings.db_statement_timeout_ms)
+        # a pooled connection indefinitely. The info key makes the after_begin
+        # listener re-apply the cap on every transaction, so it survives
+        # mid-request commits. Background jobs use async_session_factory() /
+        # job_session() directly and are not affected.
+        session.info[_TIMEOUT_INFO_KEY] = settings.db_statement_timeout_ms
         try:
             yield session
             await session.commit()
         except Exception:
             await session.rollback()
             raise
+
+
+@asynccontextmanager
+async def request_session() -> AsyncGenerator[AsyncSession]:
+    """Session for request-tier work that cannot use Depends(get_db).
+
+    Same engine/pool and the same request statement_timeout cap as get_db,
+    without the DI lifecycle: no auto-commit, caller manages transactions.
+    For paths that serve a user request but manage their own session - e.g.
+    the SSE front stream, which builds its snapshot in a short-lived session
+    so no DB connection is held while the stream is open.
+
+    Every session that runs queries on behalf of a user request MUST carry
+    the request timeout cap. The 2026-08-13 incident: the stream snapshot
+    used a bare async_session_factory() session, so the coalesce query it
+    ran had no statement_timeout and kept spilling query temp for ~13
+    minutes after the request-path twin of the same query had been killed
+    at 30 s - filling the disk and taking Postgres down for everyone. Use
+    this instead of async_session_factory() for anything request-shaped.
+    """
+    async with async_session_factory() as session:
+        session.info[_TIMEOUT_INFO_KEY] = settings.db_statement_timeout_ms
+        yield session
 
 
 @asynccontextmanager
@@ -114,15 +155,11 @@ async def job_session() -> AsyncGenerator[AsyncSession]:
     ceiling that is still far above the short request timeout. Unlike get_db
     this does NOT auto-commit; the job manages its own transactions.
 
-    Note: SET LOCAL is per-transaction, so for a job that commits between
-    units of work the cap re-applies only to the first transaction after
-    entry. Jobs here follow an execute-then-commit pattern (not
-    `async with db.begin()`), so the pre-emptive SET joins the same
-    transaction as the job's first query. Left as an opt-in because the
-    default ceiling is unlimited.
+    The after_begin listener re-applies the cap on every transaction, so a
+    job that commits between units of work keeps its ceiling for each one
+    (this previously only covered the first transaction after entry). Left
+    as an opt-in because the default ceiling is unlimited.
     """
     async with async_session_factory() as session:
-        await _set_local_statement_timeout(
-            session, settings.db_job_statement_timeout_ms
-        )
+        session.info[_TIMEOUT_INFO_KEY] = settings.db_job_statement_timeout_ms
         yield session

--- a/sheaf/schemas/front.py
+++ b/sheaf/schemas/front.py
@@ -101,10 +101,10 @@ class FrontRead(BaseModel):
     # back for open fronts on /v1/fronts/current; closed fronts (history)
     # always carry the literal value.
     member_since: dict[str, datetime] = {}
-    # Members whose walk-back hit the safety depth cap. The corresponding
-    # `member_since` entry is a lower bound, not the true chain start.
-    # UIs should render these with a "> X ago" prefix. Empty in the
-    # overwhelming majority of cases — chains are typically 1-3 entries.
+    # Retained for API compatibility; always empty since the coalesce
+    # walk-back became a set-based query with no depth cap. Historically
+    # listed members whose recursive walk-back hit the safety depth cap
+    # (their `member_since` was a lower bound, rendered as "> X ago").
     member_since_capped: list[str] = []
     # True iff at least one FrontAuditEvent row exists for this front.
     # Lets the UI grey out the history button on entries that have never

--- a/tests/test_fronts_coalesce.py
+++ b/tests/test_fronts_coalesce.py
@@ -255,3 +255,171 @@ def test_replace_fronts_auto_end_aligns_with_new_started_at(
     history = auth_client.get("/v1/fronts").json()
     f1 = next(f for f in history if f["id"] == f1_id)
     assert f1["ended_at"] == f2["started_at"]
+
+
+# ---------------------------------------------------------------------------
+# 2026-08-13 incident regression: dense shared-boundary history must not
+# blow up the coalesce query
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt) -> str:
+    return dt.isoformat()
+
+
+def _make_closed_front(
+    client: httpx.Client, member_ids: list[str], started, ended
+) -> str:
+    """Create a front and immediately backdate it to [started, ended]."""
+    f = client.post("/v1/fronts", json={"member_ids": member_ids}).json()
+    r = client.patch(
+        f"/v1/fronts/{f['id']}",
+        json={"started_at": _iso(started), "ended_at": _iso(ended)},
+    )
+    assert r.status_code == 200, r.text
+    return f["id"]
+
+
+def test_dense_shared_boundary_history_regression(auth_client: httpx.Client):
+    """The 2026-08-13 prod incident shape, miniaturised.
+
+    A member's history where EVERY level of the chain has several fronts
+    sharing the exact same boundary timestamps (what a second-rounded
+    PluralKit import produces). The old recursive walk-back enumerated
+    every predecessor PATH - K predecessors per level to the power of L
+    levels (here 4^12 = ~16.7M chain rows, spilling to query temp; the
+    real incident spilled ~19 GB and filled the disk). The set-based
+    query is one sorted pass over the member's fronts, so this must
+    return instantly and still produce the true chain start.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    a = _create_member(auth_client, "Avalanche")
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+    hour = timedelta(hours=1)
+    levels, per_level = 12, 4
+
+    # L levels x K duplicate fronts, all spanning [base+i*1h, base+(i+1)*1h].
+    for i in range(levels):
+        for _ in range(per_level):
+            _make_closed_front(auth_client, [a], base + i * hour, base + (i + 1) * hour)
+
+    # The open front picks up exactly where the lattice ends.
+    cur = auth_client.post("/v1/fronts", json={"member_ids": [a]}).json()
+    r = auth_client.patch(
+        f"/v1/fronts/{cur['id']}", json={"started_at": _iso(base + levels * hour)}
+    )
+    assert r.status_code == 200, r.text
+
+    t0 = time.monotonic()
+    fronts = _current(auth_client)
+    elapsed = time.monotonic() - t0
+
+    assert len(fronts) == 1
+    since = datetime.fromisoformat(fronts[0]["member_since"][a])
+    assert since == base, f"expected chain start {base}, got {since}"
+    # Generous bound: the query is a single sorted pass over ~49 rows. The
+    # old path-enumerating query would spill for minutes on this shape.
+    assert elapsed < 10, f"/current took {elapsed:.1f}s on the dense fixture"
+    # No member may be flagged as depth-capped: the set-based query has no cap.
+    assert fronts[0]["member_since_capped"] == []
+
+
+def test_overlapping_fronts_merge_into_one_run(auth_client: httpx.Client):
+    """Overlapping fronts for the same member merge into one contiguous run.
+
+    Interval-merge contiguity (deliberate semantic refinement over the old
+    exact-boundary walk): A [10:00-11:00] and B [10:30-11:30] overlap, and
+    the open front starts at B's end. The member was continuously fronting
+    from 10:00, so member_since walks through the overlap to A's start.
+    The old recursive query would have stopped at B (10:30) because no
+    front's ended_at == 10:30 exactly.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    a = _create_member(auth_client, "Overlap")
+    base = datetime(2024, 6, 1, 10, 0, tzinfo=UTC)
+    h = timedelta(hours=1)
+
+    _make_closed_front(auth_client, [a], base, base + h)  # 10:00-11:00
+    _make_closed_front(auth_client, [a], base + h / 2, base + h + h / 2)  # 10:30-11:30
+
+    cur = auth_client.post("/v1/fronts", json={"member_ids": [a]}).json()
+    r = auth_client.patch(
+        f"/v1/fronts/{cur['id']}", json={"started_at": _iso(base + h + h / 2)}
+    )
+    assert r.status_code == 200, r.text
+
+    fronts = _current(auth_client)
+    assert len(fronts) == 1
+    since = datetime.fromisoformat(fronts[0]["member_since"][a])
+    assert since == base
+
+
+def test_gap_still_breaks_run_with_dense_history(auth_client: httpx.Client):
+    """A genuine gap still breaks the run even when the segments on either
+    side are internally dense - the merge must not paper over real gaps."""
+    from datetime import UTC, datetime, timedelta
+
+    a = _create_member(auth_client, "Gappy")
+    base = datetime(2024, 6, 2, 8, 0, tzinfo=UTC)
+    h = timedelta(hours=1)
+
+    # Dense island long before the gap: 8:00-9:00 twice, 9:00-10:00 twice.
+    for _ in range(2):
+        _make_closed_front(auth_client, [a], base, base + h)
+        _make_closed_front(auth_client, [a], base + h, base + 2 * h)
+
+    # Gap 10:00 -> 12:00, then the run containing the current front.
+    _make_closed_front(auth_client, [a], base + 4 * h, base + 5 * h)  # 12:00-13:00
+    cur = auth_client.post("/v1/fronts", json={"member_ids": [a]}).json()
+    r = auth_client.patch(
+        f"/v1/fronts/{cur['id']}", json={"started_at": _iso(base + 5 * h)}
+    )
+    assert r.status_code == 200, r.text
+
+    fronts = _current(auth_client)
+    since = datetime.fromisoformat(fronts[0]["member_since"][a])
+    # Walks back through 13:00 <- 12:00 but NOT across the 10:00-12:00 gap.
+    assert since == base + 4 * h
+
+
+def test_multiple_open_fronts_report_one_continuous_since(
+    auth_client: httpx.Client,
+):
+    """A member in two concurrently-open fronts is one continuously-fronting
+    member: both entries report the same member_since (the earlier start).
+    Under the old per-seed walk the later entry reported its own started_at
+    even though the member never stopped fronting."""
+    from datetime import UTC, datetime, timedelta
+
+    a = _create_member(auth_client, "Ada")
+    b = _create_member(auth_client, "Brook")
+    base = datetime(2024, 6, 3, 9, 0, tzinfo=UTC)
+
+    # replace_fronts=False explicitly: the system default (replace_fronts_default)
+    # is True for new systems, which would auto-end f1 when f2 is created -
+    # this test needs both fronts genuinely open at once.
+    f1 = auth_client.post(
+        "/v1/fronts", json={"member_ids": [a], "replace_fronts": False}
+    ).json()
+    r = auth_client.patch(f"/v1/fronts/{f1['id']}", json={"started_at": _iso(base)})
+    assert r.status_code == 200, r.text
+
+    f2 = auth_client.post(
+        "/v1/fronts", json={"member_ids": [a, b], "replace_fronts": False}
+    ).json()
+    r = auth_client.patch(
+        f"/v1/fronts/{f2['id']}",
+        json={"started_at": _iso(base + timedelta(hours=1))},
+    )
+    assert r.status_code == 200, r.text
+
+    fronts = _current(auth_client)
+    assert len(fronts) == 2
+    for f in fronts:
+        since = datetime.fromisoformat(f["member_since"][a])
+        assert since == base, (
+            f"open front {f['id']}: Ada has been fronting continuously "
+            f"since {base}, got {since}"
+        )


### PR DESCRIPTION
## What

Fixes a production-stability bug where computing "fronting since" on a large imported front history could take the whole database down, and closes two statement-timeout coverage gaps that turned a 30-second query failure into a multi-minute outage.

## The query

With coalesce-contiguous-fronts enabled, the walk that finds how far back a member's unbroken fronting run extends was a recursive CTE joining `prev.ended_at = chain.started_at` with `UNION ALL`. That enumerates paths, not states: on an imported history whose switch boundaries share timestamps (PluralKit exports round to the second, so thousands collide), every step matches multiple predecessors and the intermediate set grows multiplicatively per level. The depth cap bounded depth, not width. A genuine ~14k-front imported history recently blew this up into ~19 GB of Postgres query temp, filling the volume and briefly failing queries for every user.

The replacement is a set-based gaps-and-islands pass: one sorted window scan over the fronting members' own entries, where a run breaks only when the running MAX of `ended_at` falls strictly before the next `started_at` (an open front reaches infinity). Cost is O(n log n) in the member's own front count, no recursion, no width explosion.

Semantics are identical wherever fronts do not overlap, which is all live-written data - the pre-existing coalesce test suite passes unchanged. One deliberate refinement: overlapping fronts for the same member now merge into a single continuous run, where the old exact-boundary walk under-counted (a member continuously fronting across overlapping imported entries now gets the earlier, correct "since"). The walk-back depth cap is gone with nothing to need it; `member_since_capped` stays in the API for compatibility and is always empty.

## The timeout

Two gaps, found root-causing why the incident query ran ~13 minutes when the request cap is 30 seconds:

- The realtime stream endpoint builds its snapshots in self-managed sessions (deliberately, so no pooled connection is held for the stream's lifetime) - and those sessions never carried the per-request `statement_timeout`. The uncapped stream twin of the coalesce query is what kept spilling long after the `/current` copy had been correctly killed at 30 s.
- `get_db` applied `SET LOCAL statement_timeout` once per session; `SET LOCAL` is transaction-scoped, so the first mid-request commit silently dropped the cap for the rest of that request.

Sessions now opt into the cap via `session.info`, and an `after_begin` listener re-applies `SET LOCAL` at the start of every transaction. A new `request_session()` context manager carries the request-tier cap for paths that cannot use `Depends(get_db)`, and the stream endpoint's three sessions use it. Background jobs keep their separate (default unlimited) ceiling - verified live: capped sessions hold the cap across a commit, bare job sessions stay at 0.

## Tests

New regression fixture reproducing the incident shape, miniaturised: 4 duplicate fronts per level x 12 levels, all sharing exact boundary timestamps (~16.7M chain paths under the old query; instant under the new one), asserting the true chain start, a wall-clock bound, and an empty capped list. Plus overlap-merge, dense-history-with-a-real-gap, and member-in-two-open-fronts cases. Full behavioural config green: 1783 passed.

## Docs

Changelog entries for both fixes, and SELFHOSTING.md gains a short "Postgres safety limits" section recommending `temp_file_limit` + `log_temp_files`, so a self-hosted instance's worst case is one failed query rather than a full data volume.
