### PR TITLE
Rename the OpenPlural format to PluralPort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Sheaf are documented here. The format is based on [Keep a
 
 - **Groups and custom fields can now be put in the order you want.** Up/down arrows on the Groups page move a group among the groups next to it (its siblings, when nested), and the same arrows in Settings > Custom fields reorder your fields; dragging a group still moves it into or out of another group, so the two gestures stay distinct. The order you set is respected everywhere the app lists your groups - groups you have not rearranged stay alphabetical - and it travels with your backups, so a restore puts everything back in the order you left it. Public profiles and share links follow it too: groups and custom fields appear to visitors in the order you arranged them, the same as inside the app.
 
+### Changed
+
+- **The OpenPlural interchange format is now called PluralPort**, following the standard's own rename upstream (a name conflict; the spec version stays 0.1). Exports now stamp `pluralport_version` and download as `.pluralport.zip`, and the API's format/source values are `pluralport` / `pluralport_file`. Nothing you already have stops working: files stamped with the old `openplural_version` (or bundles carrying `openplural.json`) still import, the old API values are still accepted as deprecated aliases, and self-hosters can keep the `OPENPLURAL_MAX_PRESERVED_MB` env var (the new `PLURALPORT_MAX_PRESERVED_MB` name wins if both are set).
+
 ### Fixed
 
 - **Dragging a group onto another to nest it now works in Firefox.** The drag never started there: Firefox requires drag data to be set when a drag begins, and the groups page never set any. Chrome-family browsers tolerated the omission, which is why the same gesture worked in one browser and was simply inert in the other.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open-source plural system tracking. A self-hostable replacement for SimplyPlural
 
 [Android/WearOS](https://github.com/sheaf-project/android) is on the [Play Store](https://play.google.com/store/apps/details?id=systems.lupine.sheaf) (or sideload the APK from [Releases](https://github.com/sheaf-project/android/releases)), and [iOS/WatchOS](https://github.com/sheaf-project/ios) is on the [App Store](https://apps.apple.com/us/app/sheaf-plural-system-tracker/id6766770364). Both ship a watch companion app and complication.
 
-Sheaf supports the [OpenPlural](https://github.com/skylartaylor/openplural) data standard proposal as a founding project, and ships import and export for v0.1 today.
+Sheaf supports the [PluralPort](https://github.com/PluralPort/spec) data standard proposal (formerly OpenPlural) as a founding project, and ships import and export for v0.1 today.
 
 ## Why
 
@@ -49,8 +49,8 @@ SimplyPlural is shutting down. Many alternatives are either incomplete, closed-s
 - **Front-history retention** - Opt-in per-system window that ages out old closed fronts. A privacy control rather than a tier limit: off by default, with a fixed 14-day import grace so a freshly restored archive is never abruptly deleted, and tightening it takes a deferred, re-auth-gated countdown.
 - **System Safety** — Optional grace period and re-auth (password / TOTP) on destructive actions (member/journal/group/etc deletion, revision unpin)
 - **Realtime front stream** - `GET /v1/fronts/stream` pushes your front changes over Server-Sent Events instead of making you poll, aimed at home automation (Home Assistant, Node-RED) and live UI updates. The client dials out and holds the connection open, so a LAN-only consumer works with no inbound reachability at all. There is an official [Home Assistant integration](https://github.com/sheaf-project/sheaf-ha) built on it.
-- **Imports** — SimplyPlural, PluralKit (export file or live via your `pk;token`), Tupperbox, PluralSpace, Prism, Ampersand, OpenPlural, and Sheaf's own exports. Granular control over what to bring across; PK switch log is converted to Sheaf front intervals, and the preview tells you what will be deduplicated, shortened, or capped before you commit to it. See **[docs/IMPORT.md](docs/IMPORT.md)** for the full migration guide.
-- **OpenPlural** - Import and export for [OpenPlural](https://github.com/skylartaylor/openplural) v0.1, as either a single JSON document or an `.openplural.zip` bundle carrying image bytes. Sheaf data the draft spec doesn't model yet rides in a namespaced extensions key so a round-trip is lossless, and other apps' unmodellable data is preserved on import and re-emitted on the next export rather than dropped. See **[docs/OPENPLURAL.md](docs/OPENPLURAL.md)**.
+- **Imports** - SimplyPlural, PluralKit (export file or live via your `pk;token`), Tupperbox, PluralSpace, Prism, Ampersand, PluralPort, and Sheaf's own exports. Granular control over what to bring across; PK switch log is converted to Sheaf front intervals, and the preview tells you what will be deduplicated, shortened, or capped before you commit to it. See **[docs/IMPORT.md](docs/IMPORT.md)** for the full migration guide.
+- **PluralPort** - Import and export for [PluralPort](https://github.com/PluralPort/spec) v0.1 (formerly OpenPlural; files written against the old name still import), as either a single JSON document or a `.pluralport.zip` bundle carrying image bytes. Sheaf data the draft spec doesn't model yet rides in a namespaced extensions key so a round-trip is lossless, and other apps' unmodellable data is preserved on import and re-emitted on the next export rather than dropped. See **[docs/PLURALPORT.md](docs/PLURALPORT.md)**.
 - **File storage** — File uploads with filesystem or S3-compatible backends
 - **Data export** — sync JSON (Article 20 portability), async zip with image bytes that imports back as-is, and a separate Article 15 endpoint covering everything we know about your account
 - **Front-history export** - Fronting history on its own as CSV (one row per front, with duration and co-fronters), JSON, or ICS to drop into a calendar app
@@ -192,8 +192,8 @@ Key endpoints:
 | `POST /v1/imports/api` | Import a PluralKit system live via `pk;token` |
 | `GET /v1/imports` | Import job history and status |
 | `POST /v1/import/{source}/preview` | Preview a file before committing to it |
-| `GET /v1/export` | Export plural system content (sync JSON; `format=openplural` for OpenPlural) |
-| `POST /v1/export/jobs` | Queue an async export: full backup with image bytes, an `.openplural.zip` bundle, or front history as CSV / JSON / ICS |
+| `GET /v1/export` | Export plural system content (sync JSON; `format=pluralport` for PluralPort) |
+| `POST /v1/export/jobs` | Queue an async export: full backup with image bytes, a `.pluralport.zip` bundle, or front history as CSV / JSON / ICS |
 | `POST /v1/account/data` | Article 15 — everything we know about your account |
 | `POST /v1/files/upload` | Upload avatar |
 
@@ -270,7 +270,7 @@ Shipped items are listed here for context; the [CHANGELOG](CHANGELOG.md) has the
 - [x] PluralKit one-shot import (file or live API via `pk;token`)
 - [ ] PluralKit bidirectional sync
 - [x] Importers for Tupperbox, PluralSpace, Prism, and Ampersand
-- [x] OpenPlural v0.1 import and export, with lossless round-trip and foreign-extension preservation ([docs/OPENPLURAL.md](docs/OPENPLURAL.md))
+- [x] PluralPort v0.1 import and export, with lossless round-trip and foreign-extension preservation ([docs/PLURALPORT.md](docs/PLURALPORT.md))
 - [x] Member and group relationships with a system graph
 - [x] Archived members
 - [x] Subgroups (nested groups) with a drag-to-reparent tree

--- a/alembic/versions/f5a6b7c8d9e0_rename_openplural_to_pluralport.py
+++ b/alembic/versions/f5a6b7c8d9e0_rename_openplural_to_pluralport.py
@@ -1,0 +1,48 @@
+"""Rename stored openplural values to pluralport
+
+Revision ID: f5a6b7c8d9e0
+Revises: e4f5a6b7c8d9
+Create Date: 2026-09-09
+
+The OpenPlural data standard was renamed to PluralPort upstream (name
+conflict). Data-only migration: re-label the two places the old format
+name is stored as a value - the import-job source and the export-job
+format. No DDL, so no lock_timeout guard is needed; both UPDATEs take
+ordinary row locks on small tables.
+
+Deliberately NOT touched: the systems.openplural_archive column. Its
+name is baked into the AAD of every encrypted archive blob in
+production, so renaming it would make existing data undecryptable. Only
+stored format labels change here.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f5a6b7c8d9e0"
+down_revision: Union[str, None] = "e4f5a6b7c8d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE import_jobs SET source = 'pluralport_file' "
+        "WHERE source = 'openplural_file'"
+    )
+    op.execute(
+        "UPDATE export_jobs SET format = 'pluralport' "
+        "WHERE format = 'openplural'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE import_jobs SET source = 'openplural_file' "
+        "WHERE source = 'pluralport_file'"
+    )
+    op.execute(
+        "UPDATE export_jobs SET format = 'openplural' "
+        "WHERE format = 'pluralport'"
+    )

--- a/docs/IMPORT.md
+++ b/docs/IMPORT.md
@@ -152,7 +152,7 @@ same preview-then-import flow as PK and covers:
   statistics and listed separately on the Members page). Every importer that
   brings custom fronts across creates them with **keep fronting private** on,
   so an imported "Asleep" never announces itself on a shared page until you
-  release the guard yourself; a Sheaf backup or an OpenPlural file that
+  release the guard yourself; a Sheaf backup or a PluralPort file that
   records the setting restores what it recorded instead.
 - Custom field definitions and per-member values.
 - Groups with parent hierarchy and member memberships.
@@ -175,21 +175,27 @@ bucket. The async `/v1/export/jobs` endpoint produces a zip with image bytes
 included; the import side that consumes those zips is on the roadmap (see
 [CHANGELOG.md](../CHANGELOG.md)).
 
-## OpenPlural import
+## PluralPort import
 
 For moving data in from any app that speaks the
-[OpenPlural](https://github.com/skylartaylor/openplural) v0.1 standard, including
-a Sheaf OpenPlural export. Accepts either a bare `.json` document or an
-`.openplural.zip` bundle (`openplural.json` + `assets/`); the runner detects
-which by content. The envelope is translated back to the native shape and run
-through the same importer as a Sheaf re-import, so dedup, the member cap, the
-image-restore pipeline (for bundles), and the avatar-policy gate all apply. A
-file whose `openplural_version` this build does not understand is rejected
-rather than partially imported.
+[PluralPort](https://github.com/PluralPort/spec) v0.1 standard (formerly
+OpenPlural), including a Sheaf PluralPort export. Accepts either a bare
+`.json` document or a `.pluralport.zip` bundle (`pluralport.json` +
+`assets/`); the runner detects which by content. The envelope is translated
+back to the native shape and run through the same importer as a Sheaf
+re-import, so dedup, the member cap, the image-restore pipeline (for
+bundles), and the avatar-policy gate all apply. A file whose
+`pluralport_version` this build does not understand is rejected rather than
+partially imported.
 
-Sheaf round-trips its own OpenPlural exports losslessly: anything the v0.1 spec
+Files from before the format's rename still import: the deprecated
+`openplural_version` envelope key is accepted as a v0.1 alias
+(`pluralport_version` wins if a file carries both), and a bundle whose inner
+document is still named `openplural.json` reads the same as a current one.
+
+Sheaf round-trips its own PluralPort exports losslessly: anything the v0.1 spec
 cannot model rides under `extensions.sheaf.*` and is restored on import. See
-[OPENPLURAL.md](OPENPLURAL.md) for the full mapping, the per-version
+[PLURALPORT.md](PLURALPORT.md) for the full mapping, the per-version
 implementation log, and the known gaps.
 
 ---

--- a/docs/PLURALPORT.md
+++ b/docs/PLURALPORT.md
@@ -1,26 +1,41 @@
-# Sheaf OpenPlural support: implementation log
+# Sheaf PluralPort support: implementation log
 
-[OpenPlural](https://github.com/skylartaylor/openplural) is a draft (v0.1)
+[PluralPort](https://github.com/PluralPort/spec) is a draft (v0.1)
 interchange format for plural-system data: systems, members, fronting history,
 groups, taxonomy, custom fields, notes, and assets, with a registered
 `extensions.<app>` namespace for anything an app models that the core spec does
 not yet cover. The point of it is that one good exporter beats N pairwise
-converters: map your records to the OpenPlural core once and every other adopter
+converters: map your records to the PluralPort core once and every other adopter
 can read them.
 
 Sheaf is a founding adopter. Its exporter lives in
-`sheaf/services/openplural_export.py` and the inverse importer in
-`sheaf/services/openplural_import.py`; the import runner that wires them to the
-async job system is `sheaf/services/openplural_import_runner.py`.
+`sheaf/services/pluralport_export.py` and the inverse importer in
+`sheaf/services/pluralport_import.py`; the import runner that wires them to the
+async job system is `sheaf/services/pluralport_import_runner.py`.
+
+## The OpenPlural rename
+
+The format was called **OpenPlural** until a name conflict forced an upstream
+rename to **PluralPort**; the spec's version string stayed at `0.1`. Files
+written against the old name keep importing into Sheaf: the v0.1 reader
+accepts the deprecated `openplural_version` envelope key as an alias with
+identical semantics (when a file carries both keys, `pluralport_version`
+wins), and a bundle whose inner document is still named `openplural.json` is
+read the same as one named `pluralport.json`. Sheaf's own exports now emit
+`pluralport_version` and download as `.pluralport.zip`. The API keeps the
+pre-rename request values working too (`format=openplural`,
+`source=openplural_file`, `/v1/import/openplural/preview`), and self-hosters
+can keep the old `OPENPLURAL_MAX_PRESERVED_MB` env var (see
+`docs/SELFHOSTING.md`).
 
 ## How to use this file
 
-Every Sheaf OpenPlural export stamps two versions in its `producer` block:
+Every Sheaf PluralPort export stamps two versions in its `producer` block:
 
 - `producer.app_version` - the Sheaf release that produced the file (e.g.
   `1.1.0`), taken from package metadata.
 - `producer.exporter_version` - the version of the *mapping logic* itself
-  (`OPENPLURAL_IMPL_VERSION`, currently `0.1.0`). This moves independently of
+  (`PLURALPORT_IMPL_VERSION`, currently `0.1.0`). This moves independently of
   the Sheaf release whenever the field mapping changes in a way worth tracking.
 
 When you are handed an export and need to know exactly how that build mapped its
@@ -41,18 +56,21 @@ The envelope carries a `producer` object describing what wrote it:
 | `producer.app` | `"Sheaf"` | `APP_NAME` |
 | `producer.app_id` | `"sheaf"` | `APP_ID`, the registered namespace key |
 | `producer.app_version` | the Sheaf release, e.g. `"1.1.0"` | package metadata (`sheaf.__version__`) |
-| `producer.exporter_version` | `"0.1.0"` | `OPENPLURAL_IMPL_VERSION` |
+| `producer.exporter_version` | `"0.1.0"` | `PLURALPORT_IMPL_VERSION` |
 
-Separately, the top-level `openplural_version` field records the *spec* version
-the file targets, currently `"0.1"` (`OPENPLURAL_VERSION`). This is not the
+Separately, the top-level `pluralport_version` field records the *spec* version
+the file targets, currently `"0.1"` (`PLURALPORT_VERSION`). This is not the
 Sheaf version and not the exporter version - it is the contract the document
 claims to satisfy.
 
 The importer is strict about it. `SUPPORTED_VERSIONS = {"0.1"}`, and
 `_check_version` raises an `ImportPayloadError` for any other
-`openplural_version` rather than silently part-importing a document it does not
-understand. A file stamped, say, `openplural_version: "0.2"` will be rejected by
-a build that only knows `0.1`; this is deliberate per the spec.
+`pluralport_version` rather than silently part-importing a document it does not
+understand. A file stamped, say, `pluralport_version: "0.2"` will be rejected by
+a build that only knows `0.1`; this is deliberate per the spec. Per the spec's
+versioning rule, the deprecated pre-rename `openplural_version` key is accepted
+as a v0.1 alias with identical semantics; if a file carries both keys,
+`pluralport_version` wins.
 
 ## Provenance and lineage
 
@@ -111,7 +129,7 @@ that nothing in the DB layer can hand it back on the next export yet.
 The same `build_envelope` builder backs two delivery shapes, which differ only
 in how assets travel.
 
-### Sync JSON: `GET /v1/export?format=openplural`
+### Sync JSON: `GET /v1/export?format=pluralport`
 
 A single JSON document. Assets are **uri-only**: each `Asset` carries its avatar
 or image URL but no bytes. Because there are no blobs, the export emits a
@@ -119,16 +137,16 @@ top-level `info` warning with code `asset_uri_only`:
 
 ```json
 {"level": "info", "code": "asset_uri_only",
- "message": "Assets are referenced by URL only; export with images (the .openplural.zip bundle) to include the binary blobs."}
+ "message": "Assets are referenced by URL only; export with images (the .pluralport.zip bundle) to include the binary blobs."}
 ```
 
 Use this for a quick portable copy of structured data (systems, members, fronts,
 groups, tags, custom fields, journals); the images themselves only resolve if
 the destination can reach those URLs.
 
-### Async bundle: `.openplural.zip`
+### Async bundle: `.pluralport.zip`
 
-Produced by the async export job path. The zip contains `openplural.json` plus
+Produced by the async export job path. The zip contains `pluralport.json` plus
 an `assets/<storage_key>` entry for every internal image blob. In this shape each
 bundled asset additionally carries pointers under its own namespace:
 
@@ -159,10 +177,11 @@ present so the document stays spec-valid for an app that does not understand
 
 ---
 
-## Sheaf 1.1.0 - initial OpenPlural v0.1 support
+## Sheaf 1.1.0 - initial PluralPort v0.1 support
 
-First release with OpenPlural import/export. `OPENPLURAL_IMPL_VERSION = 0.1.0`,
-targeting spec `openplural_version 0.1`. The exporter is a pure transform over
+First release with PluralPort import/export (shipped under the format's
+pre-rename OpenPlural name; see "The OpenPlural rename" above). `PLURALPORT_IMPL_VERSION = 0.1.0`,
+targeting spec `pluralport_version 0.1`. The exporter is a pure transform over
 the native Article-20 export dict (version `"2"`); the importer is its inverse
 and translates back to that same native dict before delegating to the native
 importer, so all the import guards (member cap, safe-JSON, decompressed-size
@@ -171,9 +190,9 @@ one place and cannot drift per-format.
 
 ### Direct mappings
 
-Sheaf fields that land in OpenPlural core records.
+Sheaf fields that land in PluralPort core records.
 
-| Sheaf (native export) | OpenPlural core record / field |
+| Sheaf (native export) | PluralPort core record / field |
 |---|---|
 | `system.id` / `name` / `description` / `tag` / `color` | `System.id` / `name` / `description` / `tag` / `color` |
 | `system.avatar_url` | `Asset` (kind `avatar`) + `System.avatar_asset_id` |
@@ -208,10 +227,10 @@ Sheaf fields that land in OpenPlural core records.
 #### Birthday precision mapping
 
 Sheaf stores a birthday as a flat string, either with or without a year, and the
-exporter (`_birthday`) derives an OpenPlural precision-aware sub-record from its
+exporter (`_birthday`) derives a PluralPort precision-aware sub-record from its
 shape:
 
-| Sheaf stored value | OpenPlural `birthday` |
+| Sheaf stored value | PluralPort `birthday` |
 |---|---|
 | `"YYYY-MM-DD"` (3 parts) | `{"value": "YYYY-MM-DD", "precision": "day", "year_visible": true}` |
 | `"MM-DD"` (2 parts, year-less) | `{"value": "MM-DD", "precision": "month_day", "year_visible": false}` |
@@ -222,7 +241,7 @@ Sheaf string (and tolerates a plain string too).
 
 ### `extensions.sheaf.*` (platform-specific data)
 
-Everything Sheaf models that OpenPlural v0.1 has no core record for is preserved
+Everything Sheaf models that PluralPort v0.1 has no core record for is preserved
 losslessly under the registered `sheaf` namespace, so a round-trip restores it
 and another app can at least carry it forward. None of this is lost; it is just
 opaque to apps that do not speak Sheaf.
@@ -247,7 +266,7 @@ opaque to apps that do not speak Sheaf.
 
 #### File-level extensions
 
-These are the native sub-sections with no OpenPlural v0.1 core representation,
+These are the native sub-sections with no PluralPort v0.1 core representation,
 carried verbatim under `extensions.sheaf.<key>` (the `_EXT_PASSTHROUGH_SECTIONS`
 tuple), plus the lineage chain.
 
@@ -270,7 +289,7 @@ lifted directly into the native dict.
 ### Edge cases and decisions
 
 - **Privacy / visibility buckets.** Sheaf's `PrivacyLevel`
-  (`public` / `friends` / `private`) maps 1:1 onto the OpenPlural visibility
+  (`public` / `friends` / `private`) maps 1:1 onto the PluralPort visibility
   vocabulary (`{public, friends, private, trusted, unknown}`), rounding
   anything unrecognised to the strictest-safe `"unknown"` rather than
   guessing. Note the *shape*: on **system / member / custom-field** the spec
@@ -281,7 +300,7 @@ lifted directly into the native dict.
   **Note (journal) `visibility`** is a plain string in the spec, not the
   object, and stays a string both directions. (Treating the privacy object as
   a bare string was the cause of the `unhashable type: 'dict'` import crash on
-  spec-conformant files, e.g. a PluralSpace export routed through OpenPlural.)
+  spec-conformant files, e.g. a PluralSpace export routed through PluralPort.)
 - **Front status is free text.** `fronts[].custom_status` becomes
   `FrontPeriod.status` verbatim; there is no controlled vocabulary on the Sheaf
   side, so none is imposed.
@@ -308,14 +327,14 @@ lifted directly into the native dict.
 
 ### Preserving data Sheaf cannot model (incoming)
 
-Sheaf maps the subset of OpenPlural it models; without preservation, a file from
+Sheaf maps the subset of PluralPort it models; without preservation, a file from
 another app would lose everything Sheaf has no home for. To avoid being a lossy
 hop, the importer captures that residual on import and re-merges it into the next
-OpenPlural export. This is the **baseline tier** of the preservation contract
-Sheaf proposed upstream ([skylartaylor/openplural#11](https://github.com/skylartaylor/openplural/issues/11)):
+PluralPort export. This is the **baseline tier** of the preservation contract
+Sheaf proposed upstream ([PluralPort/spec#11](https://github.com/PluralPort/spec/issues/11)):
 file-level and whole-section passthrough.
 
-What is preserved (`services/openplural_archive.py`, `extract_residual`):
+What is preserved (`services/pluralport_archive.py`, `extract_residual`):
 
 | Residual | Source |
 | --- | --- |
@@ -327,8 +346,12 @@ What is preserved (`services/openplural_archive.py`, `extract_residual`):
 
 Storage: the residual is JSON, zlib-compressed, then encrypted at rest (it can
 carry message bodies and other content Sheaf treats as sensitive), and parked on
-`System.openplural_archive`. It is bounded by `OPENPLURAL_MAX_PRESERVED_MB`
-(default 8, measured on the raw JSON); a file over that has its residual dropped
+`System.openplural_archive` (the column keeps its pre-rename name: the AAD baked
+into the stored ciphertext is derived from it, so renaming it would make
+existing data undecryptable; the exported key is `pluralport_archive`, with the
+old spelling still accepted on import). It is bounded by
+`PLURALPORT_MAX_PRESERVED_MB` (default 8, measured on the raw JSON; the
+pre-rename `OPENPLURAL_MAX_PRESERVED_MB` env var still works); a file over that has its residual dropped
 with a warning rather than stored unbounded. The residual rides the native
 Article-20 export (decrypted) and is deleted with the account, so it is the
 user's data with the usual export and erasure coverage. Re-importing from a
@@ -346,8 +369,8 @@ silently dropping them.
 Much of what currently round-trips via `extensions.sheaf.*` should move to core
 records or dedicated modules if the matching upstream work lands. Sheaf filed
 issues #2 through #9 against
-[skylartaylor/openplural](https://github.com/skylartaylor/openplural) toward
-that (drafts live in `../sheaf-design-docs/openplural-adoption/`):
+[PluralPort/spec](https://github.com/PluralPort/spec) toward
+that (drafts live in `../sheaf-design-docs/pluralport-adoption/`):
 
 - **#2 - Add nullable `parent_post_id` to `BoardPost`.** Board posts carry a
   single-level reply pointer (`parent_message_id`) with no core field today; it
@@ -369,7 +392,7 @@ that (drafts live in `../sheaf-design-docs/openplural-adoption/`):
 - **#8 - Specify markdown flavour and in-body image embed syntax.** Pin how
   `description` / `body` markdown and embedded image references are written so
   bodies render identically across apps.
-- **#9 - Standardise the `.openplural` zip bundle format.** Where bundled asset
+- **#9 - Standardise the `.pluralport` zip bundle format.** Where bundled asset
   bytes live in the archive, so the `bundle_path` pointer can move out of the
   Sheaf namespace into the core asset shape.
 
@@ -387,7 +410,7 @@ When the mapping logic changes - a field moves from `extensions.sheaf.*` into a
 new core record, a new section is mapped, an enum is remapped, an upstream issue
 lands - do two things:
 
-1. Bump `OPENPLURAL_IMPL_VERSION` in `sheaf/services/openplural_export.py` (and
+1. Bump `PLURALPORT_IMPL_VERSION` in `sheaf/services/pluralport_export.py` (and
    add the new value to the importer's `SUPPORTED_VERSIONS` if the change is not
    backward-compatible for reading older files).
 2. Add a new dated `## Sheaf X.Y.Z` section here describing exactly what changed.

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -1100,13 +1100,13 @@ MAX_IMPORT_RESTORED_IMAGES=20000 # per-import image-restore cap (archive import)
 
 The last knob bounds how many images one export-with-images archive import will restore. The storage quota already bounds the restored bytes; this bounds the number of normalization passes a single job can demand, so a crafted zip full of tiny images can't monopolise the import runner. An import that hits the cap completes with a warning and strips the remaining image references. Raise it if your system genuinely has more images than the default.
 
-OpenPlural imports additionally preserve data Sheaf cannot model (other apps' `extensions` namespaces, the chat/relationships modules, non-tag taxonomy) so a Sheaf-in-the-middle round-trip is not lossy: that residual is compressed and encrypted on the system and re-emitted on the next OpenPlural export. Its size is bounded by:
+PluralPort imports additionally preserve data Sheaf cannot model (other apps' `extensions` namespaces, the chat/relationships modules, non-tag taxonomy) so a Sheaf-in-the-middle round-trip is not lossy: that residual is compressed and encrypted on the system and re-emitted on the next PluralPort export. Its size is bounded by:
 
 ```env
-OPENPLURAL_MAX_PRESERVED_MB=8    # max preserved unsupported-data per system; 0 = unlimited
+PLURALPORT_MAX_PRESERVED_MB=8    # max preserved unsupported-data per system; 0 = unlimited
 ```
 
-Measured on the raw (pre-compression) JSON. A file whose unsupported data exceeds this has its residual dropped with a warning rather than stored unbounded. `0` disables the cap (unlimited), matching the storage-quota convention. See `docs/OPENPLURAL.md` for what gets preserved.
+Measured on the raw (pre-compression) JSON. A file whose unsupported data exceeds this has its residual dropped with a warning rather than stored unbounded. `0` disables the cap (unlimited), matching the storage-quota convention. The setting was named `OPENPLURAL_MAX_PRESERVED_MB` before the format's rename from OpenPlural to PluralPort; the old env var name is still accepted (the new one wins if both are set). See `docs/PLURALPORT.md` for what gets preserved.
 
 ### Animated avatars
 

--- a/sheaf/api/v1/export.py
+++ b/sheaf/api/v1/export.py
@@ -15,11 +15,11 @@ import logging
 import uuid
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, BeforeValidator, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -71,7 +71,7 @@ from sheaf.services.activity_log import log_activity
 from sheaf.services.custom_fields import field_value_plaintext
 from sheaf.services.journals import entry_plaintext, revision_plaintext
 from sheaf.services.members import member_plaintext
-from sheaf.services.openplural_archive import unpack_residual
+from sheaf.services.pluralport_archive import unpack_residual
 from sheaf.services.security_events import record_security_event
 
 router = APIRouter(prefix="/export", tags=["export"])
@@ -114,6 +114,11 @@ def _safe_decrypt(value: str | None, aad: bytes) -> str | None:
 # name) can't be decrypted. Null would risk a NOT NULL violation on re-import;
 # a placeholder re-imports cleanly and signals the field was unrecoverable.
 _UNREADABLE_PLACEHOLDER = "[unreadable]"
+
+
+def _normalise_export_format(value: object) -> object:
+    """Map the deprecated pre-rename format name onto its current one."""
+    return "pluralport" if value == "openplural" else value
 
 
 def _safe_plaintext(fn: Callable, *, fallback):
@@ -246,14 +251,22 @@ async def _note_api_key_export(
 async def export_all(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    format: Literal["sheaf", "openplural"] = Query(
-        "sheaf",
-        description=(
-            "Output format. 'sheaf' is the native re-importable JSON; "
-            "'openplural' wraps it in an OpenPlural v0.1 envelope "
-            "(uri-only assets; use the async zip export for image bytes)."
+    format: Annotated[
+        Literal["sheaf", "pluralport"],
+        # "openplural" is the format's pre-rename name; normalised here so
+        # existing callers keep working while the documented enum stays
+        # pluralport-only.
+        BeforeValidator(_normalise_export_format),
+        Query(
+            description=(
+                "Output format. 'sheaf' is the native re-importable JSON; "
+                "'pluralport' wraps it in a PluralPort v0.1 envelope "
+                "(uri-only assets; use the async zip export for image "
+                "bytes). 'openplural' is accepted as a deprecated alias "
+                "for 'pluralport'."
+            ),
         ),
-    ),
+    ] = "sheaf",
 ):
     """Export the user's plural-system content as JSON. Article 20 - data
     portability. Re-importable into another Sheaf instance.
@@ -266,7 +279,7 @@ async def export_all(
     result = await db.execute(select(System).where(System.user_id == user.id))
     system = result.scalar_one_or_none()
     if system is None:
-        return _maybe_openplural(_empty_export(), format)
+        return _maybe_pluralport(_empty_export(), format)
 
     # Members. Member.name is encrypted ciphertext, so DB-side ORDER BY on
     # it is meaningless - sort in Python after decrypting names below.
@@ -595,20 +608,20 @@ async def export_all(
         ],
         "share_views": [_share_view_dict(v) for v in share_views],
     }
-    return _maybe_openplural(native, format)
+    return _maybe_pluralport(native, format)
 
 
-def _maybe_openplural(native: dict, format: str) -> dict:
-    """Return the native dict unchanged, or wrap it in an OpenPlural v0.1
-    envelope when `format == "openplural"`.
+def _maybe_pluralport(native: dict, format: str) -> dict:
+    """Return the native dict unchanged, or wrap it in a PluralPort v0.1
+    envelope when `format == "pluralport"`.
 
     The sync path produces uri-only assets (no image bytes); the async
-    zip builder calls `openplural_export.build_envelope` directly with
+    zip builder calls `pluralport_export.build_envelope` directly with
     `include_asset_bytes=True` for the bundle.
     """
-    if format != "openplural":
+    if format != "pluralport":
         return native
-    from sheaf.services.openplural_export import build_envelope
+    from sheaf.services.pluralport_export import build_envelope
 
     return build_envelope(native, exported_at=datetime.now(UTC).isoformat())
 
@@ -743,10 +756,13 @@ def _system_dict(system: System) -> dict:
             "journal_max_revision_days": system.journal_max_revision_days,
             "pinned_revision_max_per_target": system.pinned_revision_max_per_target,
         },
-        # OpenPlural import residual (foreign data Sheaf cannot model),
+        # PluralPort import residual (foreign data Sheaf cannot model),
         # decrypted to a plain dict so it rides the portability export and
-        # is re-merged on a Sheaf OpenPlural export. None when empty.
-        "openplural_archive": (
+        # is re-merged on a Sheaf PluralPort export. None when empty. The
+        # DB column keeps its pre-rename openplural name (the AAD baked
+        # into the stored ciphertext is frozen); the exported KEY uses the
+        # new name, and the importer accepts both spellings.
+        "pluralport_archive": (
             unpack_residual(system.openplural_archive, system_id=system.id) or None
         ),
     }
@@ -1011,17 +1027,25 @@ def _poll_dict(poll) -> dict:
 class ExportJobRequest(BaseModel):
     include_images: bool = False
     # Artefact format: "sheaf_native" (export.json + images/) or
-    # "openplural" (openplural.json + assets/, an .openplural.zip bundle), or
+    # "pluralport" (pluralport.json + assets/, a .pluralport.zip bundle), or
     # a standalone front-history file ("fronts_csv" / "fronts_json" /
     # "fronts_ics") - a single file of just the fronting history, no zip.
     # include_images is ignored for the fronts_* formats.
     format: Literal[
         "sheaf_native",
-        "openplural",
+        "pluralport",
         "fronts_csv",
         "fronts_json",
         "fronts_ics",
     ] = "sheaf_native"
+
+    @field_validator("format", mode="before")
+    @classmethod
+    def _legacy_format_alias(cls, value: object) -> object:
+        # "openplural" is the format's pre-rename name; accepted as a
+        # deprecated request alias and normalised before the Literal check
+        # so it stays out of the documented enum.
+        return "pluralport" if value == "openplural" else value
     # Step-up auth: same shape and rules as POST /v1/account/data. Always
     # required; mirrors the Article 15 lock since this is the broader read
     # (everything the user has, including binary blobs).
@@ -1183,8 +1207,8 @@ async def download_export_job(
         format_extension,
     )
 
-    if job.format == "openplural":
-        filename = f"sheaf-export-{job.id}.openplural.zip"
+    if job.format == "pluralport":
+        filename = f"sheaf-export-{job.id}.pluralport.zip"
     elif job.format in FRONT_HISTORY_FORMATS:
         filename = (
             f"sheaf-front-history-{job.id}.{format_extension(job.format)}"

--- a/sheaf/api/v1/imports.py
+++ b/sheaf/api/v1/imports.py
@@ -30,7 +30,7 @@ from sheaf.auth.dependencies import get_current_user
 from sheaf.crypto import encrypt
 from sheaf.database import get_db
 from sheaf.encrypted_fields import import_credential_aad
-from sheaf.models.import_job import ImportJob, ImportJobStatus
+from sheaf.models.import_job import ImportJob, ImportJobSource, ImportJobStatus
 from sheaf.models.user import User
 from sheaf.schemas.imports import (
     ImportApiCreateRequest,
@@ -168,6 +168,12 @@ async def create_file_import(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="options must be a JSON object",
             )
+
+    # Deprecated alias from before the OpenPlural -> PluralPort rename:
+    # normalise the old source value before validation so pre-rename
+    # clients keep working. The job row always records the new value.
+    if source == "openplural_file":
+        source = ImportJobSource.PLURALPORT_FILE.value
 
     try:
         body = ImportFileCreateRequest(

--- a/sheaf/api/v1/pluralport_import.py
+++ b/sheaf/api/v1/pluralport_import.py
@@ -1,13 +1,13 @@
-"""OpenPlural import - preview endpoint.
+"""PluralPort import - preview endpoint.
 
 The actual import runs asynchronously through the unified job runner
-(POST /v1/imports/file with source=openplural_file). This is the
-synchronous preview: parse an OpenPlural v0.1 export, translate it to
+(POST /v1/imports/file with source=pluralport_file). This is the
+synchronous preview: parse a PluralPort v0.1 export, translate it to
 the native shape, and summarise the importable data. Preview writes
 nothing.
 
-Accepts both shapes the exporter produces: a bare OpenPlural JSON
-document and an `.openplural.zip` bundle (`openplural.json` +
+Accepts both shapes the exporter produces: a bare PluralPort JSON
+document and an `.pluralport.zip` bundle (`pluralport.json` +
 `assets/`), distinguished by the zip magic bytes. The response carries
 `archive` / `image_count` so the client knows which flavour it
 previewed, and `lineage_length` so it can surface the file's prior
@@ -24,7 +24,7 @@ from sheaf.models.system import System
 from sheaf.models.user import User
 from sheaf.services.front_retention import front_retention_preview_warning
 from sheaf.services.import_parsing import ImportPayloadError
-from sheaf.services.openplural_import import (
+from sheaf.services.pluralport_import import (
     inherited_lineage,
     looks_like_zip,
     parse_bundle_async,
@@ -73,13 +73,17 @@ async def _get_user_system(user: User, db: AsyncSession) -> System:
     return system
 
 
-@router.post("/openplural/preview")
-async def preview_openplural_import(
+@router.post("/pluralport/preview")
+# Deprecated alias from before the OpenPlural -> PluralPort rename. Same
+# handler, kept working for older clients but hidden from the OpenAPI
+# schema; remove once nothing calls it any more.
+@router.post("/openplural/preview", include_in_schema=False)
+async def preview_pluralport_import(
     file: UploadFile,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Parse an OpenPlural export (JSON or .openplural.zip) and summarise it."""
+    """Parse a PluralPort export (JSON or .pluralport.zip) and summarise it."""
     data = await file.read()
     if len(data) > MAX_IMPORT_SIZE:
         raise HTTPException(
@@ -137,7 +141,7 @@ async def preview_openplural_import(
         }
     except ImportPayloadError as exc:
         # User-facing parse/version failures (bad JSON, bad zip, unknown
-        # openplural_version) map to a 400 with the short message.
+        # pluralport_version) map to a 400 with the short message.
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from exc

--- a/sheaf/api/v1/router.py
+++ b/sheaf/api/v1/router.py
@@ -25,8 +25,8 @@ from sheaf.api.v1 import (
     messages,
     notification_channels,
     notifications_public,
-    openplural_import,
     pk_import,
+    pluralport_import,
     pluralspace_import,
     polls,
     prism_import,
@@ -174,7 +174,7 @@ v1_router.include_router(
     dependencies=[Depends(require_scope("import:write"))],
 )
 v1_router.include_router(
-    openplural_import.router,
+    pluralport_import.router,
     dependencies=[Depends(require_scope("import:write"))],
 )
 v1_router.include_router(

--- a/sheaf/config.py
+++ b/sheaf/config.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from ipaddress import IPv4Network, IPv6Network, ip_network
 from pathlib import Path
 
-from pydantic import field_validator, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 logger = logging.getLogger("sheaf")
@@ -185,13 +185,20 @@ class Settings(BaseSettings):
     # the body is buffered anywhere. Must be >= the largest per-endpoint cap
     # (currently the 100MB import endpoint) plus a little multipart overhead.
     max_request_body_size_mb: int = 110
-    # OpenPlural import: max size (MB) of foreign data Sheaf cannot model
+    # PluralPort import: max size (MB) of foreign data Sheaf cannot model
     # (other apps' `extensions` namespaces, the chat/relationships modules,
     # front_events/front_comments, non-tag taxonomy) that gets preserved as
-    # an opaque archive on the system and re-emitted on the next OpenPlural
+    # an opaque archive on the system and re-emitted on the next PluralPort
     # export. Measured on the raw (pre-compression) JSON; over this, the
     # residual is dropped with a warning rather than stored unbounded.
-    openplural_max_preserved_mb: int = 8
+    # The env var was OPENPLURAL_MAX_PRESERVED_MB before the format's
+    # rename; both names are honoured (the new one wins if both are set).
+    pluralport_max_preserved_mb: int = Field(
+        default=8,
+        validation_alias=AliasChoices(
+            "pluralport_max_preserved_mb", "openplural_max_preserved_mb"
+        ),
+    )
 
     # Storage quotas per tier (MB). 0 = unlimited.
     storage_quota_free_mb: int = 50

--- a/sheaf/encrypted_fields.py
+++ b/sheaf/encrypted_fields.py
@@ -68,6 +68,11 @@ def system_note_aad(system_id) -> bytes:
     return field_aad("systems", "note", system_id)
 
 
+# FROZEN NAME: the format this column serves was renamed OpenPlural ->
+# PluralPort, but this helper (and the systems.openplural_archive column
+# it names) must keep the old string - it is the AAD baked into every
+# encrypted archive blob in production, so renaming it would make that
+# data undecryptable.
 def system_openplural_archive_aad(system_id) -> bytes:
     return field_aad("systems", "openplural_archive", system_id)
 

--- a/sheaf/models/export_job.py
+++ b/sheaf/models/export_job.py
@@ -49,7 +49,9 @@ class ExportJob(UUIDMixin, Base):
     )
 
     # Output format: "sheaf_native" (export.json + images/) or
-    # "openplural" (openplural.json + assets/, an .openplural.zip bundle).
+    # "pluralport" (pluralport.json + assets/, a .pluralport.zip bundle).
+    # Pre-rename "openplural" rows were migrated to "pluralport"; the API
+    # still accepts the old value as a deprecated request alias.
     format: Mapped[str] = mapped_column(
         String(32),
         nullable=False,

--- a/sheaf/models/import_job.py
+++ b/sheaf/models/import_job.py
@@ -34,11 +34,13 @@ class ImportJobSource(enum.StrEnum):
     SHEAF_ARCHIVE = "sheaf_archive"
     PLURALSPACE_FILE = "pluralspace_file"
     PRISM_FILE = "prism_file"
-    # OpenPlural v0.1 envelope: a bare .json document or an .openplural.zip
-    # bundle (openplural.json + assets/). The runner sniffs which by the
+    # PluralPort v0.1 envelope: a bare .json document or a .pluralport.zip
+    # bundle (pluralport.json + assets/). The runner sniffs which by the
     # zip magic; both translate to the native shape and reuse the Sheaf
-    # JSON / archive importers underneath.
-    OPENPLURAL_FILE = "openplural_file"
+    # JSON / archive importers underneath. The API still accepts the
+    # pre-rename "openplural_file" as a deprecated request alias (it is
+    # normalised before validation); stored rows were migrated.
+    PLURALPORT_FILE = "pluralport_file"
     # Ampersand JSON export ({revision, config, database}). Base64 images
     # inline as data URIs; decoded + stored like the archive importers.
     AMPERSAND_FILE = "ampersand_file"

--- a/sheaf/models/system.py
+++ b/sheaf/models/system.py
@@ -217,13 +217,17 @@ class System(UUIDMixin, TimestampMixin, Base):
         Integer, default=0, server_default="0", nullable=False
     )
 
-    # OpenPlural import residual: foreign data Sheaf does not model (other
+    # PluralPort import residual: foreign data Sheaf does not model (other
     # apps' `extensions` namespaces, the chat/relationships modules,
     # front_events/front_comments, non-tag taxonomy) preserved verbatim on
-    # import and re-merged into the next OpenPlural export, so a
+    # import and re-merged into the next PluralPort export, so a
     # Sheaf-in-the-middle round-trip does not silently drop it. Stored
     # encrypted (it can carry message bodies) and zlib-compressed; see
-    # services/openplural_archive.py. NULL when nothing was preserved.
+    # services/pluralport_archive.py. NULL when nothing was preserved.
+    # NB the column (and attribute) name is FROZEN at the format's old
+    # OpenPlural name: the AAD string derived from it is baked into every
+    # encrypted archive blob in production, so renaming it would make
+    # existing data undecryptable. Only the format branding changed.
     openplural_archive: Mapped[str | None] = mapped_column(
         Text, nullable=True, info={"encrypted": True}
     )

--- a/sheaf/schemas/imports.py
+++ b/sheaf/schemas/imports.py
@@ -44,7 +44,7 @@ class ImportFileCreateRequest(BaseModel):
         ImportJobSource.SHEAF_ARCHIVE,
         ImportJobSource.PLURALSPACE_FILE,
         ImportJobSource.PRISM_FILE,
-        ImportJobSource.OPENPLURAL_FILE,
+        ImportJobSource.PLURALPORT_FILE,
         ImportJobSource.AMPERSAND_FILE,
     ]
     idempotency_key: uuid.UUID

--- a/sheaf/services/export_builder.py
+++ b/sheaf/services/export_builder.py
@@ -53,20 +53,20 @@ image references removed.
 """
 
 
-_OPENPLURAL_README = """\
-This zip is an OpenPlural v0.1 bundle export of your Sheaf data.
+_PLURALPORT_README = """\
+This zip is a PluralPort v0.1 bundle export of your Sheaf data.
 
 Contents:
-- openplural.json -- your plural-system content mapped to the OpenPlural
-  v0.1 data standard (https://github.com/skylartaylor/openplural).
+- pluralport.json -- your plural-system content mapped to the PluralPort
+  v0.1 data standard (https://github.com/PluralPort/spec).
   Systems, members, groups, tags, custom fields, front history, and
-  journals map to OpenPlural core records; everything Sheaf has that
+  journals map to PluralPort core records; everything Sheaf has that
   the spec does not yet model is preserved under extensions.sheaf.*
 - assets/ -- the binary blobs (avatars, banners, journal images)
   referenced by the assets[] entries via their bundle_path.
 
 Re-importable into Sheaf (Settings -> Import) and into any other app
-that supports OpenPlural v0.1. See docs/OPENPLURAL.md in the Sheaf
+that supports PluralPort v0.1. See docs/PLURALPORT.md in the Sheaf
 source for the field-by-field mapping and known gaps.
 """
 
@@ -238,8 +238,8 @@ async def _assemble_zip_to_tempfile(
         README.txt    -- explains the asymmetry around image re-import
         images/<key>  -- (when include_images) the binary blobs
 
-    OpenPlural bundle (`fmt="openplural"`):
-        openplural.json   -- OpenPlural v0.1 envelope
+    PluralPort bundle (`fmt="pluralport"`):
+        pluralport.json   -- PluralPort v0.1 envelope
         README.txt        -- bundle notes
         assets/<key>      -- (when include_images) the referenced blobs
 
@@ -260,8 +260,8 @@ async def _assemble_zip_to_tempfile(
     os.close(fd)  # zipfile reopens the path; we just needed exclusive creation
     try:
         with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            if fmt == "openplural":
-                from sheaf.services.openplural_export import build_envelope
+            if fmt == "pluralport":
+                from sheaf.services.pluralport_export import build_envelope
 
                 envelope = build_envelope(
                     native_payload,
@@ -269,12 +269,12 @@ async def _assemble_zip_to_tempfile(
                     include_asset_bytes=include_images,
                 )
                 zf.writestr(
-                    "openplural.json",
+                    "pluralport.json",
                     json.dumps(envelope, indent=2, default=str).encode("utf-8"),
                 )
-                zf.writestr("README.txt", _OPENPLURAL_README)
+                zf.writestr("README.txt", _PLURALPORT_README)
                 if include_images:
-                    await _add_openplural_assets(zf, envelope)
+                    await _add_pluralport_assets(zf, envelope)
             else:
                 zf.writestr(
                     "export.json",
@@ -332,8 +332,8 @@ async def _assemble_fronts_to_tempfile(
     return tmp_path, size_bytes
 
 
-async def _add_openplural_assets(zf: zipfile.ZipFile, envelope: dict) -> None:
-    """Pack the blobs the OpenPlural envelope references under assets/<key>.
+async def _add_pluralport_assets(zf: zipfile.ZipFile, envelope: dict) -> None:
+    """Pack the blobs the PluralPort envelope references under assets/<key>.
 
     Only assets carrying an `extensions.sheaf.storage_key` (Sheaf-internal
     references) have bytes to bundle; external CDN URLs stay uri-only.
@@ -351,14 +351,14 @@ async def _add_openplural_assets(zf: zipfile.ZipFile, envelope: dict) -> None:
         try:
             blob = await storage.get(key)
         except Exception:  # noqa: BLE001
-            logger.warning("Skipping unreadable asset %s in OpenPlural export", key)
+            logger.warning("Skipping unreadable asset %s in PluralPort export", key)
             continue
         if blob is None:
             # Row references a blob absent from storage: the export.json still
             # lists it, so the archive is internally inconsistent (missing on
             # restore). Distinct from the unreadable case above.
             logger.warning(
-                "OpenPlural export: asset %s missing from storage, omitted "
+                "PluralPort export: asset %s missing from storage, omitted "
                 "though still referenced", key,
             )
             continue

--- a/sheaf/services/front_history_export.py
+++ b/sheaf/services/front_history_export.py
@@ -1,7 +1,7 @@
 """Standalone front-history export: CSV / JSON / ICS.
 
 A lighter-weight companion to the full account export. Where the native /
-OpenPlural exports produce a whole-account zip, this produces a single
+PluralPort exports produce a whole-account zip, this produces a single
 file containing only the system's front history, in a format the user
 picks:
 

--- a/sheaf/services/import_runner.py
+++ b/sheaf/services/import_runner.py
@@ -453,8 +453,8 @@ def _register_builtin_handlers() -> None:
     # pk_import_runner registers both pluralkit_file and pluralkit_api.
     from sheaf.services import (
         ampersand_import_runner,  # noqa: F401
-        openplural_import_runner,  # noqa: F401
         pk_import_runner,  # noqa: F401
+        pluralport_import_runner,  # noqa: F401
         pluralspace_import_runner,  # noqa: F401
         prism_import_runner,  # noqa: F401
         sheaf_archive_import_runner,  # noqa: F401

--- a/sheaf/services/pluralport_archive.py
+++ b/sheaf/services/pluralport_archive.py
@@ -1,24 +1,27 @@
-"""OpenPlural import-residual preservation.
+"""PluralPort import-residual preservation.
 
-Sheaf's OpenPlural importer maps the subset of the format it models and,
+Sheaf's PluralPort importer maps the subset of the format it models and,
 without this module, drops the rest. That makes Sheaf a lossy hop: a
 file from another app loses that app's `extensions` namespaces, its chat
 and relationships modules, switch-style `front_events` / `front_comments`,
 and non-tag taxonomy on the way through.
 
 This module captures that residual on import and re-merges it into the
-next OpenPlural export, so a Sheaf-in-the-middle round-trip preserves it.
+next PluralPort export, so a Sheaf-in-the-middle round-trip preserves it.
 This is the "baseline" tier of the preservation contract Sheaf proposed
-upstream (skylartaylor/openplural#11): file-level and whole-section
+upstream (PluralPort/spec#11): file-level and whole-section
 passthrough. Per-record foreign `extensions` (which need stable record
 identity to re-attach) are not preserved yet and are reported with a
 warning; that is the follow-up "full passthrough" tier.
 
 Storage: the residual is JSON, zlib-compressed (it can be large), then
 encrypted at rest (it can carry message bodies and other content Sheaf
-treats as sensitive), and parked on `System.openplural_archive`. It is
-bounded by `settings.openplural_max_preserved_mb` (measured on the raw
-JSON) so a hostile or huge file cannot grow the row without limit.
+treats as sensitive), and parked on `System.openplural_archive`. (The
+column and its AAD keep the pre-rename OpenPlural name: the AAD string is
+baked into every encrypted archive blob in production, so renaming it
+would make existing data undecryptable.) It is bounded by
+`settings.pluralport_max_preserved_mb` (measured on the raw JSON) so a
+hostile or huge file cannot grow the row without limit.
 """
 
 from __future__ import annotations
@@ -38,13 +41,13 @@ _OWN_NS = "sheaf"
 # verbatim. `chat` / `relationships` are spec modules Sheaf has no feature
 # for; `front_comments` are time-anchored comments on fronting that Sheaf
 # has no model for. NB `front_events` are NOT here: the importer converts
-# them to interval fronts (see openplural_import._fronts_from_events), so
+# them to interval fronts (see pluralport_import._fronts_from_events), so
 # they are consumed, not preserved.
 _PASSTHROUGH_TOP_LEVEL = ("chat", "relationships", "front_comments")
 
 
 def extract_residual(envelope: dict) -> dict:
-    """Return the parts of an OpenPlural envelope Sheaf does not model.
+    """Return the parts of a PluralPort envelope Sheaf does not model.
 
     Empty dict when there is nothing to preserve. Pure: no IO.
     """
@@ -156,17 +159,18 @@ def pack_residual(
     JSON: it bounds what we are willing to retain, not the on-disk size.
 
     ``system_id`` is the owning system's id; the ciphertext is AAD-bound to
-    the ``systems.openplural_archive`` cell so it cannot be relocated to
-    another system's row.
+    the ``systems.openplural_archive`` cell (the column keeps its pre-rename
+    name for AAD compatibility) so it cannot be relocated to another
+    system's row.
     """
     if not residual:
         return None, None
     raw = json.dumps(residual, separators=(",", ":")).encode("utf-8")
     if max_bytes and len(raw) > max_bytes:
         return None, (
-            f"preserved {len(raw)} bytes of unsupported OpenPlural data exceeds "
+            f"preserved {len(raw)} bytes of unsupported PluralPort data exceeds "
             f"the {max_bytes // (1024 * 1024)}MB limit "
-            "(OPENPLURAL_MAX_PRESERVED_MB); it was not retained"
+            "(PLURALPORT_MAX_PRESERVED_MB); it was not retained"
         )
     compressed = zlib.compress(raw, 9)
     token = encrypt(

--- a/sheaf/services/pluralport_export.py
+++ b/sheaf/services/pluralport_export.py
@@ -1,26 +1,26 @@
-"""OpenPlural v0.1 export mapping.
+"""PluralPort v0.1 export mapping.
 
-Sheaf is a founding adopter of the OpenPlural data standard
-(https://github.com/skylartaylor/openplural). This module is a *pure*
+Sheaf is a founding adopter of the PluralPort data standard
+(https://github.com/PluralPort/spec). This module is a *pure*
 transform: it takes the native Article-20 export dict that
 ``sheaf/api/v1/export.py::export_all`` already produces (version "2")
-and reshapes it into an OpenPlural v0.1 envelope. It performs no DB
+and reshapes it into a PluralPort v0.1 envelope. It performs no DB
 access and no decryption - everything it needs is already plaintext in
 the native dict.
 
-The mapping follows the Sheaf card in ``../openplural/adopt.md``. Every
-field Sheaf has that OpenPlural v0.1 can model goes into a core record;
+The mapping follows the Sheaf card in ``../pluralport-spec/adopt.md``. Every
+field Sheaf has that PluralPort v0.1 can model goes into a core record;
 everything else is preserved losslessly under the namespaced
 ``extensions.sheaf`` key so a round-trip back into Sheaf restores it and
-another app can at least carry it forward. See ``docs/OPENPLURAL.md``
+another app can at least carry it forward. See ``docs/PLURALPORT.md``
 for the full per-field rationale and the running implementation log.
 
 Two delivery shapes share this builder:
 
-* The sync ``GET /v1/export?format=openplural`` path emits a single
+* The sync ``GET /v1/export?format=pluralport`` path emits a single
   JSON document with *uri-only* assets (avatar URLs, no bytes) and a
   top-level ``asset_uri_only`` warning.
-* The async ``.openplural.zip`` bundle additionally writes the blobs to
+* The async ``.pluralport.zip`` bundle additionally writes the blobs to
   ``assets/<key>`` and records the in-zip path under each asset's
   ``extensions.sheaf.bundle_path`` (the official bundle-path convention
   is still pending upstream issue #9; until it lands we keep ``uri``
@@ -35,10 +35,10 @@ import uuid
 from sheaf import __version__
 
 # What this module targets / advertises.
-OPENPLURAL_VERSION = "0.1"
+PLURALPORT_VERSION = "0.1"
 # Bumped independently of the Sheaf app version when the *mapping* logic
 # changes in a way worth tracking; surfaces as producer.exporter_version.
-OPENPLURAL_IMPL_VERSION = "0.1.0"
+PLURALPORT_IMPL_VERSION = "0.1.0"
 APP_ID = "sheaf"
 APP_NAME = "Sheaf"
 # The reverse-DNS-free registered namespace key Sheaf owns in the spec.
@@ -49,11 +49,11 @@ EXT_NS = "sheaf"
 # member can reference it by id.
 _ASSET_NS = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
 
-# Native sub-sections with no OpenPlural v0.1 core representation. Carried
+# Native sub-sections with no PluralPort v0.1 core representation. Carried
 # verbatim under extensions.sheaf.<key> so the round-trip is lossless and
 # the importer can lift them straight back. Each is parked pending the
 # matching upstream module (polls/reminders -> v0.2, etc); see the table
-# in docs/OPENPLURAL.md.
+# in docs/PLURALPORT.md.
 _EXT_PASSTHROUGH_SECTIONS = (
     "polls",
     "reminders",
@@ -61,14 +61,14 @@ _EXT_PASSTHROUGH_SECTIONS = (
     "revisions",
     "watch_tokens",
     "uploaded_files",
-    # OpenPlural v0.1 has no relationship core record, so the types and both
+    # PluralPort v0.1 has no relationship core record, so the types and both
     # edge tables ride the file-level extensions.sheaf.* passthrough (NOT the
     # reserved top-level `relationships` key, which is for foreign preserved
     # modules; see _merge_preserved).
     "relationship_types",
     "member_relationships",
     "group_relationships",
-    # OpenPlural v0.1 has no sharing/visibility module, so the curated share
+    # PluralPort v0.1 has no sharing/visibility module, so the curated share
     # views ride the passthrough. Share GRANTS are absent from the native
     # export by design (a grant is a live capability), so nothing here can
     # republish a system on re-import.
@@ -92,7 +92,7 @@ def _internal_key(url: str) -> str | None:
 
 def _birthday(raw: str | None) -> dict | None:
     """Map Sheaf's ``"MM-DD"`` / ``"YYYY-MM-DD"`` birthday string to an
-    OpenPlural precision-aware Birthday sub-record."""
+    PluralPort precision-aware Birthday sub-record."""
     if not raw:
         return None
     parts = raw.split("-")
@@ -162,7 +162,7 @@ def build_envelope(
     inherited_lineage: list | None = None,
     include_asset_bytes: bool = False,
 ) -> dict:
-    """Transform a native export dict into an OpenPlural v0.1 envelope.
+    """Transform a native export dict into a PluralPort v0.1 envelope.
 
     ``exported_at`` is an ISO-8601 UTC timestamp supplied by the caller
     (this module takes no clock). ``inherited_lineage`` is any
@@ -231,7 +231,7 @@ def build_envelope(
             "notify_on_front_self": m.get("notify_on_front_self"),
             "notify_on_front_member_ids": m.get("notify_on_front_member_ids"),
             # Protective share guards. Carried so a round-trip through
-            # OpenPlural never returns a member less protected than they were.
+            # PluralPort never returns a member less protected than they were.
             "never_shareable": m.get("never_shareable"),
             "fronting_private": m.get("fronting_private"),
         }
@@ -266,7 +266,7 @@ def build_envelope(
                 "description": g.get("description"),
                 "color": g.get("color"),
                 "parent_group_id": g.get("parent_id"),
-                # OpenPlural v0.1 has no group privacy field, so the group's
+                # PluralPort v0.1 has no group privacy field, so the group's
                 # exposure ceiling rides the sheaf extension rather than being
                 # invented as a core key. Carried for the same reason
                 # `never_shareable` is carried on a member: a round-trip must
@@ -405,7 +405,7 @@ def build_envelope(
         {
             "app": APP_ID,
             "app_version": app_version,
-            "exporter_version": OPENPLURAL_IMPL_VERSION,
+            "exporter_version": PLURALPORT_IMPL_VERSION,
             "exported_at": exported_at,
         }
     )
@@ -423,19 +423,19 @@ def build_envelope(
                 "code": "asset_uri_only",
                 "message": (
                     "Assets are referenced by URL only; export with images "
-                    "(the .openplural.zip bundle) to include the binary blobs."
+                    "(the .pluralport.zip bundle) to include the binary blobs."
                 ),
             }
         )
 
     envelope: dict = {
-        "openplural_version": OPENPLURAL_VERSION,
+        "pluralport_version": PLURALPORT_VERSION,
         "exported_at": exported_at,
         "producer": {
             "app": APP_NAME,
             "app_id": APP_ID,
             "app_version": app_version,
-            "exporter_version": OPENPLURAL_IMPL_VERSION,
+            "exporter_version": PLURALPORT_IMPL_VERSION,
         },
         "capabilities": {"modules": modules},
         "systems": systems,
@@ -458,8 +458,8 @@ def build_envelope(
     # Re-merge any preserved residual from a prior foreign import (the
     # baseline passthrough tier: file-level extensions + whole un-consumed
     # sections). Sheaf stores this encrypted on the system; the native
-    # export decrypts it into `system.openplural_archive` as a plain dict.
-    preserved = sys_data.get("openplural_archive") if isinstance(sys_data, dict) else None
+    # export decrypts it into `system.pluralport_archive` as a plain dict.
+    preserved = sys_data.get("pluralport_archive") if isinstance(sys_data, dict) else None
     if isinstance(preserved, dict) and preserved:
         _merge_preserved(envelope, preserved)
     return envelope
@@ -501,10 +501,10 @@ _VALID_VISIBILITY = {"public", "friends", "private", "trusted", "unknown"}
 
 
 def _privacy(val: str | None) -> str:
-    """Sheaf privacy/visibility -> OpenPlural conservative bucket.
+    """Sheaf privacy/visibility -> PluralPort conservative bucket.
 
     Sheaf's PrivacyLevel (public/friends/private) maps 1:1 onto the
-    OpenPlural visibility vocabulary; anything unrecognised rounds to
+    PluralPort visibility vocabulary; anything unrecognised rounds to
     the strictest-safe ``unknown``.
     """
     if val in _VALID_VISIBILITY:
@@ -513,7 +513,7 @@ def _privacy(val: str | None) -> str:
 
 
 def _privacy_obj(val: str | None) -> dict:
-    """Wrap a Sheaf privacy bucket in the OpenPlural Privacy *object*
+    """Wrap a Sheaf privacy bucket in the PluralPort Privacy *object*
     (``{"visibility": ...}``), which is the spec shape for system / member /
     custom-field privacy. Sheaf has no richer raw source detail to carry, so
     the optional ``source`` key is omitted. (Note/journal ``visibility`` is a

--- a/sheaf/services/pluralport_import.py
+++ b/sheaf/services/pluralport_import.py
@@ -1,23 +1,29 @@
-"""OpenPlural v0.1 import: envelope -> native Sheaf shape.
+"""PluralPort v0.1 import: envelope -> native Sheaf shape.
 
-Sheaf's OpenPlural importer is deliberately thin. Rather than re-walk
-every record type, it *translates* an OpenPlural v0.1 envelope back into
+Sheaf's PluralPort importer is deliberately thin. Rather than re-walk
+every record type, it *translates* a PluralPort v0.1 envelope back into
 the native Article-20 export dict (version "2") that
 ``sheaf_import.run_import`` already consumes, then delegates. Every
 mandatory guard (member cap, safe-JSON, decompressed-size bound, avatar
 normalisation, internal-image stripping, business caps, fresh UUIDs,
 tenant scoping) therefore lives in the native importer and cannot drift
-per-format. This module is the inverse of ``openplural_export`` and is
+per-format. This module is the inverse of ``pluralport_export`` and is
 verified against it by the round-trip test.
 
 Two payload shapes:
 
 * A bare ``.json`` document -> translate, hand to ``sheaf_import``.
-* An ``.openplural.zip`` bundle (``openplural.json`` + ``assets/<key>``)
+* An ``.pluralport.zip`` bundle (``pluralport.json`` + ``assets/<key>``)
   -> translate, then hand a ``ParsedArchive`` (with ``asset_prefix``
   ``"assets/"``) to ``sheaf_archive_import`` so the blobs are restored.
 
-See ``docs/OPENPLURAL.md`` for the field-by-field mapping and the list
+The format was called OpenPlural before an upstream rename, and files
+produced against the old name are still out there, so the v0.1 reader
+also accepts the deprecated ``openplural_version`` envelope key and the
+legacy ``openplural.json`` bundle member (see the spec's versioning
+section; the pluralport-named forms win whenever both are present).
+
+See ``docs/PLURALPORT.md`` for the field-by-field mapping and the list
 of things that round-trip via ``extensions.sheaf.*``.
 """
 
@@ -32,17 +38,20 @@ from dataclasses import dataclass
 
 from sheaf.services.import_parsing import ImportPayloadError, expect_dict, safe_json_loads
 from sheaf.services.member_defaults import default_fronting_private
-from sheaf.services.openplural_export import EXT_NS
+from sheaf.services.pluralport_export import EXT_NS
 
 # Versions this importer understands. The spec mandates rejecting an
-# unknown openplural_version rather than silently part-importing it.
+# unknown pluralport_version rather than silently part-importing it.
 SUPPORTED_VERSIONS = {"0.1"}
 
 # Matches the native archive's decompressed-size caps (DEFLATE reaches
 # ~1000:1, so the 100MB compressed upload cap alone does not bound memory).
 _MAX_JSON_DECOMPRESSED = 256 * 1024 * 1024
 _MAX_ASSET_DECOMPRESSED = 100 * 1024 * 1024
-_BUNDLE_JSON_NAME = "openplural.json"
+_BUNDLE_JSON_NAME = "pluralport.json"
+# Deprecated inner name from before the OpenPlural -> PluralPort rename;
+# still accepted so bundles exported by older builds keep importing.
+_LEGACY_BUNDLE_JSON_NAME = "openplural.json"
 _ASSET_PREFIX = "assets/"
 
 # zip local-file-header magic; lets the runner sniff bundle vs bare JSON.
@@ -54,11 +63,20 @@ def looks_like_zip(blob: bytes) -> bool:
 
 
 def _check_version(envelope: dict) -> None:
-    ver = envelope.get("openplural_version")
+    # The spec's v0.1 versioning rule: producers emit `pluralport_version`,
+    # but importers must also accept the deprecated `openplural_version`
+    # alias (identical semantics) from before the format's rename. When a
+    # file carries both keys, `pluralport_version` wins - even if only the
+    # openplural one holds a supported value.
+    if "pluralport_version" in envelope:
+        ver = envelope.get("pluralport_version")
+    else:
+        ver = envelope.get("openplural_version")
     if ver not in SUPPORTED_VERSIONS:
         raise ImportPayloadError(
-            f"unsupported openplural_version {ver!r} "
-            f"(this build understands {sorted(SUPPORTED_VERSIONS)})"
+            f"unsupported pluralport_version {ver!r} "
+            f"(this build understands {sorted(SUPPORTED_VERSIONS)}; the "
+            "deprecated openplural_version key is accepted as a v0.1 alias)"
         )
 
 
@@ -74,7 +92,7 @@ def _ext(obj: dict) -> dict:
 
 
 def _op_privacy(val: object) -> str | None:
-    """Extract the visibility bucket from an OpenPlural privacy value.
+    """Extract the visibility bucket from a PluralPort privacy value.
 
     Per the spec, `privacy` is an object: ``{"visibility": "...", "source":
     {...}}`` (on systems, members, and custom fields). We carry just the
@@ -93,7 +111,7 @@ def _op_privacy(val: object) -> str | None:
 
 
 def _birthday_to_native(b: object) -> str | None:
-    """OpenPlural Birthday sub-record -> Sheaf's flat ``MM-DD`` / ``YYYY-MM-DD``."""
+    """PluralPort Birthday sub-record -> Sheaf's flat ``MM-DD`` / ``YYYY-MM-DD``."""
     if isinstance(b, str):
         return b
     if isinstance(b, dict):
@@ -113,7 +131,7 @@ def _b64decode(value: str) -> bytes | None:
 def _decode_inline_asset(asset: dict) -> bytes | None:
     """Decoded bytes for an asset that carries its payload inline, else None.
 
-    Per the OpenPlural Asset spec an asset populates at least one of
+    Per the PluralPort Asset spec an asset populates at least one of
     ``uri`` (external URL), ``data_base64``, or ``data_uri``
     (``data:<mime>;base64,<...>``). This handles the two inline carriers,
     plus the common producer slip of putting a ``data:`` URI in the
@@ -196,7 +214,7 @@ class _InlineAssetArchive:
     / ``read_image``; this serves the decoded bytes from memory instead of
     a zip so a bare-JSON export with inline ``data_uri`` assets restores
     through the same pipeline (quota, scrub-on-failure, unused-key discard)
-    as an ``.openplural.zip`` bundle.
+    as an ``.pluralport.zip`` bundle.
     """
 
     data: dict
@@ -210,9 +228,9 @@ class _InlineAssetArchive:
 
 
 def to_native(envelope: dict, assets: _AssetMap | None = None) -> dict:
-    """Translate an OpenPlural v0.1 envelope into the native export dict.
+    """Translate a PluralPort v0.1 envelope into the native export dict.
 
-    Pure transform: no DB, no IO. Mirrors ``openplural_export.build_envelope``.
+    Pure transform: no DB, no IO. Mirrors ``pluralport_export.build_envelope``.
     Pass a prebuilt ``assets`` map to reuse its inline-asset decode (the
     JSON runner does, to route inline images through the archive path).
     """
@@ -268,7 +286,7 @@ def to_native(envelope: dict, assets: _AssetMap | None = None) -> dict:
                 "pluralkit_id": _pluralkit_id(m.get("source_refs")),
                 "emoji": ext.get("emoji"),
                 "is_custom_front": bool(m.get("is_custom_front")),
-                # OpenPlural `archived` is a bool; Sheaf stores a timestamp.
+                # PluralPort `archived` is a bool; Sheaf stores a timestamp.
                 # The exact archive time is not portable through the bool, so
                 # stamp it with the file's exported_at on import.
                 "archived_at": (
@@ -484,7 +502,7 @@ def _file_extensions(envelope: dict) -> dict:
 
 
 def _fronts_from_events(events: object) -> list[dict]:
-    """Convert OpenPlural point-in-time ``front_events`` (a switch log) into
+    """Convert PluralPort point-in-time ``front_events`` (a switch log) into
     Sheaf interval fronts.
 
     Each event names who is fronting *from its timestamp onward*; the
@@ -574,8 +592,8 @@ def _field_value_index(values: object) -> dict[str, list[dict]]:
 
 
 def parse_json(blob: bytes) -> dict:
-    """Parse + version-check a bare OpenPlural JSON document."""
-    envelope = expect_dict(safe_json_loads(blob), descriptor="OpenPlural export")
+    """Parse + version-check a bare PluralPort JSON document."""
+    envelope = expect_dict(safe_json_loads(blob), descriptor="PluralPort export")
     _check_version(envelope)
     return envelope
 
@@ -600,7 +618,7 @@ def build_json_import(envelope: dict) -> tuple[dict, _InlineAssetArchive | None]
 
 
 def parse_bundle(blob: bytes):
-    """Open an .openplural.zip, validate, and return a translated
+    """Open a .pluralport.zip, validate, and return a translated
     ``ParsedArchive`` ready for ``sheaf_archive_import.run_import``.
 
     Returns ``(ParsedArchive, envelope)``: the archive carries the
@@ -615,19 +633,26 @@ def parse_bundle(blob: bytes):
         raise ImportPayloadError("file is not a valid zip archive") from exc
 
     names = set(zf.namelist())
-    if _BUNDLE_JSON_NAME not in names:
+    # Prefer pluralport.json; fall back to the deprecated openplural.json
+    # so pre-rename bundles keep importing.
+    if _BUNDLE_JSON_NAME in names:
+        json_name = _BUNDLE_JSON_NAME
+    elif _LEGACY_BUNDLE_JSON_NAME in names:
+        json_name = _LEGACY_BUNDLE_JSON_NAME
+    else:
         raise ImportPayloadError(
-            f"OpenPlural bundle must contain {_BUNDLE_JSON_NAME} "
-            "(is this an .openplural.zip export?)"
+            f"PluralPort bundle must contain {_BUNDLE_JSON_NAME} "
+            f"(or the legacy {_LEGACY_BUNDLE_JSON_NAME}; is this a "
+            ".pluralport.zip export?)"
         )
-    if zf.getinfo(_BUNDLE_JSON_NAME).file_size > _MAX_JSON_DECOMPRESSED:
+    if zf.getinfo(json_name).file_size > _MAX_JSON_DECOMPRESSED:
         raise ImportPayloadError(
-            f"{_BUNDLE_JSON_NAME} decompresses to more than "
+            f"{json_name} decompresses to more than "
             f"{_MAX_JSON_DECOMPRESSED // (1024 * 1024)}MB; refusing to parse"
         )
 
     envelope = expect_dict(
-        safe_json_loads(zf.read(_BUNDLE_JSON_NAME)), descriptor="OpenPlural bundle"
+        safe_json_loads(zf.read(json_name)), descriptor="PluralPort bundle"
     )
     _check_version(envelope)
 

--- a/sheaf/services/pluralport_import_runner.py
+++ b/sheaf/services/pluralport_import_runner.py
@@ -1,8 +1,8 @@
-"""Async runner handler for OpenPlural v0.1 imports.
+"""Async runner handler for PluralPort v0.1 imports.
 
 Wrap-pattern handler. Sniffs whether the payload is a bare JSON document
-or an ``.openplural.zip`` bundle, translates the envelope to the native
-shape (``openplural_import.to_native``), and delegates to the existing
+or an ``.pluralport.zip`` bundle, translates the envelope to the native
+shape (``pluralport_import.to_native``), and delegates to the existing
 native importer: ``sheaf_import.run_import`` for JSON,
 ``sheaf_archive_import.run_import`` for the bundle (which restores the
 ``assets/`` blobs). All the import guards therefore live in one place.
@@ -10,7 +10,7 @@ native importer: ``sheaf_import.run_import`` for JSON,
 Lineage: any ``extensions.sheaf.lineage`` carried in is surfaced as an
 info event. v0.1 Sheaf does not yet persist inherited lineage across a
 DB round-trip (there is no column for it), so a re-export starts a fresh
-Sheaf-only chain - see the limitation noted in docs/OPENPLURAL.md and
+Sheaf-only chain - see the limitation noted in docs/PLURALPORT.md and
 upstream issue #7.
 """
 
@@ -32,14 +32,14 @@ from sheaf.services.import_runner import (
     update_counts,
 )
 from sheaf.services.import_storage import get_payload
-from sheaf.services.openplural_archive import (
+from sheaf.services.pluralport_archive import (
     extract_residual,
     has_per_record_foreign_extensions,
     merge_residual,
     pack_residual,
     unpack_residual,
 )
-from sheaf.services.openplural_import import (
+from sheaf.services.pluralport_import import (
     build_json_import,
     inherited_lineage,
     looks_like_zip,
@@ -47,7 +47,7 @@ from sheaf.services.openplural_import import (
     parse_json,
 )
 
-logger = logging.getLogger("sheaf.imports.openplural")
+logger = logging.getLogger("sheaf.imports.pluralport")
 
 
 def _note_lineage(job: ImportJob, envelope: dict) -> None:
@@ -63,7 +63,7 @@ def _note_lineage(job: ImportJob, envelope: dict) -> None:
         stage="parse",
         message=(
             f"file carries lineage from {len(lineage)} prior export(s) "
-            f"[{apps}]; not persisted in this release (see docs/OPENPLURAL.md)"
+            f"[{apps}]; not persisted in this release (see docs/PLURALPORT.md)"
         ),
     )
 
@@ -71,7 +71,7 @@ def _note_lineage(job: ImportJob, envelope: dict) -> None:
 def _preserve_residual(job: ImportJob, system, envelope: dict) -> None:
     """Capture the parts of the envelope Sheaf cannot model and park them
     (encrypted, compressed, size-capped) on the system so the next
-    OpenPlural export re-emits them. Baseline (file-level + whole-section)
+    PluralPort export re-emits them. Baseline (file-level + whole-section)
     passthrough; per-record foreign extensions are warned, not stored."""
     if has_per_record_foreign_extensions(envelope):
         append_event(
@@ -80,15 +80,18 @@ def _preserve_residual(job: ImportJob, system, envelope: dict) -> None:
             stage="preserve",
             message=(
                 "per-record extensions from other apps were not preserved "
-                "(file-level passthrough only in this release); see docs/OPENPLURAL.md"
+                "(file-level passthrough only in this release); see docs/PLURALPORT.md"
             ),
         )
     residual = extract_residual(envelope)
     if not residual:
         return
+    # `openplural_archive` is the column's frozen historical name, kept from
+    # before the format was renamed to PluralPort because the AAD derived
+    # from it is baked into every stored blob. See models/system.py.
     existing = unpack_residual(system.openplural_archive, system_id=system.id)
     merged = merge_residual(existing, residual)
-    max_bytes = settings.openplural_max_preserved_mb * 1024 * 1024
+    max_bytes = settings.pluralport_max_preserved_mb * 1024 * 1024
     token, warning = pack_residual(merged, system_id=system.id, max_bytes=max_bytes)
     if warning:
         append_event(job, level="warning", stage="preserve", message=warning)
@@ -143,16 +146,16 @@ def _base_counts(job: ImportJob, base) -> None:
     )
 
 
-async def handle_openplural_file(job: ImportJob, db: AsyncSession) -> None:
-    """Run an OpenPlural import (bare JSON or .openplural.zip) for a job."""
+async def handle_pluralport_file(job: ImportJob, db: AsyncSession) -> None:
+    """Run a PluralPort import (bare JSON or .pluralport.zip) for a job."""
     if job.payload_storage_key is None:
         raise ImportPayloadError(
-            "OpenPlural job has no payload - was the upload step skipped?"
+            "PluralPort job has no payload - was the upload step skipped?"
         )
     blob = await get_payload(job.payload_storage_key)
     if blob is None:
         raise ImportPayloadError(
-            "OpenPlural payload missing from storage - "
+            "PluralPort payload missing from storage - "
             "the blob may have been swept by orphan cleanup"
         )
 
@@ -168,7 +171,7 @@ async def _run_json(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
         job,
         level="info",
         stage="parse",
-        message=f"parsed {len(blob)} bytes of OpenPlural JSON",
+        message=f"parsed {len(blob)} bytes of PluralPort JSON",
     )
     _note_lineage(job, envelope)
     native, inline_archive = build_json_import(envelope)
@@ -243,7 +246,7 @@ async def _run_bundle(job: ImportJob, db: AsyncSession, blob: bytes) -> None:
         level="info",
         stage="parse",
         message=(
-            f"parsed {len(blob)} bytes of OpenPlural bundle "
+            f"parsed {len(blob)} bytes of PluralPort bundle "
             f"({len(parsed.image_keys)} bundled asset(s))"
         ),
     )
@@ -263,7 +266,7 @@ async def _run_archive(
     job: ImportJob, db: AsyncSession, parsed, envelope: dict, *, missing_label: str
 ) -> None:
     """Import a native dict whose images are restored from blobs (an
-    ``.openplural.zip`` bundle or an inline-asset bare JSON), delegating to
+    ``.pluralport.zip`` bundle or an inline-asset bare JSON), delegating to
     ``sheaf_archive_import`` for the image pipeline plus every section
     guard. ``missing_label`` phrases the per-asset "couldn't restore this"
     warning for the payload shape."""
@@ -322,4 +325,4 @@ async def _run_archive(
     )
 
 
-register_handler(ImportJobSource.OPENPLURAL_FILE.value, handle_openplural_file)
+register_handler(ImportJobSource.PLURALPORT_FILE.value, handle_pluralport_file)

--- a/sheaf/services/sheaf_archive_import.py
+++ b/sheaf/services/sheaf_archive_import.py
@@ -85,8 +85,8 @@ class ParsedArchive:
     bytes can be fetched lazily by storage key.
 
     `asset_prefix` is the in-zip directory blobs live under. The native
-    Sheaf archive uses ``images/``; the OpenPlural bundle reuses this
-    same struct with ``assets/`` (see ``openplural_import``).
+    Sheaf archive uses ``images/``; the PluralPort bundle reuses this
+    same struct with ``assets/`` (see ``pluralport_import``).
     """
 
     data: dict

--- a/sheaf/services/sheaf_import.py
+++ b/sheaf/services/sheaf_import.py
@@ -171,7 +171,7 @@ _VALID_FIELD_TYPE = {e.value for e in FieldType}
 
 def _privacy(val: object) -> str:
     # `val` is untrusted/translated import data: guard the type before the
-    # set membership test. A non-string (e.g. an OpenPlural `{visibility:
+    # set membership test. A non-string (e.g. a PluralPort `{visibility:
     # ...}` privacy object that reached here un-extracted) must default
     # rather than raise `TypeError: unhashable type` mid-import.
     if isinstance(val, str) and val in _VALID_PRIVACY:
@@ -676,7 +676,7 @@ def measure_native_payload(data: dict, report: ClampReport) -> None:
 
     Reads the same keys ``run_import`` clamps, calling the same helpers, so the
     preview's warnings match what the import would shorten. The archive and
-    OpenPlural importers translate to this shape, so they reuse this for their
+    PluralPort importers translate to this shape, so they reuse this for their
     previews too. Defensive: only string values are measured and only list
     shapes are counted, so a malformed upload can't raise here.
     """
@@ -1174,15 +1174,22 @@ async def run_import(
                             )
                         )
 
-            # OpenPlural import residual: a native export carries it as a
+            # PluralPort import residual: a native export carries it as a
             # plain dict (decrypted in export.py). Re-pack (compress +
             # encrypt) and merge onto the column so a Sheaf backup/restore
-            # preserves another app's data the same way the OpenPlural
-            # importer does. See services/openplural_archive.py.
-            op_archive = sys_data.get("openplural_archive")
+            # preserves another app's data the same way the PluralPort
+            # importer does. See services/pluralport_archive.py. Exports
+            # from before the OpenPlural -> PluralPort rename carry the
+            # key under its old name; the new spelling wins when a file
+            # (oddly) has both. The DB column itself keeps the old name
+            # (AAD-frozen).
+            if "pluralport_archive" in sys_data:
+                op_archive = sys_data.get("pluralport_archive")
+            else:
+                op_archive = sys_data.get("openplural_archive")
             if isinstance(op_archive, dict) and op_archive:
                 from sheaf.config import settings
-                from sheaf.services.openplural_archive import (
+                from sheaf.services.pluralport_archive import (
                     merge_residual,
                     pack_residual,
                     unpack_residual,
@@ -1197,7 +1204,7 @@ async def run_import(
                 token, _warn = pack_residual(
                     merged,
                     system_id=system.id,
-                    max_bytes=settings.openplural_max_preserved_mb * 1024 * 1024,
+                    max_bytes=settings.pluralport_max_preserved_mb * 1024 * 1024,
                 )
                 if token is not None:
                     system.openplural_archive = token

--- a/tests/test_config_pluralport_alias.py
+++ b/tests/test_config_pluralport_alias.py
@@ -1,0 +1,35 @@
+"""PLURALPORT_MAX_PRESERVED_MB env alias.
+
+The setting was OPENPLURAL_MAX_PRESERVED_MB before the format's upstream
+rename to PluralPort. Deploys that set the old name must keep working, so
+the field carries an AliasChoices validation alias; these tests pin that
+both spellings resolve (and that the new one wins when both are set).
+
+`_env_file=None` disables reading the repo `.env` so the tests exercise
+env vars and defaults only, matching the other config tests.
+"""
+
+from __future__ import annotations
+
+from sheaf.config import Settings
+
+
+def test_default_when_neither_env_var_set(monkeypatch):
+    monkeypatch.delenv("PLURALPORT_MAX_PRESERVED_MB", raising=False)
+    monkeypatch.delenv("OPENPLURAL_MAX_PRESERVED_MB", raising=False)
+
+    assert Settings(_env_file=None).pluralport_max_preserved_mb == 8
+
+
+def test_legacy_env_var_still_honoured(monkeypatch):
+    monkeypatch.delenv("PLURALPORT_MAX_PRESERVED_MB", raising=False)
+    monkeypatch.setenv("OPENPLURAL_MAX_PRESERVED_MB", "3")
+
+    assert Settings(_env_file=None).pluralport_max_preserved_mb == 3
+
+
+def test_new_env_var_wins_over_legacy(monkeypatch):
+    monkeypatch.setenv("PLURALPORT_MAX_PRESERVED_MB", "5")
+    monkeypatch.setenv("OPENPLURAL_MAX_PRESERVED_MB", "3")
+
+    assert Settings(_env_file=None).pluralport_max_preserved_mb == 5

--- a/tests/test_encrypted_fields_registry.py
+++ b/tests/test_encrypted_fields_registry.py
@@ -182,6 +182,8 @@ _GOLDEN_BINDINGS = {
     "member_description_aad": ("members", "description"),
     "member_note_aad": ("members", "note"),
     "system_note_aad": ("systems", "note"),
+    # Frozen at the pre-rename OpenPlural name: this AAD is baked into
+    # every encrypted archive blob in production (see encrypted_fields).
     "system_openplural_archive_aad": ("systems", "openplural_archive"),
     "front_custom_status_aad": ("fronts", "custom_status"),
     "journal_title_aad": ("journal_entries", "title"),

--- a/tests/test_export_import_parity.py
+++ b/tests/test_export_import_parity.py
@@ -235,6 +235,10 @@ CLASSIFICATION: dict[type, dict] = {
             "safety_applies_to_relationships",
             "safety_applies_to_archive", "safety_applies_to_profile_visibility",
             "journal_max_revisions", "journal_max_revision_days",
+            # This set holds COLUMN names. `openplural_archive` keeps its
+            # pre-rename spelling because the name is baked into the AAD of
+            # every stored blob; the export key it maps to is
+            # `pluralport_archive`.
             "pinned_revision_max_per_target", "openplural_archive",
         },
         "excluded": {

--- a/tests/test_imports_pluralport_runner.py
+++ b/tests/test_imports_pluralport_runner.py
@@ -1,10 +1,10 @@
-"""End-to-end tests for the OpenPlural import runner.
+"""End-to-end tests for the PluralPort import runner.
 
-The OpenPlural importer translates an envelope back to the native shape
+The PluralPort importer translates an envelope back to the native shape
 and delegates to the Sheaf JSON / archive importers, so these tests
-build real OpenPlural payloads with ``build_envelope`` (the exporter)
+build real PluralPort payloads with ``build_envelope`` (the exporter)
 and drive them through ``POST /v1/imports/file`` with
-``source=openplural_file``. That makes each happy-path test a genuine
+``source=pluralport_file``. That makes each happy-path test a genuine
 export->import round-trip. Failure paths cover the version guard, the
 member-cap precheck, and the zip guards inherited from the archive path.
 """
@@ -19,7 +19,7 @@ import zipfile
 
 import httpx
 
-from sheaf.services.openplural_export import build_envelope
+from sheaf.services.pluralport_export import build_envelope
 from tests._import_runner_helpers import (
     drive_import_runner,
     set_member_limit,
@@ -80,7 +80,7 @@ def _bundle_bytes(native: dict, images: dict[str, bytes]) -> bytes:
     env = build_envelope(native, exported_at=_EXPORTED_AT, include_asset_bytes=True)
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("openplural.json", json.dumps(env))
+        zf.writestr("pluralport.json", json.dumps(env))
         zf.writestr("README.txt", "test bundle")
         for key, blob in images.items():
             zf.writestr(f"assets/{key}", blob)
@@ -91,11 +91,12 @@ def _post(
     client: httpx.Client,
     payload: bytes,
     *,
-    filename: str = "export.openplural.json",
+    filename: str = "export.pluralport.json",
     options: dict | None = None,
+    source: str = "pluralport_file",
 ) -> dict:
     form: dict[str, str] = {
-        "source": "openplural_file",
+        "source": source,
         "idempotency_key": str(uuid.uuid4()),
     }
     if options is not None:
@@ -119,7 +120,7 @@ def _files_list(client: httpx.Client) -> list[dict]:
 
 
 def test_json_round_trip_imports_core_records(auth_client: httpx.Client):
-    """A Sheaf-produced OpenPlural JSON re-imports its members, fronts,
+    """A Sheaf-produced PluralPort JSON re-imports its members, fronts,
     groups, and tags."""
     job = _post(auth_client, _envelope_bytes(_native()))
     drive_import_runner()
@@ -145,7 +146,7 @@ def test_custom_front_without_the_guard_key_lands_guarded(
     owner said no": it means the source has no notion of the guard, and a
     custom front is the one member kind whose state must not start published.
     Fed here as a native member with no guard column at all, which is what an
-    OpenPlural file written by anything else turns into."""
+    PluralPort file written by anything else turns into."""
     native = _native()
     native["members"].append({"id": "m3", "name": "OpAsleep", "is_custom_front": True})
     job = _post(auth_client, _envelope_bytes(native))
@@ -183,10 +184,10 @@ def test_custom_front_with_a_released_guard_round_trips(auth_client: httpx.Clien
 
 
 def test_bundle_round_trip_restores_avatar(auth_client: httpx.Client):
-    """An .openplural.zip bundle restores the avatar blob under a fresh
+    """An .pluralport.zip bundle restores the avatar blob under a fresh
     key owned by the importing user."""
     payload = _bundle_bytes(_native(avatar=True), {_AVATAR_KEY: _TINY_PNG})
-    job = _post(auth_client, payload, filename="export.openplural.zip")
+    job = _post(auth_client, payload, filename="export.pluralport.zip")
     drive_import_runner()
     final = wait_for_terminal(auth_client, job["id"])
 
@@ -201,7 +202,7 @@ def test_bundle_round_trip_restores_avatar(auth_client: httpx.Client):
 
 
 def _inline_asset_envelope(*, carrier: str) -> bytes:
-    """A bare-JSON OpenPlural envelope from a foreign producer whose avatar
+    """A bare-JSON PluralPort envelope from a foreign producer whose avatar
     bytes ride inline on the asset (not in a bundle). ``carrier`` selects
     where the bytes sit: ``uri_data`` (a ``data:`` URI a producer put in
     the ``uri`` field, as pluralport does), ``data_uri`` (the spec field),
@@ -216,7 +217,7 @@ def _inline_asset_envelope(*, carrier: str) -> bytes:
     else:
         asset["data_base64"] = b64
     env = {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "exported_at": _EXPORTED_AT,
         "producer": {"app": "Pluralport", "app_id": "pluralport"},
         "systems": [{"id": "s1", "name": "OP System", "privacy": "public"}],
@@ -286,7 +287,7 @@ def test_preview_reports_counts_and_lineage(auth_client: httpx.Client):
     """The preview endpoint summarises without writing, and surfaces the
     lineage length of the file."""
     resp = auth_client.post(
-        "/v1/import/openplural/preview",
+        "/v1/import/pluralport/preview",
         files={"file": ("e.json", _envelope_bytes(_native()), "application/json")},
     )
     assert resp.status_code == 200, resp.text
@@ -305,7 +306,7 @@ def test_front_events_imported_as_fronts(auth_client: httpx.Client):
     """A switch-log style file (front_events, no front_periods) imports its
     fronting history as intervals instead of dropping it."""
     env = {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "producer": {"app": "PluralKit", "app_id": "pluralkit"},
         "systems": [{"id": "s1", "name": "SwitchLog Sys", "privacy": "public"}],
         "members": [
@@ -331,7 +332,7 @@ def test_front_events_imported_as_fronts(auth_client: httpx.Client):
 def _foreign_envelope_bytes() -> bytes:
     """An envelope as if from another app, carrying data Sheaf cannot model."""
     env = {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "producer": {"app": "Prism", "app_id": "prism"},
         "systems": [{"id": "s1", "name": "Foreign Sys", "privacy": "public"}],
         "members": [{"id": "m1", "name": "ForeignIris", "privacy": "private"}],
@@ -352,7 +353,7 @@ def _foreign_envelope_bytes() -> bytes:
 def test_foreign_data_preserved_and_re_exported(auth_client: httpx.Client):
     """Data Sheaf cannot model (foreign extensions, chat/relationships,
     non-tag taxonomy) survives an import and comes back out on a Sheaf
-    OpenPlural export, instead of being dropped."""
+    PluralPort export, instead of being dropped."""
     job = _post(auth_client, _foreign_envelope_bytes())
     drive_import_runner()
     final = wait_for_terminal(auth_client, job["id"])
@@ -365,8 +366,8 @@ def test_foreign_data_preserved_and_re_exported(auth_client: httpx.Client):
         for e in final["events"]
     ), final["events"]
 
-    # Re-export as OpenPlural: the foreign residual is merged back in.
-    resp = auth_client.get("/v1/export", params={"format": "openplural"})
+    # Re-export as PluralPort: the foreign residual is merged back in.
+    resp = auth_client.get("/v1/export", params={"format": "pluralport"})
     assert resp.status_code == 200, resp.text
     env = resp.json()
     assert env["extensions"]["prism"] == {"theme": "dark"}
@@ -382,14 +383,14 @@ def test_foreign_data_preserved_and_re_exported(auth_client: httpx.Client):
 
 def test_unknown_version_fails(auth_client: httpx.Client):
     env = build_envelope(_native(), exported_at=_EXPORTED_AT)
-    env["openplural_version"] = "0.2"
+    env["pluralport_version"] = "0.2"
     job = _post(auth_client, json.dumps(env).encode())
     drive_import_runner()
     final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any(
-        "unsupported openplural_version" in e["message"] for e in final["events"]
+        "unsupported pluralport_version" in e["message"] for e in final["events"]
     ), final["events"]
 
 
@@ -411,25 +412,25 @@ def test_garbage_json_fails(auth_client: httpx.Client):
     assert final["status"] == "failed", final
 
 
-def test_bundle_rejects_missing_openplural_json(auth_client: httpx.Client):
+def test_bundle_rejects_missing_pluralport_json(auth_client: httpx.Client):
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("data.json", "{}")
-    job = _post(auth_client, buf.getvalue(), filename="x.openplural.zip")
+    job = _post(auth_client, buf.getvalue(), filename="x.pluralport.zip")
     drive_import_runner()
     final = wait_for_terminal(auth_client, job["id"])
 
     assert final["status"] == "failed", final
     assert any(
-        "must contain openplural.json" in e["message"] for e in final["events"]
+        "must contain pluralport.json" in e["message"] for e in final["events"]
     ), final["events"]
 
 
 def test_bundle_rejects_decompression_bomb(auth_client: httpx.Client):
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("openplural.json", b" " * (260 * 1024 * 1024))
-    job = _post(auth_client, buf.getvalue(), filename="x.openplural.zip")
+        zf.writestr("pluralport.json", b" " * (260 * 1024 * 1024))
+    job = _post(auth_client, buf.getvalue(), filename="x.pluralport.zip")
     drive_import_runner()
     final = wait_for_terminal(auth_client, job["id"])
 
@@ -437,3 +438,150 @@ def test_bundle_rejects_decompression_bomb(auth_client: httpx.Client):
     assert any(
         "decompresses to more than" in e["message"] for e in final["events"]
     ), final["events"]
+
+
+# --- Legacy-name compatibility (OpenPlural -> PluralPort rename) -------------
+
+
+def test_legacy_openplural_version_envelope_imports(auth_client: httpx.Client):
+    """A pre-rename file stamped `openplural_version` still imports: the
+    spec keeps the old key as a deprecated v0.1 alias."""
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    env["openplural_version"] = env.pop("pluralport_version")
+    job = _post(auth_client, json.dumps(env).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 2, final["counts"]
+
+
+def test_both_version_keys_pluralport_wins(auth_client: httpx.Client):
+    """A file carrying a bogus `pluralport_version` alongside a valid
+    `openplural_version` is rejected: the new key wins outright per the
+    spec, it is not a fallback for a bad value."""
+    env = build_envelope(_native(), exported_at=_EXPORTED_AT)
+    env["pluralport_version"] = "bogus"
+    env["openplural_version"] = "0.1"
+    job = _post(auth_client, json.dumps(env).encode())
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "failed", final
+    assert any(
+        "unsupported pluralport_version" in e["message"] for e in final["events"]
+    ), final["events"]
+    assert auth_client.get("/v1/members").json() == []
+
+
+def test_bundle_with_legacy_inner_json_imports(auth_client: httpx.Client):
+    """A pre-rename bundle (openplural.json inside the zip) still imports,
+    including its bundled assets."""
+    native = _native(avatar=True)
+    env = build_envelope(
+        native, exported_at=_EXPORTED_AT, include_asset_bytes=True
+    )
+    env["openplural_version"] = env.pop("pluralport_version")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("openplural.json", json.dumps(env))
+        zf.writestr(f"assets/{_AVATAR_KEY}", _TINY_PNG)
+    job = _post(auth_client, buf.getvalue(), filename="old.openplural.zip")
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["counts"]["members_imported"] == 2, final["counts"]
+    assert final["counts"].get("images_imported", 0) == 1, final["counts"]
+
+
+def test_legacy_source_value_accepted_and_normalised(auth_client: httpx.Client):
+    """POST /v1/imports/file with the pre-rename source "openplural_file"
+    still enqueues, and the job row records the new value."""
+    job = _post(
+        auth_client, _envelope_bytes(_native()), source="openplural_file"
+    )
+    assert job["source"] == "pluralport_file", job
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+
+    assert final["status"] == "complete", final
+    assert final["source"] == "pluralport_file", final
+
+
+def test_legacy_preview_route_still_works(auth_client: httpx.Client):
+    """The pre-rename /v1/import/openplural/preview path is a working
+    (schema-hidden) alias of the pluralport preview."""
+    resp = auth_client.post(
+        "/v1/import/openplural/preview",
+        files={"file": ("e.json", _envelope_bytes(_native()), "application/json")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["system_name"] == "OP System"
+    assert body["member_count"] == 2
+    # Preview must not have created anything.
+    assert auth_client.get("/v1/members").json() == []
+
+
+def test_export_format_openplural_alias_emits_pluralport(
+    auth_client: httpx.Client,
+):
+    """GET /v1/export?format=openplural (the pre-rename value) is accepted
+    and produces a current envelope: pluralport_version, no legacy key."""
+    resp = auth_client.get("/v1/export", params={"format": "openplural"})
+    assert resp.status_code == 200, resp.text
+    env = resp.json()
+    assert env["pluralport_version"] == "0.1"
+    assert "openplural_version" not in env
+
+
+def test_native_import_accepts_legacy_archive_key(auth_client: httpx.Client):
+    """A native Sheaf export written before the rename carries the
+    preserved foreign residual under system.openplural_archive; the
+    importer still restores it, and it re-emits on a PluralPort export
+    (and under the renamed key in the native export)."""
+    native = {
+        "version": "2",
+        "system": {
+            "name": "Legacy Archive Sys",
+            "privacy": "public",
+            "openplural_archive": {"extensions": {"legacyapp": {"kept": True}}},
+        },
+        "members": [{"id": "m1", "name": "ArchIris"}],
+    }
+    job = _post(auth_client, json.dumps(native).encode(), source="sheaf_file")
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    env = auth_client.get("/v1/export", params={"format": "pluralport"}).json()
+    assert env["extensions"]["legacyapp"] == {"kept": True}, env["extensions"]
+    native_out = auth_client.get("/v1/export").json()
+    assert native_out["system"]["pluralport_archive"]["extensions"][
+        "legacyapp"
+    ] == {"kept": True}
+    assert "openplural_archive" not in native_out["system"]
+
+
+def test_native_import_archive_key_pluralport_wins(auth_client: httpx.Client):
+    """If a (hand-edited) native file carries both archive keys, the
+    renamed pluralport_archive wins, mirroring the version-key rule."""
+    native = {
+        "version": "2",
+        "system": {
+            "name": "Both Keys Sys",
+            "privacy": "public",
+            "pluralport_archive": {"extensions": {"newapp": {"win": 1}}},
+            "openplural_archive": {"extensions": {"oldapp": {"lose": 1}}},
+        },
+        "members": [{"id": "m1", "name": "BothIris"}],
+    }
+    job = _post(auth_client, json.dumps(native).encode(), source="sheaf_file")
+    drive_import_runner()
+    final = wait_for_terminal(auth_client, job["id"])
+    assert final["status"] == "complete", final
+
+    env = auth_client.get("/v1/export", params={"format": "pluralport"}).json()
+    assert env["extensions"].get("newapp") == {"win": 1}, env["extensions"]
+    assert "oldapp" not in env["extensions"], env["extensions"]

--- a/tests/test_pluralport_archive.py
+++ b/tests/test_pluralport_archive.py
@@ -1,4 +1,4 @@
-"""Unit tests for OpenPlural import-residual preservation (the baseline
+"""Unit tests for PluralPort import-residual preservation (the baseline
 passthrough tier). Pure functions: extraction, compress+encrypt pack/unpack,
 size cap, merge, per-record detection, and re-merge on export.
 """
@@ -7,15 +7,15 @@ from __future__ import annotations
 
 import uuid
 
-from sheaf.services.openplural_archive import (
+from sheaf.services.pluralport_archive import (
     extract_residual,
     has_per_record_foreign_extensions,
     merge_residual,
     pack_residual,
     unpack_residual,
 )
-from sheaf.services.openplural_export import build_envelope
-from sheaf.services.openplural_import import to_native
+from sheaf.services.pluralport_export import build_envelope
+from sheaf.services.pluralport_import import to_native
 
 _EXPORTED_AT = "2026-06-20T00:00:00+00:00"
 
@@ -25,7 +25,7 @@ def _foreign_envelope() -> dict:
     not model (foreign extensions, chat + relationships modules,
     front_comments, non-tag taxonomy)."""
     return {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "producer": {"app": "Prism", "app_id": "prism"},
         "systems": [{"id": "s1", "name": "Foreign", "privacy": "public"}],
         "members": [{"id": "m1", "name": "Iris", "privacy": "private"}],
@@ -112,9 +112,9 @@ def test_preserved_residual_re_merges_on_export():
     on the (native) system as a plain dict, comes back out in the envelope."""
     residual = extract_residual(_foreign_envelope())
     native = to_native(
-        {"openplural_version": "0.1", "systems": [{"id": "s1", "name": "S"}], "members": []}
+        {"pluralport_version": "0.1", "systems": [{"id": "s1", "name": "S"}], "members": []}
     )
-    native["system"]["openplural_archive"] = residual
+    native["system"]["pluralport_archive"] = residual
     env = build_envelope(native, exported_at=_EXPORTED_AT)
     # Foreign extensions ride alongside Sheaf's namespace.
     assert env["extensions"]["prism"] == {"theme": "dark", "legacyCoFronters": [1, 2]}

--- a/tests/test_pluralport_export.py
+++ b/tests/test_pluralport_export.py
@@ -1,10 +1,10 @@
-"""Unit tests for the OpenPlural exporter / inverse-importer transforms.
+"""Unit tests for the PluralPort exporter / inverse-importer transforms.
 
 These are pure-function tests (no DB, no HTTP): they exercise
-``openplural_export.build_envelope`` and ``openplural_import.to_native``
+``pluralport_export.build_envelope`` and ``pluralport_import.to_native``
 directly, plus the version guard and lineage handling. The end-to-end
 job-runner behaviour (guards, dedup, image restore) is covered by
-``test_imports_openplural_runner.py``.
+``test_imports_pluralport_runner.py``.
 """
 
 from __future__ import annotations
@@ -12,12 +12,12 @@ from __future__ import annotations
 import pytest
 
 from sheaf.services.import_parsing import ImportPayloadError
-from sheaf.services.openplural_export import (
-    OPENPLURAL_IMPL_VERSION,
-    OPENPLURAL_VERSION,
+from sheaf.services.pluralport_export import (
+    PLURALPORT_IMPL_VERSION,
+    PLURALPORT_VERSION,
     build_envelope,
 )
-from sheaf.services.openplural_import import inherited_lineage, parse_json, to_native
+from sheaf.services.pluralport_import import inherited_lineage, parse_json, to_native
 
 _EXPORTED_AT = "2026-06-20T00:00:00+00:00"
 
@@ -90,19 +90,19 @@ def _native() -> dict:
 
 def test_envelope_producer_and_version_stamp():
     env = build_envelope(_native(), exported_at=_EXPORTED_AT, app_version="1.1.0")
-    assert env["openplural_version"] == OPENPLURAL_VERSION == "0.1"
+    assert env["pluralport_version"] == PLURALPORT_VERSION == "0.1"
     p = env["producer"]
     assert p["app"] == "Sheaf"
     assert p["app_id"] == "sheaf"
     assert p["app_version"] == "1.1.0"
-    assert p["exporter_version"] == OPENPLURAL_IMPL_VERSION
+    assert p["exporter_version"] == PLURALPORT_IMPL_VERSION
     assert env["exported_at"] == _EXPORTED_AT
 
 
 def test_core_records_mapped():
     env = build_envelope(_native(), exported_at=_EXPORTED_AT)
     assert env["systems"][0]["name"] == "Sys"
-    # privacy is the OpenPlural Privacy object, not a bare string.
+    # privacy is the PluralPort Privacy object, not a bare string.
     assert env["systems"][0]["privacy"] == {"visibility": "public"}
     # pluralkit_id becomes a source_ref, not a core member field.
     m1 = next(m for m in env["members"] if m["id"] == "m1")
@@ -159,7 +159,7 @@ def test_lineage_appends_and_accumulates():
     lineage = env["extensions"]["sheaf"]["lineage"]
     assert lineage[-1] == {
         "app": "sheaf", "app_version": "1.1.0",
-        "exporter_version": OPENPLURAL_IMPL_VERSION, "exported_at": _EXPORTED_AT,
+        "exporter_version": PLURALPORT_IMPL_VERSION, "exported_at": _EXPORTED_AT,
     }
     # A prior hop carried in is preserved ahead of Sheaf's entry.
     prior = [{"app": "simply_plural", "exported_at": "2023-01-01T00:00:00+00:00"}]
@@ -209,8 +209,8 @@ def test_round_trip_to_native_restores_fields():
 
 def test_import_rejects_unknown_version():
     bad = build_envelope(_native(), exported_at=_EXPORTED_AT)
-    bad["openplural_version"] = "0.2"
-    with pytest.raises(ImportPayloadError, match="unsupported openplural_version"):
+    bad["pluralport_version"] = "0.2"
+    with pytest.raises(ImportPayloadError, match="unsupported pluralport_version"):
         to_native(bad)
 
 
@@ -219,8 +219,77 @@ def test_parse_json_rejects_non_dict_and_bad_version():
 
     with pytest.raises(ImportPayloadError):
         parse_json(json.dumps([1, 2, 3]).encode())
-    with pytest.raises(ImportPayloadError, match="unsupported openplural_version"):
-        parse_json(json.dumps({"openplural_version": "9.9"}).encode())
+    with pytest.raises(ImportPayloadError, match="unsupported pluralport_version"):
+        parse_json(json.dumps({"pluralport_version": "9.9"}).encode())
+
+
+def test_legacy_openplural_version_key_still_accepted():
+    """Pre-rename files stamp `openplural_version`; the spec keeps it as a
+    deprecated v0.1 alias with identical semantics."""
+    env = {
+        "openplural_version": "0.1",
+        "systems": [{"id": "s1", "name": "Legacy Sys", "privacy": "public"}],
+        "members": [{"id": "m1", "name": "OldName"}],
+    }
+    native = to_native(env)
+    assert native["system"]["name"] == "Legacy Sys"
+    assert native["members"][0]["name"] == "OldName"
+    # parse_json runs the same version check.
+    import json
+
+    assert parse_json(json.dumps(env).encode())["systems"][0]["name"] == "Legacy Sys"
+
+
+def test_both_version_keys_pluralport_wins():
+    """When a file carries both keys, `pluralport_version` wins per the
+    spec - even when only the deprecated key holds a supported value. A
+    bogus pluralport_version therefore rejects the file outright."""
+    env = {
+        "pluralport_version": "9.9",
+        "openplural_version": "0.1",
+        "members": [{"id": "m1", "name": "A"}],
+    }
+    with pytest.raises(ImportPayloadError, match="unsupported pluralport_version"):
+        to_native(env)
+    # And the other way around: a valid pluralport_version imports fine
+    # regardless of what the stale alias says.
+    env2 = {
+        "pluralport_version": "0.1",
+        "openplural_version": "9.9",
+        "members": [{"id": "m1", "name": "A"}],
+    }
+    assert to_native(env2)["members"][0]["name"] == "A"
+
+
+def test_bundle_accepts_legacy_inner_json_name():
+    """A pre-rename bundle carries openplural.json instead of
+    pluralport.json; both open, and pluralport.json wins if both exist."""
+    import io
+    import json
+    import zipfile
+
+    from sheaf.services.pluralport_import import parse_bundle
+
+    def _zip(entries: dict[str, str]) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for name, body in entries.items():
+                zf.writestr(name, body)
+        return buf.getvalue()
+
+    legacy_env = json.dumps(
+        {"openplural_version": "0.1", "systems": [{"id": "s", "name": "Old"}]}
+    )
+    parsed, _ = parse_bundle(_zip({"openplural.json": legacy_env}))
+    assert parsed.data["system"]["name"] == "Old"
+
+    new_env = json.dumps(
+        {"pluralport_version": "0.1", "systems": [{"id": "s", "name": "New"}]}
+    )
+    parsed, _ = parse_bundle(
+        _zip({"openplural.json": legacy_env, "pluralport.json": new_env})
+    )
+    assert parsed.data["system"]["name"] == "New"
 
 
 def test_front_events_convert_to_intervals():
@@ -228,7 +297,7 @@ def test_front_events_convert_to_intervals():
     event runs until the next, an empty-assignment event is a gap, and the
     last event stays open-ended."""
     env = {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "members": [{"id": "m1", "name": "A"}, {"id": "m2", "name": "B"}],
         "front_events": [
             {"id": "e1", "at": "2026-01-01T00:00:00+00:00",
@@ -252,7 +321,7 @@ def test_front_events_dedup_against_periods():
     """A file carrying both a period and an identical event collapses to one
     front (no double-import); the open-ended period is preserved."""
     env = {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "members": [{"id": "m1", "name": "A"}],
         "front_periods": [
             {"id": "p1", "started_at": "2026-01-01T00:00:00+00:00", "ended_at": None,
@@ -277,12 +346,12 @@ def test_privacy_buckets_round_to_known():
 
 
 def test_privacy_object_extracted_on_import():
-    """Spec-conformant OpenPlural privacy is an object {visibility, source};
+    """Spec-conformant PluralPort privacy is an object {visibility, source};
     to_native must extract the visibility string rather than pass the dict
     through (which crashed the native importer: unhashable type 'dict').
-    Repro of the reported PluralSpace-via-OpenPlural import failure."""
+    Repro of the reported PluralSpace-via-PluralPort import failure."""
     env = {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "systems": [
             {
                 "id": "s1",
@@ -306,7 +375,7 @@ def test_privacy_object_extracted_on_import():
 def test_privacy_bare_string_still_accepted_on_import():
     """Older / lenient files with a bare-string privacy still read."""
     env = {
-        "openplural_version": "0.1",
+        "pluralport_version": "0.1",
         "systems": [{"id": "s1", "name": "S", "privacy": "public"}],
     }
     assert to_native(env)["system"]["privacy"] == "public"

--- a/tests/test_pluralport_parity.py
+++ b/tests/test_pluralport_parity.py
@@ -1,20 +1,20 @@
-"""OpenPlural export-coverage guard.
+"""PluralPort export-coverage guard.
 
 ``test_export_import_parity.py`` proves every user-data column is either
 *exported* in the native Article-20 dump or deliberately *excluded*. This
-test extends that to the OpenPlural exporter: every column the native
+test extends that to the PluralPort exporter: every column the native
 export carries (each model's ``exported`` set) must have a stated
-disposition in the OpenPlural envelope, one of:
+disposition in the PluralPort envelope, one of:
 
-* ``core``  - mapped to an OpenPlural v0.1 core record/field,
+* ``core``  - mapped to a PluralPort v0.1 core record/field,
 * ``ext``   - preserved under ``extensions.sheaf.*`` (lossless, opaque),
 * ``gap``   - intentionally not carried, with a reason.
 
 The dispositions below are read against ``CLASSIFICATION`` live, so a
 newly-added *exported* column fails here until someone decides how the
-OpenPlural exporter should treat it (and wires it into
-``openplural_export.build_envelope``). That is the whole point: it stops
-a new field silently falling out of the OpenPlural format the same way
+PluralPort exporter should treat it (and wires it into
+``pluralport_export.build_envelope``). That is the whole point: it stops
+a new field silently falling out of the PluralPort format the same way
 the native parity guard stops it falling out of the native one.
 """
 
@@ -26,17 +26,17 @@ from tests.test_export_import_parity import CLASSIFICATION
 
 # Per model: every column in that model's `exported` set maps to exactly
 # one disposition. `gap` carries a reason string; `core`/`ext`/`residual`
-# are bare markers. Keep in sync with openplural_export.build_envelope.
+# are bare markers. Keep in sync with pluralport_export.build_envelope.
 CORE = "core"
 EXT = "ext"
 # The preservation channel itself: it does not map to one envelope field,
 # it carries the FOREIGN residual (other apps' extensions/modules) that is
-# re-merged into the envelope on export. See openplural_archive.py.
+# re-merged into the envelope on export. See pluralport_archive.py.
 RESIDUAL = "residual"
 
 DISPOSITION: dict[str, dict[str, object]] = {
     "System": {
-        # Core OpenPlural System fields.
+        # Core PluralPort System fields.
         "name": CORE, "description": CORE, "tag": CORE, "color": CORE,
         "privacy": CORE, "avatar_url": CORE,
         # extensions.sheaf.* (note + prefs + the safety/retention blocks).
@@ -58,6 +58,8 @@ DISPOSITION: dict[str, dict[str, object]] = {
         "safety_applies_to_profile_visibility": EXT,
         "journal_max_revisions": EXT, "journal_max_revision_days": EXT,
         "pinned_revision_max_per_target": EXT,
+        # Column name frozen pre-rename for AAD compatibility; the
+        # exported key is pluralport_archive.
         "openplural_archive": RESIDUAL,
     },
     "Member": {
@@ -65,7 +67,7 @@ DISPOSITION: dict[str, dict[str, object]] = {
         "pronouns": CORE, "avatar_url": CORE, "banner_url": CORE,
         "color": CORE, "birthday": CORE, "is_custom_front": CORE,
         "privacy": CORE, "created_at": CORE,
-        # archived_at maps to the OpenPlural core Member.archived boolean.
+        # archived_at maps to the PluralPort core Member.archived boolean.
         "archived_at": CORE,
         # pluralkit_id becomes a SourceRef(app="pluralkit").
         "pluralkit_id": CORE,
@@ -132,18 +134,18 @@ DISPOSITION: dict[str, dict[str, object]] = {
     "PollVote": "_all_ext",
     "PollVoteEvent": "_all_ext",
     # Relationship types + both edge tables carry verbatim under the file-level
-    # extensions.sheaf.<section> passthrough (OpenPlural v0.1 has no
+    # extensions.sheaf.<section> passthrough (PluralPort v0.1 has no
     # relationship core record).
     "RelationshipType": "_all_ext",
     "MemberRelationship": "_all_ext",
     "GroupRelationship": "_all_ext",
     # User is classified in the native guard purely so new account columns
     # cannot skip export review; every column is excluded there, so there is
-    # nothing to give an OpenPlural disposition. The empty dict records that
+    # nothing to give a PluralPort disposition. The empty dict records that
     # deliberately (an empty exported set maps to no dispositions).
     "User": {},
     # Share views ride the same file-level extensions.sheaf.share_views
-    # passthrough (OpenPlural v0.1 has no sharing/visibility module).
+    # passthrough (PluralPort v0.1 has no sharing/visibility module).
     "ShareView": "_all_ext",
     "ShareViewMember": "_all_ext",
     "ShareViewField": "_all_ext",
@@ -160,8 +162,8 @@ def _disposition_for(model_name: str, exported: set[str]) -> dict[str, object]:
     if entry == "_all_ext":
         return {col: EXT for col in exported}
     assert isinstance(entry, dict), (
-        f"{model_name} has no OpenPlural disposition. Add it to "
-        f"tests/test_openplural_parity.py (core / ext / gap per column)."
+        f"{model_name} has no PluralPort disposition. Add it to "
+        f"tests/test_pluralport_parity.py (core / ext / gap per column)."
     )
     return entry
 
@@ -169,12 +171,12 @@ def _disposition_for(model_name: str, exported: set[str]) -> dict[str, object]:
 @pytest.mark.parametrize(
     "model", list(CLASSIFICATION), ids=lambda m: m.__name__
 )
-def test_every_exported_column_has_an_openplural_disposition(model: type):
-    """Every natively-exported column must have an OpenPlural disposition.
+def test_every_exported_column_has_an_pluralport_disposition(model: type):
+    """Every natively-exported column must have a PluralPort disposition.
 
     A new column added to a model's `exported` set in the native parity
     guard fails here until it is given a disposition and (if core/ext)
-    threaded into openplural_export.build_envelope.
+    threaded into pluralport_export.build_envelope.
     """
     name = model.__name__
     exported: set[str] = set(CLASSIFICATION[model]["exported"])
@@ -182,10 +184,10 @@ def test_every_exported_column_has_an_openplural_disposition(model: type):
 
     missing = exported - set(disposition)
     assert not missing, (
-        f"{name}: exported column(s) {sorted(missing)} have no OpenPlural "
+        f"{name}: exported column(s) {sorted(missing)} have no PluralPort "
         f"disposition. Decide core / ext / gap in "
-        f"tests/test_openplural_parity.py and wire core/ext fields into "
-        f"openplural_export.build_envelope."
+        f"tests/test_pluralport_parity.py and wire core/ext fields into "
+        f"pluralport_export.build_envelope."
     )
 
     phantom = set(disposition) - exported

--- a/tests/test_share_view_portability.py
+++ b/tests/test_share_view_portability.py
@@ -5,7 +5,7 @@ does. An export therefore carries view names, flags and membership but no
 token, no token hash and no grant row, and an import restores the curation
 while leaving the system published to nobody.
 
-Covers both file formats: the native Sheaf export and the OpenPlural
+Covers both file formats: the native Sheaf export and the PluralPort
 envelope (whose importer lifts the `extensions.sheaf.share_views` and
 relationships passthrough sections back into the native shape).
 
@@ -21,7 +21,7 @@ import uuid
 
 import httpx
 
-from sheaf.services.openplural_export import build_envelope
+from sheaf.services.pluralport_export import build_envelope
 from tests._import_runner_helpers import drive_import_runner, wait_for_terminal
 
 _EXPORTED_AT = "2026-07-01T00:00:00+00:00"
@@ -384,11 +384,11 @@ def test_import_guards_malformed_share_views(auth_client: httpx.Client):
     assert views[0]["name"] == "x" * 100, views[0]["name"]
 
 
-# --- OpenPlural round trip ---------------------------------------------------
+# --- PluralPort round trip ---------------------------------------------------
 
 
-def _openplural_native() -> dict:
-    native = _native_with_views("OpenPlural View")
+def _pluralport_native() -> dict:
+    native = _native_with_views("PluralPort View")
     native["system"]["name"] = "OP Share Portability"
     native["relationship_types"] = [
         {
@@ -423,26 +423,26 @@ def _openplural_native() -> dict:
     return native
 
 
-def test_openplural_envelope_carries_the_passthrough_sections():
+def test_pluralport_envelope_carries_the_passthrough_sections():
     """Sanity check on the exporter half: the sections the importer lifts back
     are actually written where it looks for them."""
-    env = build_envelope(_openplural_native(), exported_at=_EXPORTED_AT)
+    env = build_envelope(_pluralport_native(), exported_at=_EXPORTED_AT)
     sheaf_ext = env["extensions"]["sheaf"]
-    assert sheaf_ext["share_views"][0]["name"] == "OpenPlural View"
+    assert sheaf_ext["share_views"][0]["name"] == "PluralPort View"
     assert sheaf_ext["relationship_types"][0]["name"] == "OpPartner"
     assert len(sheaf_ext["member_relationships"]) == 1
     assert len(sheaf_ext["group_relationships"]) == 1
 
 
-def test_openplural_roundtrip_restores_views_and_relationships(
+def test_pluralport_roundtrip_restores_views_and_relationships(
     auth_client: httpx.Client,
 ):
-    """The sections the OpenPlural exporter parks under extensions.sheaf.* come
+    """The sections the PluralPort exporter parks under extensions.sheaf.* come
     back on import - they used to be written and then dropped on the way in.
     Share views arrive inert here too."""
-    env = build_envelope(_openplural_native(), exported_at=_EXPORTED_AT)
+    env = build_envelope(_pluralport_native(), exported_at=_EXPORTED_AT)
     final = _run(
-        auth_client, json.dumps(env).encode(), source="openplural_file"
+        auth_client, json.dumps(env).encode(), source="pluralport_file"
     )
     counts = final["counts"]
     assert counts["share_views_imported"] == 1, counts
@@ -455,12 +455,12 @@ def test_openplural_roundtrip_restores_views_and_relationships(
     field_id = {f["name"]: f["id"] for f in dump["custom_fields"]}
     group_id = {g["name"]: g["id"] for g in dump["groups"]}
 
-    # Group privacy has no OpenPlural v0.1 core field, so it rides
+    # Group privacy has no PluralPort v0.1 core field, so it rides
     # extensions.sheaf on the group record; this proves that passthrough works
     # in both directions.
     assert _group_by_name(dump, "ShareGroup")["privacy"] == "friends"
 
-    view = _view_by_name(auth_client, "OpenPlural View")
+    view = _view_by_name(auth_client, "PluralPort View")
     assert view["include_members"] is False
     assert view["include_bio"] is True
     assert view["fronting_show_count"] is False

--- a/web/src/components/settings/data-export-card.tsx
+++ b/web/src/components/settings/data-export-card.tsx
@@ -36,13 +36,13 @@ import {
 } from "@/components/ui/select";
 
 type ExportMode = "with_images" | "account_data" | "front_history";
-type ExportFormat = "sheaf_native" | "openplural";
+type ExportFormat = "sheaf_native" | "pluralport";
 type FrontHistoryFormat = "fronts_csv" | "fronts_json" | "fronts_ics";
 
 // Friendly labels for every artefact format a job row can carry.
 const FORMAT_LABELS: Record<ExportJobFormat, string> = {
   sheaf_native: "Sheaf native",
-  openplural: "OpenPlural",
+  pluralport: "PluralPort",
   fronts_csv: "Front history (CSV)",
   fronts_json: "Front history (JSON)",
   fronts_ics: "Front history (Calendar)",
@@ -248,7 +248,7 @@ export function DataExportCard() {
       const a = document.createElement("a");
       a.href = url;
       const date = new Date().toISOString().slice(0, 10);
-      const ext = format === "openplural" ? "openplural.json" : "json";
+      const ext = format === "pluralport" ? "pluralport.json" : "json";
       a.download = `sheaf-export-${date}.${ext}`;
       a.click();
       URL.revokeObjectURL(url);
@@ -330,15 +330,15 @@ export function DataExportCard() {
                   type="radio"
                   name="export-format"
                   className="mt-0.5 h-4 w-4 border-input"
-                  checked={format === "openplural"}
-                  onChange={() => setFormat("openplural")}
+                  checked={format === "pluralport"}
+                  onChange={() => setFormat("pluralport")}
                 />
                 <span>
-                  OpenPlural
+                  PluralPort
                   <span className="block text-xs text-muted-foreground">
-                    OpenPlural v0.1, for interchange with other
-                    OpenPlural-compatible apps. JSON export here is uri-only;
-                    the full backup is a .openplural.zip with image bytes.
+                    PluralPort v0.1, for interchange with other
+                    PluralPort-compatible apps. JSON export here is uri-only;
+                    the full backup is a .pluralport.zip with image bytes.
                   </span>
                 </span>
               </label>
@@ -367,8 +367,8 @@ export function DataExportCard() {
             </p>
             <p className="text-xs text-muted-foreground mb-3 max-w-prose">
               Uses the <strong>format</strong> selected above
-              {format === "openplural"
-                ? " (OpenPlural .openplural.zip)."
+              {format === "pluralport"
+                ? " (PluralPort .pluralport.zip)."
                 : " (Sheaf native zip)."}
             </p>
             <Button onClick={() => setMode("with_images")} variant="outline">

--- a/web/src/components/settings/data-import-card.tsx
+++ b/web/src/components/settings/data-import-card.tsx
@@ -13,7 +13,7 @@ export function DataImportCard() {
           Supported sources: SimplyPlural (export file), PluralKit (export file
           or live API via your <code>pk;token</code>), Tupperbox (export file),
           Sheaf (export file), Octocon and compatible forks (via PK export), Prism
-          (export file), PluralSpace (export file), OpenPlural (export file).
+          (export file), PluralSpace (export file), PluralPort (export file).
         </p>
         <Link to="/import">
           <Button variant="outline">Import data</Button>

--- a/web/src/lib/imports.ts
+++ b/web/src/lib/imports.ts
@@ -17,7 +17,7 @@ export type ImportJobSource =
   | "sheaf_archive"
   | "pluralspace_file"
   | "prism_file"
-  | "openplural_file"
+  | "pluralport_file"
   | "ampersand_file";
 
 export type ImportJobStatus =
@@ -80,7 +80,7 @@ export const SOURCE_LABELS: Record<ImportJobSource, string> = {
   sheaf_archive: "Sheaf (with images)",
   pluralspace_file: "PluralSpace",
   prism_file: "Prism",
-  openplural_file: "OpenPlural",
+  pluralport_file: "PluralPort",
   ampersand_file: "Ampersand",
 };
 

--- a/web/src/lib/pluralport-import.ts
+++ b/web/src/lib/pluralport-import.ts
@@ -1,29 +1,29 @@
 /**
- * OpenPlural import - preview call.
+ * PluralPort import - preview call.
  *
  * Mirrors the Sheaf native re-import: a synchronous preview step counts
- * the sections in the uploaded file (a bare openplural.json document or
- * an .openplural.zip bundle, sniffed server-side) so the card can show
+ * the sections in the uploaded file (a bare pluralport.json document or
+ * a .pluralport.zip bundle, sniffed server-side) so the card can show
  * per-section counts and a member selector before the user commits. The
  * actual import is enqueued via lib/imports.ts under source
- * "openplural_file".
+ * "pluralport_file".
  */
 import { apiFetch } from "./api-client";
 import type { SheafPreviewSummary } from "./sheaf-import";
 
-// OpenPlural carries the same section counts as the Sheaf preview, plus
+// PluralPort carries the same section counts as the Sheaf preview, plus
 // the length of the export lineage (how many prior exports this file has
 // passed through).
-export interface OpenpluralPreviewSummary extends SheafPreviewSummary {
+export interface PluralportPreviewSummary extends SheafPreviewSummary {
   lineage_length: number;
 }
 
-export async function previewOpenpluralImport(
+export async function previewPluralportImport(
   file: File,
-): Promise<OpenpluralPreviewSummary> {
+): Promise<PluralportPreviewSummary> {
   const form = new FormData();
   form.append("file", file);
-  return apiFetch<OpenpluralPreviewSummary>("/v1/import/openplural/preview", {
+  return apiFetch<PluralportPreviewSummary>("/v1/import/pluralport/preview", {
     method: "POST",
     headers: {},
     body: form,

--- a/web/src/lib/systems.ts
+++ b/web/src/lib/systems.ts
@@ -13,19 +13,19 @@ export function updateMySystem(data: SystemUpdate, skipErrorToast = false) {
   });
 }
 
-export function exportData(format: "sheaf_native" | "openplural" = "sheaf_native") {
-  const q = format === "openplural" ? "?format=openplural" : "";
+export function exportData(format: "sheaf_native" | "pluralport" = "sheaf_native") {
+  const q = format === "pluralport" ? "?format=pluralport" : "";
   return apiFetch<Record<string, unknown>>(`/v1/export${q}`);
 }
 
 // --- Article 15 + async export jobs ---------------------------------------
 
-// Artefact format for an export job. "sheaf_native" / "openplural" are the
+// Artefact format for an export job. "sheaf_native" / "pluralport" are the
 // full-system exports; the fronts_* values are standalone front-history files
 // (a single CSV / JSON / iCalendar file, no zip).
 export type ExportJobFormat =
   | "sheaf_native"
-  | "openplural"
+  | "pluralport"
   | "fronts_csv"
   | "fronts_json"
   | "fronts_ics";
@@ -49,8 +49,8 @@ export function listExportJobs() {
 
 export function createExportJob(body: {
   include_images: boolean;
-  // Artefact format: "sheaf_native" (export.json + images/), "openplural"
-  // (an .openplural.zip bundle), or a standalone front-history file
+  // Artefact format: "sheaf_native" (export.json + images/), "pluralport"
+  // (a .pluralport.zip bundle), or a standalone front-history file
   // (fronts_csv / fronts_json / fronts_ics). Defaults server-side to
   // "sheaf_native" when omitted. include_images is ignored for fronts_*.
   format?: ExportJobFormat;

--- a/web/src/routes/import.tsx
+++ b/web/src/routes/import.tsx
@@ -36,9 +36,9 @@ import {
   previewImport as previewPrism,
 } from "@/lib/prism-import";
 import {
-  type OpenpluralPreviewSummary,
-  previewOpenpluralImport,
-} from "@/lib/openplural-import";
+  type PluralportPreviewSummary,
+  previewPluralportImport,
+} from "@/lib/pluralport-import";
 import {
   type AmpersandPreviewSummary,
   previewImport as previewAmpersand,
@@ -205,13 +205,13 @@ function SourcePicker({ onSelect }: { onSelect: (s: Source) => void }) {
         onClick={() => onSelect("op")}
       >
         <CardHeader>
-          <CardTitle className="text-base">Import from OpenPlural</CardTitle>
+          <CardTitle className="text-base">Import from PluralPort</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            Import an OpenPlural v0.1 export from Sheaf or another
-            OpenPlural-compatible app. Upload the <code>.json</code>{" "}
-            document, or the <code>.openplural.zip</code> bundle (the
+            Import a PluralPort v0.1 export from Sheaf or another
+            PluralPort-compatible app. Upload the <code>.json</code>{" "}
+            document, or the <code>.pluralport.zip</code> bundle (the
             bundle restores avatars and embedded images too).
           </p>
         </CardContent>
@@ -1666,14 +1666,14 @@ function PrismImportFlow({ onBack }: { onBack: () => void }) {
 }
 
 // ---------------------------------------------------------------------------
-// OpenPlural import flow
+// PluralPort import flow
 // ---------------------------------------------------------------------------
 
 function OPImportFlow({ onBack }: { onBack: () => void }) {
   const navigate = useNavigate();
   const [step, setStep] = useState<Step>("upload");
   const [file, setFile] = useState<File | null>(null);
-  const [preview, setPreview] = useState<OpenpluralPreviewSummary | null>(null);
+  const [preview, setPreview] = useState<PluralportPreviewSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   // One idempotency key per flow visit - a double-click on Import
   // reuses it, so the server dedupes instead of enqueueing twice.
@@ -1693,7 +1693,7 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
   const [importPolls, setImportPolls] = useState(true);
   const [importNotifications, setImportNotifications] = useState(true);
   const [importReminders, setImportReminders] = useState(true);
-  // Only meaningful for the .openplural.zip bundle (preview.archive).
+  // Only meaningful for the .pluralport.zip bundle (preview.archive).
   const [restoreImages, setRestoreImages] = useState(true);
 
   const importIncoming = allMembers
@@ -1706,7 +1706,7 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
     setFile(f);
     setError(null);
     try {
-      const p = await previewOpenpluralImport(f);
+      const p = await previewPluralportImport(f);
       setPreview(p);
       setStep("preview");
     } catch (err) {
@@ -1721,7 +1721,7 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
     try {
       const isArchive = preview?.archive ?? false;
       const job = await createFileImport({
-        source: "openplural_file",
+        source: "pluralport_file",
         file,
         idempotencyKey: idemKey,
         options: {
@@ -1739,7 +1739,7 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
           // Reminders need a channel; without notifications there's nothing
           // for them to attach to.
           reminders: importReminders && importNotifications,
-          // The images toggle only applies to the .openplural.zip bundle.
+          // The images toggle only applies to the .pluralport.zip bundle.
           ...(isArchive ? { images: restoreImages } : {}),
         },
       });
@@ -1766,19 +1766,22 @@ function OPImportFlow({ onBack }: { onBack: () => void }) {
       {step === "upload" && (
         <Card className="max-w-lg">
           <CardHeader>
-            <CardTitle className="text-base">Upload OpenPlural export</CardTitle>
+            <CardTitle className="text-base">Upload PluralPort export</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <p className="text-sm text-muted-foreground">
-              Upload an OpenPlural v0.1 export from Sheaf or another
-              OpenPlural-compatible app. Either the bare{" "}
+              Upload a PluralPort v0.1 export from Sheaf or another
+              PluralPort-compatible app. Either the bare{" "}
               <code>.json</code> document, or the full{" "}
-              <code>.openplural.zip</code> bundle (the bundle restores
+              <code>.pluralport.zip</code> bundle (the bundle restores
               avatars and embedded images too).
             </p>
             <input
               type="file"
-              accept=".json,.zip,.openplural.zip,application/json,application/zip"
+              // .openplural.zip stays accepted: bundles exported before
+              // the format's rename must still be selectable (the server
+              // sniffs content, so they import fine).
+              accept=".json,.zip,.pluralport.zip,.openplural.zip,application/json,application/zip"
               onChange={handleFileSelect}
               className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
             />

--- a/web/src/routes/imports.tsx
+++ b/web/src/routes/imports.tsx
@@ -110,7 +110,7 @@ export function ImportsPage() {
         <Card className="max-w-lg">
           <CardContent className="py-6 text-sm text-muted-foreground">
             No imports yet. Bring in data from PluralKit, SimplyPlural,
-            Tupperbox, PluralSpace, Prism, OpenPlural, or a Sheaf export.
+            Tupperbox, PluralSpace, Prism, PluralPort, or a Sheaf export.
             <div className="mt-4">
               <Button size="sm" asChild>
                 <Link to="/import">Start an import</Link>


### PR DESCRIPTION
The interchange format Sheaf co-designed was renamed upstream after a name conflict. The spec version string is unchanged at `0.1`, so this is branding plus one new envelope key, not a format revision. The spec now lives at [PluralPort/spec](https://github.com/PluralPort/spec).

## What changes on the wire

Exports stamp `pluralport_version: "0.1"` and download as `.pluralport.zip` carrying `pluralport.json`. The API's values become `format=pluralport` and `source=pluralport_file`, and the preview endpoint is `/v1/import/pluralport/preview`. Internally the services, schemas, tests, docs and web modules all follow the name.

## Nothing existing breaks

The spec's v0.1 versioning rule requires importers to keep accepting the deprecated `openplural_version` key with identical semantics, and requires `pluralport_version` to win when a file carries both. That last part is the easy thing to get backwards, so it is pinned by a test in both directions: a file with a bogus `pluralport_version` and a valid `openplural_version` is rejected, not quietly imported under the alias.

Beyond the envelope key, every other old spelling is still accepted as a deprecated alias: the legacy `openplural.json` bundle member, `format=openplural`, `source=openplural_file`, the old preview route (still working, but `include_in_schema=False` so the generated schema stays pluralport-only), `.openplural.zip` in the web file picker so exports already sitting on disk still select, and the `OPENPLURAL_MAX_PRESERVED_MB` env var for selfhosters (the new `PLURALPORT_MAX_PRESERVED_MB` wins if both are set).

## The one name that does not move

`systems.openplural_archive`, its model attribute, and `system_openplural_archive_aad` keep their pre-rename spelling. That string is the AAD bound into every encrypted residual-archive blob, so renaming it would make existing stored data undecryptable. All 24 sites that reference it now carry a comment saying why, because a partially-renamed file reading an `openplural`-named attribute is exactly where someone would later "finish the job". The exported JSON key does move to `pluralport_archive`, and the native importer accepts both spellings with the new one winning.

## Migration and deploy note

The migration is data-only: it relabels `import_jobs.source` and `export_jobs.format`. Both are `String(32)` rather than Postgres enums, so there is no type surgery and no lock-taking DDL. Downgrade is symmetric.

Worth picking a quiet moment for the deploy: during a rolling restart there is a narrow window where an old instance sees a relabelled row. Harmless for the historical completed rows, but an import job sitting `pending` at that exact moment with the old source value would fail and need re-running.

## Verification

Ruff, tsc, eslint and the web build are clean. The legacy env var alias, the query-param alias normalisation (`?format=openplural` returns 200 while a bogus value still 422s), and the generated OpenAPI enums were each checked directly rather than assumed. Stackless parity and unit tests pass; the full behavioural suite on the `selfhosted/none` config is 2051 passed / 155 skipped, which includes bringing up a stack and running the new migration.

New tests cover each compatibility path individually: legacy envelope key, both-keys precedence in either direction, legacy bundle member, legacy source and format values, the legacy preview route, the legacy archive key, and the old env var.

## Not in scope

Historical alembic migrations and historical changelog entries keep their original wording, as does the record of upstream issues filed under the old name.