### PR TITLE
Keep imported files from referencing another account's uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Security
+
+- **Imported files can no longer smuggle in references to another account's uploads.** Sheaf stores every uploaded image under a path that names the account it belongs to, and when it shows a profile it turns any such reference it finds into a working image link. The importers for other apps' formats (PluralKit, Tupperbox, SimplyPlural, PluralSpace, Prism, Ampersand) copied bios, system and group descriptions and journal entries across word for word, so a hand-edited export file could name an image belonging to a *different* account and have Sheaf serve it from the importing profile - a way to read someone else's uploaded picture, and to keep reading it after they had deleted it. Those importers now drop any reference to Sheaf's own storage on the way in; nothing written in another app can legitimately point at it. Prose and genuinely external images are untouched, and Sheaf's own backup format is unaffected (it already re-homed images to the importing account). Avatar fields get the same treatment, including the case where the reference is dressed up as an ordinary web address on the instance's image host.
+- **Sheaf no longer signs a link to a file that does not belong to the profile it is shown on.** The final step that turns a stored image reference into a working link now checks that the file belongs to the account whose profile, member, or journal entry is being shown, and refuses to sign it otherwise. Previously it signed whatever it was given and trusted that everything writing to those fields had already checked. That trust now sits in one place instead of being spread across every writer, so old rows written before those checks existed, and anything that slips past them in future, cannot produce a working link to someone else's file. Nothing changes for your own images.
+- **Group descriptions now get the same write-time checks as member bios and system descriptions.** Creating or editing a group runs the same two passes those have always had: image addresses are validated and normalised, and a reference to another account's uploaded file is dropped. Groups were the one description field with neither.
+
 ## [1.3.6] - 2026-08-18
 
 ### Fixed

