### PR TITLE
Bump nanoid to 3.3.18 (GHSA follow-up)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5973,9 +5973,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves the follow-up Dependabot alert #77: the upstream 3.3.17 patch for the `customAlphabet` / `customRandom` size=0 infinite loop was incomplete, and 3.3.18 supersedes it.

Same posture as #261: transitive build-time dependency (`vite` -> `postcss` -> `nanoid`), not shipped to browsers, no attacker-controlled size reaches those functions, so real exposure is negligible - but the patch is free. Lockfile-only bump within postcss's `^3.3.16` constraint; only nanoid's `version` / `resolved` / `integrity` lines move and `npm ci` stays in sync.

3.3.18 is the newest release in the 3.x line postcss is pinned to, so this is as far forward as this dependency can roll until upstream cuts another backport.