### PR TITLE
Fix the syft install: verify the tarball under its release filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,11 +296,15 @@ jobs:
         run: |
           ./.github/scripts/with-retry.sh sh -c '
             set -eu
-            curl -sSfL -o /tmp/syft.tar.gz               "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz"
-            curl -sSfL -o /tmp/syft-checksums.txt               "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_checksums.txt"
-            (cd /tmp && grep "syft_${SYFT_VERSION}_linux_amd64.tar.gz$" syft-checksums.txt | sha256sum -c -)
-            tar -xzf /tmp/syft.tar.gz -C /tmp syft
-            sudo install /tmp/syft /usr/local/bin/syft
+            cd /tmp
+            # The tarball must keep its ORIGINAL release filename: sha256sum -c
+            # verifies the name recorded inside the checksums file, so a
+            # renamed download can never pass verification.
+            curl -sSfL -O "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz"
+            curl -sSfL -o syft-checksums.txt "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_checksums.txt"
+            grep "syft_${SYFT_VERSION}_linux_amd64.tar.gz$" syft-checksums.txt | sha256sum -c -
+            tar -xzf "syft_${SYFT_VERSION}_linux_amd64.tar.gz" syft
+            sudo install syft /usr/local/bin/syft
           '
           syft version
 


### PR DESCRIPTION
Fixes the deterministic docker-publish failure on main introduced by #279: the install downloaded the release tarball renamed to `syft.tar.gz`, but `sha256sum -c` verifies the filename recorded inside the checksums file, so verification failed with "No such file or directory" on every attempt (and the retry wrapper dutifully retried a permanent failure four times).

The tarball now keeps its original release filename. Root cause of the escape: the docker jobs are skipped on pull requests, so #279's new step first executed on the post-merge main push. This time the exact script body was executed locally against the real v1.51.1 release before committing: checksum OK, extraction OK, binary runs.

Worth considering separately: running the docker job (build only, no push) on PRs that touch `.github/workflows/` so workflow changes to that path cannot ship untested again.