### PR TITLE
Fix external image URL entry navigating away inside the member form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- **Setting a member's avatar or banner to an external image URL works again on the web.** Pressing Set (or Enter) in the image-URL box triggered the browser's own page navigation instead of setting the image: the URL box was a form nested inside the member editing form, which React does not deliver events for, so the browser fell back to natively submitting it - producing an "are you sure you want to leave this page?" prompt and losing the image (and any other unsaved edits with it). The URL box no longer uses a form at all; Set and the Enter key both just set the image, in place.
+
 ## [1.4.0] - 2026-09-02
 
 ### Added

--- a/web/src/components/avatar-upload.tsx
+++ b/web/src/components/avatar-upload.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { uploadFile } from "@/lib/files";
 import { apiErrorMessage } from "@/lib/api-errors";
@@ -70,13 +70,7 @@ export function AvatarUpload({
     if (file && file.type.startsWith("image/")) setPendingFile(file);
   }
 
-  function handleUrlSubmit(e: FormEvent) {
-    e.preventDefault();
-    // This <form> is nested inside the parent profile <form>. Submit events
-    // bubble through React's tree (even across Radix portals), so without
-    // stopPropagation the parent form saves with stale state before our
-    // onUpload takes effect.
-    e.stopPropagation();
+  function handleUrlSet() {
     const trimmed = urlValue.trim();
     if (!trimmed) return;
     // Allowlist the scheme so a javascript:/data:/file: URL can't ride in
@@ -152,19 +146,37 @@ export function AvatarUpload({
           )}
         </div>
         {showUrlInput && (
-          <form onSubmit={handleUrlSubmit} className="flex gap-1">
+          // Deliberately NOT a <form>: same fix as BannerUpload. React does
+          // not deliver onSubmit for a form nested in another form - the
+          // browser natively submits the inner one, navigating the page and
+          // losing the edit. Explicit button + Enter handler instead; the
+          // Enter handler preventDefaults so the key can't implicitly
+          // submit the OUTER profile form.
+          <div className="flex gap-1">
             <Input
               value={urlValue}
               onChange={(e) => setUrlValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleUrlSet();
+                }
+              }}
               placeholder="https://..."
               className="h-7 text-xs"
               type="url"
               autoFocus
             />
-            <Button type="submit" size="sm" variant="ghost" className="h-7 px-2 text-xs">
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-xs"
+              onClick={handleUrlSet}
+            >
               Set
             </Button>
-          </form>
+          </div>
         )}
         {error && <p className="text-xs text-destructive">{error}</p>}
       </div>

--- a/web/src/components/banner-upload.tsx
+++ b/web/src/components/banner-upload.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { uploadFile } from "@/lib/files";
 import { apiErrorMessage } from "@/lib/api-errors";
@@ -64,11 +64,7 @@ export function BannerUpload({
     if (file && file.type.startsWith("image/")) setPendingFile(file);
   }
 
-  function handleUrlSubmit(e: FormEvent) {
-    e.preventDefault();
-    // Nested <form>; stop the submit bubbling to the parent profile form
-    // (see AvatarUpload for the full rationale).
-    e.stopPropagation();
+  function handleUrlSet() {
     const trimmed = urlValue.trim();
     if (!trimmed) return;
     if (!/^https?:\/\//i.test(trimmed)) {
@@ -146,19 +142,39 @@ export function BannerUpload({
         )}
       </div>
       {showUrlInput && (
-        <form onSubmit={handleUrlSubmit} className="flex gap-1">
+        // Deliberately NOT a <form>: this control sits inside the member
+        // profile <form>, and React does not deliver onSubmit for a form
+        // nested in another form - the browser natively submits the inner
+        // one instead, navigating the page (and losing the whole edit).
+        // A plain div with an explicit button and an Enter handler does the
+        // same job with no submit semantics at all. The Enter handler
+        // preventDefaults so the key can't implicitly submit the OUTER
+        // form either.
+        <div className="flex gap-1">
           <Input
             value={urlValue}
             onChange={(e) => setUrlValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleUrlSet();
+              }
+            }}
             placeholder="https://..."
             className="h-7 text-xs"
             type="url"
             autoFocus
           />
-          <Button type="submit" size="sm" variant="ghost" className="h-7 px-2 text-xs">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 text-xs"
+            onClick={handleUrlSet}
+          >
             Set
           </Button>
-        </form>
+        </div>
       )}
       {error && <p className="text-xs text-destructive">{error}</p>}
       <AvatarCropperDialog


### PR DESCRIPTION
Fixes the web bug where setting a member's banner (or avatar) to an external image URL triggered an "are you sure you want to leave this page?" prompt and never set the image.

Root cause, reproduced headlessly against React 19 with a minimal harness: the image-URL box was a `<form>` nested inside the member editing `<form>`, and React does not deliver `onSubmit` for a form nested in another form - neither the inner nor the outer handler fires, so the existing `preventDefault`/`stopPropagation` guard was dead code and the browser natively GET-submitted the inner form. That navigation is the leave-page prompt (the dialog's beforeunload guard) and the lost edit.

The URL box is no longer a form: Set is an explicit `type="button"` and Enter is handled on the input with `preventDefault`, so it also cannot implicitly submit the outer member form. Applied to both `BannerUpload` and `AvatarUpload` (identical latent bug). Both the click and Enter paths were re-verified in the same harness: value set, zero navigation.

Swept the rest of the components for the pattern: every other `<form onSubmit>` is top-level or portal-mounted. The bio image picker's external-URL form is unaffected because it renders in a portal-mounted dialog and was never DOM-nested - which is why bio embeds worked while avatar/banner URLs didn't.

No backend change. tsc, eslint, and a production build are clean.