### PR TITLE
Accept an omitted value as null on PUT /v1/members/{id}/fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Clearing a member's custom field no longer fails with some client libraries.** Clearing a field is expressed as `value: null` on `PUT /v1/members/{id}/fields` - but several client serialisers omit null fields entirely rather than writing them (the Android app's JSON library does this, which is how clearing a field from Android broke), and the server rejected an entry with no `value` at all. An omitted `value` is now accepted and clears the field exactly like an explicit null. Absence has no other meaning on this endpoint, so nothing changes for any client that already sends the null.
+
 ## [1.4.0] - 2026-09-02
 
 ### Added

--- a/sheaf/schemas/custom_field.py
+++ b/sheaf/schemas/custom_field.py
@@ -262,7 +262,14 @@ def _validate_value_for_field(
 
 class CustomFieldValueSet(BaseModel):
     field_id: uuid.UUID
-    value: Any
+    # Defaulted so an entry that OMITS `value` clears the field exactly like an
+    # explicit null. Absence has no other meaning on this endpoint (the handler
+    # upserts every entry it is given; there is no omit-to-leave-alone mode),
+    # and several client serialisers drop null object fields by default - Moshi
+    # on Android serialised "clear this field" as {"field_id": ...} and the
+    # whole request 422'd. Without the default, `Any` is a required field in
+    # Pydantic v2.
+    value: Any = None
 
 
 class CustomFieldValueRead(BaseModel):

--- a/tests/test_custom_field_select.py
+++ b/tests/test_custom_field_select.py
@@ -226,3 +226,52 @@ def test_legacy_envelope_value_still_validated(auth_client: httpx.Client):
         json=[{"field_id": field["id"], "value": {"v": "nope"}}],
     )
     assert resp.status_code == 400, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Clearing a value: explicit null and omitted `value` are the same thing
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_value_clears_like_explicit_null(auth_client: httpx.Client):
+    """An entry that omits `value` entirely clears the field, exactly like an
+    explicit null. Several client serialisers drop null object fields by
+    default (Moshi on Android is how this was found: clearing a field
+    serialised to [{"field_id": ...}] and the whole request 422'd), and
+    absence has no other meaning on this endpoint - the handler upserts
+    every entry it is given."""
+    member = _member(auth_client)
+    field = auth_client.post(
+        "/v1/fields",
+        json={"name": "Likes", "field_type": "text"},
+    ).json()
+
+    # Populate.
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": "tea"}],
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Clear by omitting `value` entirely.
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"]}],
+    )
+    assert resp.status_code == 200, resp.text
+    row = next(v for v in resp.json() if v["field_id"] == field["id"])
+    assert row["value"] is None
+
+    # And the sibling path: explicit null still clears, identically.
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": "coffee"}],
+    )
+    assert resp.status_code == 200, resp.text
+    resp = auth_client.put(
+        f"/v1/members/{member}/fields",
+        json=[{"field_id": field["id"], "value": None}],
+    )
+    assert resp.status_code == 200, resp.text
+    row = next(v for v in resp.json() if v["field_id"] == field["id"])
+    assert row["value"] is None


### PR DESCRIPTION
Fixes clearing a member custom field from clients whose JSON serialiser omits null object fields (Moshi on Android is how this surfaced: emptying a field serialised to `[{"field_id": ...}]` and the whole request 422'd - see sheaf-project/android#68 for the client-side half).

`value: Any` with no default is a required field in Pydantic v2, so an entry that omitted `value` was rejected outright. It now defaults to `None`, making an omitted value clear the field exactly like an explicit null. This is safe because absence has no other meaning on this endpoint: the handler upserts every entry it is given, there is no omit-to-leave-alone mode, and `None` already flows correctly through type validation, the text cap, and encrypted storage. Clients that send the explicit null are unchanged.

Checked for siblings: the only other no-default `Any` in the schemas is a response model, and the PATCH endpoints that do distinguish omitted from null (`fields_set` semantics) are deliberate and untouched.

Regression test pins both clearing spellings as equivalent. Full behavioural config green. The Android explicit-null fix remains necessary independently - self-hosted servers upgrade on their own schedule, so this is defence in depth for other clients, not a replacement.