### PR TITLE
Install syft under the CI retry wrapper, pinned and checksummed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,24 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
+      # A plain release download under the house retry wrapper: the
+      # download-syft action fetches the binary with no retry, and the
+      # GitHub release CDN flakes often enough to fail whole publish jobs.
+      # Pinned version + checksum, verified against the release's own
+      # checksums file, so a corrupted or truncated download cannot land.
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        env:
+          SYFT_VERSION: 1.51.1
+        run: |
+          ./.github/scripts/with-retry.sh sh -c '
+            set -eu
+            curl -sSfL -o /tmp/syft.tar.gz               "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz"
+            curl -sSfL -o /tmp/syft-checksums.txt               "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_checksums.txt"
+            (cd /tmp && grep "syft_${SYFT_VERSION}_linux_amd64.tar.gz$" syft-checksums.txt | sha256sum -c -)
+            tar -xzf /tmp/syft.tar.gz -C /tmp syft
+            sudo install /tmp/syft /usr/local/bin/syft
+          '
+          syft version
 
       # Sign by digest. cosign stores the signature at <repo>:sha256-DIGEST.sig
       # so a single sign call covers every tag pointing at the same digest.


### PR DESCRIPTION
Fixes the transient docker-job failure where the `Install syft` step (anchore/sbom-action/download-syft) died on a flaky GitHub release download and failed the whole publish job.

The installer action cannot be wrapped in a retry, so the step is now a plain release download run under the existing `.github/scripts/with-retry.sh` (the same wrapper already covering cosign's OIDC flake): pinned syft version, tarball verified against the release's own checksums file, and the download-verify-install sequence retried as one unit so a truncated fetch retries rather than failing or installing.

cosign stays on its installer action for now - it has not flaked - but can move to the same pattern if it ever does. No change to what gets signed or attested.