### PR TITLE
Send an explicit null when clearing a custom field on the web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 ### Fixed
 
+- **Clearing a member's custom field now works from the web app.** Emptying a field and saving silently kept the old value: the web skipped empty fields from the save request entirely, and the server only touches the entries it is given, so nothing ever asked it to clear. The same skip also meant a ticked yes/no field could never be unticked, and a multiselect could never be emptied back to nothing. An emptied field that has a stored value is now sent as an explicit clear. (This is the web sibling of the Android clear-a-field bug; each client tripped over the same endpoint in its own way.)
+
+### Fixed
+
 - **Front-change notifications with hidden co-fronters no longer say "and" twice.** A switch like five members starting with two of them hidden from the channel rendered "A, B, and C, and 2 others started fronting" - the visible names were joined into a finished list and the "N others" tail then bolted on with its own "and". The tail now joins the same list as the names, so the "and" lands exactly once, before the true final item: "A, B, C, and 2 others started fronting."
 
 ### Fixed

--- a/web/src/routes/members.tsx
+++ b/web/src/routes/members.tsx
@@ -517,7 +517,19 @@ function MemberFieldValues({ memberId }: { memberId: string }) {
           ? []
           : "";
       const val = effectiveValue(f.id, fallback);
-      if (isEmptyValue(f.field_type, val)) continue;
+      if (isEmptyValue(f.field_type, val)) {
+        // An emptied field still needs SAYING when the server holds a value
+        // for it: the endpoint only upserts the entries it is given, so
+        // skipping the entry entirely means "leave it as it was" and the
+        // field could never be cleared (nor a stored-true boolean unticked,
+        // nor a multiselect emptied). An explicit null clears it, and works
+        // against every deployed server version. A field the server has no
+        // row for stays skipped - there is nothing to clear.
+        if (f.id in serverValues) {
+          payload.push({ field_id: f.id, value: null });
+        }
+        continue;
+      }
       payload.push({ field_id: f.id, value: valueForWire(f.field_type, val) });
     }
     setValues.mutate(


### PR DESCRIPTION
Fixes clearing a member's custom field from the web app, the web sibling of the Android clear-a-field bug (#274, backend fix, automerging).

Emptying a field and saving silently kept the old value: `handleSave` skipped empty editor values from the PUT payload entirely, and `PUT /v1/members/{id}/fields` only upserts the entries it is given, so the server was never asked to clear anything. The same skip meant a stored-true boolean field could never be unticked and a multiselect could never be emptied.

An emptied field is now sent as `{field_id, value: null}` when the server currently holds a value for it - an explicit clear that works against every deployed server version, independent of the #274 rollout. Fields the server has no row for stay skipped, so never-set fields do not accrue null rows.

For the record, the endpoint has now collected three distinct client failure shapes: explicit-null clients always worked, Android dropped the `value` key (422, fixed server-side in #274), and the web dropped the whole entry (silent no-op, fixed here).

tsc, eslint, and a production build are clean.