### PR TITLE
Say "and" once in front notifications with hidden co-fronters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ### Fixed
 
+- **Front-change notifications with hidden co-fronters no longer say "and" twice.** A switch like five members starting with two of them hidden from the channel rendered "A, B, and C, and 2 others started fronting" - the visible names were joined into a finished list and the "N others" tail then bolted on with its own "and". The tail now joins the same list as the names, so the "and" lands exactly once, before the true final item: "A, B, C, and 2 others started fronting."
+
+### Fixed
+
 - **Setting a member's avatar or banner to an external image URL works again on the web.** Pressing Set (or Enter) in the image-URL box triggered the browser's own page navigation instead of setting the image: the URL box was a form nested inside the member editing form, which React does not deliver events for, so the browser fell back to natively submitting it - producing an "are you sure you want to leave this page?" prompt and losing the image (and any other unsaved edits with it). The URL box no longer uses a form at all; Set and the Enter key both just set the image, in place.
 
 ## [1.4.0] - 2026-09-02

--- a/sheaf/services/notifications/payload.py
+++ b/sheaf/services/notifications/payload.py
@@ -36,18 +36,21 @@ def _name(member_names: dict[uuid.UUID, str], mid: uuid.UUID) -> str:
     return member_names.get(mid, "(unknown)")
 
 
+def _oxford_join(items: list[str]) -> str:
+    """Comma-and-style join: A / A and B / A, B, and C."""
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
 def _join_names(
     members: list[uuid.UUID], member_names: dict[uuid.UUID, str]
 ) -> str:
-    """Comma-and-style join: A / A and B / A, B, and C."""
-    names = [_name(member_names, m) for m in members]
-    if not names:
-        return ""
-    if len(names) == 1:
-        return names[0]
-    if len(names) == 2:
-        return f"{names[0]} and {names[1]}"
-    return ", ".join(names[:-1]) + f", and {names[-1]}"
+    return _oxford_join([_name(member_names, m) for m in members])
 
 
 def _redacted_others(count: int, redaction: CofrontRedaction) -> str:
@@ -64,16 +67,19 @@ def _phrase(
     member_names: dict[uuid.UUID, str],
     redaction: CofrontRedaction,
 ) -> str:
-    """Build a noun phrase covering visible + invisible participants."""
-    visible_part = _join_names(visible, member_names)
-    if invisible_count == 0:
-        return visible_part
-    redacted = _redacted_others(invisible_count, redaction)
-    if not visible_part:
-        return redacted
-    if len(visible) == 1:
-        return f"{visible_part} and {redacted}"
-    return f"{visible_part}, and {redacted}"
+    """Build a noun phrase covering visible + invisible participants.
+
+    The redacted tail joins the SAME list as the visible names, and the
+    whole thing is comma-and joined exactly once, so the "and" lands only
+    before the true final item: "A, B, C, and 2 others". Joining the names
+    first and bolting the tail on afterwards is how a five-member switch
+    with two private members used to render "A, B, and C, and 2 others" -
+    two "and"s in one phrase.
+    """
+    items = [_name(member_names, m) for m in visible]
+    if invisible_count > 0:
+        items.append(_redacted_others(invisible_count, redaction))
+    return _oxford_join(items)
 
 
 def _cofront_changed_for(

--- a/tests/test_notifications_payload.py
+++ b/tests/test_notifications_payload.py
@@ -323,3 +323,76 @@ def test_flap_within_window_nets_to_suppressed():
         visible_member_ids={a, b},
     )
     assert msg.suppress is True
+
+
+# ---------------------------------------------------------------------------
+# Redacted-tail grammar: exactly one "and", exactly single spaces
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_visible_plus_hidden_says_and_exactly_once():
+    """Five-member switch, two private: the reported bug rendered
+    "A, B, and C, and 2 others" - the visible names were oxford-joined on
+    their own and the redacted tail bolted on with a second "and". The tail
+    must instead join the same list, so the "and" lands once, before the
+    true final item."""
+    ids = [uuid.uuid4() for _ in range(5)]
+    names = dict(zip(ids, ["Ash", "Brook", "Cedar", "Dee", "Em"]))
+    msg = render_message(
+        _channel(redaction="count"),
+        payload=_payload([], ids),
+        member_names=names,
+        visible_member_ids=set(ids[:3]),
+    )
+    # Name order is set-derived, so assert structure, not sequence: all three
+    # visible names, the tail LAST (right before the verb), one "and", no
+    # doubled spaces.
+    for name in ("Ash", "Brook", "Cedar"):
+        assert name in msg.body
+    assert msg.body.endswith(", and 2 others started fronting.")
+    assert msg.body.count(" and ") == 1
+    assert "  " not in msg.body
+
+
+def test_two_visible_plus_hidden_tail_grammar():
+    ids = [uuid.uuid4() for _ in range(3)]
+    names = dict(zip(ids, ["Ash", "Brook", "Cedar"]))
+    msg = render_message(
+        _channel(redaction="count"),
+        payload=_payload([], ids),
+        member_names=names,
+        visible_member_ids=set(ids[:2]),
+    )
+    assert "Ash" in msg.body and "Brook" in msg.body
+    assert msg.body.endswith(", and 1 other started fronting.")
+    assert msg.body.count(" and ") == 1
+    assert "  " not in msg.body
+
+
+def test_one_visible_plus_hidden_tail_grammar():
+    ids = [uuid.uuid4() for _ in range(3)]
+    names = dict(zip(ids, ["Ash", "Brook", "Cedar"]))
+    msg = render_message(
+        _channel(redaction="someone"),
+        payload=_payload([], ids),
+        member_names=names,
+        visible_member_ids={ids[0]},
+    )
+    assert "Ash and 2 others started fronting." in msg.body
+    assert msg.body.count(" and ") == 1
+    assert "  " not in msg.body
+
+
+def test_all_visible_unchanged_by_tail_fix():
+    ids = [uuid.uuid4() for _ in range(3)]
+    names = dict(zip(ids, ["Ash", "Brook", "Cedar"]))
+    msg = render_message(
+        _channel(),
+        payload=_payload([], ids),
+        member_names=names,
+        visible_member_ids=set(ids),
+    )
+    for name in ("Ash", "Brook", "Cedar"):
+        assert name in msg.body
+    assert msg.body.count(" and ") == 1
+    assert "  " not in msg.body


### PR DESCRIPTION
Fixes the long-standing report that a switch with five members, two of them hidden from the channel, rendered a front-change notification like "A, B, and C, and 2 others started fronting" - "and" twice.

The visible names were oxford-joined into a complete list on their own, and the redacted "N others" tail was then appended with a second "and". The tail now joins the same item list as the names, and the whole phrase is comma-and joined exactly once, so the "and" lands only before the true final item: "A, B, C, and 2 others started fronting." One visible name plus a tail reads "A and 2 others", and fully-visible switches are unchanged.

The double space from the same original report no longer reproduces on main; it appears to have been cured incidentally by the aggregation rewrite of this renderer. The new tests pin single-spacing anyway, alongside every arity of visible-names-plus-tail. Pure-function tests only; the full payload suite passes (22/22).