--- a/sheaf/api/v1/files.py
+++ b/sheaf/api/v1/files.py
@@ -273,7 +273,7 @@ async def upload_file(
         raise
 
     return {
-        "url": resolve_avatar_url(key),
+        "url": resolve_avatar_url(key, user.id),
         "key": key,
         "size": file_size,
         # True iff the original upload had more than one frame. When the
@@ -328,7 +328,7 @@ async def list_files(
         {
             "id": str(f.id),
             "key": f.key,
-            "url": resolve_avatar_url(f.key),
+            "url": resolve_avatar_url(f.key, user.id),
             "purpose": f.purpose,
             "content_type": f.content_type,
             "size_bytes": f.size_bytes,

--- a/sheaf/api/v1/groups.py
+++ b/sheaf/api/v1/groups.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import selectinload
 
 from sheaf.auth.dependencies import get_current_user, require_scope
 from sheaf.database import get_db
+from sheaf.files import owned_description_urls
 from sheaf.models.group import Group
 from sheaf.models.member import Member
 from sheaf.models.pending_action import PendingActionType
@@ -115,7 +116,19 @@ async def create_group(
                 detail=f"Group nesting cannot exceed {MAX_GROUP_DEPTH} levels",
             )
 
-    group = Group(system_id=system.id, **body.model_dump())
+    fields = body.model_dump()
+    # Drop embedded refs to another account's storage keys, exactly as the
+    # member and system write handlers do. Groups were the gap: nothing here
+    # ran an ownership pass, so a foreign /v1/files/{key} pasted into a group
+    # description was stored verbatim, ready for the day something renders it.
+    # Enforced at the handler because this is where the authenticated user
+    # exists; the schema validator that runs `normalize_description_urls` has
+    # no request context and cannot know whose keys these are.
+    fields["description"] = owned_description_urls(
+        fields.get("description"), user.id
+    )
+
+    group = Group(system_id=system.id, **fields)
     db.add(group)
     await db.commit()
     groups_created_total.inc()
@@ -153,6 +166,12 @@ async def update_group(
     system = await _get_user_system(user, db)
     group = await _get_own_group(group_id, system, db)
     update_data = body.model_dump(exclude_unset=True)
+
+    # Same ownership pass as create_group; see the note there.
+    if "description" in update_data:
+        update_data["description"] = owned_description_urls(
+            update_data["description"], user.id
+        )
 
     # Validate parent_id if being changed
     if "parent_id" in update_data:
@@ -256,7 +275,7 @@ async def get_group_members(
     group = result.scalar_one_or_none()
     if group is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
-    return [decrypt_member_for_read(m) for m in group.members]
+    return [decrypt_member_for_read(m, user.id) for m in group.members]
 
 
 @router.put(
@@ -295,4 +314,4 @@ async def set_group_members(
 
     group.members = members
     await db.commit()
-    return [decrypt_member_for_read(m) for m in members]
+    return [decrypt_member_for_read(m, user.id) for m in members]

--- a/sheaf/api/v1/journals.py
+++ b/sheaf/api/v1/journals.py
@@ -150,7 +150,7 @@ async def list_journals(
     )
     items: list[JournalEntryRead] = []
     for r in page:
-        item = JournalEntryRead.model_validate(decrypt_entry_for_read(r))
+        item = JournalEntryRead.model_validate(decrypt_entry_for_read(r, user.id))
         item.pending_delete_at = pending.get(r.id)
         items.append(item)
     return JournalListResponse(items=items, next_cursor=next_cursor)
@@ -191,7 +191,7 @@ async def create_entry(
         ) from exc
     await db.commit()
     await db.refresh(entry)
-    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
+    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry, user.id))
 
 
 @router.get("/{entry_id}", response_model=JournalEntryReadWithCount)
@@ -208,7 +208,7 @@ async def get_entry(
     pending = await pending_finalize_after_by_target(
         db, system, PendingActionType.JOURNAL_DELETE
     )
-    payload = JournalEntryReadWithCount.model_validate(decrypt_entry_for_read(entry))
+    payload = JournalEntryReadWithCount.model_validate(decrypt_entry_for_read(entry, user.id))
     payload.revision_count = count
     payload.pending_delete_at = pending.get(entry.id)
     return payload
@@ -247,7 +247,7 @@ async def patch_entry(
         ) from exc
     await db.commit()
     await db.refresh(entry)
-    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
+    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry, user.id))
 
 
 @router.delete(
@@ -368,7 +368,7 @@ async def list_revisions(
         )
 
     return [
-        ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
+        ContentRevisionRead.model_validate(decrypt_revision_for_read(r, user.id))
         for r in page
     ]
 
@@ -401,7 +401,7 @@ async def restore_revision(
     )
     await db.commit()
     await db.refresh(entry)
-    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry))
+    return JournalEntryRead.model_validate(decrypt_entry_for_read(entry, user.id))
 
 
 @router.post(
@@ -436,7 +436,7 @@ async def pin_journal_revision(
         ) from exc
     await db.commit()
     await db.refresh(revision)
-    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
+    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision, user.id))
 
 
 @router.post(
@@ -491,5 +491,5 @@ async def unpin_journal_revision(
     await db.commit()
     await db.refresh(revision)
     return UnpinRevisionResponse(
-        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision)),
+        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision, user.id)),
     )

--- a/sheaf/api/v1/members.py
+++ b/sheaf/api/v1/members.py
@@ -147,6 +147,7 @@ async def list_members(
     decoded = [
         decrypt_member_for_read(
             m,
+            user.id,
             has_bio_revisions=m.id in with_revisions,
             pending_delete_at=pending.get(m.id),
         )
@@ -215,7 +216,7 @@ async def create_member(
     db.add(member)
     await db.commit()
     await db.refresh(member)
-    return decrypt_member_for_read(member)
+    return decrypt_member_for_read(member, user.id)
 
 
 # Quick-switch ranker tunables. Window is generous relative to the
@@ -309,6 +310,7 @@ async def top_fronters(
     return [
         decrypt_member_for_read(
             m,
+            user.id,
             has_bio_revisions=m.id in with_revisions,
             pending_delete_at=pending.get(m.id),
         )
@@ -329,6 +331,7 @@ async def get_member(
     )
     return decrypt_member_for_read(
         member,
+        user.id,
         has_bio_revisions=await _member_has_bio_revisions(db, member.id),
         pending_delete_at=pending.get(member.id),
     )
@@ -400,6 +403,7 @@ async def update_member(
     await db.refresh(member)
     return decrypt_member_for_read(
         member,
+        user.id,
         has_bio_revisions=await _member_has_bio_revisions(db, member.id),
     )
 
@@ -483,6 +487,7 @@ async def archive_member(
         await db.refresh(member)
     return decrypt_member_for_read(
         member,
+        user.id,
         has_bio_revisions=await _member_has_bio_revisions(db, member.id),
     )
 
@@ -507,6 +512,7 @@ async def unarchive_member(
         await db.refresh(member)
     return decrypt_member_for_read(
         member,
+        user.id,
         has_bio_revisions=await _member_has_bio_revisions(db, member.id),
     )
 
@@ -652,7 +658,7 @@ async def list_bio_revisions(
         )
 
     return [
-        ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
+        ContentRevisionRead.model_validate(decrypt_revision_for_read(r, user.id))
         for r in page
     ]
 
@@ -687,6 +693,7 @@ async def restore_bio_revision(
     await db.refresh(member)
     return decrypt_member_for_read(
         member,
+        user.id,
         has_bio_revisions=await _member_has_bio_revisions(db, member.id),
     )
 
@@ -723,7 +730,7 @@ async def pin_bio_revision(
         ) from exc
     await db.commit()
     await db.refresh(revision)
-    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
+    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision, user.id))
 
 
 @router.post(
@@ -778,5 +785,5 @@ async def unpin_bio_revision(
     await db.commit()
     await db.refresh(revision)
     return UnpinRevisionResponse(
-        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision)),
+        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision, user.id)),
     )

--- a/sheaf/api/v1/messages.py
+++ b/sheaf/api/v1/messages.py
@@ -723,7 +723,7 @@ async def list_revisions(
         )
 
     return [
-        ContentRevisionRead.model_validate(decrypt_revision_for_read(r))
+        ContentRevisionRead.model_validate(decrypt_revision_for_read(r, user.id))
         for r in page
     ]
 
@@ -789,7 +789,7 @@ async def pin_message_revision(
         ) from exc
     await db.commit()
     await db.refresh(revision)
-    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision))
+    return ContentRevisionRead.model_validate(decrypt_revision_for_read(revision, user.id))
 
 
 @router.post(
@@ -843,7 +843,7 @@ async def unpin_message_revision(
     await db.commit()
     await db.refresh(revision)
     return UnpinRevisionResponse(
-        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision)),
+        revision=ContentRevisionRead.model_validate(decrypt_revision_for_read(revision, user.id)),
     )
 
 

--- a/sheaf/api/v1/relationships.py
+++ b/sheaf/api/v1/relationships.py
@@ -492,7 +492,7 @@ async def relationship_graph(
                 RelationshipGraphNode(
                     id=m.id,
                     name=m.display_name or name_pt,
-                    avatar_url=resolve_avatar_url(m.avatar_url),
+                    avatar_url=resolve_avatar_url(m.avatar_url, user.id),
                     color=m.color,
                 )
             )

--- a/sheaf/api/v1/tags.py
+++ b/sheaf/api/v1/tags.py
@@ -141,7 +141,7 @@ async def get_tag_members(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Tag not found"
         )
-    return [decrypt_member_for_read(m) for m in tag.members]
+    return [decrypt_member_for_read(m, user.id) for m in tag.members]
 
 
 @router.put(
@@ -188,7 +188,7 @@ async def set_tag_members(
 
     tag.members = members
     await db.commit()
-    return [decrypt_member_for_read(m) for m in members]
+    return [decrypt_member_for_read(m, user.id) for m in members]
 
 
 @router.delete(

--- a/sheaf/files.py
+++ b/sheaf/files.py
@@ -194,26 +194,47 @@ def normalize_avatar_url(url: str | None) -> str | None:
     return url
 
 
-def resolve_avatar_url(url: str | None) -> str | None:
+def resolve_avatar_url(url: str | None, owner_id: object) -> str | None:
     """Convert a stored avatar_url (key or external URL) to a displayable URL.
 
     Priority:
     1. None → None
     2. External URL (not ours) → returned as-is
-    3. Internal URL or bare key, S3 + s3_public_url + signed → {cdn}/{key}?token=…
-    4. Internal URL or bare key, S3 + s3_public_url + unsigned → {cdn}/{key}
-    5. Internal URL or bare key, image_serving=signed → /v1/files/{key}?token=…
-    6. Internal URL or bare key, image_serving=unsigned → /v1/files/{key}
+    3. Internal key NOT owned by `owner_id` → unsigned /v1/files/{key}
+    4. Internal URL or bare key, S3 + s3_public_url + signed → {cdn}/{key}?token=…
+    5. Internal URL or bare key, S3 + s3_public_url + unsigned → {cdn}/{key}
+    6. Internal URL or bare key, image_serving=signed → /v1/files/{key}?token=…
+    7. Internal URL or bare key, image_serving=unsigned → /v1/files/{key}
 
     Recognising our own CDN hostname matters for DB rows written before this
     code landed: they store the full CDN URL, and we want them signed on
     read just the same as bare keys.
+
+    `owner_id` is the account the row belongs to, and it is REQUIRED
+    positionally rather than defaulted so a new caller cannot quietly opt out
+    of the check - a missed call site is a TypeError at import/first-call, not
+    a silent hole. Signing is a capability grant: this function is what turns a
+    storage key into a URL that actually serves bytes. `owned_avatar_url` gates
+    the write handlers, but handlers get added, importers get written, and rows
+    already in the database predate every one of those guards, so the signer
+    does not get to assume its input was vetted.
+
+    A key from somebody else's namespace comes back as the bare, UNSIGNED
+    ``/v1/files/{key}`` path rather than None. That is the fail-closed choice:
+    with signing on (the default) the serve endpoint rejects it with 403, so no
+    bytes move; with signing off the instance already serves every key to
+    anyone who asks, so there is no capability to withhold. Returning the path
+    instead of None also leaves the broken reference visible to the person
+    whose profile it is, rather than silently blanking a field they can still
+    see in their own editor.
     """
     if url is None:
         return None
     key = _to_internal_key(url)
     if key is None:
         return url
+    if internal_key_owner(key) != str(owner_id):
+        return f"/v1/files/{key}"
     if settings.storage_backend == "s3" and settings.s3_public_url:
         if settings.image_serving == "signed":
             return sign_cdn_url(key)
@@ -223,7 +244,7 @@ def resolve_avatar_url(url: str | None) -> str | None:
     return f"/v1/files/{key}"
 
 
-def resolve_description_urls(text: str | None) -> str | None:
+def resolve_description_urls(text: str | None, owner_id: object) -> str | None:
     """Sign image URLs in markdown descriptions for display.
 
     Handles all three forms an internal reference can take:
@@ -232,6 +253,13 @@ def resolve_description_urls(text: str | None) -> str | None:
       3. bare key (unusual, but _to_internal_key accepts it)
 
     Anything _to_internal_key doesn't recognise is left untouched.
+
+    `owner_id` is the account this text belongs to, REQUIRED for the same
+    reason `resolve_avatar_url` requires it: an embed naming a key outside that
+    account's namespace is re-pointed at the canonical but UNSIGNED
+    ``/v1/files/{key}`` instead of being signed, so it 403s at serve time when
+    signing is on and nothing is granted that the instance was not already
+    giving away. See `resolve_avatar_url` for the full reasoning.
     """
     if text is None:
         return None
@@ -240,7 +268,7 @@ def resolve_description_urls(text: str | None) -> str | None:
         key = _to_internal_key(image.url)
         if key is None:
             return None
-        resolved = resolve_avatar_url(key)
+        resolved = resolve_avatar_url(key, owner_id)
         return render_markdown_image(image, resolved or "/v1/files/" + key)
 
     return rewrite_markdown_images(text, _replace)

--- a/sheaf/schemas/group.py
+++ b/sheaf/schemas/group.py
@@ -3,12 +3,27 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
+from sheaf.files import normalize_description_urls
+
 
 class GroupCreate(BaseModel):
     name: str = Field(max_length=100)
     description: str | None = None
     color: str | None = Field(default=None, max_length=7)
     parent_id: uuid.UUID | None = None
+
+    # Group descriptions are markdown that renders image embeds, exactly like a
+    # system description or a member bio, so they get the same normalisation
+    # those have always had: our own refs canonicalised to /v1/files/{key} with
+    # signed query params stripped, external refs validated (HTTPS, no internal
+    # IPs) and dropped when the instance policy says so. This was missing here
+    # while every sibling schema had it, which left group descriptions as the
+    # one markdown field where an http:// or internal-IP image survived to the
+    # renderer.
+    @field_validator("description", mode="before")
+    @classmethod
+    def _normalize_description(cls, v: str | None) -> str | None:
+        return normalize_description_urls(v)
 
 
 class GroupUpdate(BaseModel):
@@ -23,6 +38,12 @@ class GroupUpdate(BaseModel):
         if v is None:
             raise ValueError("cannot be null")
         return v
+
+    # Same normalisation as GroupCreate; see the note there.
+    @field_validator("description", mode="before")
+    @classmethod
+    def _normalize_description(cls, v: str | None) -> str | None:
+        return normalize_description_urls(v)
 
 
 class GroupRead(BaseModel):

--- a/sheaf/schemas/journal.py
+++ b/sheaf/schemas/journal.py
@@ -74,12 +74,18 @@ class JournalEntryRead(BaseModel):
     updated_at: datetime
     # finalize_after timestamp if queued for delete; null otherwise.
     pending_delete_at: datetime | None = None
+    # The account whose uploads this body may reference. Excluded from the
+    # response; see MemberRead.owner_user_id for why it is required. NOT
+    # `author_user_id`: that is whoever typed the entry (and is nullable on
+    # imported rows), while this is the account the storage keys have to
+    # belong to.
+    owner_user_id: uuid.UUID = Field(exclude=True)
 
     model_config = {"from_attributes": True}
 
     @field_serializer("body")
     def _sign_body_urls(self, v: str) -> str:
-        return resolve_description_urls(v) or v
+        return resolve_description_urls(v, self.owner_user_id) or v
 
 
 class JournalEntryReadWithCount(JournalEntryRead):
@@ -103,12 +109,17 @@ class ContentRevisionRead(BaseModel):
     body: str
     created_at: datetime
     pinned_at: datetime | None = None
+    # The account whose uploads this revision body may reference. Excluded
+    # from the response; see MemberRead.owner_user_id. NOT the `user_id`
+    # above, which is the editor who made the revision and is null on
+    # imported history.
+    owner_user_id: uuid.UUID = Field(exclude=True)
 
     model_config = {"from_attributes": True}
 
     @field_serializer("body")
     def _sign_body_urls(self, v: str) -> str:
-        return resolve_description_urls(v) or v
+        return resolve_description_urls(v, self.owner_user_id) or v
 
 
 class RestoreRevisionRequest(BaseModel):

--- a/sheaf/schemas/member.py
+++ b/sheaf/schemas/member.py
@@ -129,13 +129,19 @@ class MemberRead(BaseModel):
     # Set when the member is archived (soft-hidden from lists / switcher /
     # pickers; still shown in history). Null = active.
     archived_at: datetime | None = None
+    # The account that owns this row's uploads. Required, and excluded from
+    # the response: it exists purely so the serialisers below can tell "this
+    # profile's own file" from "somebody else's key sitting in this column".
+    # Required rather than defaulted so a construction site that forgets it
+    # fails loudly instead of silently signing whatever it was handed.
+    owner_user_id: uuid.UUID = Field(exclude=True)
 
     model_config = {"from_attributes": True}
 
     @field_serializer("avatar_url", "banner_url")
     def _sign_avatar_url(self, v: str | None) -> str | None:
-        return resolve_avatar_url(v)
+        return resolve_avatar_url(v, self.owner_user_id)
 
     @field_serializer("description")
     def _sign_description_urls(self, v: str | None) -> str | None:
-        return resolve_description_urls(v)
+        return resolve_description_urls(v, self.owner_user_id)

--- a/sheaf/schemas/system.py
+++ b/sheaf/schemas/system.py
@@ -110,16 +110,20 @@ class SystemRead(BaseModel):
     show_member_created_date: bool
     created_at: datetime
     updated_at: datetime
+    # The account that owns this system's uploads. Excluded from the response;
+    # see MemberRead.owner_user_id for why it is required. Populated straight
+    # from System.user_id, so `from_attributes` fills it in.
+    user_id: uuid.UUID = Field(exclude=True)
 
     model_config = {"from_attributes": True}
 
     @field_serializer("avatar_url")
     def _sign_avatar_url(self, v: str | None) -> str | None:
-        return resolve_avatar_url(v)
+        return resolve_avatar_url(v, self.user_id)
 
     @field_serializer("description")
     def _sign_description_urls(self, v: str | None) -> str | None:
-        return resolve_description_urls(v)
+        return resolve_description_urls(v, self.user_id)
 
 
 class DeleteConfirmationUpdate(BaseModel):

--- a/sheaf/services/ampersand_import.py
+++ b/sheaf/services/ampersand_import.py
@@ -84,6 +84,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_image_strip import strip_internal_image_refs_md_to_none
 from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_media import (
     ImportImageError,
@@ -308,7 +309,18 @@ async def run_import(
             sys_ref = _coerce_str(amp_m.get("system"))
             if sys_ref:
                 amp_id_to_system[amp_id] = sys_ref
-        plaintext_desc = _coerce_str(amp_m.get("description"))
+        # Bio markdown from a foreign export runs through the internal-image
+        # strip on the way in. Any embed pointing at this instance's storage
+        # (/v1/files/..., the CDN host, or a bare key) is re-signed into a live
+        # capability URL every time the profile is read, so a doctored
+        # Ampersand file could name another account's upload key and turn this
+        # importer into a cross-tenant read of that file, one that outlives the
+        # owner deleting or un-sharing it. An Ampersand export has no
+        # legitimate internal Sheaf ref to preserve, so all of them go;
+        # external images and the surrounding text are left alone.
+        plaintext_desc = strip_internal_image_refs_md_to_none(
+            _coerce_str(amp_m.get("description"))
+        )
         member_id = uuid.uuid4()
         member = Member(
             id=member_id,
@@ -487,7 +499,10 @@ async def _import_systems_as_groups(
             id=uuid.uuid4(),
             system_id=system.id,
             name=name,
-            description=_coerce_str(amp_s.get("description")),
+            # Same reason as the member description above.
+            description=strip_internal_image_refs_md_to_none(
+                _coerce_str(amp_s.get("description"))
+            ),
             color=_normalize_color(amp_s.get("color")),
         )
         db.add(group)
@@ -848,7 +863,15 @@ async def _import_journals(
             if subtitle:
                 body_parts.append(f"*{subtitle}*")
             body_parts.append(_coerce_str(amp_j.get("body")) or "")
-            body = "\n\n".join(p for p in body_parts if p)
+            # Same cross-tenant capability risk as the descriptions above:
+            # a journal body is re-signed on read (`schemas/journal.py` runs
+            # `resolve_description_urls` over it), so an internal Sheaf storage
+            # key smuggled in through a crafted export would come back as a
+            # live serve URL for somebody else's upload. A journal written in
+            # another app has no legitimate Sheaf ref to preserve.
+            body = strip_internal_image_refs_md_to_none(
+                "\n\n".join(p for p in body_parts if p)
+            ) or ""
 
             image_keys: list[str] = []
             if images_enabled:
@@ -892,7 +915,10 @@ async def _import_journals(
     if options.notes:
         for amp_n in _coll(data, "notes"):
             title = _coerce_str(amp_n.get("title"))
-            content = _coerce_str(amp_n.get("content")) or ""
+            # Same reason as above.
+            content = strip_internal_image_refs_md_to_none(
+                _coerce_str(amp_n.get("content"))
+            ) or ""
             entry_id = uuid.uuid4()
             entry = JournalEntry(
                 id=entry_id,

--- a/sheaf/services/import_parsing.py
+++ b/sheaf/services/import_parsing.py
@@ -24,6 +24,8 @@ from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
+from sheaf.services.import_image_strip import is_internal_image_ref
+
 # Per-payload element cap. PK / TB / SP / Sheaf exports of plausible
 # real systems are in the low tens of thousands of elements at most;
 # 5M leaves headroom for an order-of-magnitude growth without making
@@ -50,6 +52,17 @@ def sanitize_external_avatar_url(url: Any) -> str | None:
     forbids hotlinking (ALLOW_EXTERNAL_IMAGES=false), the same policy
     the regular profile-write path enforces via normalize_avatar_url.
 
+    "External" is enforced, not assumed. The scheme check alone does not
+    get there: when the instance runs with a CDN hostname configured
+    (`S3_PUBLIC_URL`), `https://{cdn}/avatars/{someone_else}/{uuid}.png`
+    is a perfectly well-formed https URL that happens to name OUR storage.
+    Stored as-is it would be re-signed into a live serve URL on every read
+    of the importing user's profile - a cross-tenant read of another
+    account's upload, and one that outlives the owner deleting it. A
+    third-party export has no legitimate reason to reference this
+    instance's storage in any of its three forms (serve path, CDN host,
+    bare key), so all three are dropped.
+
     Every importer routes source avatar URLs through here so the rules
     can't drift between formats.
     """
@@ -58,6 +71,8 @@ def sanitize_external_avatar_url(url: Any) -> str | None:
     if not url or not isinstance(url, str):
         return None
     if not url.startswith(("http://", "https://")):
+        return None
+    if is_internal_image_ref(url):
         return None
     if not settings.allow_external_images:
         return None

--- a/sheaf/services/journals.py
+++ b/sheaf/services/journals.py
@@ -377,10 +377,19 @@ def revision_plaintext(revision: ContentRevision) -> tuple[str | None, str]:
     return title, body
 
 
-def decrypt_revision_for_read(revision: ContentRevision) -> dict:
-    """Build a dict suitable for ContentRevisionRead.model_validate(...)."""
+def decrypt_revision_for_read(
+    revision: ContentRevision, owner_user_id: uuid.UUID
+) -> dict:
+    """Build a dict suitable for ContentRevisionRead.model_validate(...).
+
+    `owner_user_id` is the account that owns the revision's target, and it is
+    positional-required because ContentRevisionRead only signs image refs whose
+    storage keys sit in that account's namespace. `revision.user_id` is NOT a
+    substitute: it names the editor, and it is null on imported history.
+    """
     title, body = revision_plaintext(revision)
     return {
+        "owner_user_id": owner_user_id,
         "id": revision.id,
         "target_type": revision.target_type,
         "target_id": revision.target_id,
@@ -408,10 +417,19 @@ def entry_plaintext(entry: JournalEntry) -> tuple[str | None, str]:
     return title, body
 
 
-def decrypt_entry_for_read(entry: JournalEntry) -> dict:
-    """Build a dict suitable for JournalEntryRead.model_validate(...)."""
+def decrypt_entry_for_read(
+    entry: JournalEntry, owner_user_id: uuid.UUID
+) -> dict:
+    """Build a dict suitable for JournalEntryRead.model_validate(...).
+
+    `owner_user_id` is positional-required for the same reason it is on
+    `decrypt_revision_for_read`: the body's image refs are only signed when
+    their keys belong to that account, and `entry.author_user_id` is the
+    person who wrote it (null on imported entries), not the owner.
+    """
     title, body = entry_plaintext(entry)
     return {
+        "owner_user_id": owner_user_id,
         "id": entry.id,
         "system_id": entry.system_id,
         "member_id": entry.member_id,

--- a/sheaf/services/members.py
+++ b/sheaf/services/members.py
@@ -12,6 +12,7 @@ decrypt the whole table.
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 
 from sheaf.crypto import blind_index, decrypt, encrypt
@@ -70,11 +71,19 @@ def set_member_note(member: Member, plaintext: str | None) -> None:
 
 def decrypt_member_for_read(
     member: Member,
+    owner_user_id: uuid.UUID,
     *,
     has_bio_revisions: bool = False,
     pending_delete_at: datetime | None = None,
 ) -> MemberRead:
     """Build a MemberRead with name + description decrypted to plaintext.
+
+    `owner_user_id` is the account that owns this member's system, and it is
+    positional-required: MemberRead signs avatar / banner / bio image refs on
+    serialisation, and it will only sign keys that live in this account's
+    namespace. Members are reached from several routers (members, groups,
+    tags), so the id has to be threaded from the request rather than guessed
+    here - Member itself only knows its system_id.
 
     `has_bio_revisions` is opt-in: callers that need an accurate value
     (the /v1/members endpoints, since the bio history button reads it)
@@ -111,6 +120,7 @@ def decrypt_member_for_read(
         "has_bio_revisions": has_bio_revisions,
         "pending_delete_at": pending_delete_at,
         "archived_at": member.archived_at,
+        "owner_user_id": owner_user_id,
     })
 
 

--- a/sheaf/services/pk_import.py
+++ b/sheaf/services/pk_import.py
@@ -54,6 +54,7 @@ from sheaf.services.import_content_dedup import (
     normalize_front_interval,
 )
 from sheaf.services.import_dedup import ImportConflictStrategy
+from sheaf.services.import_image_strip import strip_internal_image_refs_md_to_none
 from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_parsing import sanitize_external_avatar_url
 
@@ -211,7 +212,18 @@ def build_member(
     if not plaintext_name:
         return None
     plaintext_name = clamp_str(plaintext_name, il.M_NAME, report=report)
-    plaintext_description = _clean_str(pk_m.get("description"))
+    # Description markdown arrives from another app, so strip any embed that
+    # points at this instance's storage. Those refs are re-signed into live
+    # capability URLs when the profile is read back (resolve_description_urls),
+    # so a hand-edited export carrying an embed under another user's avatar
+    # prefix would become a cross-tenant read of their uploads, and one
+    # that keeps working after the owner un-shares or deletes the file. A
+    # PluralKit export has no legitimate reason to reference Sheaf storage at
+    # all, so every internal ref goes; external images and the surrounding
+    # prose are left exactly as they were.
+    plaintext_description = strip_internal_image_refs_md_to_none(
+        _clean_str(pk_m.get("description"))
+    )
 
     pk_hid = _clean_str(pk_m.get("id"))
 
@@ -284,7 +296,10 @@ async def import_groups(
             id=uuid.uuid4(),
             system_id=system_id,
             name=name,
-            description=_clean_str(pk_g.get("description")),
+            # Same reason as the member description above.
+            description=strip_internal_image_refs_md_to_none(
+                _clean_str(pk_g.get("description"))
+            ),
             color=_normalize_color(pk_g.get("color")),
         )
         db.add(group)

--- a/sheaf/services/pluralspace_import.py
+++ b/sheaf/services/pluralspace_import.py
@@ -127,6 +127,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_image_strip import strip_internal_image_refs_md_to_none
 from sheaf.services.import_limits import ClampReport, clamp_list, clamp_str
 from sheaf.services.import_media import (
     ImportImageError,
@@ -538,7 +539,18 @@ async def run_import(
         # member `description` (the bio, encrypted Text) is intentionally
         # uncapped, matching the create API; only `note` carries M_NOTE and
         # PluralSpace exports have no note-equivalent field to map.
-        plaintext_description = _clean_str(m_data.get("description"))
+        #
+        # It is also markdown authored in another app, so it goes through the
+        # internal-image strip first. An embed pointing at this instance's
+        # storage (/v1/files/..., the CDN host, or a bare key) is re-signed
+        # into a live capability URL on every read, so a crafted export could
+        # name another account's upload key and read that file through the
+        # importing user's own profile, indefinitely and past a delete. A
+        # PluralSpace export has no legitimate internal Sheaf ref to keep, so
+        # all of them are dropped; external images and prose are untouched.
+        plaintext_description = strip_internal_image_refs_md_to_none(
+            _clean_str(m_data.get("description"))
+        )
         member_id = uuid.uuid4()
         member = Member(
             id=member_id,
@@ -791,7 +803,10 @@ def _apply_system_profile(data: dict, system: System, report: ClampReport) -> No
     name = _clean_str(sys_data.get("name"))
     if name and not system.name:
         system.name = clamp_str(name, il.SYS_NAME, report=report)
-    description = _clean_str(sys_data.get("description"))
+    # Same reason as the member description above.
+    description = strip_internal_image_refs_md_to_none(
+        _clean_str(sys_data.get("description"))
+    )
     if description and not system.description:
         # System description (the long bio) is intentionally uncapped, like the
         # create API; only `note` carries the SYS_NOTE business cap and
@@ -907,7 +922,10 @@ async def _import_groups(
                 id=uuid.uuid4(),
                 system_id=system_id,
                 name=clamp_str(name, il.GROUP_NAME, report=report),
-                description=_clean_str(g_data.get("description")),
+                # Same reason as the member description above.
+                description=strip_internal_image_refs_md_to_none(
+                    _clean_str(g_data.get("description"))
+                ),
                 color=_normalize_color(g_data.get("color")),
             )
             db.add(group)
@@ -1222,7 +1240,15 @@ async def _import_journals(
         if not isinstance(j_data, dict):
             continue
         title = _clean_str(j_data.get("title"))
-        body = _clean_str(j_data.get("content")) or ""
+        # Same cross-tenant capability risk as the descriptions above:
+        # a journal body is re-signed on read (`schemas/journal.py` runs
+        # `resolve_description_urls` over it), so an internal Sheaf storage
+        # key smuggled in through a crafted export would come back as a
+        # live serve URL for somebody else's upload. A journal written in
+        # another app has no legitimate Sheaf ref to preserve.
+        body = strip_internal_image_refs_md_to_none(
+            _clean_str(j_data.get("content"))
+        ) or ""
         # PluralSpace inlines `{id, name}` for each referenced member;
         # the name is plaintext, so we can use it directly for author
         # attribution without decrypting the Sheaf row.

--- a/sheaf/services/prism_import.py
+++ b/sheaf/services/prism_import.py
@@ -132,6 +132,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_image_strip import strip_internal_image_refs_md_to_none
 from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_media import (
     ImportImageError,
@@ -421,7 +422,18 @@ async def run_import(
         plaintext_name = clamp_str(
             _clean_str(m.get("name")) or "unnamed", il.M_NAME, report=report
         )
-        plaintext_description = _clean_str(m.get("notes"))
+        # Notes become the member bio, and they are markdown written in
+        # another app, so strip internal image embeds before storing. A ref to
+        # this instance's storage (/v1/files/..., the CDN host, or a bare key)
+        # is re-signed into a live capability URL each time the profile is
+        # read, so a doctored export could carry another account's upload key
+        # and serve that file from the importing user's profile, still working
+        # after the owner un-shares or deletes it. A Prism export has no
+        # legitimate reason to reference Sheaf storage, so every internal ref
+        # goes; external images and the surrounding prose are left as they are.
+        plaintext_description = strip_internal_image_refs_md_to_none(
+            _clean_str(m.get("notes"))
+        )
         custom_color = _normalize_color(m.get("customColorHex")) if m.get(
             "customColorEnabled"
         ) else None
@@ -715,7 +727,10 @@ def _apply_system_profile(
     name = _clean_str(block.get("systemName"))
     if name and not system.name:
         system.name = clamp_str(name, il.SYS_NAME, report=report)
-    description = _clean_str(block.get("systemDescription"))
+    # Same reason as the member notes above.
+    description = strip_internal_image_refs_md_to_none(
+        _clean_str(block.get("systemDescription"))
+    )
     if description and not system.description:
         system.description = description
     color = _normalize_color(block.get("systemColor")) or _normalize_color(
@@ -756,7 +771,10 @@ async def _import_groups(
                 id=uuid.uuid4(),
                 system_id=system_id,
                 name=clamp_str(name, il.GROUP_NAME, report=report),
-                description=_clean_str(g.get("description")),
+                # Same reason as the member notes above.
+                description=strip_internal_image_refs_md_to_none(
+                    _clean_str(g.get("description"))
+                ),
                 color=_normalize_color(g.get("colorHex")),
             )
             db.add(group)
@@ -1004,7 +1022,13 @@ async def _import_notes(
         if not isinstance(n, dict):
             continue
         title = _clean_str(n.get("title"))
-        body = _clean_str(n.get("body")) or ""
+        # Same cross-tenant capability risk as the descriptions above:
+        # a journal body is re-signed on read (`schemas/journal.py` runs
+        # `resolve_description_urls` over it), so an internal Sheaf storage
+        # key smuggled in through a crafted export would come back as a
+        # live serve URL for somebody else's upload. A journal written in
+        # another app has no legitimate Sheaf ref to preserve.
+        body = strip_internal_image_refs_md_to_none(_clean_str(n.get("body"))) or ""
         member_id_str = _clean_str(n.get("memberId"))
         handle = ps_id_to_handle.get(member_id_str) if member_id_str else None
         author_names: list[str] = []

--- a/sheaf/services/sp_import.py
+++ b/sheaf/services/sp_import.py
@@ -63,6 +63,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_image_strip import strip_internal_image_refs_md_to_none
 from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_parsing import sanitize_external_avatar_url
 from sheaf.services.member_limits import enforce_import_member_cap
@@ -413,8 +414,18 @@ async def run_import(
         )
         if sp_name and not system.name:
             system.name = clamp_str(sp_name, il.SYS_NAME, report=report)
-        sp_desc = _coerce_str(sp_user.get("desc")) or _coerce_str(
-            sp_settings.get("desc")
+        # Every description in a SimplyPlural export is markdown written in
+        # another app, so it goes through the internal-image strip before it
+        # is stored. Refs to this instance's storage (/v1/files/..., the CDN
+        # host, or a bare key) are re-signed into live capability URLs when
+        # the profile is read back, so a crafted export could embed another
+        # account's upload key and read that file through the importer's own
+        # profile, long after the owner deleted or un-shared it. Nothing in a
+        # SimplyPlural file can legitimately point at Sheaf storage, so all
+        # internal refs are dropped and external images plus the surrounding
+        # prose survive unchanged.
+        sp_desc = strip_internal_image_refs_md_to_none(
+            _coerce_str(sp_user.get("desc")) or _coerce_str(sp_settings.get("desc"))
         )
         if sp_desc:
             system.description = sp_desc
@@ -444,7 +455,10 @@ async def run_import(
         )
         if sp_id:
             sp_id_to_name[sp_id] = plaintext_name
-        plaintext_description = _coerce_str(sp_m.get("desc"))
+        # Same reason as the system description above.
+        plaintext_description = strip_internal_image_refs_md_to_none(
+            _coerce_str(sp_m.get("desc"))
+        )
         member_id = uuid.uuid4()
         member = Member(
             id=member_id,
@@ -486,7 +500,10 @@ async def run_import(
             )
             if sp_id:
                 sp_id_to_name[sp_id] = plaintext_cf_name
-            plaintext_cf_description = _coerce_str(sp_cf.get("desc"))
+            # Same reason as the system description above.
+            plaintext_cf_description = strip_internal_image_refs_md_to_none(
+                _coerce_str(sp_cf.get("desc"))
+            )
             member_id = uuid.uuid4()
             member = Member(
                 id=member_id,
@@ -685,7 +702,12 @@ async def run_import(
                 id=uuid.uuid4(),
                 system_id=system.id,
                 name=name,
-                description=sp_g.get("desc"),
+                # Same reason as the system description above. The _coerce_str
+                # matches `name` just above it: without it a non-string `desc`
+                # (a dict, a number, a list) would reach a Text column as-is.
+                description=strip_internal_image_refs_md_to_none(
+                    _coerce_str(sp_g.get("desc"))
+                ),
                 color=_normalize_color(sp_g.get("color")),
             )
             db.add(group)

--- a/sheaf/services/tb_import.py
+++ b/sheaf/services/tb_import.py
@@ -58,6 +58,7 @@ from sheaf.services.import_dedup import (
     load_member_match_index,
     resolve_member,
 )
+from sheaf.services.import_image_strip import strip_internal_image_refs_md_to_none
 from sheaf.services.import_limits import ClampReport, clamp_str
 from sheaf.services.import_parsing import sanitize_external_avatar_url
 from sheaf.services.member_limits import enforce_import_member_cap
@@ -244,7 +245,17 @@ def _build_member(
     if not plaintext_name:
         return None
     plaintext_name = clamp_str(plaintext_name, il.M_NAME, report=report)
-    plaintext_description = _clean_str(tupper.get("description"))
+    # Description markdown from a foreign export gets the internal-image strip
+    # before it is stored. Refs to this instance's storage (/v1/files/..., the
+    # CDN host, or a bare key) are re-signed into live capability URLs on read,
+    # so an attacker-authored Tupperbox file could embed another account's
+    # upload key and read that file through their own profile, indefinitely.
+    # Nothing in a Tupperbox export can legitimately point at Sheaf storage,
+    # so all internal refs are dropped; external images and the prose around
+    # them are untouched.
+    plaintext_description = strip_internal_image_refs_md_to_none(
+        _clean_str(tupper.get("description"))
+    )
 
     member_id = uuid.uuid4()
     return Member(
@@ -321,7 +332,10 @@ async def _import_groups(
             id=uuid.uuid4(),
             system_id=system_id,
             name=name,
-            description=_clean_str(tb_g.get("description")),
+            # Same reason as the member description above.
+            description=strip_internal_image_refs_md_to_none(
+                _clean_str(tb_g.get("description"))
+            ),
         )
         db.add(group)
         group_index.register(name, group)

--- a/tests/test_file_signing.py
+++ b/tests/test_file_signing.py
@@ -19,6 +19,11 @@ from sheaf.files import (
 )
 from sheaf.markdown_images import iter_markdown_images
 
+# Two account ids. Storage keys are `{prefix}/{user_id}/{uuid}.{ext}`, so the
+# second segment is what every ownership check keys off.
+_OWNER = "11111111-1111-1111-1111-111111111111"
+_OTHER = "22222222-2222-2222-2222-222222222222"
+
 
 @pytest.fixture(autouse=True)
 def reset_settings(monkeypatch):
@@ -81,8 +86,10 @@ def test_resolve_avatar_url_s3_cdn_signed_routes_through_cdn(monkeypatch):
     monkeypatch.setattr(settings, "s3_public_url", "https://images.example.com")
     monkeypatch.setattr(settings, "image_serving", "signed")
 
-    resolved = resolve_avatar_url("avatars/user/abc.png")
-    assert resolved.startswith("https://images.example.com/avatars/user/abc.png?token=")
+    resolved = resolve_avatar_url(f"avatars/{_OWNER}/abc.png", _OWNER)
+    assert resolved.startswith(
+        f"https://images.example.com/avatars/{_OWNER}/abc.png?token="
+    )
     assert "expires=" in resolved
 
 
@@ -92,8 +99,8 @@ def test_resolve_avatar_url_s3_cdn_unsigned_is_bare(monkeypatch):
     monkeypatch.setattr(settings, "image_serving", "unsigned")
 
     assert (
-        resolve_avatar_url("avatars/user/abc.png")
-        == "https://images.example.com/avatars/user/abc.png"
+        resolve_avatar_url(f"avatars/{_OWNER}/abc.png", _OWNER)
+        == f"https://images.example.com/avatars/{_OWNER}/abc.png"
     )
 
 
@@ -101,10 +108,10 @@ def test_resolve_avatar_url_filesystem_signed_uses_app_serve(monkeypatch):
     monkeypatch.setattr(settings, "storage_backend", "filesystem")
     monkeypatch.setattr(settings, "image_serving", "signed")
 
-    resolved = resolve_avatar_url("avatars/user/abc.png")
-    assert resolved.startswith("/v1/files/avatars/user/abc.png?token=")
+    resolved = resolve_avatar_url(f"avatars/{_OWNER}/abc.png", _OWNER)
+    assert resolved.startswith(f"/v1/files/avatars/{_OWNER}/abc.png?token=")
     # And matches what sign_file_url would produce
-    assert resolved == sign_file_url("avatars/user/abc.png")
+    assert resolved == sign_file_url(f"avatars/{_OWNER}/abc.png")
 
 
 def test_resolve_avatar_url_s3_without_public_url_falls_back_to_app_serve(monkeypatch):
@@ -113,16 +120,18 @@ def test_resolve_avatar_url_s3_without_public_url_falls_back_to_app_serve(monkey
     monkeypatch.setattr(settings, "s3_public_url", "")
     monkeypatch.setattr(settings, "image_serving", "signed")
 
-    resolved = resolve_avatar_url("avatars/user/abc.png")
-    assert resolved.startswith("/v1/files/avatars/user/abc.png?token=")
+    resolved = resolve_avatar_url(f"avatars/{_OWNER}/abc.png", _OWNER)
+    assert resolved.startswith(f"/v1/files/avatars/{_OWNER}/abc.png?token=")
 
 
 def test_resolve_avatar_url_external_url_passthrough():
-    assert resolve_avatar_url("https://gravatar.com/x.png") == "https://gravatar.com/x.png"
+    assert resolve_avatar_url("https://gravatar.com/x.png", _OWNER) == (
+        "https://gravatar.com/x.png"
+    )
 
 
 def test_resolve_avatar_url_none():
-    assert resolve_avatar_url(None) is None
+    assert resolve_avatar_url(None, _OWNER) is None
 
 
 def test_resolve_avatar_url_legacy_full_cdn_url_gets_signed(monkeypatch):
@@ -132,9 +141,11 @@ def test_resolve_avatar_url_legacy_full_cdn_url_gets_signed(monkeypatch):
     monkeypatch.setattr(settings, "s3_public_url", "https://images.example.com")
     monkeypatch.setattr(settings, "image_serving", "signed")
 
-    stored = "https://images.example.com/avatars/user/abc.png"
-    resolved = resolve_avatar_url(stored)
-    assert resolved.startswith("https://images.example.com/avatars/user/abc.png?token=")
+    stored = f"https://images.example.com/avatars/{_OWNER}/abc.png"
+    resolved = resolve_avatar_url(stored, _OWNER)
+    assert resolved.startswith(
+        f"https://images.example.com/avatars/{_OWNER}/abc.png?token="
+    )
     assert "expires=" in resolved
 
 
@@ -145,13 +156,18 @@ def test_resolve_avatar_url_stored_signed_cdn_url_resigns(monkeypatch):
     monkeypatch.setattr(settings, "s3_public_url", "https://images.example.com")
     monkeypatch.setattr(settings, "image_serving", "signed")
 
-    stored = "https://images.example.com/avatars/user/abc.png?token=deadbeef&expires=1"
-    resolved = resolve_avatar_url(stored)
+    stored = (
+        f"https://images.example.com/avatars/{_OWNER}/abc.png"
+        "?token=deadbeef&expires=1"
+    )
+    resolved = resolve_avatar_url(stored, _OWNER)
     assert "token=deadbeef" not in resolved
     assert "expires=1&" not in resolved and not resolved.endswith("expires=1")
     # And is in fact a valid signed URL
     q = parse_qs(urlparse(resolved).query)
-    assert verify_file_token("avatars/user/abc.png", q["token"][0], q["expires"][0])
+    assert verify_file_token(
+        f"avatars/{_OWNER}/abc.png", q["token"][0], q["expires"][0]
+    )
 
 
 def test_normalize_avatar_url_strips_cdn_url_to_key(monkeypatch):
@@ -288,8 +304,10 @@ def test_normalize_description_urls_cdn_preserved_even_when_external_disabled(mo
 
 
 def test_resolve_description_urls_signs_hosted(monkeypatch):
-    result = resolve_description_urls("![pic](/v1/files/members/m/a.png)")
-    assert "/v1/files/members/m/a.png" in result
+    result = resolve_description_urls(
+        f"![pic](/v1/files/bios/{_OWNER}/a.png)", _OWNER
+    )
+    assert f"/v1/files/bios/{_OWNER}/a.png" in result
     assert "token=" in result
     assert "expires=" in result
 
@@ -300,34 +318,37 @@ def test_resolve_description_urls_resigns_legacy_cdn_row(monkeypatch):
     monkeypatch.setattr(settings, "storage_backend", "s3")
     monkeypatch.setattr(settings, "s3_public_url", "https://cdn.example.com")
     result = resolve_description_urls(
-        "![pic](https://cdn.example.com/members/m/a.png?token=STALE&expires=1)"
+        f"![pic](https://cdn.example.com/bios/{_OWNER}/a.png?token=STALE&expires=1)",
+        _OWNER,
     )
     assert "STALE" not in result
-    assert "cdn.example.com/members/m/a.png" in result
+    assert f"cdn.example.com/bios/{_OWNER}/a.png" in result
     assert "token=" in result
 
 
 def test_resolve_description_urls_leaves_external_untouched(monkeypatch):
-    result = resolve_description_urls("![avatar](https://gravatar.com/x.png)")
+    result = resolve_description_urls(
+        "![avatar](https://gravatar.com/x.png)", _OWNER
+    )
     assert result == "![avatar](https://gravatar.com/x.png)"
 
 
 def test_resolve_description_urls_leaves_data_uri_alone():
     """A data: URI carries its own bytes; it is not a bare storage key."""
     text = "![dot](data:image/png;base64,iVBORw0KGgo=)"
-    assert resolve_description_urls(text) == text
+    assert resolve_description_urls(text, _OWNER) == text
 
 
 @pytest.mark.parametrize(
     ("text", "expected_alt"),
     [
-        ("![foo [bar]](/v1/files/bios/u/nested.png)", "foo [bar]"),
-        (r"![foo \] bar](/v1/files/bios/u/escaped.png)", r"foo \] bar"),
+        (f"![foo [bar]](/v1/files/bios/{_OWNER}/nested.png)", "foo [bar]"),
+        (rf"![foo \] bar](/v1/files/bios/{_OWNER}/escaped.png)", r"foo \] bar"),
     ],
 )
 def test_resolve_description_urls_uses_commonmark_image_grammar(text, expected_alt):
     """Alt text with nested or escaped brackets survives the rewrite."""
-    result = resolve_description_urls(text)
+    result = resolve_description_urls(text, _OWNER)
 
     rewritten = list(iter_markdown_images(result))
     assert len(rewritten) == 1
@@ -337,30 +358,27 @@ def test_resolve_description_urls_uses_commonmark_image_grammar(text, expected_a
 
 def test_resolve_description_urls_signs_hosted_reference_image():
     """Reference syntax resolves to the same signed URL as the inline form."""
-    text = "![portrait][photo]\n\n[photo]: /v1/files/bios/u/photo.png"
+    text = f"![portrait][photo]\n\n[photo]: /v1/files/bios/{_OWNER}/photo.png"
 
-    result = resolve_description_urls(text)
+    result = resolve_description_urls(text, _OWNER)
 
-    assert "![portrait](/v1/files/bios/u/photo.png?token=" in result
+    assert f"![portrait](/v1/files/bios/{_OWNER}/photo.png?token=" in result
 
 
 def test_resolve_description_urls_leaves_code_examples_alone():
     """Code spans and code blocks are prose, not image fetches."""
     text = (
-        "Inline `![example](/v1/files/bios/u/a.png)`\n\n"
-        "```markdown\n![example](/v1/files/bios/u/b.png)\n```\n\n"
-        "    ![example](/v1/files/bios/u/c.png)\n"
+        f"Inline `![example](/v1/files/bios/{_OWNER}/a.png)`\n\n"
+        f"```markdown\n![example](/v1/files/bios/{_OWNER}/b.png)\n```\n\n"
+        f"    ![example](/v1/files/bios/{_OWNER}/c.png)\n"
     )
 
-    assert resolve_description_urls(text) == text
+    assert resolve_description_urls(text, _OWNER) == text
 
 
 # ---------------------------------------------------------------------------
 # Ownership binding: a caller can't persist another account's storage key
 # (which would be re-signed into a live serve URL on read).
-
-_OWNER = "11111111-1111-1111-1111-111111111111"
-_OTHER = "22222222-2222-2222-2222-222222222222"
 
 
 def test_internal_key_owner_extracts_user_segment():
@@ -430,6 +448,79 @@ def test_owned_description_urls_mixed_keeps_own_drops_foreign():
     result = owned_description_urls(text, _OWNER)
     assert f"avatars/{_OWNER}/m.png" in result
     assert _OTHER not in result
+
+
+# ---------------------------------------------------------------------------
+# The signer is the backstop: it refuses to mint a capability for a key that
+# is not the profile's, whatever wrote the row. Catches legacy rows and any
+# writer that ever slips past the handler-side ownership filters.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_avatar_url_does_not_sign_foreign_key():
+    stored = f"avatars/{_OTHER}/abc.png"
+
+    resolved = resolve_avatar_url(stored, _OWNER)
+
+    # Unsigned canonical serve path: 403s at the serve endpoint while signing
+    # is on, and never carries a token that would actually fetch the bytes.
+    assert resolved == f"/v1/files/avatars/{_OTHER}/abc.png"
+    assert "token=" not in resolved
+
+
+def test_resolve_avatar_url_does_not_sign_foreign_cdn_url(monkeypatch):
+    """The CDN form is the sneaky one: it looks like an ordinary external
+    https URL, so the importer scheme checks wave it through."""
+    monkeypatch.setattr(settings, "storage_backend", "s3")
+    monkeypatch.setattr(settings, "s3_public_url", "https://images.example.com")
+    monkeypatch.setattr(settings, "image_serving", "signed")
+
+    stored = f"https://images.example.com/avatars/{_OTHER}/abc.png"
+
+    resolved = resolve_avatar_url(stored, _OWNER)
+
+    assert resolved == f"/v1/files/avatars/{_OTHER}/abc.png"
+    assert "token=" not in resolved
+
+
+def test_resolve_avatar_url_does_not_sign_ownerless_key():
+    """A key outside the upload prefixes has no owner segment to match."""
+    resolved = resolve_avatar_url(f"exports/{_OWNER}/dump.zip", _OWNER)
+
+    assert resolved == f"/v1/files/exports/{_OWNER}/dump.zip"
+    assert "token=" not in resolved
+
+
+def test_resolve_avatar_url_accepts_uuid_owner_object():
+    import uuid
+
+    key = f"avatars/{_OWNER}/abc.png"
+    assert "token=" in resolve_avatar_url(key, uuid.UUID(_OWNER))
+    assert resolve_avatar_url(key, uuid.UUID(_OTHER)) == f"/v1/files/{key}"
+
+
+def test_resolve_description_urls_does_not_sign_foreign_embed():
+    """A bio row carrying somebody else's key - however it got there - must
+    not come back as a working URL."""
+    text = f"before ![pic](/v1/files/bios/{_OTHER}/a.png) after"
+
+    result = resolve_description_urls(text, _OWNER)
+
+    assert result == f"before ![pic](/v1/files/bios/{_OTHER}/a.png) after"
+    assert "token=" not in result
+
+
+def test_resolve_description_urls_mixed_signs_own_only():
+    text = (
+        f"![mine](/v1/files/bios/{_OWNER}/m.png) "
+        f"![theirs](/v1/files/bios/{_OTHER}/t.png)"
+    )
+
+    result = resolve_description_urls(text, _OWNER)
+
+    images = {img.alt: img.url for img in iter_markdown_images(result)}
+    assert "token=" in images["mine"]
+    assert images["theirs"] == f"/v1/files/bios/{_OTHER}/t.png"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_groups_tags.py
+++ b/tests/test_groups_tags.py
@@ -202,3 +202,56 @@ def test_member_side_tag_set_rejects_unknown_tag(auth_client: httpx.Client):
         json={"tag_ids": [str(uuid.uuid4())]},
     )
     assert resp.status_code == 400
+
+
+# --- Group descriptions get the same ownership filter as bios --------------
+
+
+_FOREIGN_EMBED = (
+    "![x](/v1/files/avatars/22222222-2222-2222-2222-222222222222/stolen.png)"
+)
+
+
+def test_create_group_strips_foreign_image_ref(auth_client: httpx.Client):
+    """A storage key from another account must not be persisted here.
+
+    Members and systems have filtered this on write for a while; groups were
+    the gap. Anything that later renders a group description would re-sign
+    whatever key it found into a working serve URL for somebody else's file.
+    """
+    resp = auth_client.post(
+        "/v1/groups",
+        json={"name": "FilterMe", "description": f"mine {_FOREIGN_EMBED}"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "/v1/files/" not in (body["description"] or ""), body
+    assert "mine" in (body["description"] or ""), body
+
+
+def test_update_group_strips_foreign_image_ref(auth_client: httpx.Client):
+    created = auth_client.post("/v1/groups", json={"name": "FilterMeToo"})
+    group_id = created.json()["id"]
+
+    resp = auth_client.patch(
+        f"/v1/groups/{group_id}",
+        json={"description": f"mine {_FOREIGN_EMBED}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "/v1/files/" not in (body["description"] or ""), body
+    assert "mine" in (body["description"] or ""), body
+
+
+def test_update_group_keeps_external_image_ref(auth_client: httpx.Client):
+    """The filter is about ownership, not about images: an external URL is
+    still the owner's call (subject to the instance's hotlink policy)."""
+    created = auth_client.post("/v1/groups", json={"name": "KeepExternal"})
+    group_id = created.json()["id"]
+
+    resp = auth_client.patch(
+        f"/v1/groups/{group_id}",
+        json={"description": "![pic](https://gravatar.com/x.png)"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert "gravatar.com/x.png" in resp.json()["description"]

--- a/tests/test_import_internal_image_refs.py
+++ b/tests/test_import_internal_image_refs.py
@@ -1,0 +1,162 @@
+"""A foreign export must not be able to name this instance's storage keys.
+
+Sheaf keys every upload as ``{prefix}/{user_id}/{uuid}.{ext}`` and the read
+path signs any internal key it is handed into a working serve URL. So a
+hand-edited export from another app - a bio, a system description, a group
+description, a journal body - that embeds ``/v1/files/avatars/<someone
+else>/x.png`` would, once imported, be re-signed on every read of the
+importing user's own profile: a live cross-tenant read of somebody else's
+file, still working after they delete or un-share it.
+
+Nothing in a PluralKit / Tupperbox / SimplyPlural / PluralSpace / Prism /
+Ampersand file can legitimately point at Sheaf storage, so every internal ref
+is dropped on the way in. These are the host-runnable halves (pure builders and
+profile-appliers, no DB); the SimplyPlural and Ampersand walks live inside
+``run_import`` and are covered end-to-end in the runner suites.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sheaf.config import settings
+from sheaf.models.system import System
+from sheaf.services.import_limits import ClampReport
+from sheaf.services.import_parsing import sanitize_external_avatar_url
+from sheaf.services.members import member_description_plaintext
+from sheaf.services.pk_import import build_member as pk_build_member
+from sheaf.services.pluralspace_import import (
+    _apply_system_profile as ps_apply_system_profile,
+)
+from sheaf.services.prism_import import (
+    _apply_system_profile as prism_apply_system_profile,
+)
+from sheaf.services.tb_import import _build_member as tb_build_member
+
+# Somebody else's account, and a key in their namespace.
+_VICTIM = "22222222-2222-2222-2222-222222222222"
+_FOREIGN_KEY = f"avatars/{_VICTIM}/stolen.png"
+_POISON = f"Hello ![x](/v1/files/{_FOREIGN_KEY}) there"
+_EXTERNAL = "![gravatar](https://gravatar.com/x.png)"
+
+
+def _blank_system() -> System:
+    """A System with the fields the profile-appliers read, all empty.
+
+    They only fill blanks, so an unset description is what lets the imported
+    value through at all.
+    """
+    return System(name="", description=None, color=None, avatar_url=None)
+
+
+# --- PluralKit -------------------------------------------------------------
+
+
+def test_pk_member_description_drops_internal_ref():
+    member = pk_build_member(
+        {"name": "Alpha", "description": _POISON},
+        uuid.uuid4(),
+        report=ClampReport(),
+    )
+
+    description = member_description_plaintext(member)
+    assert _VICTIM not in description
+    assert "/v1/files/" not in description
+    # Only the embed goes; the prose around it is the user's own writing.
+    assert "Hello" in description and "there" in description
+
+
+def test_pk_member_description_keeps_external_image():
+    member = pk_build_member(
+        {"name": "Alpha", "description": _EXTERNAL},
+        uuid.uuid4(),
+        report=ClampReport(),
+    )
+
+    assert member_description_plaintext(member) == _EXTERNAL
+
+
+# --- Tupperbox -------------------------------------------------------------
+
+
+def test_tb_member_description_drops_internal_ref():
+    member = tb_build_member(
+        {"id": 1, "name": "Beta", "description": _POISON},
+        uuid.uuid4(),
+        ClampReport(),
+    )
+
+    description = member_description_plaintext(member)
+    assert _VICTIM not in description
+    assert "/v1/files/" not in description
+
+
+# --- PluralSpace -----------------------------------------------------------
+
+
+def test_pluralspace_system_description_drops_internal_ref():
+    system = _blank_system()
+
+    ps_apply_system_profile(
+        {"system": {"name": "S", "description": _POISON}},
+        system,
+        ClampReport(),
+    )
+
+    assert _VICTIM not in system.description
+    assert "/v1/files/" not in system.description
+
+
+# --- Prism -----------------------------------------------------------------
+
+
+def test_prism_system_description_drops_internal_ref():
+    system = _blank_system()
+
+    prism_apply_system_profile(
+        {
+            "systemSettings": [
+                {"systemName": "S", "systemDescription": _POISON}
+            ]
+        },
+        system,
+        ClampReport(),
+    )
+
+    assert _VICTIM not in system.description
+    assert "/v1/files/" not in system.description
+
+
+# --- The shared avatar gate every foreign importer routes through ----------
+
+
+def test_sanitize_external_avatar_url_rejects_cdn_form_internal_key(monkeypatch):
+    """The one that gets past a scheme check.
+
+    With a CDN hostname configured, ``https://{cdn}/avatars/{victim}/x.png`` is
+    a well-formed https URL that happens to name our own storage - and
+    ``resolve_avatar_url`` recognises the CDN form, so storing it would hand
+    the importing profile a re-signed URL for the victim's file.
+    """
+    monkeypatch.setattr(settings, "s3_public_url", "https://images.example.com")
+    monkeypatch.setattr(settings, "allow_external_images", True)
+
+    assert (
+        sanitize_external_avatar_url(f"https://images.example.com/{_FOREIGN_KEY}")
+        is None
+    )
+
+
+def test_sanitize_external_avatar_url_rejects_serve_path_and_bare_key(monkeypatch):
+    monkeypatch.setattr(settings, "allow_external_images", True)
+
+    assert sanitize_external_avatar_url(f"/v1/files/{_FOREIGN_KEY}") is None
+    assert sanitize_external_avatar_url(_FOREIGN_KEY) is None
+
+
+def test_sanitize_external_avatar_url_still_allows_genuine_external(monkeypatch):
+    monkeypatch.setattr(settings, "s3_public_url", "https://images.example.com")
+    monkeypatch.setattr(settings, "allow_external_images", True)
+
+    url = "https://cdn.pluralkit.example/avatars/abc.png"
+    assert sanitize_external_avatar_url(url) == url

--- a/tests/test_imports_ampersand_runner.py
+++ b/tests/test_imports_ampersand_runner.py
@@ -293,3 +293,46 @@ def test_reimport_dedups_members(auth_client: httpx.Client):
     # Members match by name on the second pass; none re-created.
     assert final["counts"]["members_imported"] == 0
     assert final["counts"]["members_skipped"] >= 1
+
+
+# --- Foreign exports cannot smuggle in this instance's storage keys ---------
+
+
+def test_import_strips_internal_image_refs(auth_client: httpx.Client):
+    """Sheaf keys uploads as `{prefix}/{user_id}/{uuid}.{ext}` and re-signs any
+    internal key it finds in a bio, description or journal body into a working
+    serve URL. A hand-edited Ampersand file naming another account's key would
+    otherwise become a live cross-tenant read through the importing user's own
+    profile. Nothing in an Ampersand export legitimately references Sheaf
+    storage, so every internal ref is dropped on the way in - the prose and any
+    genuinely external image around it are untouched."""
+    victim_key = "avatars/22222222-2222-2222-2222-222222222222/stolen.png"
+    poison = f"mine ![x](/v1/files/{victim_key})"
+
+    data = _sample_data(with_avatar=False)
+    db = data["database"]
+    db["members"][0]["description"] = poison
+    db["systems"][0]["description"] = poison
+    db["journalPosts"][0]["body"] = poison
+    db["notes"][0]["content"] = poison
+
+    job = _post_file(auth_client, data, options={"notes": True})
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    member = next(
+        m for m in auth_client.get("/v1/members").json() if m["name"] == "Member0"
+    )
+    assert "/v1/files/" not in (member["description"] or ""), member
+    assert "mine" in (member["description"] or ""), member
+
+    group = next(
+        g for g in auth_client.get("/v1/groups").json() if g["name"] == "Root system"
+    )
+    assert "/v1/files/" not in (group["description"] or ""), group
+
+    bodies = [e["body"] for e in auth_client.get("/v1/journals").json()["items"]]
+    assert bodies, "expected the imported journal + note"
+    for body in bodies:
+        assert "/v1/files/" not in body, bodies

--- a/tests/test_imports_tb_sp_runner.py
+++ b/tests/test_imports_tb_sp_runner.py
@@ -726,3 +726,107 @@ def test_sp_imports_chatmessages_flat_array(auth_client: httpx.Client):
     assert final["counts"].get("messages_imported", 0) == 1, final["counts"]
     bodies = [m["body"] for m in auth_client.get("/v1/export").json()["messages"]]
     assert any("flat hello" in b for b in bodies), bodies
+
+
+# --- Foreign exports cannot smuggle in this instance's storage keys ---------
+#
+# Sheaf keys uploads as `{prefix}/{user_id}/{uuid}.{ext}` and re-signs any
+# internal key it finds in a bio or description into a working serve URL. A
+# hand-edited export naming another account's key would therefore become a
+# live cross-tenant read through the importing user's own profile. No SP or TB
+# file has a legitimate reason to reference Sheaf storage, so every internal
+# ref is dropped on the way in.
+
+_VICTIM_KEY = "avatars/22222222-2222-2222-2222-222222222222/stolen.png"
+
+
+def test_sp_strips_internal_image_refs_from_descriptions(
+    auth_client: httpx.Client,
+):
+    poison = f"mine ![x](/v1/files/{_VICTIM_KEY})"
+    payload = _sp_payload(
+        users=[{"_id": "ownerX", "uid": "ownerX", "username": "Sys", "desc": poison}],
+        members=[
+            {"_id": "spm1", "name": "RefAlice", "private": False, "desc": poison},
+        ],
+        groups=[{"_id": "spg1", "name": "RefGroup", "desc": poison}],
+    )
+    job = _post_file(
+        auth_client,
+        source="simplyplural_file",
+        payload=payload,
+        options={"system_profile": True},
+    )
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    member = next(
+        m for m in auth_client.get("/v1/members").json() if m["name"] == "RefAlice"
+    )
+    assert "/v1/files/" not in (member["description"] or ""), member
+    # The surrounding prose is the user's own writing and survives.
+    assert "mine" in (member["description"] or ""), member
+
+    group = next(
+        g for g in auth_client.get("/v1/groups").json() if g["name"] == "RefGroup"
+    )
+    assert "/v1/files/" not in (group["description"] or ""), group
+
+
+def test_sp_drops_avatar_url_pointing_at_our_own_storage(
+    auth_client: httpx.Client,
+):
+    """A bare storage key in `avatarUrl` is not an external URL, whatever the
+    export claims. It must not survive into avatar_url, where it would be
+    signed on every read."""
+    payload = _sp_payload(
+        members=[
+            {
+                "_id": "spm1",
+                "name": "RefBob",
+                "private": False,
+                "avatarUrl": f"/v1/files/{_VICTIM_KEY}",
+            },
+        ],
+    )
+    job = _post_file(auth_client, source="simplyplural_file", payload=payload)
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    member = next(
+        m for m in auth_client.get("/v1/members").json() if m["name"] == "RefBob"
+    )
+    assert not member["avatar_url"], member
+
+
+def test_tb_strips_internal_image_refs_from_descriptions(
+    auth_client: httpx.Client,
+):
+    poison = f"mine ![x](/v1/files/{_VICTIM_KEY})"
+    payload = json.dumps(
+        {
+            "tuppers": [
+                {"id": 901, "name": "RefTupper", "description": poison, "group_id": 91},
+            ],
+            "groups": [{"id": 91, "name": "RefTupperGroup", "description": poison}],
+        }
+    ).encode()
+    job = _post_file(auth_client, source="tupperbox_file", payload=payload)
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    member = next(
+        m for m in auth_client.get("/v1/members").json() if m["name"] == "RefTupper"
+    )
+    assert "/v1/files/" not in (member["description"] or ""), member
+    assert "mine" in (member["description"] or ""), member
+
+    group = next(
+        g
+        for g in auth_client.get("/v1/groups").json()
+        if g["name"] == "RefTupperGroup"
+    )
+    assert "/v1/files/" not in (group["description"] or ""), group


### PR DESCRIPTION
Third-party importers (PluralKit, Tupperbox, SimplyPlural, PluralSpace, Prism, Ampersand) stored description, bio and journal markdown from the file verbatim. Sheaf's image serve URLs are signed on read and the read path signed any internal storage key it was handed, so a crafted export could reference another account's upload and, once imported, receive a working and continuously refreshed link to it. Avatar fields had the same gap in a different shape: the importer avatar gate only checked the URL scheme, so a well-formed https URL naming this instance's own storage (including the CDN-hostname form when S3_PUBLIC_URL is set) was stored and re-signed on every read.

Three layers, so the fix does not depend on any single writer being correct:

- Every foreign importer now strips internal image references from the markdown it stores, the same treatment native backups have always had (twenty sites across the six importers). A foreign export has no legitimate reason to reference this instance's storage.
- The shared avatar gate every importer routes through now rejects all three internal forms (serve path, CDN hostname, bare key) rather than assuming a valid scheme means external.
- The authenticated signers now verify ownership: resolve_avatar_url and resolve_description_urls take the owning account and refuse to sign a key outside its namespace, degrading it to a canonical unsigned path the serve endpoint rejects. The owner parameter is required rather than optional, so a future call site cannot quietly opt out; a foreign reference already in the database from any past writer degrades to a broken image instead of a live link. Group descriptions also gain the ownership filtering and external-image policy every sibling markdown field already had.

Tests cover the strip per importer format, the avatar gate's three internal forms, foreign-key non-signing on both resolvers (own keys still sign), and the group write filtering. Full test suite green; 219 host-side unit tests pass. One new dependency-free behaviour note: a stored foreign reference on an owner's own page now renders as a broken image rather than resolving, which is the fail-closed direction.